### PR TITLE
ios: disable os_activity_mode in environment variable in ErnRunner scheme

### DIFF
--- a/ern-runner-gen/runner-hull/ios/ErnRunner.xcodeproj/xcshareddata/xcschemes/ErnRunner.xcscheme
+++ b/ern-runner-gen/runner-hull/ios/ErnRunner.xcodeproj/xcshareddata/xcschemes/ErnRunner.xcscheme
@@ -61,6 +61,13 @@
             ReferencedContainer = "container:ErnRunner.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>


### PR DESCRIPTION
![screen shot 2017-09-19 at 10 35 57 am](https://user-images.githubusercontent.com/31863333/30607178-f7ebe910-9d28-11e7-944d-02de6c442413.png)

This fix is to disable those console dump for ErnRunner. 