### PR TITLE
Light refactoring and cleanup of android utils

### DIFF
--- a/ern-local-cli/src/lib/utils.js
+++ b/ern-local-cli/src/lib/utils.js
@@ -40,7 +40,7 @@ import path from 'path'
 const simctl = require('node-simctl')
 
 const {
-  runAndroid
+  runAndroidProject
 } = android
 
 //
@@ -505,7 +505,7 @@ async function generateContainerForRunner (
 }
 
 async function launchAndroidRunner (pathToAndroidRunner: string) {
-  return runAndroid({
+  return runAndroidProject({
     projectPath: pathToAndroidRunner,
     packageName: 'com.walmartlabs.ern'
   })


### PR DESCRIPTION
Also to introduce `runAndroidApk` function as an alternative to `runAndroidProject`, to allow installing an Android APK on a simulator/connected device.