### PR TITLE
prompt for a valid npm package name

### DIFF
--- a/ern-core/src/MiniApp.js
+++ b/ern-core/src/MiniApp.js
@@ -93,7 +93,7 @@ Are you sure this is a MiniApp ?`)
   }
 
   static async create (
-    appName: string,
+    miniAppName: string,
     packageName: string, {
       platformVersion = Platform.currentVersion,
       scope
@@ -110,7 +110,7 @@ Are you sure this is a MiniApp ?`)
         Platform.switchToVersion(platformVersion)
       }
 
-      log.info(`Creating ${appName} MiniApp`)
+      log.info(`Creating ${miniAppName} MiniApp`)
 
       const reactNativeDependency = await spin(
         `Retrieving react-native version from Manifest`,
@@ -121,16 +121,16 @@ Are you sure this is a MiniApp ?`)
       }
 
       await spin(
-        `Creating ${appName} project using react-native v${reactNativeDependency.version}. This might take a while.`,
-        reactnative.init(appName, reactNativeDependency.version))
+        `Creating ${miniAppName} project using react-native v${reactNativeDependency.version}. This might take a while.`,
+        reactnative.init(miniAppName, reactNativeDependency.version))
 
       // Inject ern specific data in MiniApp package.json
-      const appPackageJsonPath = `${process.cwd()}/${appName}/package.json`
+      const appPackageJsonPath = `${process.cwd()}/${miniAppName}/package.json`
       const appPackageJson = JSON.parse(fs.readFileSync(appPackageJsonPath, 'utf-8'))
       appPackageJson.ern = {
         version: `${platformVersion}`,
         moduleType: `${ModuleTypes.MINIAPP}`,
-        miniAppName: utils.camelize(appName, false)
+        miniAppName
       }
       appPackageJson.private = false
       appPackageJson.keywords
@@ -147,7 +147,7 @@ Are you sure this is a MiniApp ?`)
       // Remove react-native generated android and ios projects
       // They will be replaced with our owns when user uses `ern run android`
       // or `ern run ios` command
-      const miniAppPath = `${process.cwd()}/${appName}`
+      const miniAppPath = `${process.cwd()}/${miniAppName}`
       shell.cd(miniAppPath)
       shell.rm('-rf', 'android')
       shell.rm('-rf', 'ios')

--- a/ern-core/src/MiniApp.js
+++ b/ern-core/src/MiniApp.js
@@ -99,7 +99,8 @@ Are you sure this is a MiniApp ?`)
     } : {
       platformVersion: string,
       scope?: string
-    }) {
+    },
+    packageName: string) {
     try {
       if (fs.existsSync(path.join('node_modules', 'react-native'))) {
         throw new Error('It seems like there is already a react native app in this directory. Use another directory.')
@@ -123,7 +124,6 @@ Are you sure this is a MiniApp ?`)
         `Creating ${appName} project using react-native v${reactNativeDependency.version}. This might take a while.`,
         reactnative.init(appName, reactNativeDependency.version))
 
-      //
       // Inject ern specific data in MiniApp package.json
       const appPackageJsonPath = `${process.cwd()}/${appName}/package.json`
       const appPackageJson = JSON.parse(fs.readFileSync(appPackageJsonPath, 'utf-8'))
@@ -138,17 +138,12 @@ Are you sure this is a MiniApp ?`)
         : appPackageJson.keywords = [ModuleTypes.MINIAPP]
 
       if (scope) {
-        appPackageJson.name = `@${scope}/${appName.toLowerCase()}`
+        appPackageJson.name = `@${scope}/${packageName}`
       } else {
-        appPackageJson.name = appName.toLowerCase()
+        appPackageJson.name = packageName
       }
 
-      log.info(`Your MiniApp name when published to npm will be ${appPackageJson.name}.`)
-      log.info(`This is because NPM does not allow package names containing upper case letters.`)
-
       fs.writeFileSync(appPackageJsonPath, JSON.stringify(appPackageJson, null, 2))
-
-      //
       // Remove react-native generated android and ios projects
       // They will be replaced with our owns when user uses `ern run android`
       // or `ern run ios` command

--- a/ern-core/src/MiniApp.js
+++ b/ern-core/src/MiniApp.js
@@ -93,14 +93,14 @@ Are you sure this is a MiniApp ?`)
   }
 
   static async create (
-    appName: string, {
+    appName: string,
+    packageName: string, {
       platformVersion = Platform.currentVersion,
       scope
     } : {
       platformVersion: string,
       scope?: string
-    },
-    packageName: string) {
+    }) {
     try {
       if (fs.existsSync(path.join('node_modules', 'react-native'))) {
         throw new Error('It seems like there is already a react native app in this directory. Use another directory.')

--- a/ern-core/src/utils.js
+++ b/ern-core/src/utils.js
@@ -58,10 +58,7 @@ export function camelize (word: string, lowercaseFirstLetter: boolean = false): 
  * @returns {string}
  */
 export function splitCamelCaseString (camelCaseString: string) {
-  if (!camelCaseString) {
-    return camelCaseString
-  }
-  return camelCaseString.split(/(?=[A-Z])/).map((token) => {
+  return camelCaseString && camelCaseString.split(/(?=[A-Z])/).map((token) => {
     return token.toLowerCase()
   })
 }

--- a/ern-core/src/utils.js
+++ b/ern-core/src/utils.js
@@ -50,3 +50,18 @@ export function camelize (word: string, lowercaseFirstLetter: boolean = false): 
   word = camelCase(word)
   return word && word[0][lowercaseFirstLetter ? 'toLowerCase' : 'toUpperCase']() + word.substring(1)
 }
+
+/**
+ * Split the camel case string
+ *
+ * @param camelCaseString
+ * @returns {string}
+ */
+export function splitCamelCaseString (camelCaseString: string) {
+  if (!camelCaseString) {
+    return camelCaseString
+  }
+  return camelCaseString.split(/(?=[A-Z])/).map((token) => {
+    return token.toLowerCase()
+  })
+}

--- a/ern-local-cli/src/commands/create-miniapp.js
+++ b/ern-local-cli/src/commands/create-miniapp.js
@@ -41,13 +41,17 @@ exports.handler = async function ({
     let packageName = appName
     if (packageName !== packageName.toLowerCase()) {
       log.info(`NPM does not allow package names containing upper case letters.`)
-      const answer = await _promptForPackageName(core.splitCamelCaseString(appName).join('-'))
-      packageName = answer.packageName
+      let appNameToken = core.splitCamelCaseString(appName)
+      if (appNameToken) {
+        const answer = await _promptForPackageName(appNameToken.join('-'))
+        packageName = answer.packageName
+      }
     }
-    await MiniApp.create(appName, {
-      platformVersion: platformVersion && platformVersion.replace('v', ''),
-      scope
-    }, packageName)
+    await MiniApp.create(appName,
+      packageName, {
+        platformVersion: platformVersion && platformVersion.replace('v', ''),
+        scope
+      })
     log.info(`${appName} MiniApp was successfully created !`)
     log.info(`================================================`)
     log.info(chalk.bold.white('To run your MiniApp on Android :'))
@@ -68,7 +72,7 @@ function _promptForPackageName (packageName: string) {
   return inquirer.prompt([{
     type: 'input',
     name: 'packageName',
-    message: `Please type package name to publish to npm. Press Enter to use the default.`,
+    message: `Type package name to publish to npm. Press Enter to use the default.`,
     default: () => {
       return `${packageName}`
     },
@@ -76,7 +80,7 @@ function _promptForPackageName (packageName: string) {
       if (value && value === value.toLowerCase()) {
         return true
       }
-      return 'Please check npm package name rules https://docs.npmjs.com/files/package.json'
+      return 'Check npm package name rules https://docs.npmjs.com/files/package.json'
     }
   }])
 }


### PR DESCRIPTION
The PR aims at prompting user if MiniApp contains uppercase letters. New packages must not have uppercase letters in the name.

```
$ ern create-miniapp HelloWorld
NPM does not allow package names containing upper case letters.
? Please type package name to publish to npm. Press Enter to use the default. (hello-world)
```
