### PR TITLE
Add BinaryStore and first store implementation ErnBinaryStore

### DIFF
--- a/ern-core/src/BinaryStore.js
+++ b/ern-core/src/BinaryStore.js
@@ -1,0 +1,12 @@
+// @flow
+
+import {
+  NativeApplicationDescriptor
+} from 'ern-util'
+
+export interface BinaryStore {
+  addBinary (descriptor: NativeApplicationDescriptor, binary: any) : Promise<boolean>;
+  removeBinary (descriptor: NativeApplicationDescriptor) : Promise<boolean>;
+  getBinary (descriptor: NativeApplicationDescriptor, options: Object) : Promise<string>;
+  hasBinary (descriptor: NativeApplicationDescriptor) : Promise<boolean>;
+}

--- a/ern-core/src/ErnBinaryStore.js
+++ b/ern-core/src/ErnBinaryStore.js
@@ -1,0 +1,91 @@
+// @flow
+
+import type { BinaryStore } from './BinaryStore'
+import {
+  NativeApplicationDescriptor
+} from 'ern-util'
+import {
+  exec,
+  spawn
+} from 'child_process'
+import fs from 'fs'
+import path from 'path'
+import tmp from 'tmp'
+
+export default class ErnBinaryStore implements BinaryStore {
+  _config: Object
+
+  constructor (config: Object) {
+    this._config = config
+  }
+
+  async addBinary (descriptor: NativeApplicationDescriptor, binaryPath: string) : Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      exec(`curl -XPOST ${this._config.url} -F file=@"${binaryPath};filename=${this.buildNativeBinaryFileName(descriptor)}"`,
+        (error, stdout, stderr) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(true)
+          }
+        })
+    })
+  }
+
+  async removeBinary (descriptor: NativeApplicationDescriptor) : Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      exec(`curl -XDELETE ${this.urlToBinary(descriptor)}`,
+        (error, stdout, stderr) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(true)
+          }
+        })
+    })
+  }
+
+  async getBinary (descriptor: NativeApplicationDescriptor, {
+    outDir
+  } : {
+    outDir?: string
+  } = {}) : Promise<string> {
+    return new Promise((resolve, reject) => {
+      const tmpOutDir = outDir || tmp.dirSync({ unsafeCleanup: true }).name
+      const outputFilePath = path.join(tmpOutDir, this.buildNativeBinaryFileName(descriptor))
+      const outputFile = fs.createWriteStream(outputFilePath)
+      const curl = spawn('curl', [ this.urlToBinary(descriptor) ])
+      curl.stdout.pipe(outputFile)
+      outputFile.on('error', err => reject(err))
+      curl.on('close', err => err ? reject(err) : resolve(outputFilePath))
+    })
+  }
+
+  async hasBinary (descriptor: NativeApplicationDescriptor) : Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      exec(`curl -XOPTIONS -s -o /dev/null -w '%{http_code}' ${this.urlToBinary(descriptor)}`,
+        (error, stdout, stderr) => {
+          if (error) {
+            reject(error)
+          } else {
+            stdout.startsWith('404') ? resolve(false) : resolve(true)
+          }
+        })
+    })
+  }
+
+  urlToBinary (descriptor: NativeApplicationDescriptor) {
+    return `${this._config.url}/${this.buildNativeBinaryFileName(descriptor)}`
+  }
+
+  buildNativeBinaryFileName (descriptor: NativeApplicationDescriptor) {
+    if (!descriptor.version || !descriptor.platform) {
+      throw new Error('[buildNativeBinaryFileName] Require a complete native application descriptor')
+    }
+    return `${descriptor.name}-${descriptor.platform}-${descriptor.version}.${this.getNativeBinaryFileExt(descriptor.platform)}`
+  }
+
+  getNativeBinaryFileExt (platformName: string) {
+    return platformName === 'android' ? 'apk' : 'app'
+  }
+}

--- a/ern-core/src/index.js
+++ b/ern-core/src/index.js
@@ -18,6 +18,7 @@ import {
   codepush as _codepush
 } from './clients'
 import * as _dependencyLookup from './dependencyLookup'
+import _ErnBinaryStore from './ErnBinaryStore'
 
 export const handleCopyDirective = _handleCopyDirective
 export const Platform = _Platform
@@ -35,6 +36,7 @@ export const utils = _utils
 export const MavenUtils = _MavenUtils
 export const Publisher = _Publisher
 export const ContainerGeneratorConfig = _ContainerGeneratorConfig
+export const ErnBinaryStore = _ErnBinaryStore
 
 export default ({
   handleCopyDirective: _handleCopyDirective,
@@ -52,5 +54,6 @@ export default ({
   utils: _utils,
   MavenUtils: _MavenUtils,
   Publisher: _Publisher,
-  ContainerGeneratorConfig: _ContainerGeneratorConfig
+  ContainerGeneratorConfig: _ContainerGeneratorConfig,
+  ErnBinaryStore: _ErnBinaryStore
 })


### PR DESCRIPTION
Add the `BinaryStore` interface and first concrete implementation of a binary store provider : `ErnBinaryStore`.

A `Binary Store` is a file storage service (hosted on some server) that can be used by `Electrode Native` to store mobile application binaries (APKs for Android, APPs for iOS) and retrieve them on demand.

`ErnBinaryStore` is the client class to access the [Electrode Native Binary Store](https://github.com/electrode-io/electrode-native-binarystore) server. Different binary store client/server implementations might come in the future, but this is the one provided part of `Electrode Native` platform.

Binary stores will be used by some existing react-native commands (`ern start` and maybe `ern run-ios` / `ern run-android`) in order to easily launch the binary associated to any given mobile application version, and some new `ern` commands will also be introduced to get access to a binary store.