### PR TITLE
Remove usage of boom module in cauldron-api

### DIFF
--- a/ern-cauldron-api/src/api.js
+++ b/ern-cauldron-api/src/api.js
@@ -5,7 +5,6 @@ import { Dependency } from 'ern-util'
 import {
   alreadyExists,
   buildReactNativeSourceMapFileName,
-  checkNotFound,
   joiValidate,
   shasum
 } from './util'
@@ -249,7 +248,6 @@ export default class CauldronApi {
     if (!platform) {
       throw new Error(`Cannot remove version from unexisting ${nativeApplicationName}:${platformName}`)
     }
-    checkNotFound(platform, `No platform named ${platformName}`)
     if (_.remove(platform.versions, x => x.name === versionName).length > 0) {
       await this.commit(`Remove version ${versionName} from ${nativeApplicationName} ${platformName}`)
     }

--- a/ern-cauldron-api/src/util.js
+++ b/ern-cauldron-api/src/util.js
@@ -2,7 +2,6 @@
 
 import _ from 'lodash'
 import crypto from 'crypto'
-import Boom from 'boom'
 import Joi from 'joi'
 
 // ====================================
@@ -37,11 +36,6 @@ export function buildReactNativeSourceMapFileName (
   appName: string,
   versionName: string) {
   return `${appName}@${versionName}.map`
-}
-
-export function checkNotFound (val: any, message: string, ...data: any) {
-  if (val == null) { throw Boom.notFound(message, data) }
-  return val
 }
 
 //

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "babel-preset-env": "^1.2.2",
     "babel-preset-flow": "^6.23.0",
     "babel-register": "^6.22.0",
-    "boom": "^4.3.0",
     "chai": "^3.5.0",
     "cross-env": "^3.2.4",
     "dir-compare": "^1.3.0",


### PR DESCRIPTION
[boom](https://www.npmjs.com/package/boom) module usage in `cauldron-api` was a left-over of the old Cauldron technology stack (node based service). Only one function left was making use of it, with no real purpose.

The problem also being that `boom` is not declared as a direct dependency of `cauldron-api`, so it was not part of it, making the import fail under some circumstances.

This PR gets rid of `boom` usage in `cauldron-api` and also removes `boom` from our top level platform dev dependencies as it is not used directly anymore, even not in tests.

Fixes https://github.com/electrode-io/electrode-native/issues/171