### PR TITLE
Add --version flag to ern command

### DIFF
--- a/ern-local-cli/src/index.js
+++ b/ern-local-cli/src/index.js
@@ -10,6 +10,7 @@ import {
 } from 'ern-util'
 import chalk from 'chalk'
 import yargs from 'yargs'
+import { execSync } from 'child_process'
 
 // ==============================================================================
 // Geeky eye candy
@@ -26,6 +27,18 @@ function showInfo () {
   const currentCauldronRepo = ernConfig.getValue('cauldronRepoInUse') || '-NONE-'
   console.log(chalk.cyan(`[v${Platform.currentVersion}]`) + chalk.cyan(` [Cauldron: ${currentCauldronRepo}]`))
   console.log('')
+}
+
+function showVersion () {
+  // get electrode-native local-cli version
+  if (ernConfig.getValue('platformVersion')) {
+    log.info(`ern-local-cli : ${ernConfig.getValue('platformVersion')}`)
+  }
+  // get electrode-native global-cli version
+  const packageInfo = JSON.parse(execSync(`npm ls -g electrode-native --json`).toString())
+  if (packageInfo && packageInfo.dependencies) {
+    log.info(`electrode-native : ${packageInfo.dependencies['electrode-native'].version}`)
+  }
 }
 
 // ==============================================================================
@@ -49,6 +62,8 @@ export default function run () {
   } else if (argv['log-level']) {
     ernConfig.setValue('loglevel', argv['log-level'])
     return log.info(`Log level is now set to ${argv['log-level']}`)
+  } else if (argv['version']) {
+    return showVersion()
   }
 
   return yargs


### PR DESCRIPTION
Fixes [Issue](https://github.com/electrode-io/electrode-native/issues/101)

We added the support for `ern` CLI to support `--version` flag.

Usage 
```
ern --version
 ___ _        _               _       _  _      _   _
| __| |___ __| |_ _ _ ___  __| |___  | \| |__ _| |_(_)_ _____
| _|| / -_) _|  _| '_/ _ \/ _` / -_) | .` / _` |  _| \ V / -_)
|___|_\___\__|\__|_| \___/\__,_\___| |_|\_\__,_|\__|_|\_/\___|
[v1000.0.0] [Cauldron: -NONE-]

ern-local-cli : 1000.0.0
electrode-native : 1.0.9
``` 
