### PR TITLE
Correct loading message

### DIFF
--- a/ern-local-cli/src/lib/utils.js
+++ b/ern-local-cli/src/lib/utils.js
@@ -535,7 +535,7 @@ async function launchIosRunner (pathToIosRunner: string) {
     // do nothing if there is no simulator launched
   }
 
-  const spinner = ora(`Wating for device to boot`).start()
+  const spinner = ora(`Waiting for device to boot`).start()
 
   await launchSimulator(device.udid)
 


### PR DESCRIPTION
Noticed this while re-booting:

![wat](https://user-images.githubusercontent.com/1858316/30995064-9d4cda5a-a46c-11e7-94ab-b58b4c5968e9.jpg)

This corrects the loading message typo!