### PR TITLE
Add metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.5.1",
   "description": "",
   "keywords": [],
-  "author": "",
+  "author": "Walmart Labs <http://walmartlabs.com/>",
   "license": "Apache-2.0",
   "scripts": {
     "setup-dev": "node setup-dev.js",
@@ -77,8 +77,13 @@
   },
   "engines": {
     "node": ">=4.5"
+  },
+  "bugs": {
+    "url": "https://github.com/electrode-io/electrode-native/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/electrode-io/electrode-native.git"
-  }
+  },
+  "homepage": "http://www.electrode.io"
 }

--- a/package.json
+++ b/package.json
@@ -77,5 +77,8 @@
   },
   "engines": {
     "node": ">=4.5"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/electrode-io/electrode-native.git"
   }
 }


### PR DESCRIPTION
* **Problem:** The package.json lacks some metadata. npm complains:
    ```
    npm WARN ern-platform@0.5.1 No repository field.
    ```
* **Solution:** Add the metadata!
* **Testing:** Make sure the JSON isn't malformed:
    ```
    node -pe 'require("./package.json")'
    ```

    (Should output JSON and not throw)