### PR TITLE
Add support for generating composite MiniApp with extra JS dependencies

### DIFF
--- a/ern-container-gen/src/utils.js
+++ b/ern-container-gen/src/utils.js
@@ -97,9 +97,11 @@ export async function reactNativeBundleIos (paths: any) {
 export async function generateMiniAppsComposite (
   miniappsPaths: Array<DependencyPath>,
   outDir: string, {
-    pathToYarnLock
+    pathToYarnLock,
+    extraJsDependencies = []
   } : {
-    pathToYarnLock?: string
+    pathToYarnLock?: string,
+    extraJsDependencies?: Array<DependencyPath>
   } = {}) {
   shell.mkdir('-p', outDir)
   shell.cd(outDir)
@@ -134,6 +136,7 @@ export async function generateMiniAppsComposite (
     compositePackageJson.dependencies = getPackageJsonDependenciesUsingMiniAppDeltas(miniAppsDeltas, yarnLock)
     // This helps to start the local packager withing the comopsiteMiniApps folder for debugging multiple miniapps
     compositePackageJson.scripts = {'start': 'node node_modules/react-native/local-cli/cli.js start'}
+
     fs.writeFileSync(path.join(outDir, 'package.json'), JSON.stringify(compositePackageJson, null, 2), 'utf8')
 
     // Now that the composite package.json is similar to the one used to generated yarn.lock
@@ -150,6 +153,11 @@ export async function generateMiniAppsComposite (
     let packageJson = JSON.parse(fs.readFileSync(`${outDir}/package.json`, 'utf-8'))
     packageJson.scripts = {'start': 'node node_modules/react-native/local-cli/cli.js start'}
     fs.writeFileSync(path.join(outDir, 'package.json'), JSON.stringify(packageJson, null, 2), 'utf8')
+  }
+
+  // Add optional extra JavaScript dependencies
+  for (const extraJsDependency of extraJsDependencies) {
+    await yarn.add(extraJsDependency)
   }
 
   let entryIndexJsContent = ''

--- a/ern-local-cli/src/commands/start.js
+++ b/ern-local-cli/src/commands/start.js
@@ -2,6 +2,10 @@
 
 import utils from '../lib/utils'
 import start from '../lib/start'
+import _ from 'lodash'
+import {
+  DependencyPath
+} from 'ern-util'
 
 exports.command = 'start'
 exports.desc = 'Start a composite MiniApp'
@@ -22,6 +26,11 @@ exports.builder = function (yargs: any) {
       type: 'array',
       alias: 'w',
       describe: 'A list of one or more folder name from node_modules that should be watched for changes'
+    })
+    .option('extraJsDependencies', {
+      type: 'array',
+      alias: 'e',
+      describe: 'Additional JavaScript dependencies to add to the composite JavaScript bundle'
     })
     .group(['packageName', 'activityName'], 'Android binary specific options:')
     .option('packageName', {
@@ -49,15 +58,17 @@ exports.handler = async function ({
   watchNodeModules,
   packageName,
   activityName,
-  bundleId
+  bundleId,
+  extraJsDependencies = []
 } : {
   descriptor?: string,
   miniapps?: Array<string>,
   watchNodeModules?: Array<string>,
   packageName?: string,
   activityName?: string,
-  bundleId?: string
-}) {
+  bundleId?: string,
+  extraJsDependencies?: Array<string>
+} = {}) {
   try {
     await start({
       miniapps,
@@ -65,7 +76,8 @@ exports.handler = async function ({
       watchNodeModules,
       packageName,
       activityName,
-      bundleId
+      bundleId,
+      extraJsDependencies: _.map(extraJsDependencies, d => DependencyPath.fromString(d))
     })
   } catch (e) {
     log.error(e.message)

--- a/ern-local-cli/src/lib/start.js
+++ b/ern-local-cli/src/lib/start.js
@@ -34,14 +34,16 @@ export default async function start ({
   watchNodeModules = [],
   packageName,
   activityName,
-  bundleId
+  bundleId,
+  extraJsDependencies
 } : {
   miniapps?: Array<string>,
   descriptor?: string,
   watchNodeModules: Array<string>,
   packageName?: string,
   activityName?: string,
-  bundleId?: string
+  bundleId?: string,
+  extraJsDependencies?: Array<DependencyPath>
 } = {}) {
   let miniAppsPaths: Array<DependencyPath> = _.map(miniapps, DependencyPath.fromString)
   let napDescriptor
@@ -73,7 +75,10 @@ export default async function start ({
     pathToYarnLock = await cauldron.getPathToYarnLock(napDescriptor)
   }
   await spin('Generating MiniApps composite',
-    generateMiniAppsComposite(miniAppsPaths, workingDir, {pathToYarnLock}))
+    generateMiniAppsComposite(miniAppsPaths, workingDir, {
+      pathToYarnLock,
+      extraJsDependencies
+    }))
 
   let miniAppsLinks = ernConfig.getValue('miniAppsLinks', {})
 


### PR DESCRIPTION
This PR add support to add extra JavaScript dependencies to the composite MiniApp. 
`start` command is now using this support through a new option `--extraJsDependencies`

This proves to be useful in case some dependencies of the MiniApps that are `dev` only, needs to be part of the Composite. For example, if a MiniApp is making use of `remote-redux-devtools` as a `devDependency`, the dependency won't be part of the Composite by default, due to the fact that only `production` dependencies are installed when generating a Composite. 

With this support, it is now possible to add the dependency to the Composite, if needed.

Example:

```bash
$ ern start \
-n testbinary:android:17.18.0 \
-p com.walmart.android \
-a app.main.MainActivity \
-e remote-redux-devtools@^0.5.7
```