### PR TITLE
Add isCauldronActive check

### DIFF
--- a/ern-local-cli/src/commands/cauldron/add/dependencies.js
+++ b/ern-local-cli/src/commands/cauldron/add/dependencies.js
@@ -37,6 +37,12 @@ exports.handler = async function ({
   containerVersion?: string,
   descriptor?: string
 }) {
+  await utils.logErrorAndExitIfNotSatisfied({
+    cauldronIsActive: {
+      extraErrorMessage: 'A Cauldron must be active in order to use this command'
+    }
+  })
+
   if (!descriptor) {
     descriptor = await utils.askUserToChooseANapDescriptorFromCauldron({ onlyNonReleasedVersions: true })
   }

--- a/ern-local-cli/src/commands/cauldron/add/miniapps.js
+++ b/ern-local-cli/src/commands/cauldron/add/miniapps.js
@@ -45,6 +45,12 @@ exports.handler = async function ({
   force?: boolean,
   containerVersion?: string
 }) {
+  await utils.logErrorAndExitIfNotSatisfied({
+    cauldronIsActive: {
+      extraErrorMessage: 'A Cauldron must be active in order to use this command'
+    }
+  })
+
   if (!descriptor) {
     descriptor = await utils.askUserToChooseANapDescriptorFromCauldron({ onlyNonReleasedVersions: true })
   }

--- a/ern-local-cli/src/commands/cauldron/add/nativeapp.js
+++ b/ern-local-cli/src/commands/cauldron/add/nativeapp.js
@@ -39,6 +39,9 @@ exports.handler = async function ({
   copyFromVersion?: string
 }) {
   await utils.logErrorAndExitIfNotSatisfied({
+    cauldronIsActive: {
+      extraErrorMessage: 'A Cauldron must be active in order to use this command'
+    },
     isCompleteNapDescriptorString: { descriptor },
     napDescritorDoesNotExistsInCauldron: {
       descriptor,

--- a/ern-local-cli/src/commands/cauldron/del/dependencies.js
+++ b/ern-local-cli/src/commands/cauldron/del/dependencies.js
@@ -44,6 +44,12 @@ exports.handler = async function ({
   containerVersion?: string,
   force?: boolean
 }) {
+  await utils.logErrorAndExitIfNotSatisfied({
+    cauldronIsActive: {
+      extraErrorMessage: 'A Cauldron must be active in order to use this command'
+    }
+  })
+
   if (!descriptor) {
     descriptor = await utils.askUserToChooseANapDescriptorFromCauldron({ onlyNonReleasedVersions: true })
   }

--- a/ern-local-cli/src/commands/cauldron/del/miniapps.js
+++ b/ern-local-cli/src/commands/cauldron/del/miniapps.js
@@ -40,6 +40,12 @@ exports.handler = async function ({
   containerVersion?: string,
   descriptor?: string
 }) {
+  await utils.logErrorAndExitIfNotSatisfied({
+    cauldronIsActive: {
+      extraErrorMessage: 'A Cauldron must be active in order to use this command'
+    }
+  })
+
   if (!descriptor) {
     descriptor = await utils.askUserToChooseANapDescriptorFromCauldron({ onlyNonReleasedVersions: true })
   }

--- a/ern-local-cli/src/commands/cauldron/del/nativeapp.js
+++ b/ern-local-cli/src/commands/cauldron/del/nativeapp.js
@@ -21,6 +21,9 @@ exports.handler = async function ({
   descriptor: string
 }) {
   await utils.logErrorAndExitIfNotSatisfied({
+    cauldronIsActive: {
+      extraErrorMessage: 'A Cauldron must be active in order to use this command'
+    },
     isCompleteNapDescriptorString: { descriptor },
     napDescriptorExistInCauldron: {
       descriptor,

--- a/ern-local-cli/src/commands/cauldron/get/config.js
+++ b/ern-local-cli/src/commands/cauldron/get/config.js
@@ -20,6 +20,12 @@ exports.handler = async function ({
 } : {
   descriptor: string
 }) {
+  await utils.logErrorAndExitIfNotSatisfied({
+    cauldronIsActive: {
+      extraErrorMessage: 'A Cauldron must be active in order to use this command'
+    }
+  })
+
   const config = await cauldron.getConfig(NativeApplicationDescriptor.fromString(descriptor))
   log.info(JSON.stringify(config, null, 2))
 }

--- a/ern-local-cli/src/commands/cauldron/get/dependency.js
+++ b/ern-local-cli/src/commands/cauldron/get/dependency.js
@@ -21,6 +21,9 @@ exports.handler = async function ({
   descriptor: string
 }) {
   await utils.logErrorAndExitIfNotSatisfied({
+    cauldronIsActive: {
+      extraErrorMessage: 'A Cauldron must be active in order to use this command'
+    },
     isCompleteNapDescriptorString: { descriptor },
     napDescriptorExistInCauldron: {
       descriptor,

--- a/ern-local-cli/src/commands/cauldron/get/nativeapp.js
+++ b/ern-local-cli/src/commands/cauldron/get/nativeapp.js
@@ -21,6 +21,9 @@ exports.handler = async function ({
   descriptor: string
 }) {
   await utils.logErrorAndExitIfNotSatisfied({
+    cauldronIsActive: {
+      extraErrorMessage: 'A Cauldron must be active in order to use this command'
+    },
     isCompleteNapDescriptorString: { descriptor },
     napDescriptorExistInCauldron: {
       descriptor,

--- a/ern-local-cli/src/commands/cauldron/update/dependencies.js
+++ b/ern-local-cli/src/commands/cauldron/update/dependencies.js
@@ -37,6 +37,12 @@ exports.handler = async function ({
   descriptor?: string,
   containerVersion?: string
 }) {
+  await utils.logErrorAndExitIfNotSatisfied({
+    cauldronIsActive: {
+      extraErrorMessage: 'A Cauldron must be active in order to use this command'
+    }
+  })
+
   if (!descriptor) {
     descriptor = await utils.askUserToChooseANapDescriptorFromCauldron({ onlyNonReleasedVersions: true })
   }

--- a/ern-local-cli/src/commands/cauldron/update/miniapps.js
+++ b/ern-local-cli/src/commands/cauldron/update/miniapps.js
@@ -47,6 +47,12 @@ exports.handler = async function ({
   descriptor?: string,
   force?: boolean
 }) {
+  await utils.logErrorAndExitIfNotSatisfied({
+    cauldronIsActive: {
+      extraErrorMessage: 'A Cauldron must be active in order to use this command'
+    }
+  })
+
   if (!descriptor) {
     descriptor = await utils.askUserToChooseANapDescriptorFromCauldron({ onlyNonReleasedVersions: true })
   }

--- a/ern-local-cli/src/commands/cauldron/update/nativeapp.js
+++ b/ern-local-cli/src/commands/cauldron/update/nativeapp.js
@@ -30,6 +30,9 @@ exports.handler = async function ({
   isReleased: boolean
 }) {
   await utils.logErrorAndExitIfNotSatisfied({
+    cauldronIsActive: {
+      extraErrorMessage: 'A Cauldron must be active in order to use this command'
+    },
     isCompleteNapDescriptorString: { descriptor },
     napDescriptorExistInCauldron: {
       descriptor,

--- a/ern-local-cli/src/lib/Ensure.js
+++ b/ern-local-cli/src/lib/Ensure.js
@@ -204,4 +204,10 @@ export default class Ensure {
       }
     }
   }
+
+  static cauldronIsActive (extraErrorMessage: string = '') {
+    if (!cauldron.isActive()) {
+      throw new Error(`There is no active Cauldron\n${extraErrorMessage}`)
+    }
+  }
 }

--- a/ern-local-cli/src/lib/utils.js
+++ b/ern-local-cli/src/lib/utils.js
@@ -88,7 +88,8 @@ async function logErrorAndExitIfNotSatisfied ({
   dependencyNotInNativeApplicationVersionContainer,
   dependencyIsInNativeApplicationVersionContainer,
   dependencyIsInNativeApplicationVersionContainerWithDifferentVersion,
-  dependencyNotInUseByAMiniApp
+  dependencyNotInUseByAMiniApp,
+  cauldronIsActive
 } : {
   noGitOrFilesystemPath?: {
     obj: string | Array<string>,
@@ -153,10 +154,19 @@ async function logErrorAndExitIfNotSatisfied ({
     dependency: string | Array<string> | void,
     napDescriptor: NativeApplicationDescriptor,
     extraErrorMessage?: string
+  },
+  cauldronIsActive?: {
+    extraErrorMessage?: string
   }
 } = {}) {
   const spinner = ora('Performing initial checks').start()
   try {
+    if (cauldronIsActive) {
+      spinner.text = 'Ensuring that a Cauldron is active'
+      Ensure.cauldronIsActive(
+        cauldronIsActive.extraErrorMessage
+      )
+    }
     if (isValidContainerVersion) {
       spinner.text = 'Ensuring that container version is valid'
       Ensure.isValidContainerVersion(

--- a/ern-local-cli/test/Esnure-test.js
+++ b/ern-local-cli/test/Esnure-test.js
@@ -12,6 +12,7 @@ import * as fixtures from './fixtures/common'
 
 const getNativeAppStub = sinon.stub(cauldron, 'getNativeApp')
 const isPublishedToNpmStub = sinon.stub(utils, 'isPublishedToNpm')
+let cauldronIsActiveStub
 
 function resolveCauldronGetNativeAppWith(data) {
   getNativeAppStub.resolves(data)
@@ -19,6 +20,10 @@ function resolveCauldronGetNativeAppWith(data) {
 
 beforeEach(() => {
   isPublishedToNpmStub.reset()
+})
+
+afterEach(() => {
+  cauldronIsActiveStub && cauldronIsActiveStub.restore()
 })
 
 after(() => {
@@ -56,13 +61,13 @@ describe('Ensure.js', () => {
   describe('isValidContainerVersion', () => {
     fixtures.validContainerVersions.forEach(version => {
       it('shoud not throw if version is valid', () => {
-        expect(() => Ensure.isValidContainerVersion(version), `throw for ${version}`).to.not.throw
+        expect(() => Ensure.isValidContainerVersion(version), `throw for ${version}`).to.not.throw()
       })
     })
 
     fixtures.invalidContainerVersions.forEach(version => {
       it('should throw if version is invalid', () => {
-        expect(() => Ensure.isValidContainerVersion(version), `does not throw for ${version}`).to.throw
+        expect(() => Ensure.isValidContainerVersion(version), `does not throw for ${version}`).to.throw()
       })
     })
   })
@@ -73,13 +78,13 @@ describe('Ensure.js', () => {
   describe('isCompleteNapDescriptorString', () => {
     fixtures.completeNapDescriptors.forEach(napDescriptor => {
       it('shoud not throw if given a complete napDescriptor string', () => {
-        expect(() => Ensure.isCompleteNapDescriptorString(napDescriptor), `throw for ${napDescriptor}`).to.not.throw
+        expect(() => Ensure.isCompleteNapDescriptorString(napDescriptor), `throw for ${napDescriptor}`).to.not.throw()
       })
     })
 
     fixtures.incompleteNapDescriptors.forEach(napDescriptor => {
       it('should throw if given a partial napDescriptor string', () => {
-        expect(() => Ensure.isCompleteNapDescriptorString(napDescriptor), `does not throw for ${napDescriptor}`).to.throw
+        expect(() => Ensure.isCompleteNapDescriptorString(napDescriptor), `does not throw for ${napDescriptor}`).to.throw()
       })
     })
   })
@@ -90,13 +95,13 @@ describe('Ensure.js', () => {
   describe('noGitOrFilesystemPath', () => {
     fixtures.withoutGitOrFileSystemPath.forEach(obj => {
       it('shoud not throw if no git or file system path', () => {
-        expect(() => Ensure.noGitOrFilesystemPath(obj), `throw for ${obj}`).to.not.throw
+        expect(() => Ensure.noGitOrFilesystemPath(obj), `throw for ${obj}`).to.not.throw()
       })
     })
 
     fixtures.withGitOrFileSystemPath.forEach(obj => {
       it('should throw if git or file system path', () => {
-        expect(() => Ensure.noGitOrFilesystemPath(obj), `does not throw for ${obj}`).to.throw
+        expect(() => Ensure.noGitOrFilesystemPath(obj), `does not throw for ${obj}`).to.throw()
       })
     })
   })
@@ -129,6 +134,21 @@ describe('Ensure.js', () => {
     it('should throw if dependency is not published to npm', async () => {
       isPublishedToNpmStub.resolves(false)
       assert(await doesThrow(Ensure.publishedToNpm, 'nonpublished@1.0.0'))
+    })
+  })
+
+  // ==========================================================
+  // cauldronIsActive
+  // ==========================================================
+  describe('cauldronIsActive', () => {
+    it('should not throw if a cauldron is active', () => {
+      cauldronIsActiveStub = sinon.stub(cauldron, 'isActive').returns(true)
+      expect(() => Ensure.cauldronIsActive(), `does throw when cauldron is active`).to.not.throw()
+    })
+
+    it('should throw if no cauldron is active', () => {
+      cauldronIsActiveStub = sinon.stub(cauldron, 'isActive').returns(false)
+      expect(() => Ensure.cauldronIsActive(), `does not throw when cauldron is not active`).to.throw()
     })
   })
 })

--- a/ern-local-cli/test/utils-test.js
+++ b/ern-local-cli/test/utils-test.js
@@ -64,6 +64,12 @@ beforeEach(() => {
   oraFailStub.reset()
 })
 
+let cauldronIsActiveStub
+
+afterEach(() => {
+  cauldronIsActiveStub && cauldronIsActiveStub.restore()
+})
+
 function useCauldronFixture(fixture) {
   getAllNativeAppsStub.resolves(fixture.nativeApps)
 }
@@ -214,6 +220,22 @@ describe('utils.js', () => {
         })
         assertNoErrorLoggedAndNoProcessExit()
       })
+    })
+
+    it('[cauldronIsActive] Shoud log error and exit process if cauldron is not active', async () => {
+      cauldronIsActiveStub = sinon.stub(cauldron, 'isActive').returns(false)
+      await utils.logErrorAndExitIfNotSatisfied({
+        cauldronIsActive: {}
+      })
+      assertLoggedErrorAndExitedProcess()
+    })
+
+    it('[cauldronIsActive] Shoud not log error not exit process if cauldron is active', async () => {
+      cauldronIsActiveStub = sinon.stub(cauldron, 'isActive').returns(true)
+      await utils.logErrorAndExitIfNotSatisfied({
+        cauldronIsActive: {}
+      })
+      assertNoErrorLoggedAndNoProcessExit()
     })
   })
 


### PR DESCRIPTION
- Add new `isCauldronActive` check to `Ensure` class and use it in `logErrorAndExitIfNotSatisfied` util function. 

- Add appropriate unit tests (also fix some unit tests that were not using chai `throw` in a correct way).

- Add `isCauldronActive` check to all `Cauldron` commands, to ensure that a Cauldron is active before the command is run, and if not, fail with a proper error message.