### PR TITLE
Add support for ignoring rnpm assets

### DIFF
--- a/ern-container-gen/src/generators/android/AndroidGenerator.js
+++ b/ern-container-gen/src/generators/android/AndroidGenerator.js
@@ -120,7 +120,9 @@ export default class AndroidGenerator {
     await bundleMiniApps(miniapps, paths, 'android', {pathToYarnLock})
 
     // Rnpm handling
-    this.copyRnpmAssets(miniapps, paths)
+    if (!this._containerGeneratorConfig.ignoreRnpmAssets) {
+      this.copyRnpmAssets(miniapps, paths)
+    }
 
     // Finally, container hull project is fully generated, now let's just
     // build it and publish resulting AAR

--- a/ern-container-gen/src/generators/ios/IosGenerator.js
+++ b/ern-container-gen/src/generators/ios/IosGenerator.js
@@ -90,8 +90,10 @@ export default class IosGenerator {
         await bundleMiniApps(miniapps, paths, 'ios', {pathToYarnLock})
       }
 
-      // Handle resources copying
-      this.copyRnpmAssets(miniapps, paths)
+      // Copy potential rnpm provided assets
+      if (!this._containerGeneratorConfig.ignoreRnpmAssets) {
+        this.copyRnpmAssets(miniapps, paths)
+      }
 
       // Publish resulting container to git repo
       if (gitHubPublisher) {

--- a/ern-core/src/ContainerGeneratorConfig.js
+++ b/ern-core/src/ContainerGeneratorConfig.js
@@ -27,6 +27,7 @@ export default class ContainerGeneratorConfig {
   publishers: Array<Publisher>
   containerVersion: string
   platform: string
+  ignoreRnpmAssets: boolean
 
   constructor (platform: string, config: any) {
     this.platform = platform
@@ -44,6 +45,9 @@ export default class ContainerGeneratorConfig {
         for (const p of config.publishers) {
           this.publishers.push(ContainerGeneratorConfig.createPublisher(p.name, p.url))
         }
+      }
+      if (config.ignoreRnpmAssets) {
+        this.ignoreRnpmAssets = config.ignoreRnpmAssets
       }
     } else if (platform === 'android') {
       // No container config provided. Lets create a default maven publisher for android


### PR DESCRIPTION
Add `ignoreRnpmAssets` boolean property to Container generator config in Cauldron.

If this property is `true`, it will not copy rnpm assets to the Container during generation. Otherwise it will copy rnpm assets.

By default, if not present in configuration, it will default to `false`.

Sample:
```
"config": {
  "containerGenerator": {
     "containerVersion": "1.16.22",
     "ignoreRnpmAssets": true,
      "publishers": [
...
```