### PR TITLE
Windows support - Continued

### DIFF
--- a/ern-core/src/MavenPublisher.js
+++ b/ern-core/src/MavenPublisher.js
@@ -39,7 +39,8 @@ export default class MavenPublisher implements Publisher {
   }
 
   async buildAndUploadArchive (moduleName: string): Promise<*> {
-    let cmd = `./gradlew ${moduleName}:uploadArchives `
+    const gradlew = /^win/.test(process.platform) ? 'gradlew' : './gradlew'
+    let cmd = `${gradlew} ${moduleName}:uploadArchives `
     return new Promise((resolve, reject) => {
       exec(cmd,
         (err, stdout, stderr) => {

--- a/ern-core/src/MavenUtils.js
+++ b/ern-core/src/MavenUtils.js
@@ -6,6 +6,7 @@ import {httpGet} from './utils'
 import fs from 'fs'
 import shell from 'shelljs'
 import os from 'os'
+import path from 'path'
 
 const HOME_DIRECTORY = os.homedir()
 const FILE_REGEX = /^file:\/\//
@@ -28,14 +29,16 @@ export default class MavenUtils {
   static targetRepositoryGradleStatement (mavenRepositoryUrl: string): ?string {
     const repoType = this.mavenRepositoryType(mavenRepositoryUrl)
     if (repoType === 'file') {
-      return `repository(url: "${mavenRepositoryUrl}")`
+      // Replace \ by \\ for Windows
+      return `repository(url: "${mavenRepositoryUrl.replace(/\\/g, '\\\\')}")`
     } else if (repoType === 'http') {
       return `repository(url: "${mavenRepositoryUrl}") { authentication(userName: mavenUser, password: mavenPassword) }`
     }
   }
 
   static getDefaultMavenLocalDirectory = () => {
-    return `file://${HOME_DIRECTORY}/.m2/repository`
+    const pathToRepository = path.join(HOME_DIRECTORY, '.m2', 'repository')
+    return `file://${pathToRepository}`
   }
 
   static isLocalMavenRepo (repoUrl: string): boolean {

--- a/ern-util/src/android.js
+++ b/ern-util/src/android.js
@@ -206,7 +206,8 @@ export async function androidGetBootAnimProp () {
 export async function buildAndInstallApp (projectPath: string) {
   return new Promise((resolve, reject) => {
     shell.cd(projectPath)
-    exec(`./gradlew installDebug`,
+    const gradlew = /^win/.test(process.platform) ? 'gradlew' : './gradlew'
+    exec(`${gradlew} installDebug`,
     (err, stdout, stderr) => {
       if (err || stderr) {
         log.error(err || stderr)


### PR DESCRIPTION
This pull request adds complete support of `run-android` command on Windows.

`create-miniapp` and `run-android` commands are now both properly working end-to-end on Windows (tested on my Windows workstation). Which in turns means that `runner-gen` and `container-gen` are also properly working on Windows (at least in the basic use case of a starter MiniApp).

Will continue exploring the rest of the commands on Windows and make necessary cross platform adjustments where needed, more pull requests to follow.