### PR TITLE
Disable run-ios command for non Mac OS X platforms

### DIFF
--- a/ern-local-cli/src/commands/run-ios.js
+++ b/ern-local-cli/src/commands/run-ios.js
@@ -54,6 +54,10 @@ exports.handler = async function ({
   dev?: boolean,
   usePreviousEmulator?: boolean
 }) {
+  if (process.platform !== 'darwin') {
+    return log.error('This command can only be used on Mac OS X')
+  }
+
   let emulatorConfig = ernConfig.getValue('emulatorConfig', {
     android: {usePreviousEmulator: false, emulatorName: ''},
     ios: {usePreviousEmulator: false, simulatorUdid: ''}


### PR DESCRIPTION
Log an appropriate error message in case `run-ios` command is used on a non Mac OS X machine (Windows or Linux).