### PR TITLE
Remove deprecated miniapp command

### DIFF
--- a/ern-local-cli/src/commands/miniapp.js
+++ b/ern-local-cli/src/commands/miniapp.js
@@ -1,7 +1,0 @@
-// @flow
-
-exports.command = 'miniapp'
-exports.desc = 'Commands to create and work with MiniApps'
-exports.builder = function (yargs: any) {
-  return yargs.commandDir('miniapp').demandCommand(1, 'needs a command')
-}


### PR DESCRIPTION
Remove deprecated `ern miniapp` command. 

This command was still showing up in the command list when running `ern` but command directory did not existed anymore, which was leading in an exception being thrown when trying to run this command.

Thanks @gmbharath12 for reporting