### PR TITLE
Remove all binary access from Cauldron

### DIFF
--- a/ern-cauldron-api/src/index.js
+++ b/ern-cauldron-api/src/index.js
@@ -9,8 +9,7 @@ export default function factory (
   cauldronPath: string,
   branch: string = 'master') {
   const sourcemapStore = new FileStore(cauldronPath, repository, branch, 'sourcemaps')
-  const binaryStore = new FileStore(cauldronPath, repository, branch, 'binaries')
   const yarnlockStore = new FileStore(cauldronPath, repository, branch, 'yarnlocks')
   const dbStore = new GitStore(cauldronPath, repository, branch)
-  return new Api(dbStore, binaryStore, sourcemapStore, yarnlockStore)
+  return new Api(dbStore, sourcemapStore, yarnlockStore)
 }

--- a/ern-core/src/cauldron.js
+++ b/ern-core/src/cauldron.js
@@ -179,32 +179,6 @@ class Cauldron {
     }
   }
 
-  async addNativeBinary (
-    napDescriptor: NativeApplicationDescriptor,
-    binaryPath: string) : Promise<*> {
-    try {
-      this.throwIfPartialNapDescriptor(napDescriptor)
-      await this.throwIfNativeApplicationNotInCauldron(napDescriptor)
-      return this.cauldron.createNativeBinary(
-                napDescriptor.name, napDescriptor.platform, napDescriptor.version, binaryPath)
-    } catch (e) {
-      log.error(`[addNativeBinary] ${e}`)
-      throw e
-    }
-  }
-
-  async getNativeBinary (napDescriptor: NativeApplicationDescriptor) : Promise<*> {
-    try {
-      this.throwIfPartialNapDescriptor(napDescriptor)
-      await this.throwIfNativeApplicationNotInCauldron(napDescriptor)
-      return this.cauldron.getNativeBinary(
-        napDescriptor.name, napDescriptor.platform, napDescriptor.version)
-    } catch (e) {
-      log.error(`[getNativeBinary] ${e}`)
-      throw e
-    }
-  }
-
   async hasYarnLock (napDescriptor: NativeApplicationDescriptor) : Promise<boolean> {
     try {
       this.throwIfPartialNapDescriptor(napDescriptor)


### PR DESCRIPTION
We won't store binaries in Cauldron anymore, as we are going to rely on a [binary store](https://github.com/electrode-io/electrode-native-binarystore) instead.

This code is therefore deprecated and won't be used anymore. Cleaning it up.