### PR TITLE
Set top level package version to 1000.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ern-platform",
-  "version": "0.5.1",
+  "version": "1000.0.0",
   "description": "",
   "keywords": [],
   "license": "Apache-2.0",


### PR DESCRIPTION
Top level platform `package.json` file is only used for development / lerna flow, as we don't publish this package. 

The version therefore does not really matter here, but for some reason it was set to `0.5.1` for a while, which might be confusing.

This PR is just setting top level `package.json` version to `1000.0.0` which is coherent as it's our dev version number.