### PR TITLE
Container generator light refactoring

### DIFF
--- a/ern-container-gen/src/generateContainer.js
+++ b/ern-container-gen/src/generateContainer.js
@@ -39,7 +39,7 @@ export default async function generateContainer ({
   pathToYarnLock?: string
 } = {}) {
   const PLUGINS_DOWNLOAD_DIRECTORY = path.join(workingDirectory, 'plugins')
-  const OUT_DIRECTORY = path.join(workingDirectory, 'out')
+  const OUT_DIRECTORY = path.join(workingDirectory, 'out', generator.platform)
   const COMPOSITE_MINIAPP_DIRECTORY = path.join(workingDirectory, 'compositeMiniApp')
 
   const paths : ContainerGeneratorPaths = {
@@ -54,8 +54,8 @@ export default async function generateContainer ({
   shell.rm('-rf', OUT_DIRECTORY)
   shell.rm('-rf', COMPOSITE_MINIAPP_DIRECTORY)
   shell.mkdir('-p', PLUGINS_DOWNLOAD_DIRECTORY)
-  shell.mkdir('-p', path.join(OUT_DIRECTORY, generator.platform))
-  shell.mkdir('-p', path.join(OUT_DIRECTORY, 'ios'))
+  shell.mkdir('-p', OUT_DIRECTORY)
+  shell.mkdir('-p', COMPOSITE_MINIAPP_DIRECTORY)
 
   sortPlugins(plugins)
 

--- a/ern-container-gen/src/generateContainer.js
+++ b/ern-container-gen/src/generateContainer.js
@@ -5,7 +5,8 @@ import {
   shell
 } from 'ern-util'
 import {
-  MiniApp
+  MiniApp,
+  Platform
 } from 'ern-core'
 import {
   capitalizeFirstLetter
@@ -23,7 +24,6 @@ let mustacheView = {}
 export default async function generateContainer ({
   containerVersion,
   nativeAppName,
-  platformPath,
   generator,
   plugins,
   miniapps,
@@ -32,7 +32,6 @@ export default async function generateContainer ({
 } : {
   containerVersion: string,
   nativeAppName: string,
-  platformPath: string,
   generator: ContainerGenerator,
   plugins: Array<Dependency>,
   miniapps: Array<MiniApp>,
@@ -44,8 +43,8 @@ export default async function generateContainer ({
   const COMPOSITE_MINIAPP_DIRECTORY = path.join(workingDirectory, 'compositeMiniApp')
 
   const paths : ContainerGeneratorPaths = {
-    containerHull: path.join(platformPath, 'ern-container-gen', 'hull'),
-    containerTemplates: path.join(platformPath, 'ern-container-gen', 'templates'),
+    containerHull: path.join(Platform.currentPlatformVersionPath, 'ern-container-gen', 'hull'),
+    containerTemplates: path.join(Platform.currentPlatformVersionPath, 'ern-container-gen', 'templates'),
     compositeMiniApp: COMPOSITE_MINIAPP_DIRECTORY,
     pluginsDownloadDirectory: PLUGINS_DOWNLOAD_DIRECTORY,
     outDirectory: OUT_DIRECTORY

--- a/ern-container-gen/src/generateContainer.js
+++ b/ern-container-gen/src/generateContainer.js
@@ -39,40 +39,27 @@ export default async function generateContainer ({
   workingDirectory: string,
   pathToYarnLock?: string
 } = {}) {
-  // Directory from which we download all plugins sources (from npm or git)
   const PLUGINS_DOWNLOAD_DIRECTORY = path.join(workingDirectory, 'plugins')
-  // Directory where the resulting container project is stored in
   const OUT_DIRECTORY = path.join(workingDirectory, 'out')
-  // Directory from which we assemble the miniapps together / run the bundling
   const COMPOSITE_MINIAPP_DIRECTORY = path.join(workingDirectory, 'compositeMiniApp')
 
-  // Contains all interesting directorys paths
   const paths : ContainerGeneratorPaths = {
-    // Where the container project hull is stored
     containerHull: path.join(platformPath, 'ern-container-gen', 'hull'),
-    // Where the templates to be used during container generation are stored
     containerTemplates: path.join(platformPath, 'ern-container-gen', 'templates'),
-    // Where we assemble the miniapps together
     compositeMiniApp: COMPOSITE_MINIAPP_DIRECTORY,
-    // Where we download plugins
     pluginsDownloadDirectory: PLUGINS_DOWNLOAD_DIRECTORY,
-    // Where we output final generated container
     outDirectory: OUT_DIRECTORY
   }
 
-  // Clean up to start fresh
   shell.rm('-rf', PLUGINS_DOWNLOAD_DIRECTORY)
   shell.rm('-rf', OUT_DIRECTORY)
   shell.rm('-rf', COMPOSITE_MINIAPP_DIRECTORY)
   shell.mkdir('-p', PLUGINS_DOWNLOAD_DIRECTORY)
-  shell.mkdir('-p', path.join(OUT_DIRECTORY, 'android'))
+  shell.mkdir('-p', path.join(OUT_DIRECTORY, generator.platform))
   shell.mkdir('-p', path.join(OUT_DIRECTORY, 'ios'))
 
-  // Sort the plugin to have consistent ElectrodeContainer.java generated code
   sortPlugins(plugins)
 
-  // Let's make sure that react-native is included (otherwise there is
-  // something pretty much wrong)
   const reactNativePlugin = _.find(plugins, p => p.name === 'react-native')
   if (!reactNativePlugin) {
     throw new Error('react-native was not found in plugins list !')

--- a/ern-container-gen/src/generateContainer.js
+++ b/ern-container-gen/src/generateContainer.js
@@ -43,8 +43,8 @@ export default async function generateContainer ({
   const COMPOSITE_MINIAPP_DIRECTORY = path.join(workingDirectory, 'compositeMiniApp')
 
   const paths : ContainerGeneratorPaths = {
-    containerHull: path.join(Platform.currentPlatformVersionPath, 'ern-container-gen', 'hull'),
-    containerTemplates: path.join(Platform.currentPlatformVersionPath, 'ern-container-gen', 'templates'),
+    containerHull: path.join(Platform.currentPlatformVersionPath, 'ern-container-gen', 'hull', generator.platform),
+    containerTemplates: path.join(Platform.currentPlatformVersionPath, 'ern-container-gen', 'templates', generator.platform),
     compositeMiniApp: COMPOSITE_MINIAPP_DIRECTORY,
     pluginsDownloadDirectory: PLUGINS_DOWNLOAD_DIRECTORY,
     outDirectory: OUT_DIRECTORY

--- a/ern-container-gen/src/generators/android/AndroidGenerator.js
+++ b/ern-container-gen/src/generators/android/AndroidGenerator.js
@@ -100,35 +100,20 @@ export default class AndroidGenerator implements ContainerGenerator {
         }
       }
 
-      // Enhance mustache view with android specifics
       mustacheView.android = {
         repository: mavenPublisher ? MavenUtils.targetRepositoryGradleStatement(mavenPublisher.url) : undefined,
         namespace: this.namespace,
         miniapps: mustacheView.miniApps
       }
 
-      //
-      // Go through all ern-container-gen steps
-
-      // Copy the container hull to output directory and patch it
-      // - Retrieves (download) each plugin from npm or git and inject
-      //   plugin source in container
-      // - Inject configuration code for plugins that expose configuration
-      // - Create activities for MiniApps
-      // - Patch build.gradle for versioning of the container project and
-      //   to specify publication repository target
       await this.fillContainerHull(plugins, miniapps, paths, mustacheView)
 
-      // Bundle all the miniapps together and store resulting bundle in container project
       await bundleMiniApps(miniapps, paths, 'android', {pathToYarnLock})
 
-      // Rnpm handling
       if (!this._containerGeneratorConfig.ignoreRnpmAssets) {
         this.copyRnpmAssets(miniapps, paths)
       }
 
-      // Finally, container hull project is fully generated, now let's just
-      // build it and publish resulting AAR
       if (mavenPublisher) {
         await mavenPublisher.publish({workingDir: `${paths.outDirectory}/android`, moduleName: `lib`})
         log.debug(`Published com.walmartlabs.ern:${nativeAppName}-ern-container:${containerVersion}`)
@@ -222,7 +207,6 @@ export default class AndroidGenerator implements ContainerGenerator {
         await mustacheUtils.mustacheRenderToOutputFileUsingTemplateFile(pathToFile, mustacheView, pathToFile)
       }
 
-      // Create mini app activities
       log.debug(`Creating miniapp activities`)
       for (const miniApp of miniApps) {
         let tmpMiniAppView = {

--- a/ern-container-gen/src/generators/android/AndroidGenerator.js
+++ b/ern-container-gen/src/generators/android/AndroidGenerator.js
@@ -140,7 +140,7 @@ export default class AndroidGenerator implements ContainerGenerator {
 
       shell.cd(ROOT_DIR)
 
-      const copyFromPath = path.join(paths.containerHull, 'android', '{.*,*}')
+      const copyFromPath = path.join(paths.containerHull, '{.*,*}')
 
       shell.cp('-R', copyFromPath, paths.outDirectory)
 
@@ -216,7 +216,7 @@ export default class AndroidGenerator implements ContainerGenerator {
         let activityFileName = `${tmpMiniAppView.pascalCaseMiniAppName}Activity.java`
 
         log.debug(`Creating ${activityFileName}`)
-        const pathToMiniAppActivityMustacheTemplate = path.join(paths.containerTemplates, 'android', 'MiniAppActivity.mustache')
+        const pathToMiniAppActivityMustacheTemplate = path.join(paths.containerTemplates, 'MiniAppActivity.mustache')
         const pathToOutputActivityFile = path.join(paths.outDirectory, pathLibSrcMainJavaComWalmartlabsErnContainer, 'miniapps', activityFileName)
         await mustacheUtils.mustacheRenderToOutputFileUsingTemplateFile(
             pathToMiniAppActivityMustacheTemplate,

--- a/ern-container-gen/src/generators/ios/IosGenerator.js
+++ b/ern-container-gen/src/generators/ios/IosGenerator.js
@@ -79,25 +79,16 @@ export default class IosGenerator implements ContainerGenerator {
         log.debug('Will not publish since there is no publisher provided to generator.')
       }
 
-      //
-      // Go through all ern-container-gen steps
-      //
-
-      // Copy iOS container hull to generation ios output directory
       await this.fillContainerHull(plugins, miniapps, paths, mustacheView)
 
-      // Bundle all the miniapps together and store resulting bundle in container
-      // project
       if (miniapps.length > 0) {
         await bundleMiniApps(miniapps, paths, 'ios', {pathToYarnLock})
       }
 
-      // Copy potential rnpm provided assets
       if (!this._containerGeneratorConfig.ignoreRnpmAssets) {
         this.copyRnpmAssets(miniapps, paths)
       }
 
-      // Publish resulting container to git repo
       if (gitHubPublisher) {
         shell.cd(path.join(paths.outDirectory, 'ios'))
         log.debug(`Publish generated container[v${containerVersion}] to git repo: ${gitHubPublisher.url}`)

--- a/ern-container-gen/src/generators/ios/IosGenerator.js
+++ b/ern-container-gen/src/generators/ios/IosGenerator.js
@@ -153,8 +153,8 @@ export default class IosGenerator implements ContainerGenerator {
     log.debug(`[=== Starting container hull filling ===]`)
     shell.cd(`${ROOT_DIR}`)
 
-    const copyFromPath = path.join(paths.containerHull, 'ios', '{.*,*}')
-    
+    const copyFromPath = path.join(paths.containerHull, '{.*,*}')
+
     shell.cp('-R', copyFromPath, paths.outDirectory)
     await this.buildiOSPluginsViews(plugins, mustacheView)
 

--- a/ern-container-gen/src/utils.js
+++ b/ern-container-gen/src/utils.js
@@ -46,7 +46,6 @@ export async function bundleMiniApps (
       await generateMiniAppsComposite(miniAppsPaths, paths.compositeMiniApp, {pathToYarnLock})
     }
 
-    // Clear react packager cache beforehand to avoid surprises ...
     clearReactPackagerCache()
 
     if (platform === 'android') {
@@ -132,9 +131,7 @@ export async function generateMiniAppsComposite (
 
     log.debug(`[generateMiniAppsComposite] miniAppsDeltas: ${JSON.stringify(miniAppsDeltas)}`)
 
-    // Create initial package.json
     compositePackageJson.dependencies = getPackageJsonDependenciesUsingMiniAppDeltas(miniAppsDeltas, yarnLock)
-    // This helps to start the local packager withing the comopsiteMiniApps directory for debugging multiple miniapps
     compositePackageJson.scripts = {'start': 'node node_modules/react-native/local-cli/cli.js start'}
 
     fs.writeFileSync(path.join(outDir, 'package.json'), JSON.stringify(compositePackageJson, null, 2), 'utf8')
@@ -157,7 +154,6 @@ export async function generateMiniAppsComposite (
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2), 'utf8')
   }
 
-  // Add optional extra JavaScript dependencies
   for (const extraJsDependency of extraJsDependencies) {
     await yarn.add(extraJsDependency)
   }

--- a/ern-container-gen/src/utils.js
+++ b/ern-container-gen/src/utils.js
@@ -64,7 +64,7 @@ export async function bundleMiniApps (
 }
 
 export async function reactNativeBundleAndroid (paths: any) {
-  const libSrcMainPath = path.join(paths.outDirectory, 'android', 'lib', 'src', 'main')
+  const libSrcMainPath = path.join(paths.outDirectory, 'lib', 'src', 'main')
   const bundleOutput = path.join(libSrcMainPath, 'assets', 'index.android.bundle')
   const assetsDest = path.join(libSrcMainPath, 'res')
 
@@ -78,7 +78,7 @@ export async function reactNativeBundleAndroid (paths: any) {
 }
 
 export async function reactNativeBundleIos (paths: any) {
-  const miniAppOutPath = path.join(paths.outDirectory, 'ios', 'ElectrodeContainer', 'Libraries', 'MiniApp')
+  const miniAppOutPath = path.join(paths.outDirectory, 'ElectrodeContainer', 'Libraries', 'MiniApp')
   const bundleOutput = path.join(miniAppOutPath, 'MiniApp.jsbundle')
   const assetsDest = miniAppOutPath
 

--- a/ern-local-cli/src/lib/publication.js
+++ b/ern-local-cli/src/lib/publication.js
@@ -117,7 +117,6 @@ platform: 'android' | 'ios', {
       , generateContainer({
         containerVersion,
         nativeAppName,
-        platformPath: Platform.currentPlatformVersionPath,
         generator: createContainerGenerator(containerGeneratorConfig),
         plugins: nativeDependencies,
         miniapps,
@@ -173,7 +172,6 @@ version: string, {
       generateContainer({
         containerVersion: version,
         nativeAppName: containerName || napDescriptor.name,
-        platformPath: Platform.currentPlatformVersionPath,
         generator: createContainerGenerator(containerGeneratorConfig),
         plugins,
         miniapps: miniAppsInstances,

--- a/ern-runner-gen/src/index.js
+++ b/ern-runner-gen/src/index.js
@@ -173,13 +173,11 @@ export async function regenerateIosRunnerConfig (
 }
 
 export async function generateContainerForRunner ({
-  platformPath,
   plugins,
   miniapp,
   platform,
   containerGenWorkingDir
 } : {
-  platformPath: string,
   plugins: Array<Dependency>,
   miniapp: Object,
   platform: 'android' | 'ios',
@@ -194,7 +192,6 @@ export async function generateContainerForRunner ({
     containerVersion: RUNNER_CONTAINER_VERSION,
     nativeAppName: 'runner',
     generator,
-    platformPath,
     plugins,
     miniapps: [miniapp],
     workingDirectory: containerGenWorkingDir


### PR DESCRIPTION
- Clean comments (remove a lot of them that were really not needed or just plain wrong).
- Container generator has a dependency on `ern-core` so it can now the platform path from there, no need to provide platform path as a parameter to the generator. This parameter has been removed.
- Update directories paths in `paths` object given to the iOS/Android generators, so that it contains `ios` / `android` path segment. This way the platform generators do no need to always append `ios` or `android` to the provided paths.