### PR TITLE
Rename upgrade command to upgrade-miniapp

### DIFF
--- a/docs/cli/upgrade.md
+++ b/docs/cli/upgrade.md
@@ -1,9 +1,9 @@
-## `ern upgrade`
+## `ern upgrade-miniapp`
 #### Description
 * Upgrades a MiniApp to the currently activated platform version
 
 #### Syntax
-`ern upgrade`
+`ern upgrade-miniapp`
 
 **Options**  
 

--- a/ern-local-cli/src/commands/upgrade-miniapp.js
+++ b/ern-local-cli/src/commands/upgrade-miniapp.js
@@ -6,7 +6,7 @@ import {
 } from 'ern-core'
 import utils from '../lib/utils'
 
-exports.command = 'upgrade'
+exports.command = 'upgrade-miniapp'
 exports.desc = 'Upgrade a MiniApp to current or specific platform version'
 
 exports.builder = function (yargs: any) {


### PR DESCRIPTION
Renames `upgrade` command to `upgrade-miniapp`

Because this command is only to be used to upgrade MiniApps, it makes its more clear and remove some confusion that it was somehow to "upgrade" ern.