### PR TITLE
Introduce binarystore commands

### DIFF
--- a/docs/cli/binarystore/add.md
+++ b/docs/cli/binarystore/add.md
@@ -1,0 +1,39 @@
+## `ern binarystore add <descriptor> <pathToBinary>`
+
+#### Description
+
+* Add a mobile application binary to the binary store
+
+#### Syntax
+
+`ern binarystore add <descriptor> <pathToBinary>`
+
+**Parameters**  
+
+`<descriptor>`
+
+A complete native application descriptor (ex: `myapp:android:1.0.0`), representing the mobile application version associated to this binary.
+
+`<pathToBinary>`
+
+Relative or absolute path to the binary to add to the binary store. For an `Android` binary the path should point to a `.apk` file, whereas of `iOS` it should point to a `.app` file.
+
+#### Remarks
+
+* This command will only work if the following conditions are met:
+  * A binary store server is running
+  * There is an active Cauldron
+  * The active Cauldron contains proper configuration of the binary store
+
+* If a binary already exists in the store for the targeted mobile application version, it will be replaced.
+
+#### Related commands
+
+ [ern binarystore get] | Get a mobile application binary from the binary store  
+ [ern binarystore remove] | Remove a mobile application binary from the binary store
+
+___  
+
+[ern binarystore get]: ./get.md
+
+[ern binarystore remove]: ./remove.md

--- a/docs/cli/binarystore/get.md
+++ b/docs/cli/binarystore/get.md
@@ -1,0 +1,42 @@
+## `ern binarystore get <descriptor> <outDir>`
+
+#### Description
+
+* Get a mobile application binary from the binary store
+
+#### Syntax
+
+`ern binarystore get <descriptor> <outDir>`
+
+**Parameters**  
+
+`<descriptor>`
+
+A complete native application descriptor (ex: `myapp:android:1.0.0`), representing the mobile application version associated to this binary.
+
+`<outDir>`
+
+Relative or absolute path to a directory where the binary will be transfered to. If the directory does not exist, it will be ecreated.
+
+#### Remarks
+
+* This command will only work if the following conditions are met:
+  * A binary store server is running
+  * There is an active Cauldron
+  * The active Cauldron contains proper configuration of the binary store
+
+* If a binary for the same mobile application version already exists in `outDir`, it will be replaced
+
+* The binary will be named as follow `[mobile-app-name]:[platform]:[version].[ext]`  
+For example, for `myapp:android:1.0.0`, the binary filename will be `myapp-android-1.0.0.apk`. For `myapp:ios:1.0.0` it will be `myapp-ios-1.0.0.app`.
+
+
+#### Related commands
+ [ern binarystore add] | Add a mobile application binary to the binary store  
+ [ern binarystore remove] | Remove a mobile application binary from the binary store
+
+___  
+
+[ern binarystore add]: ./add.md
+
+[ern binarystore remove]: ./remove.md

--- a/docs/cli/binarystore/remove.md
+++ b/docs/cli/binarystore/remove.md
@@ -1,0 +1,35 @@
+## `ern binarystore remove <descriptor>`
+
+#### Description
+
+* Remove a mobile application binary from the binary store
+
+#### Syntax
+
+`ern binarystore get <descriptor>`
+
+**Parameters**  
+
+`<descriptor>`
+
+A complete native application descriptor (ex: `myapp:android:1.0.0`), representing the mobile application version associated to this binary.
+
+#### Remarks
+
+* This command will only work if the following conditions are met:
+  * A binary store server is running
+  * There is an active Cauldron
+  * The active Cauldron contains proper configuration of the binary store
+
+* If no binary exists in the store for the targeted mobile application version, the command will fail with an appropriate error message
+
+#### Related commands
+
+ [ern binarystore add] | Add a mobile application binary to the binary store  
+ [ern binarystore get] | Get a mobile application binary from the binary store
+
+___  
+
+[ern binarystore add]: ./add.md
+
+[ern binarystore get]: ./get.md

--- a/ern-core/src/cauldron.js
+++ b/ern-core/src/cauldron.js
@@ -431,6 +431,11 @@ class Cauldron {
     return config ? config.manifest : undefined
   }
 
+  async getBinaryStoreConfig () : Promise<*> {
+    const config = await this.cauldron.getConfig()
+    return config ? config.binaryStore : undefined
+  }
+
   async getConfig (napDescriptor: NativeApplicationDescriptor) : Promise<*> {
     let config = await this.cauldron.getConfig({
       appName: napDescriptor.name,

--- a/ern-local-cli/src/commands/binarystore.js
+++ b/ern-local-cli/src/commands/binarystore.js
@@ -1,0 +1,11 @@
+// @flow
+
+exports.command = 'binarystore'
+exports.desc = 'Binary store access commands'
+exports.builder = function (yargs: any) {
+  return yargs
+    .commandDir('binarystore')
+    .demandCommand(1, 'binarystore needs a command')
+    .strict()
+}
+exports.handler = function (argv: any) {}

--- a/ern-local-cli/src/commands/binarystore/add.js
+++ b/ern-local-cli/src/commands/binarystore/add.js
@@ -1,0 +1,56 @@
+// @flow
+
+import {
+  NativeApplicationDescriptor
+} from 'ern-util'
+import {
+  cauldron,
+  ErnBinaryStore
+} from 'ern-core'
+import utils from '../../lib/utils'
+import path from 'path'
+
+exports.command = 'add <descriptor> <pathToBinary>'
+exports.desc = 'Add a mobile application binary to the binary store'
+
+exports.builder = function (yargs: any) {
+  return yargs
+    .epilog(utils.epilog(exports))
+}
+
+exports.handler = async function ({
+  descriptor,
+  pathToBinary
+}: {
+  descriptor: string,
+  pathToBinary: string
+}) {
+  await utils.logErrorAndExitIfNotSatisfied({
+    cauldronIsActive: {
+      extraErrorMessage: 'A Cauldron must be active in order to use this command'
+    },
+    isCompleteNapDescriptorString: {
+      descriptor
+    },
+    napDescriptorExistInCauldron: {
+      descriptor,
+      extraErrorMessage: 'Cannot add binary of a non existing native application version'
+    }
+  })
+
+  const napDescriptor = NativeApplicationDescriptor.fromString(descriptor)
+
+  const binaryStoreConfig = await cauldron.getBinaryStoreConfig()
+  if (!binaryStoreConfig) {
+    return log.error('No binaryStore configuration was found in Cauldron')
+  }
+
+  try {
+    const binaryStore = new ErnBinaryStore(binaryStoreConfig)
+    const absolutePathToBinary = path.resolve(pathToBinary)
+    await binaryStore.addBinary(napDescriptor, absolutePathToBinary)
+    log.info(`Binary was successfuly added to the store for ${napDescriptor.toString()}`)
+  } catch (e) {
+    log.error(`An error happened while trying to add the binary of ${napDescriptor.toString()}`)
+  }
+}

--- a/ern-local-cli/src/commands/binarystore/get.js
+++ b/ern-local-cli/src/commands/binarystore/get.js
@@ -1,0 +1,64 @@
+// @flow
+
+import {
+  NativeApplicationDescriptor
+} from 'ern-util'
+import {
+  cauldron,
+  ErnBinaryStore
+} from 'ern-core'
+import utils from '../../lib/utils'
+import fs from 'fs'
+import path from 'path'
+import shell from 'shelljs'
+
+exports.command = 'get <descriptor> <outDir>'
+exports.desc = 'Get a mobile application binary from the binary store'
+
+exports.builder = function (yargs: any) {
+  return yargs
+    .epilog(utils.epilog(exports))
+}
+
+exports.handler = async function ({
+  descriptor,
+  outDir
+}: {
+  descriptor: string,
+  outDir: string
+}) {
+  await utils.logErrorAndExitIfNotSatisfied({
+    cauldronIsActive: {
+      extraErrorMessage: 'A Cauldron must be active in order to use this command'
+    },
+    isCompleteNapDescriptorString: {
+      descriptor
+    },
+    napDescriptorExistInCauldron: {
+      descriptor,
+      extraErrorMessage: 'Cannot add binary of a non existing native application version'
+    }
+  })
+
+  const napDescriptor = NativeApplicationDescriptor.fromString(descriptor)
+
+  const binaryStoreConfig = await cauldron.getBinaryStoreConfig()
+  if (!binaryStoreConfig) {
+    return log.error('No binaryStore configuration was found in Cauldron')
+  }
+
+  try {
+    const binaryStore = new ErnBinaryStore(binaryStoreConfig)
+    if (!await binaryStore.hasBinary(napDescriptor)) {
+      return log.error(`No binary was found in the store for ${napDescriptor.toString()}`)
+    }
+    const absoluteOutDirPath = path.resolve(outDir)
+    if (!fs.existsSync(absoluteOutDirPath)) {
+      shell.mkdir('-p', absoluteOutDirPath)
+    }
+    const pathToBinary = await binaryStore.getBinary(napDescriptor, {outDir})
+    log.info(`Binary was successfuly retrieved. Path: ${pathToBinary}`)
+  } catch (e) {
+    log.error(`An error happened while retrieving ${napDescriptor.toString()} binary`)
+  }
+}

--- a/ern-local-cli/src/commands/binarystore/remove.js
+++ b/ern-local-cli/src/commands/binarystore/remove.js
@@ -1,0 +1,57 @@
+// @flow
+
+import {
+  NativeApplicationDescriptor
+} from 'ern-util'
+import {
+  cauldron,
+  ErnBinaryStore
+} from 'ern-core'
+import utils from '../../lib/utils'
+
+exports.command = 'remove <descriptor>'
+exports.desc = 'Remove a mobile application binary from the binary store'
+
+exports.builder = function (yargs: any) {
+  return yargs
+    .epilog(utils.epilog(exports))
+}
+
+exports.handler = async function ({
+  descriptor,
+  pathToBinary
+}: {
+  descriptor: string,
+  pathToBinary: string
+}) {
+  await utils.logErrorAndExitIfNotSatisfied({
+    cauldronIsActive: {
+      extraErrorMessage: 'A Cauldron must be active in order to use this command'
+    },
+    isCompleteNapDescriptorString: {
+      descriptor
+    },
+    napDescriptorExistInCauldron: {
+      descriptor,
+      extraErrorMessage: 'Cannot add binary of a non existing native application version'
+    }
+  })
+
+  const napDescriptor = NativeApplicationDescriptor.fromString(descriptor)
+
+  const binaryStoreConfig = await cauldron.getBinaryStoreConfig()
+  if (!binaryStoreConfig) {
+    return log.error('No binaryStore configuration was found in Cauldron')
+  }
+
+  try {
+    const binaryStore = new ErnBinaryStore(binaryStoreConfig)
+    if (!await binaryStore.hasBinary(napDescriptor)) {
+      return log.error(`No binary was found in the store for ${napDescriptor.toString()}`)
+    }
+    await binaryStore.removeBinary(napDescriptor)
+    log.info(`${napDescriptor.toString()} binary was successfuly removed from the store`)
+  } catch (e) {
+    log.error(`An error happened while trying to remove ${napDescriptor.toString()} binary`)
+  }
+}


### PR DESCRIPTION
Add a few initial commands to work with a Binary Store (storing `.app` and `.apk` files)

- `ern binarystore add` 
To add the binary of a specific mobile application version to the binary store

- `ern binarystore get`
To retrieve the binary of a specific mobile application version from the binary store

- `ern binarystore remove`
To remove the binary of a specific mobile application version from the binary store

More documentation will come soon