### PR TITLE
Add cauldron repo clear command

### DIFF
--- a/docs/cli/cauldron/repo/clear.md
+++ b/docs/cli/cauldron/repo/clear.md
@@ -1,0 +1,10 @@
+## `ern cauldron repo clear>`
+#### Description
+* Go back to a state with no Cauldron activated
+
+#### Syntax
+`ern cauldron repo clear`  
+
+####Remarks
+This command allows to reset platform not to use any Cauldron. If you need to switch back to a Cauldron, you can use `ern cauldron use` command.
+

--- a/ern-local-cli/src/commands/cauldron/repo/clear.js
+++ b/ern-local-cli/src/commands/cauldron/repo/clear.js
@@ -1,0 +1,27 @@
+// @flow
+
+import {
+  Platform
+} from 'ern-core'
+import {
+  config as ernConfig
+} from 'ern-util'
+import shell from 'shelljs'
+import utils from '../../../lib/utils'
+
+exports.command = 'clear'
+exports.desc = 'Do not use any Cauldron'
+
+exports.builder = function (yargs: any) {
+  return yargs.epilog(utils.epilog(exports))
+}
+
+exports.handler = function ({
+  alias
+} : {
+  alias: string
+}) {
+  ernConfig.setValue('cauldronRepoInUse', undefined)
+  shell.rm('-rf', `${Platform.rootDirectory}/cauldron`)
+  log.info(`Done.`)
+}


### PR DESCRIPTION
Add new command `ern cauldron repo clear` which allows to go back to a state with no Cauldron activated.  

Before this command, once a Cauldron repository was in use, there was no way to go back to not using any Cauldron, unless manually editing the `~/.ern/.ernrc` file. 