### PR TITLE
Update ern add command with multi packages support

### DIFF
--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -1,32 +1,31 @@
-## `ern add <dependency>`
+## `ern add <packages..>`
 #### Description
-* Add the dependency to the MiniApp package.json when all checks pass
+* Add one or more package (dependency) to the MiniApp
 
 #### Syntax
-`ern add <dependency>`
+`ern add <packages..>`
 
 **Options**  
 `--dev/-d`
 
-* Add the dependency to the MiniApp package.json `devDependencies`  
+* Add the package(s) to the MiniApp `devDependencies`  
 * Checks are not performed to add development dependencies  
 
 `--peer/-p`
 
-* Add the dependency to the MiniApp package.json `peerDependencies`  
+* Add the package(s) to the MiniApp `peerDependencies`  
 * Checks are not performed to add peer dependencies
 
 #### Remarks
-* The `ern add <dependency>` command is the `ern` equivalent of `yarn add` and `npm install`
+* The `ern add <packages..>` command is the `ern` equivalent of `yarn add` and `npm install`
 When you work with a MiniApp, always use `ern add` to add packages in place of `yarn add` or `npm install`.
 
-* The `ern add <dependency>` command runs `yarn add` and it performs important additional compatibility checks.
+* The `ern add <packages..>` command runs `yarn add` and it performs important additional compatibility checks.
 
 * You don't need to specify an explicit version for a package that you add using `ern add`. If you add an explicit version for a package, it is ignored.
 
 * If the package is declared in the current platform manifest, then the version from the manifest is used.  
-
-* The `ern add <dependency>` command performs the following checks:  
+* The `ern add <packages>` command performs the following checks:  
  - If the package is declared in the manifest, then `ern` installs the package at the version declared in the manifest.
  - If the package is not declared in the manifest, then additional checks are performed:
     - If the package contains native code in any way (the package itself is a native module or it transitively contains one or more native dependencies, the command denies the package installation until a configuration is added to the manifest for this package.

--- a/ern-local-cli/src/commands/add.js
+++ b/ern-local-cli/src/commands/add.js
@@ -10,35 +10,37 @@ import utils from '../lib/utils'
 
 // Note : We use `pkg` instead of `package` because `package` is
 // a reserved JavaScript word
-exports.command = 'add <pkg>'
-exports.desc = 'Add a package to this miniapp'
+exports.command = 'add <packages..>'
+exports.desc = 'Add one or more package(s) to this miniapp'
 
 exports.builder = function (yargs: any) {
   return yargs
     .option('dev', {
       type: 'bool',
       alias: 'd',
-      describe: 'Add this package to devDependencies'
+      describe: 'Add this/these packages to devDependencies'
     })
     .option('peer', {
       type: 'bool',
       alias: 'p',
-      describe: 'Add this package to peerDependencies'
+      describe: 'Add this/these packages to peerDependencies'
     })
     .epilog(utils.epilog(exports))
 }
 
-exports.handler = function ({
-  pkg,
+exports.handler = async function ({
+  packages,
   dev = false,
   peer = false
 } : {
-  pkg: string,
+  packages: Array<string>,
   dev: boolean,
   peer: boolean
 }) {
   try {
-    return MiniApp.fromCurrentPath().addDependency(Dependency.fromString(pkg), {dev, peer})
+    for (const pkg of packages) {
+      await MiniApp.fromCurrentPath().addDependency(Dependency.fromString(pkg), {dev, peer})
+    }
   } catch (e) {
     log.error(`${e}`)
   }


### PR DESCRIPTION
Improve `ern add` command to allow for user to provide more than one package to add to the MiniApp. Thanks @swashcap 

```
➜  MovieListMiniApp ern add react-native-ernnavigation-api react-native-electrode-bridge react-native-ernmovie-api
✔ react-native-ernnavigation-api is not declared in the manifest. Performing additional checks.
✔ Adding react-native-ernnavigation-api to MiniApp
✔ Adding react-native-electrode-bridge@1.5.9 to MiniApp
✔ react-native-ernmovie-api is not declared in the manifest. Performing additional checks.
✔ Adding react-native-ernmovie-api to MiniApp
```

`package.json` dependencies extract, following command execution :

```
"dependencies": {
    "react-native-electrode-bridge": "1.5.9",
    "react-native-ernmovie-api": "0.0.9",
    "react-native-ernnavigation-api": "0.0.3"
    [...]
}
```

Closes https://github.com/electrode-io/electrode-native/issues/105
