### PR TITLE
Light refactorings

### DIFF
--- a/ern-api-gen/package.json
+++ b/ern-api-gen/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "ern-babel",
-    "test": "ern-mocha",
+    "test": "cross-env __ERN_TEST__=true ern-mocha",
     "coverage": "ern-nyc",
     "prepublish": "npm run build"
   },

--- a/ern-api-impl-gen/package.json
+++ b/ern-api-impl-gen/package.json
@@ -44,7 +44,7 @@
     }
   ],
   "scripts": {
-    "test": "ern-mocha",
+    "test": "cross-env __ERN_TEST__=true ern-mocha",
     "build": "ern-babel",
     "coverage": "ern-nyc",
     "prepublish": "yarn run build"

--- a/ern-api-impl-gen/src/generators/android/ApiImplMavenGenerator.js
+++ b/ern-api-impl-gen/src/generators/android/ApiImplMavenGenerator.js
@@ -8,6 +8,7 @@ import {
 import {
   manifest
 } from 'ern-core'
+import path from 'path'
 
 import type { ApiImplGeneratable } from '../../ApiImplGeneratable'
 
@@ -17,8 +18,6 @@ type PluginConfig = {
   origin?: Object,
   path?: string
 }
-
-const path = require('path')
 
 export const ROOT_DIR = shell.pwd()
 
@@ -51,13 +50,13 @@ export default class ApiImplMavenGenerator implements ApiImplGeneratable {
     try {
       log.debug(`[=== Starting hull filling for api impl gen for ${this.platform} ===]`)
 
-      shell.cd(`${ROOT_DIR}`)
+      shell.cd(ROOT_DIR)
 
       const outputDirectory = path.join(paths.outDirectory, `android`)
       log.debug(`Creating out directory(${outputDirectory}) for android and copying container hull to it.`)
       shell.mkdir(outputDirectory)
 
-      shell.cp(`-R`, path.join(paths.apiImplHull, `/android/*`), outputDirectory)
+      shell.cp(`-R`, path.join(paths.apiImplHull, 'android', '*'), outputDirectory)
 
       for (let plugin: Dependency of plugins) {
         log.debug(`Copying ${plugin.name} to ${outputDirectory}`)
@@ -74,17 +73,18 @@ export default class ApiImplMavenGenerator implements ApiImplGeneratable {
 
   copyPluginToOutput (paths: Object, outputDirectory: string, plugin: Dependency, pluginConfig: PluginConfig) {
     log.debug(`injecting ${plugin.name} code.`)
-    const pluginSrcDirectory = path.join(paths.pluginsDownloadDirectory, `node_modules`, plugin.scopedName, `android`, pluginConfig.android.moduleName, pluginConfig.android.moduleName === `lib` ? `src/main/java/*` : `src/main/java/`)
-    log.debug(`Copying ${plugin.name} code from ${pluginSrcDirectory} to ${path.join(outputDirectory, `/lib/src/main/java`)}`)
-    shell.cp(`-R`, pluginSrcDirectory, path.join(outputDirectory, `/lib/src/main/java/`))
+    const pluginSrcDirectory = path.join(paths.pluginsDownloadDirectory, 'node_modules', plugin.scopedName, 'android', pluginConfig.android.moduleName,
+      pluginConfig.android.moduleName === `lib` ? path.join('src', 'main', 'java', '*') : path.join('src', 'main', 'java'))
+    log.debug(`Copying ${plugin.name} code from ${pluginSrcDirectory} to ${path.join(outputDirectory, 'lib', 'src', 'main', 'java')}`)
+    shell.cp(`-R`, pluginSrcDirectory, path.join(outputDirectory, 'lib', 'src', 'main', 'java'))
   }
 
   updateBuildGradle (paths: Object, reactNativeVersion: string, outputDirectory: string): Promise<*> {
     let mustacheView = {}
     mustacheView.reactNativeVersion = reactNativeVersion
     return mustacheUtils.mustacheRenderToOutputFileUsingTemplateFile(
-      path.join(paths.apiImplHull, `/android/lib/build.gradle`),
+      path.join(paths.apiImplHull, 'android', 'lib', 'build.gradle'),
       mustacheView,
-      path.join(outputDirectory, `/lib/build.gradle`))
+      path.join(outputDirectory, 'lib', 'build.gradle'))
   }
 }

--- a/ern-api-impl-gen/src/generators/ios/ApiImplGithubGenerator.js
+++ b/ern-api-impl-gen/src/generators/ios/ApiImplGithubGenerator.js
@@ -43,16 +43,17 @@ export default class ApiImplGithubGenerator implements ApiImplGeneratable {
       const outputDirectory = path.join(paths.outDirectory, `ios`)
       log.debug(`Creating out directory(${outputDirectory}) for ios and copying container hull to it.`)
       shell.mkdir(outputDirectory)
-      shell.cp(`-R`, path.join(paths.apiImplHull, `/ios/*`), outputDirectory)
+      shell.cp(`-R`, path.join(paths.apiImplHull, 'ios', '*'), outputDirectory)
 
-      const apiImplProjectPath = `${outputDirectory}/ElectrodeApiImpl.xcodeproj/project.pbxproj`
-      const apiImplLibrariesPath = `${outputDirectory}/ElectrodeApiImpl/Libraries`
+      const apiImplProjectPath = path.join(outputDirectory, 'ElectrodeApiImpl.xcodeproj', 'project.pbxproj')
+      const apiImplLibrariesPath = path.join(outputDirectory, 'ElectrodeApiImpl', 'Libraries')
       const apiImplProject = await this.getIosApiImplProject(apiImplProjectPath)
       const apiImplTarget = apiImplProject.findTargetKey('ElectrodeApiImpl')
 
       const reactnativeplugin = new Dependency('react-native', {
         version: reactNativeVersion
       })
+
       log.debug(`Manually injecting react-native(${reactnativeplugin}) plugin to dependencies.`)
       plugins.push(reactnativeplugin)
 
@@ -62,9 +63,9 @@ export default class ApiImplGithubGenerator implements ApiImplGeneratable {
         if (pluginConfig.ios) {
           let pluginSourcePath
           if (pluginConfig.origin.scope) {
-            pluginSourcePath = `${paths.pluginsDownloadDirectory}/node_modules/@${pluginConfig.origin.scope}/${pluginConfig.origin.name}`
+            pluginSourcePath = path.join(paths.pluginsDownloadDirectory, 'node_modules', `@${pluginConfig.origin.scope}`, pluginConfig.origin.name)
           } else {
-            pluginSourcePath = `${paths.pluginsDownloadDirectory}/node_modules/${pluginConfig.origin.name}`
+            pluginSourcePath = path.join(paths.pluginsDownloadDirectory, 'node_modules', 'pluginConfig.origin.name')
           }
           if (!pluginSourcePath) {
             throw new Error(`Was not able to download ${plugin.scopedName}`)
@@ -78,7 +79,7 @@ export default class ApiImplGithubGenerator implements ApiImplGeneratable {
             for (const r of pluginConfig.ios.replaceInFile) {
               const fileContent = fs.readFileSync(`${outputDirectory}/${r.path}`, 'utf8')
               const patchedFileContent = fileContent.replace(RegExp(r.string, 'g'), r.replaceWith)
-              fs.writeFileSync(`${outputDirectory}/${r.path}`, patchedFileContent, {encoding: 'utf8'})
+              fs.writeFileSync(path.join(outputDirectory, r.path), patchedFileContent, {encoding: 'utf8'})
             }
           }
 
@@ -126,7 +127,7 @@ export default class ApiImplGithubGenerator implements ApiImplGeneratable {
 
             if (pluginConfig.ios.pbxproj.addProject) {
               for (const project of pluginConfig.ios.pbxproj.addProject) {
-                const projectAbsolutePath = `${apiImplLibrariesPath}/${project.path}/project.pbxproj`
+                const projectAbsolutePath = path.join(apiImplLibrariesPath, project.path, 'project.pbxproj')
                 apiImplProject.addProject(projectAbsolutePath, project.path, project.group, apiImplTarget, project.staticLibs)
               }
             }

--- a/ern-api-impl-gen/src/index.js
+++ b/ern-api-impl-gen/src/index.js
@@ -95,7 +95,7 @@ async function createNodePackage (
   shell.cd(outputDirectoryPath)
   await yarn.init()
   await yarn.add(apiDependencyPath)
-  shell.rm('-rf', `${outputDirectoryPath}/node_modules/`)
+  shell.rm('-rf', path.join(outputDirectoryPath, 'node_modules'))
   log.debug('Removed node modules directory')
   const packageJsonPath = path.join(outputDirectoryPath, 'package.json')
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
@@ -126,8 +126,8 @@ function formOutputDirectoryName (apiDependencyPath, outputDirectoryPath: string
   let apiName = API_NAME_RE.exec(apiDependencyObj.name)[1]
 
   return outputDirectoryPath
-    ? path.join(`${outputDirectoryPath}`, `${apiName}-impl`)
-    : path.join(`${shell.pwd()}`, `${apiName}-impl`)
+    ? path.join(outputDirectoryPath, `${apiName}-impl`)
+    : path.join(shell.pwd(), `${apiName}-impl`)
 }
 
 function getPlatforms (nativeOnly: boolean): Array<string> {

--- a/ern-cauldron-api/package.json
+++ b/ern-cauldron-api/package.json
@@ -43,7 +43,7 @@
     }
   ],
   "scripts": {
-    "test": "ern-mocha",
+    "test": "cross-env __ERN_TEST__=true ern-mocha",
     "build": "ern-babel",
     "coverage": "ern-nyc",
     "prepublish": "yarn run build"

--- a/ern-container-gen/package.json
+++ b/ern-container-gen/package.json
@@ -45,7 +45,7 @@
   ],
   "scripts": {
     "build": "ern-babel",
-    "test": "ern-mocha",
+    "test": "cross-env __ERN_TEST__=true ern-mocha",
     "coverage": "ern-nyc",
     "prepublish": "yarn run build"
   },

--- a/ern-core/package.json
+++ b/ern-core/package.json
@@ -43,7 +43,7 @@
   ],
   "scripts": {
     "build": "ern-babel",
-    "test": "ern-mocha",
+    "test": "cross-env __ERN_TEST__=true ern-mocha",
     "coverage": "ern-nyc",
     "prepublish": "yarn run build"
   },

--- a/ern-core/src/Manifest.js
+++ b/ern-core/src/Manifest.js
@@ -122,7 +122,7 @@ export class Manifest {
     }
 
     if (pluginConfigPath) {
-      let configFile = await fs.readFileSync(`${pluginConfigPath}/${pluginConfigFileName}`, 'utf-8')
+      let configFile = await fs.readFileSync(path.join(pluginConfigPath, pluginConfigFileName), 'utf-8')
       configFile = Mustache.render(configFile, { projectName })
       result = JSON.parse(configFile)
 

--- a/ern-core/src/MavenPublisher.js
+++ b/ern-core/src/MavenPublisher.js
@@ -29,7 +29,7 @@ export default class MavenPublisher implements Publisher {
   async buildAndPublishContainer (workingDir: string, moduleName: string): Promise<*> {
     try {
       log.debug(`[=== Starting build and publication ===]`)
-      shell.cd(`${workingDir}`)
+      shell.cd(workingDir)
       await this.buildAndUploadArchive(moduleName)
       log.debug(`[=== Completed build and publication of the module ===]`)
     } catch (e) {

--- a/ern-core/src/MiniApp.js
+++ b/ern-core/src/MiniApp.js
@@ -40,7 +40,7 @@ export default class MiniApp {
     this._path = miniAppPath
     this._isLocal = isLocal
 
-    const packageJsonPath = `${miniAppPath}/package.json`
+    const packageJsonPath = path.join(miniAppPath, 'package.json')
     if (!fs.existsSync(packageJsonPath)) {
       throw new Error(`This command should be run at the root of a mini-app`)
     }
@@ -128,11 +128,11 @@ Are you sure this is a MiniApp ?`)
         reactnative.init(miniAppName, reactNativeVersion))
 
       // Inject ern specific data in MiniApp package.json
-      const appPackageJsonPath = `${process.cwd()}/${miniAppName}/package.json`
+      const appPackageJsonPath = path.join(process.cwd(), miniAppName, 'package.json')
       const appPackageJson = JSON.parse(fs.readFileSync(appPackageJsonPath, 'utf-8'))
       appPackageJson.ern = {
-        version: `${platformVersion}`,
-        moduleType: `${ModuleTypes.MINIAPP}`,
+        version: platformVersion,
+        moduleType: ModuleTypes.MINIAPP,
         miniAppName
       }
       appPackageJson.private = false
@@ -150,7 +150,7 @@ Are you sure this is a MiniApp ?`)
       // Remove react-native generated android and ios projects
       // They will be replaced with our owns when user uses `ern run android`
       // or `ern run ios` command
-      const miniAppPath = `${process.cwd()}/${miniAppName}`
+      const miniAppPath = path.join(process.cwd(), miniAppName)
       shell.cd(miniAppPath)
       shell.rm('-rf', 'android')
       shell.rm('-rf', 'ios')
@@ -210,7 +210,7 @@ Are you sure this is a MiniApp ?`)
 
   // Return all native dependencies currently used by the mini-app
   get nativeDependencies () : Array<Dependency> {
-    return findNativeDependencies(`${this.path}/node_modules`)
+    return findNativeDependencies(path.join(this.path, 'node_modules'))
   }
 
   async isPublishedToNpm () : Promise<boolean> {
@@ -361,7 +361,7 @@ with "ern" : { "version" : "${this.packageJson.ernPlatformVersion}" } instead`)
     this.packageJson.ern.version = versionToUpgradeTo
 
     // Write back package.json
-    const appPackageJsonPath = `${this.path}/package.json`
+    const appPackageJsonPath = path.join(this.path, 'package.json')
     fs.writeFileSync(appPackageJsonPath, JSON.stringify(this.packageJson, null, 2))
 
     process.chdir(this.path)

--- a/ern-core/src/Platform.js
+++ b/ern-core/src/Platform.js
@@ -18,19 +18,19 @@ const ERN_LOCAL_CLI_PACKAGE = 'ern-local-cli'
 
 export default class Platform {
   static get rootDirectory () : string {
-    return `${HOME_DIRECTORY}/.ern`
+    return path.join(HOME_DIRECTORY, '.ern')
   }
 
   static get masterManifestDirectory () : string {
-    return `${this.rootDirectory}/ern-master-manifest`
+    return path.join(this.rootDirectory, 'ern-master-manifest')
   }
 
   static get overrideManifestDirectory () : string {
-    return `${this.rootDirectory}/ern-override-manifest`
+    return path.join(this.rootDirectory, 'ern-override-manifest')
   }
 
   static get versionCacheDirectory () : string {
-    return `${this.rootDirectory}/versions`
+    return path.join(this.rootDirectory, 'versions')
   }
 
   static get latestVersion () : string {

--- a/ern-core/src/handleCopyDirective.js
+++ b/ern-core/src/handleCopyDirective.js
@@ -4,14 +4,15 @@ import fs from 'fs'
 import {
   shell
 } from 'ern-util'
+import path from 'path'
 
 export default function handleCopyDirective (
   sourceRoot: string,
   destRoot: string,
   arr: Array<any>) {
   for (const cp of arr) {
-    const sourcePath = `${sourceRoot}/${cp.source}`
-    const destPath = `${destRoot}/${cp.dest}`
+    const sourcePath = path.join(sourceRoot, cp.source)
+    const destPath = path.join(destRoot, cp.dest)
     if (!fs.existsSync(destPath)) {
       shell.mkdir('-p', destPath)
     }

--- a/ern-local-cli/package.json
+++ b/ern-local-cli/package.json
@@ -44,7 +44,7 @@
   ],
   "scripts": {
     "build": "ern-babel",
-    "test": "ern-mocha",
+    "test": "cross-env __ERN_TEST__=true ern-mocha",
     "coverage": "ern-nyc",
     "prepublish": "yarn run build",
     "postinstall": "node scripts/postinstall.js"

--- a/ern-local-cli/src/commands/create-container.js
+++ b/ern-local-cli/src/commands/create-container.js
@@ -10,7 +10,8 @@ import {
 import {
   Dependency,
   DependencyPath,
-  NativeApplicationDescriptor
+  NativeApplicationDescriptor,
+  spin
 } from 'ern-util'
 import {
   runLocalContainerGen,
@@ -182,7 +183,7 @@ exports.handler = async function ({
         platform = userSelectedPlatform
       }
 
-      await runLocalContainerGen(
+      await spin('Generating Container locally', runLocalContainerGen(
         miniAppsPaths,
         platform, {
           version,
@@ -190,7 +191,7 @@ exports.handler = async function ({
           outDir,
           extraNativeDependencies: _.map(dependencies, d => Dependency.fromString(d))
         }
-      )
+      ))
     } else if (napDescriptor && version) {
       await runCauldronContainerGen(
         napDescriptor,

--- a/ern-local-cli/src/lib/publication.js
+++ b/ern-local-cli/src/lib/publication.js
@@ -248,7 +248,7 @@ miniApps: Array<Dependency>, {
     }
   }
 
-  const workingDirectory = `${Platform.rootDirectory}/CompositeOta`
+  const workingDirectory = path.join(Platform.rootDirectory, 'CompositeOta')
   const codePushMiniapps : Array<Array<string>> = await cauldron.getCodePushMiniApps(napDescriptor)
   const latestCodePushedMiniApps : Array<Dependency> = _.map(codePushMiniapps.pop(), Dependency.fromString)
 

--- a/ern-local-cli/src/lib/publication.js
+++ b/ern-local-cli/src/lib/publication.js
@@ -24,7 +24,6 @@ import {
 import inquirer from 'inquirer'
 import _ from 'lodash'
 import path from 'path'
-import ora from 'ora'
 
 function createContainerGenerator (config: ContainerGeneratorConfig) {
   switch (config.platform) {
@@ -77,8 +76,6 @@ platform: 'android' | 'ios', {
     let containerGeneratorConfig = new ContainerGeneratorConfig(platform, config)
     log.debug(`containerGeneratorConfig is generated: ${JSON.stringify(containerGeneratorConfig)}`)
 
-    const spinner = ora('Preparing MiniApp(s) and running compatibility checks').start()
-
     for (const miniappPackagePath of miniappPackagesPaths) {
       log.debug(`Retrieving ${miniappPackagePath.toString()}`)
 
@@ -94,8 +91,6 @@ platform: 'android' | 'ios', {
       currentMiniApp.nativeDependencies.forEach(d => nativeDependenciesStrings.add(d.toString()))
     }
 
-    spinner.succeed()
-
     let nativeDependencies = _.map(Array.from(nativeDependenciesStrings), d => Dependency.fromString(d))
     nativeDependencies = nativeDependencies.concat(extraNativeDependencies)
 
@@ -106,7 +101,6 @@ platform: 'android' | 'ios', {
     const duplicateNativeDependencies =
       _(nativeDependenciesWithoutVersion).groupBy().pickBy(x => x.length > 1).keys().value()
     if (duplicateNativeDependencies.length > 0) {
-      spinner.fail()
       throw new Error(`The following native dependencies are not using the same version: ${duplicateNativeDependencies}`)
     }
 

--- a/ern-local-cli/src/lib/utils.js
+++ b/ern-local-cli/src/lib/utils.js
@@ -504,13 +504,13 @@ async function generateContainerForRunner (
         containerName: 'runner'
       })
   } else {
-    await runLocalContainerGen(
+    await spin('Generating Container locally', runLocalContainerGen(
       miniAppsPaths,
       platform, {
         containerVersion: '1.0.0',
         nativeAppName: 'runner',
         extraNativeDependencies: dependenciesObjs
-      })
+      }))
   }
 }
 

--- a/ern-runner-gen/package.json
+++ b/ern-runner-gen/package.json
@@ -44,7 +44,7 @@
   ],
   "scripts": {
     "build": "ern-babel",
-    "test": "ern-mocha",
+    "test": "cross-env __ERN_TEST__=true ern-mocha",
     "coverage": "ern-nyc",
     "prepublish": "yarn run build"
   },

--- a/ern-runner-gen/src/index.js
+++ b/ern-runner-gen/src/index.js
@@ -98,12 +98,12 @@ export async function generateAndroidRunnerProject (
     pascalCaseMiniAppName: pascalCase(mainMiniAppName),
     isReactNativeDevSupportEnabled: reactNativeDevSupportEnabled === true ? 'true' : 'false'
   }
-  shell.cp('-R', `${platformPath}/ern-runner-gen/runner-hull/android/*`, outDir)
-  const files = readDir(`${platformPath}/ern-runner-gen/runner-hull/android`,
+  shell.cp('-R', path.join(platformPath, 'ern-runner-gen', 'runner-hull', 'android', '*', outDir))
+  const files = readDir(path.join(platformPath, 'ern-runner-gen', 'runner-hull', 'android'),
             (f) => (!f.endsWith('.jar') && !f.endsWith('.png')))
   for (const file of files) {
     await mustacheUtils.mustacheRenderToOutputFileUsingTemplateFile(
-                `${outDir}/${file}`, mustacheView, `${outDir}/${file}`)
+                path.join(outDir, file), mustacheView, path.join(outDir, file))
   }
 }
 
@@ -120,8 +120,10 @@ export async function regenerateAndroidRunnerConfig (
     pascalCaseMiniAppName: pascalCase(mainMiniAppName),
     isReactNativeDevSupportEnabled: reactNativeDevSupportEnabled === true ? 'true' : 'false'
   }
-  const pathToRunnerConfig = path.join(pathToRunnerProject, 'app/src/main/java/com/walmartlabs/ern/RunnerConfig.java')
-  shell.cp(`${platformPath}/ern-runner-gen/runner-hull/android/app/src/main/java/com/walmartlabs/ern/RunnerConfig.java`, pathToRunnerConfig)
+  const subPathToRunnerConfig = path.join('app', 'src', 'main', 'java', 'com', 'walmartlabs', 'ern', 'RunnerConfig.java')
+  const pathToRunnerConfigHull = path.join(platformPath, 'ern-runner-gen', 'runner-hull', 'android', subPathToRunnerConfig)
+  const pathToRunnerConfig = path.join(pathToRunnerProject, subPathToRunnerConfig)
+  shell.cp(pathToRunnerConfigHull, pathToRunnerConfig)
   await mustacheUtils.mustacheRenderToOutputFileUsingTemplateFile(
     pathToRunnerConfig, mustacheView, pathToRunnerConfig)
 }
@@ -139,14 +141,14 @@ export async function generateIosRunnerProject (
     miniAppName: mainMiniAppName,
     pascalCaseMiniAppName: pascalCase(mainMiniAppName),
     isReactNativeDevSupportEnabled: reactNativeDevSupportEnabled === true ? 'YES' : 'NO',
-    pathToElectrodeContainerXcodeProj: `${containerGenWorkingDir}/out/ios`
+    pathToElectrodeContainerXcodeProj: path.join(containerGenWorkingDir, 'out', 'ios')
   }
 
-  shell.cp('-R', `${platformPath}/ern-runner-gen/runner-hull/ios/*`, outDir)
-  const files = readDir(`${platformPath}/ern-runner-gen/runner-hull/ios`)
+  shell.cp('-R', path.join(platformPath, 'ern-runner-gen', 'runner-hull', 'ios', '*'), outDir)
+  const files = readDir(path.join(platformPath, 'ern-runner-gen', 'runner-hull', 'ios'))
   for (const file of files) {
     await mustacheUtils.mustacheRenderToOutputFileUsingTemplateFile(
-                `${outDir}/${file}`, mustacheView, `${outDir}/${file}`)
+      path.join(outDir, file), mustacheView, path.join(outDir, file))
   }
 }
 
@@ -164,7 +166,7 @@ export async function regenerateIosRunnerConfig (
     miniAppName: mainMiniAppName,
     pascalCaseMiniAppName: pascalCase(mainMiniAppName),
     isReactNativeDevSupportEnabled: reactNativeDevSupportEnabled === true ? 'YES' : 'NO',
-    pathToElectrodeContainerXcodeProj: `${containerGenWorkingDir}/out/ios`
+    pathToElectrodeContainerXcodeProj: path.join(containerGenWorkingDir, 'out', 'ios')
   }
   const pathToRunnerConfig = path.join(pathToRunnerProject, 'ErnRunner/RunnerConfig.m')
   shell.cp(`${platformPath}/ern-runner-gen/runner-hull/ios/ErnRunner/RunnerConfig.m`, pathToRunnerConfig)

--- a/ern-util-dev/package.json
+++ b/ern-util-dev/package.json
@@ -41,7 +41,7 @@
     }
   ],
   "scripts": {
-    "test": "./bin/ern-mocha.js"
+    "test": "cross-env __ERN_TEST__=true ./bin/ern-mocha.js"
   },
   "dependencies": {
     "babel-polyfill": "^6.23.0",

--- a/ern-util/package.json
+++ b/ern-util/package.json
@@ -42,7 +42,7 @@
   ],
   "scripts": {
     "build": "ern-babel",
-    "test": "ern-mocha",
+    "test": "cross-env __ERN_TEST__=true ern-mocha",
     "coverage": "ern-nyc",
     "prepublish": "yarn run build"
   },

--- a/ern-util/src/YarnCli.js
+++ b/ern-util/src/YarnCli.js
@@ -43,7 +43,7 @@ export default class YarnCli {
     if (dependencyPath.isAFileSystemPath) {
       const tmpDirPath = tmp.dirSync({unsafeCleanup: true}).name
       shell.cp('-R', `${/file:(.+)/.exec(dependencyPath.toString())[1]}/*`, tmpDirPath)
-      shell.rm('-rf', `${tmpDirPath}/node_modules`)
+      shell.rm('-rf', path.join(tmpDirPath, 'node_modules'))
       dependencyPath = DependencyPath.fromFileSystemPath(tmpDirPath)
     }
 

--- a/ern-util/src/ios.js
+++ b/ern-util/src/ios.js
@@ -6,7 +6,7 @@ import {
   execSync,
   spawn
 } from 'child_process'
-import ora from 'ora'
+import spin from './spin'
 const simctl = require('node-simctl')
 
 export async function getiPhoneDevices () {
@@ -67,20 +67,13 @@ export async function runIosApp ({
   bundleId: string
 }) {
   const iPhoneDevice = await askUserToSelectAniPhoneDevice()
-  await killAllRunningSimulators()
-  const spinner = ora(`Waiting for device to boot`).start()
-  await launchSimulator(iPhoneDevice.udid)
-
-  try {
-    spinner.text = 'Installing application on simulator'
-    await installApplicationOnDevice(iPhoneDevice.udid, appPath)
-    spinner.text = 'Launching application'
-    await launchApplication(iPhoneDevice.udid, bundleId)
-    spinner.succeed('Done')
-  } catch (e) {
-    spinner.fail(e.message)
-    throw e
-  }
+  killAllRunningSimulators()
+  await spin('Waiting for device to boot',
+    launchSimulator(iPhoneDevice.udid))
+  await spin('Installing application on simulator',
+    installApplicationOnDevice(iPhoneDevice.udid, appPath))
+  await spin('Launching application',
+    launchApplication(iPhoneDevice.udid, bundleId))
 }
 
 export async function installApplicationOnDevice (deviceUdid: string, pathToAppFile: string) {

--- a/ern-util/src/spin.js
+++ b/ern-util/src/spin.js
@@ -1,23 +1,43 @@
 // @flow
 
-import Ora from 'ora'
+import ora from 'ora'
+
+let spinner
+let isSpinning = false
 
 // promisify ora spinner
 // there is already a promise method on ora spinner, unfortunately it does
 // not return the wrapped promise so that's a bit useless.
 export default async function spin<T> (
-  msg: string,
-  prom: Promise<T>,
-  options: any) : Promise<T> {
-  const spinner = new Ora(options || msg)
-  spinner.start()
+  text: string,
+  prom: Promise<T>) : Promise<T> {
+  if (spinner) {
+    spinner.text = text
+  } else {
+    spinner = ora({
+      text,
+      enabled: global.ernLogLevel !== 'debug' &&
+               global.ernLogLevel !== 'trace'
+    })
+  }
+
+  if (!isSpinning) {
+    spinner.start()
+    isSpinning = true
+  }
 
   try {
     let result = await prom
-    spinner.succeed()
+    if (isSpinning) {
+      spinner.succeed()
+    }
     return result
   } catch (e) {
-    spinner.fail(e)
+    if (isSpinning) {
+      spinner.fail(e.message)
+    }
     throw e
+  } finally {
+    isSpinning = false
   }
 }

--- a/ern-util/src/spin.js
+++ b/ern-util/src/spin.js
@@ -17,7 +17,8 @@ export default async function spin<T> (
     spinner = ora({
       text,
       enabled: global.ernLogLevel !== 'debug' &&
-               global.ernLogLevel !== 'trace'
+               global.ernLogLevel !== 'trace' &&
+               !process.env.__ERN_TEST__
     })
   }
 


### PR DESCRIPTION
- Use `path.join` where appropriate instead of hardcoding path
- Do not use template literals when unneeded (i.e `shell.cd(ROOT_DIR)` instead of ```shell.cd(`${ROOT_DIR}`)```)
- Rework `spin` utility function
  - Make the spinner instance shared to avoid spinner collisions. Use `spin` instead of relying directly on `ora`, where appropriate.
  - Spinner is now disabled in `debug` or `trace` log level as it collides with other logs (bad looking output) and does not add any interesting information.
- `__ERN_TEST__` env variable will be set during test execution. It can be useful in case we want to skip some code or disable some things during test execution (first use part of this PR, to disable the spinners during test execution, as they are not needed)