### PR TITLE
Remove `bin` from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "flow"
   ],
   "bin": {
-    "ern": "ern-global-cli/bin/ern.js"
+    "ern": "global-cli/bin/ern.js"
   },
   "dependencies": {
     "chalk": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
     "standard",
     "flow"
   ],
-  "bin": {
-    "ern": "global-cli/bin/ern.js"
-  },
   "dependencies": {
     "chalk": "^1.1.3",
     "shelljs": "^0.7.6"


### PR DESCRIPTION
* **Problem:** `npm link` doesn't work because _package.json_’s `bin` entry points to a non-existent file
* **Solution:** Fix `bin` entry
* **Testing:** Try `npm link` in the repo's root (`npm unlink` to undo)