### PR TITLE
check if {apiName}-impl exists while create-api-impl

### DIFF
--- a/ern-local-cli/src/commands/create-api-impl.js
+++ b/ern-local-cli/src/commands/create-api-impl.js
@@ -64,10 +64,12 @@ exports.handler = async function ({
   outputDirectory: string,
   hasConfig: boolean
 }) {
-  const isPackageNameInNpm = await utils.doesPackageExistInNpm(api)
+  // check if the packageName for specified {apiName}-impl exists
+  const apiImpl = `${api}-impl`
+  const isPackageNameInNpm = await utils.doesPackageExistInNpm(apiImpl)
   // If package name exists in the npm
   if (isPackageNameInNpm) {
-    const skipNpmNameConflict = await utils.promptSkipNpmNameConflictCheck(api)
+    const skipNpmNameConflict = await utils.promptSkipNpmNameConflictCheck(apiImpl)
     // If user wants to stop execution if npm package name conflicts
     if (!skipNpmNameConflict) {
       return


### PR DESCRIPTION
Problem : create-api-impl command checks if `{apiName}` exists in npm and prompts user 
Solution : check if {apiName}-impl exists while running create-api-impl and prompt user