### PR TITLE
Introduce new Cauldron command regen-container

### DIFF
--- a/docs/cli/cauldron/regen-container.md
+++ b/docs/cli/cauldron/regen-container.md
@@ -1,0 +1,32 @@
+## `ern cauldron regen-container`
+
+#### Description
+
+Triggers the regeneration of a Container from the Cauldron.  
+
+#### Syntax
+
+`ern cauldron regen-container [-v/--containerVersion] [-d/--descriptor]`  
+
+**Options**  
+
+`-v/--containerVersion <version>`
+
+* Specify the version of the new container.
+* **Default**  Increment patch number of the current container version  
+Example: If the current container version is 1.2.3 and a version is not included in the command, the new container version will be 1.2.4.
+* You can only use a version that is greater than the current version of the Container.
+
+`-d/--descriptor <descriptor>`
+
+* The target native application version in the Cauldron (in the form of a complete native application descriptor) for which to regenerate the Container.
+**Default**  Lists all non-released native application versions from the Cauldron and  prompts you to choose one.
+**Example** `ern cauldron regen-api -d MyNativeApp:android:1.0.0`  
+
+#### Remarks
+
+* The [ern create-container] command can also generate a container given a complete native application descriptor. But the [ern create-container] will only create the Container locally and not update the Cauldron or publish the new version.  
+* This command should only be used if you need to regenerate a Container for a native application version, without adding/removing/updating any MiniApp or native dependencies (very limited use case)
+
+_________
+[ern create-container]: ../create-container.md

--- a/ern-local-cli/src/commands/cauldron/regen-container.js
+++ b/ern-local-cli/src/commands/cauldron/regen-container.js
@@ -1,0 +1,66 @@
+// @flow
+
+import {
+  NativeApplicationDescriptor
+} from 'ern-util'
+import utils from '../../lib/utils'
+
+exports.command = 'regen-container'
+exports.desc = 'Triggers the regeneration of a Container from the Cauldron'
+
+exports.builder = function (yargs: any) {
+  return yargs
+  .option('containerVersion', {
+    alias: 'v',
+    type: 'string',
+    describe: 'Version to use for generated container. If none provided, version will be patched bumped by default.'
+  })
+  .option('descriptor', {
+    type: 'string',
+    alias: 'd',
+    describe: 'A complete native application descriptor'
+  })
+  .epilog(utils.epilog(exports))
+}
+
+exports.handler = async function ({
+  descriptor,
+  containerVersion
+} : {
+  descriptor?: string,
+  containerVersion?: string
+}) {
+  await utils.logErrorAndExitIfNotSatisfied({
+    cauldronIsActive: {
+      extraErrorMessage: 'A Cauldron must be active in order to use this command'
+    }
+  })
+
+  if (!descriptor) {
+    descriptor = await utils.askUserToChooseANapDescriptorFromCauldron({ onlyNonReleasedVersions: true })
+  }
+  const napDescriptor = NativeApplicationDescriptor.fromString(descriptor)
+
+  await utils.logErrorAndExitIfNotSatisfied({
+    isCompleteNapDescriptorString: { descriptor },
+    isValidContainerVersion: containerVersion ? { containerVersion } : undefined,
+    isNewerContainerVersion: containerVersion ? {
+      containerVersion,
+      descriptor,
+      extraErrorMessage: 'To avoid conflicts with previous versions, you can only use container version newer than the current one'
+    } : undefined,
+    napDescriptorExistInCauldron: {
+      descriptor,
+      extraErrorMessage: 'This command cannot work on a non existing native application version'
+    }
+  })
+
+  try {
+    await utils.performContainerStateUpdateInCauldron(async () => {
+      return Promise.resolve()
+    }, napDescriptor, { containerVersion })
+    log.debug(`Container was succesfully regenerated !`)
+  } catch (e) {
+    log.error(`An error occured while trying to regenerate the container : ${e.message}`)
+  }
+}


### PR DESCRIPTION
In addition to what is stated in the documentation of this command below, this command also proves to be quite useful for Electrode Native developers as it allows us (through forking of a reference Cauldron / Containers git repositories) to easily validate medium/heavy refactoring of the Container Generator, by regenerating the Container of a reference native application version and validating that our code changes to the Container Generator did not introduce issues in the generate code (through git diffing of the reference Container version and new one).