### PR TITLE
Add release notes link to ern platform list command

### DIFF
--- a/ern-local-cli/src/commands/platform/list.js
+++ b/ern-local-cli/src/commands/platform/list.js
@@ -9,6 +9,8 @@ import {
 import chalk from 'chalk'
 import utils from '../../lib/utils'
 
+const BASE_RELEASE_URL = `https://github.com/electrode-io/electrode-native/releases/tag`
+
 exports.command = 'list'
 exports.desc = 'List platform versions'
 
@@ -22,14 +24,18 @@ exports.handler = function () {
     ${chalk.yellow('[INSTALLED]')}
     ${chalk.gray('[NOT INSTALLED]')}`)
   for (const version of Platform.versions) {
+    // Don't show versions pre 0.7.0 as it was not official public releases
+    // Electrode Native initial public release was 0.7.0 so starting from
+    // this version
+    if (version < '0.7.0') { continue }
     if (Platform.isPlatformVersionInstalled(version)) {
       if (Platform.currentVersion === version) {
-        log.info(chalk.green(`-> v${version}`))
+        log.info(chalk.green(`-> v${version}\t\t`) + chalk.white(`${BASE_RELEASE_URL}/v${version}`))
       } else {
-        log.info(chalk.yellow(`v${version}`))
+        log.info(chalk.yellow(`v${version}\t\t`) + chalk.white(`${BASE_RELEASE_URL}/v${version}`))
       }
     } else {
-      log.info(chalk.gray(`v${version}`))
+      log.info(chalk.gray(`v${version}\t\t`) + chalk.white(`${BASE_RELEASE_URL}/v${version}`))
     }
   }
 }


### PR DESCRIPTION
A a link to the release notes next to each listed platform version when using `ern platform list` command.

Allows to easily go through the release notes of any version by `⌘ + LEFT CLICK` on the link in the terminal.

Also `ern platform list` now don't show the versions pre `0.7.0` as they were test versions, not meant to be installed. Official initial public version release of `Electrode Native` is `0.7.0` so starting from this point.

```
➜  ern platform list
 ___ _        _               _       _  _      _   _
| __| |___ __| |_ _ _ ___  __| |___  | \| |__ _| |_(_)_ _____
| _|| / -_) _|  _| '_/ _ \/ _` / -_) | .` / _` |  _| \ V / -_)
|___|_\___\__|\__|_| \___/\__,_\___| |_|\_\__,_|\__|_|\_/\___|
[v1000.0.0] [Cauldron: benoit]

 [CURRENT] [INSTALLED] [NOT INSTALLED]
v0.7.0		https://github.com/electrode-io/electrode-native/releases/tag/v0.7.0
```