### PR TITLE
Fix global CLI for node < 6

### DIFF
--- a/global-cli/package.json
+++ b/global-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrode-native",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Electrode Native Global CLI",
   "main": "./dist/index.js",
   "bin": {

--- a/global-cli/src/index.js
+++ b/global-cli/src/index.js
@@ -44,7 +44,7 @@ if (!fs.existsSync(ERN_PATH)) {
 // Create all folders and install/activate current platform version
 function firstTimeInstall () {
   try {
-    const isDebug = process.argv.includes('--debug')
+    const isDebug = process.argv.indexOf('--debug') !== -1
 
     const spinner = ora('Performing first time install of Electrode Native').start()
 
@@ -68,7 +68,7 @@ function firstTimeInstall () {
       // Favor yarn if it is installed as it will greatly speed up install
       spinner.text = `Installing Electrode Native v${latestVersion} using yarn. This might take a while`
       installProc = spawn('yarn',
-        [ 'add', `${ERN_LOCAL_CLI_PACKAGE}@${latestVersion}`, '--exact' ],
+        [ 'add', `${ERN_LOCAL_CLI_PACKAGE}@${latestVersion}`, '--exact', '--ignore-engines' ],
         { cwd: pathToVersionDirectory })
     } else {
       spinner.text = `Installing Electrode Native v${latestVersion} using npm. This might take a while`
@@ -89,7 +89,7 @@ function firstTimeInstall () {
       if (code === 0) {
         spinner.succeed(`Hurray ! Electrode Native v${latestVersion} was successfully installed.`)
       } else {
-        spinner.fail(`Oops. Something went wrong.`)
+        spinner.fail(`Something went wrong :( Run the command again with --debug flag for more info.`)
         execSync(`rm -rf ${ERN_PATH}`)
       }
     })
@@ -97,7 +97,7 @@ function firstTimeInstall () {
     // If something went wrong, we just clean up everything.
     // Don't want to create and leave the .ern global folder hanging around
     // in a bad state
-    console.log(`Something went wrong ! ${e}`)
+    console.log(`Something went wrong :( Run the command again with --debug flag for more info.`)
     execSync(`rm -rf ${ERN_PATH}`)
   }
 }


### PR DESCRIPTION
Replace `.includes` with `.indexOf` due to the fact that `global-cli` is not transpiled to run on older versions of node and that `.includes` was introduced in ES6/Node6.