### PR TITLE
Add hooks to notify react-native ready

### DIFF
--- a/ern-container-gen/src/utils.js
+++ b/ern-container-gen/src/utils.js
@@ -150,7 +150,6 @@ export async function generateMiniAppsComposite (
     let packageJson = JSON.parse(fs.readFileSync(`${outDir}/package.json`, 'utf-8'))
     packageJson.scripts = {'start': 'node node_modules/react-native/local-cli/cli.js start'}
     fs.writeFileSync(path.join(outDir, 'package.json'), JSON.stringify(packageJson, null, 2), 'utf8')
-
   }
 
   let entryIndexJsContent = ''


### PR DESCRIPTION
- Query for react-native initialized status using `ElectrodeReactContainer.isReactNativeReady();` 
- Listen for react-native initialized
```
ElectrodeReactContainer.registerReactNativeReadyListener(new ElectrodeReactContainer.ReactNativeReadyListener() {
            @Override
            public void onReactNativeReady() {
                assert  ElectrodeReactContainer.isReactNativeReady();
            }
        });
```