### PR TITLE
generate the MiniAppsConfig even if there is only one MiniApp inside …

### DIFF
--- a/ern-container-gen/hull/android/lib/src/main/java/com/walmartlabs/ern/container/miniapps/MiniAppsConfig.java
+++ b/ern-container-gen/hull/android/lib/src/main/java/com/walmartlabs/ern/container/miniapps/MiniAppsConfig.java
@@ -11,12 +11,10 @@ import java.util.HashMap;
 public class MiniAppsConfig {
 
     {{#android}}
-    {{#hasMultipleMiniApps}}
     public static final HashMap<String, Class> MINIAPP_ACTIVITIES = new HashMap<String, Class>() {{=<% %>=}}{{<%={{ }}=%>
         {{#miniapps}}
         put("{{unscopedName}}", {{pascalCaseName}}Activity.class);
         {{/miniapps}}
     {{=<% %>=}}}};<%={{ }}=%>
-    {{/hasMultipleMiniApps}}
     {{/android}}
 }

--- a/ern-container-gen/src/generators/android/AndroidGenerator.js
+++ b/ern-container-gen/src/generators/android/AndroidGenerator.js
@@ -101,7 +101,6 @@ export default class AndroidGenerator {
     mustacheView.android = {
       repository: mavenPublisher ? MavenUtils.targetRepositoryGradleStatement(mavenPublisher.url) : undefined,
       namespace: this.namespace,
-      hasMultipleMiniApps: miniapps.length > 1,
       miniapps: miniapps
     }
 


### PR DESCRIPTION
…the container. This is needed for the navigation api.