### PR TITLE
Plugin config injection directive replaceInFile now does a global replace

### DIFF
--- a/ern-api-impl-gen/src/generators/ios/ApiImplGithubGenerator.js
+++ b/ern-api-impl-gen/src/generators/ios/ApiImplGithubGenerator.js
@@ -77,7 +77,7 @@ export default class ApiImplGithubGenerator implements ApiImplGeneratable {
           if (pluginConfig.ios.replaceInFile) {
             for (const r of pluginConfig.ios.replaceInFile) {
               const fileContent = fs.readFileSync(`${outputFolder}/${r.path}`, 'utf8')
-              const patchedFileContent = fileContent.replace(r.string, r.replaceWith)
+              const patchedFileContent = fileContent.replace(RegExp(r.string, 'g'), r.replaceWith)
               fs.writeFileSync(`${outputFolder}/${r.path}`, patchedFileContent, {encoding: 'utf8'})
             }
           }

--- a/ern-container-gen/src/generators/ios/IosGenerator.js
+++ b/ern-container-gen/src/generators/ios/IosGenerator.js
@@ -207,7 +207,7 @@ export default class IosGenerator {
           for (const r of pluginConfig.ios.replaceInFile) {
             const pathToFile = path.join(outputFolder, r.path)
             const fileContent = fs.readFileSync(pathToFile, 'utf8')
-            const patchedFileContent = fileContent.replace(r.string, r.replaceWith)
+            const patchedFileContent = fileContent.replace(RegExp(r.string, 'g'), r.replaceWith)
             fs.writeFileSync(pathToFile, patchedFileContent, { encoding: 'utf8' })
           }
         }


### PR DESCRIPTION
The `replaceInFile` plugin injection directive was only replacing the first occurrence of the matched string. 

With this PR, all found occurrences of the string are properly replaced.