### PR TITLE
Extend mustache templating exclusion to Android assets

### DIFF
--- a/ern-container-gen/src/generators/android/AndroidGenerator.js
+++ b/ern-container-gen/src/generators/android/AndroidGenerator.js
@@ -215,8 +215,10 @@ export default class AndroidGenerator {
       log.debug(`Patching hull`)
       const files = readDir(`${outputFolder}`, (f) => (!f.endsWith('.jar') && !f.endsWith('.aar') && !f.endsWith('.git')))
       for (const file of files) {
-        if (file.startsWith(`lib/src/main/java/com`) && !file.startsWith(`lib/src/main/java/com/walmartlabs/ern/container`)) {
+        if ((file.startsWith(`lib/src/main/java/com`) && !file.startsWith(`lib/src/main/java/com/walmartlabs/ern/container`)) ||
+          file.startsWith(`lib/src/main/assets`)) {
           // We don't want to Mustache process library files. It can lead to bad things
+          // We also don't want to process assets files ...
           // We just want to process container specific code (which contains mustache templates)
           log.debug(`Skipping mustaching of ${file}`)
           continue


### PR DESCRIPTION
Fix a bug that was happening during Android Container generation when some third party native modules such as `react-native-vector-icons` are used.

The problem is that Container Generator is trying to process mustache templates in `lib/src/main/assets` which is a bad thing and leads to generation errors if some of the assets (images/fonts) contain some mustache placeholders (`{{{` for ex). 

This commit extends mustache templating exclusion to the `lib/src/main/assets` as we know only assets will be present in this folder and no files to apply mustache templating on.