### PR TITLE
Add new iOS plugin configuration directive addFrameworkReference

### DIFF
--- a/ern-container-gen/hull/ios/ElectrodeContainer.xcodeproj/project.pbxproj
+++ b/ern-container-gen/hull/ios/ElectrodeContainer.xcodeproj/project.pbxproj
@@ -378,7 +378,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_ON_DEMAND_RESOURCES = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)/**",
 					"$(SRCROOT)/ElectrodeContainer/Libraries/ReactNative/**",
@@ -536,7 +535,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/ElectrodeContainer/Libraries/ReactNative/**",
@@ -573,7 +571,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/ElectrodeContainer/Libraries/ReactNative/**",

--- a/ern-container-gen/src/generators/ios/IosGenerator.js
+++ b/ern-container-gen/src/generators/ios/IosGenerator.js
@@ -276,6 +276,12 @@ export default class IosGenerator {
               containerIosProject.addToHeaderSearchPaths(path)
             }
           }
+
+          if (pluginConfig.ios.pbxproj.addFrameworkReference) {
+            for (const frameworkReference of pluginConfig.ios.pbxproj.addFrameworkReference) {
+              containerIosProject.addFramework(frameworkReference, { customFramework: true })
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
- Remove `FRAMEWORK_SEARCH_PATHS` from ios Container Hull pbxproj (as they will get created by Container generator if needed)
- Add new `addFrameworkReference` directive for plugin injection configuration. It can be used to inject references to Frameworks that are external to the container (i.e Frameworks that might be inside the host application already). For example :

```json
"addFrameworkReference": [
  "../../../Modules/WalmartIOSShared/Externals/FacebookSDK/Bolts.framework",
  "../../../Modules/WalmartIOSShared/Externals/FacebookSDK/FBSDKCoreKit.framework",
  "../../../Modules/WalmartIOSShared/Externals/FacebookSDK/FBSDKLoginKit.framework",
  "../../../Modules/WalmartIOSShared/Externals/FacebookSDK/FBSDKShareKit.framework"
]
```