### PR TITLE
Explicitly use node to run ern-local-cli postinstall script

### DIFF
--- a/ern-local-cli/package.json
+++ b/ern-local-cli/package.json
@@ -47,7 +47,7 @@
     "test": "ern-mocha",
     "coverage": "ern-nyc",
     "prepublish": "yarn run build",
-    "postinstall": "scripts/postinstall.js"
+    "postinstall": "node scripts/postinstall.js"
   },
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
Current way to declare the `ern-local-cli` postinstall script is not working on Windows. 
This PR fix this for Windows, while remaining compatible with OSX and other platforms.