### PR TITLE
Use os.homedir() instead of process.env['HOME']

### DIFF
--- a/ern-core/src/MavenUtils.js
+++ b/ern-core/src/MavenUtils.js
@@ -5,8 +5,9 @@ import {
 import {httpGet} from './utils'
 import fs from 'fs'
 import shell from 'shelljs'
+import os from 'os'
 
-const HOME_DIRECTORY = process.env['HOME']
+const HOME_DIRECTORY = os.homedir()
 const FILE_REGEX = /^file:\/\//
 
 export default class MavenUtils {
@@ -34,9 +35,6 @@ export default class MavenUtils {
   }
 
   static getDefaultMavenLocalDirectory = () => {
-    if (!HOME_DIRECTORY) {
-      throw new Error(`process.env['HOME'] is undefined !!!`)
-    }
     return `file://${HOME_DIRECTORY}/.m2/repository`
   }
 

--- a/ern-core/src/Platform.js
+++ b/ern-core/src/Platform.js
@@ -10,16 +10,14 @@ import {
 import fs from 'fs'
 import path from 'path'
 import shell from 'shelljs'
+import os from 'os'
 
-const HOME_DIRECTORY = process.env['HOME']
+const HOME_DIRECTORY = os.homedir()
 // Name of ern local client NPM package
 const ERN_LOCAL_CLI_PACKAGE = 'ern-local-cli'
 
 export default class Platform {
   static get rootDirectory () : string {
-    if (!HOME_DIRECTORY) {
-      throw new Error(`process.env['HOME'] is undefined !!!`)
-    }
     return `${HOME_DIRECTORY}/.ern`
   }
 

--- a/ern-local-cli/scripts/postinstall.js
+++ b/ern-local-cli/scripts/postinstall.js
@@ -3,6 +3,7 @@ const childProcess = require('child_process')
 const execSync = childProcess.execSync
 const fs = require('fs')
 const path = require('path')
+const os = require('os')
 
 //
 // Directory structure (stored in user home folder)
@@ -17,7 +18,7 @@ const path = require('path')
 
 const PLATFORM_VERSION = '0.8.0'
 // Path to ern platform root folder
-const ERN_PATH = process.env['ERN_HOME'] || path.join(process.env['HOME'], '.ern')
+const ERN_PATH = process.env['ERN_HOME'] || path.join(os.homedir(), '.ern')
 // Path to ern global configuration file
 const ERN_RC_GLOBAL_FILE_PATH = path.join(ERN_PATH, '.ernrc')
 // Path to ern platform manifest repo

--- a/ern-util/src/config.js
+++ b/ern-util/src/config.js
@@ -2,8 +2,9 @@
 
 import fs from 'fs'
 import path from 'path'
+import os from 'os'
 
-const ERN_RC_GLOBAL_FILE_PATH = path.join(`${process.env['HOME'] ? process.env['HOME'] : ''}/.ern`, '.ernrc')
+const ERN_RC_GLOBAL_FILE_PATH = path.join(os.homedir(), '.ern', '.ernrc')
 const ERN_RC_LOCAL_FILE_PATH = path.join(process.cwd(), '.ernrc')
 
 export class ErnConfig {

--- a/global-cli/src/index.js
+++ b/global-cli/src/index.js
@@ -6,6 +6,7 @@ const path = require('path')
 const ora = require('ora')
 const spawn = childProcess.spawn
 const execSync = childProcess.execSync
+const os = require('os')
 
 // Version update notifier
 const updateNotifier = require('update-notifier')
@@ -23,7 +24,7 @@ updateNotifier({ pkg }).notify()
 // |_ .ernrc
 
 // Path to ern platform root folder
-const ERN_PATH = path.join(process.env['HOME'], '.ern')
+const ERN_PATH = path.join(os.homedir(), '.ern')
 // Path to ern platform versions folder (containing all installed versions of the platform)
 const ERN_VERSIONS_CACHE_PATH = path.join(ERN_PATH, 'versions')
 // Path to ern global configuration file

--- a/setup-dev.js
+++ b/setup-dev.js
@@ -11,9 +11,10 @@ execSync(`npm run rebuild`)
 
 const chalk = require('chalk')
 const shell = require('shelljs')
+const os = require('os')
 
 // Path to ern platform root folder
-const ERN_PATH = `${process.env['HOME']}/.ern`
+const ERN_PATH = `${os.homedir()}/.ern`
 // Path to ern platform cache folder (containing all installed cached versions of the platform)
 const ERN_VERSIONS_CACHE_PATH = `${ERN_PATH}/versions`
 // Path from where this script is run (wherever the user cloned the repo locally)


### PR DESCRIPTION
Use Node.js [os.homedir()](https://nodejs.org/api/os.html#os_os_homedir) function to get user home directory (cross-platform), instead of looking for `HOME` environment variable (not cross-platform).