### PR TITLE
Fix “Getting Started” doc line break.

### DIFF
--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -354,6 +354,7 @@ $ ern run-android
 
 {% sample lang="ios" %}
 1) In Xcode, open the generated iOS project (in the `ios` directory).
+
 2) Replace the content of the `ViewController.h` file with the content shown below:
 
 ```objectivec


### PR DESCRIPTION
### Problem

Line formatting on a step in the “Getting Started” doc’s “Implementing the MovieApi on the native side” section is broken:

![start](https://user-images.githubusercontent.com/1858316/31028767-0d811fd8-a504-11e7-9f9d-7f8110ea314d.jpg)

### Solution

Add a line break after the first section step.

### Testing

I didn't know about GitBook’s CLI! It’s neat. Here’s how to preview this edit if you’re interested:

1. Install the GitBook CLI: `npm install -g gitbook-cli`
2. Install project GitBook plugins. Make sure you’re in the `electrode-native` directory:

   ```shell
   gitbook install
   ```
3. Run `gitbook serve` and open http://localhost:4000/getting-started/getting-started.html
4. Observe fixed formatting!

    ![end](https://user-images.githubusercontent.com/1858316/31028789-295a95ea-a504-11e7-82e3-a99cf2d00f4a.jpg)

    🎉