### PR TITLE
Update Android containergen for RN 0.49 support

### DIFF
--- a/ern-container-gen/hull/android/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactContainer.java
+++ b/ern-container-gen/hull/android/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactContainer.java
@@ -84,7 +84,12 @@ public class ElectrodeReactContainer {
         reactInstanceManagerBuilder = ReactInstanceManager.builder()
                 .setApplication(application)
                 .setBundleAssetName("index.android.bundle")
+                {{#RN_VERSION_GTE_49}}
+                .setJSMainModulePath("index.android")
+                {{/RN_VERSION_GTE_49}}
+                {{#RN_VERSION_LT_49}}
                 .setJSMainModuleName("index.android")
+                {{/RN_VERSION_LT_49}}
                 .addPackage(new MainReactPackage())
                 .setUseDeveloperSupport(reactContainerConfig.isReactNativeDeveloperSupport)
                 .setInitialLifecycleState(LifecycleState.BEFORE_CREATE);

--- a/ern-container-gen/package.json
+++ b/ern-container-gen/package.json
@@ -55,6 +55,7 @@
     "ern-util": "0.7.0",
     "fs-readdir-recursive": "^1.0.0",
     "mustache": "^2.3.0",
+    "semver": "^5.4.1",
     "shelljs": "^0.7.6",
     "tmp": "^0.0.31",
     "xcode-ern": "1.0.0"

--- a/ern-container-gen/src/generateContainer.js
+++ b/ern-container-gen/src/generateContainer.js
@@ -12,6 +12,7 @@ import {
 } from './utils.js'
 import _ from 'lodash'
 import shell from 'shelljs'
+import semver from 'semver'
 
 let mustacheView = {}
 
@@ -102,7 +103,6 @@ export default async function generateContainer ({
   }
 
   mustacheView = {
-    reactNativeVersion: reactNativePlugin.version,
     nativeAppName,
     containerVersion,
     miniApps: _.map(miniapps, miniapp => ({
@@ -116,6 +116,10 @@ export default async function generateContainer ({
     }))
   }
 
+  mustacheView = addReactNativeVersionKeysToMustacheView(
+    mustacheView,
+    reactNativePlugin.version)
+
   await generator.generateContainer(
     containerVersion,
     nativeAppName,
@@ -126,6 +130,16 @@ export default async function generateContainer ({
     {pathToYarnLock})
 
   return paths
+}
+
+function addReactNativeVersionKeysToMustacheView (
+  mustacheView: Object,
+  reactNativeVersion: string) {
+  return Object.assign(mustacheView, {
+    reactNativeVersion,
+    RN_VERSION_GTE_49: semver.gte(reactNativeVersion, '0.49.0'),
+    RN_VERSION_LT_49: semver.lt(reactNativeVersion, '0.49.0')
+  })
 }
 
 function sortPlugins (plugins: Array<Dependency>) {

--- a/ern-container-gen/yarn.lock
+++ b/ern-container-gen/yarn.lock
@@ -122,6 +122,10 @@ resolve@^1.1.6:
   dependencies:
     path-parse "^1.0.5"
 
+semver@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
+
 shelljs@^0.7.6:
   version "0.7.8"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"


### PR DESCRIPTION
Per https://github.com/facebook/react-native/commit/5d4c6e5f23e3f7f64576cccff76822d4b7635ab1, `module name` was renamed to `module path` in React Native 0.49 (Android). 

This is a breaking change for Android Container as it is calling `setJSMainModuleName` in `ElectrodeReactContainer.java`, now renamed to `setJSMainModulePath`.

This PR ensure that Android Container generator will generate proper code for React Native >= 0.49, while remaining backward compatible for previous versions of React Native.

This was properly tested using Getting Started guide as reference. Please note that version 0.49 of React Native has also been published to jCenter.