### PR TITLE
Fix multi MiniApp run

### DIFF
--- a/ern-container-gen/src/generateContainer.js
+++ b/ern-container-gen/src/generateContainer.js
@@ -109,7 +109,7 @@ export default async function generateContainer ({
     version: miniapp.version,
     unscopedName: getUnscopedModuleName(miniapp.name).replace(/-/g, ''),
     pascalCaseName: capitalizeFirstLetter(getUnscopedModuleName(miniapp.name)).replace(/-/g, ''),
-    localPath: miniapps.length === 1 ? miniapp.path : undefined,
+    localPath: miniapp.path,
     packagePath: miniapp.packageDescriptor
   }))
 

--- a/ern-container-gen/src/utils.js
+++ b/ern-container-gen/src/utils.js
@@ -37,9 +37,14 @@ export async function bundleMiniApps (
     } else {
       let miniAppsPaths : Array<DependencyPath> = []
       for (const miniapp of miniapps) {
-        if (miniapp.packagePath) {
+        if (miniapp.localPath) {
+          log.debug(`[bundleMiniApps] Using local path ${miniapp.localPath} for ${miniapp.name}`)
+          miniAppsPaths.push(DependencyPath.fromFileSystemPath(miniapp.localPath))
+        } else if (miniapp.packagePath) {
+          log.debug(`[bundleMiniApps] Using package path ${miniapp.packagePath} for ${miniapp.name}`)
           miniAppsPaths.push(miniapp.packagePath)
         } else {
+          log.debug(`[bundleMiniApps] Using built path for ${miniapp.name}`)
           miniAppsPaths.push(new DependencyPath(new Dependency(miniapp.name, {
             scope: miniapp.scope,
             version: miniapp.version


### PR DESCRIPTION
Fix `ern run-ios` / `ern run-android` when multiple MiniApps are provided and some of the MiniApps are local to the workstation.

Always favor `local path` of a MiniApp if available (MiniApp is already present on the workstation), rather than retrieving it from npm.