### PR TITLE
ios: modified nullability of properties of miniAppWithName 

### DIFF
--- a/ern-container-gen/hull/ios/ElectrodeContainer/ElectrodeReactNative.h
+++ b/ern-container-gen/hull/ios/ElectrodeContainer/ElectrodeReactNative.h
@@ -60,6 +60,6 @@ NS_ASSUME_NONNULL_BEGIN
  @return A UIViewController containing the view of the miniapp.
  */
 - (UIViewController *)miniAppWithName:(NSString *)name
-                           properties:(NSDictionary *)properties;
+                           properties:(NSDictionary _Nullable*)properties;
 @end
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Properties is allowed to be nil. Thus adding `_Nullable` to allow caller to pass in nil.
This will fix the warning in ErnRunner or any client when passing nil to this property