### PR TITLE
Light refactor of NativeApplicationDescriptor class

### DIFF
--- a/ern-util/src/NativeApplicationDescriptor.js
+++ b/ern-util/src/NativeApplicationDescriptor.js
@@ -1,7 +1,5 @@
 // @flow
 
-import noop from './noop'
-
 export default class NativeApplicationDescriptor {
   _name: string
   _platform: ?string
@@ -11,6 +9,12 @@ export default class NativeApplicationDescriptor {
     name: string,
     platform: ?string,
     version: ?string) {
+    if (!name) {
+      throw new Error('[NativeApplicationDescriptor] name is required')
+    }
+    if (!platform && version) {
+      throw new Error('[NativeApplicationDescriptor] platform is required when providing version')
+    }
     this._name = name
     this._platform = platform
     this._version = version
@@ -42,8 +46,8 @@ export default class NativeApplicationDescriptor {
 
   toString () : string {
     let str = this._name
-    this._platform ? str += `:${this._platform}` : noop()
-    this._version ? str += `:${this._version}` : noop()
+    str += this._platform ? `:${this._platform}` : ''
+    str += this._version ? `:${this._version}` : ''
     return str
   }
 }

--- a/ern-util/src/index.js
+++ b/ern-util/src/index.js
@@ -12,7 +12,6 @@ import _tagOneLine from './tagoneline'
 import _CodePushCli from './CodePushCli'
 import _Dependency from './Dependency'
 import _NativeApplicationDescriptor from './NativeApplicationDescriptor'
-import _noop from './noop'
 import _findNativeDependencies from './findNativeDependencies'
 import _Utils from './utils'
 import _DependencyPath from './DependencyPath'
@@ -31,7 +30,6 @@ export const tagOneLine = _tagOneLine
 export const CodePushCli = _CodePushCli
 export const Dependency = _Dependency
 export const NativeApplicationDescriptor = _NativeApplicationDescriptor
-export const noop = _noop
 export const findNativeDependencies = _findNativeDependencies
 export const Utils = _Utils
 export const DependencyPath = _DependencyPath
@@ -52,7 +50,6 @@ export default ({
   CodePushCli: _CodePushCli,
   Dependency: _Dependency,
   NativeApplicationDescriptor: _NativeApplicationDescriptor,
-  noop: _noop,
   findNativeDependencies: _findNativeDependencies,
   Utils: _Utils,
   DependencyPath: _DependencyPath,

--- a/ern-util/src/noop.js
+++ b/ern-util/src/noop.js
@@ -1,1 +1,0 @@
-export default function noop () { }

--- a/ern-util/test/NativeApplicationDescriptor-test.js
+++ b/ern-util/test/NativeApplicationDescriptor-test.js
@@ -1,0 +1,115 @@
+import {
+  expect
+} from 'chai'
+import NativeApplicationDescriptor from '../src/NativeApplicationDescriptor'
+
+describe('NativeApplicationDescriptor', () => {
+  describe('constructor', () => {
+    it('should instantiate a patial NativeApplicationDescriptor [name]', () => {
+      expect(() => new NativeApplicationDescriptor('MyNativeAppName')).to.not.throw()
+    })
+
+    it('should instantiate a patial NativeApplicationDescriptor [name:platform]', () => {
+      expect(() => new NativeApplicationDescriptor('MyNativeAppName', 'android')).to.not.throw()
+    })
+
+    it('should instantiate a complete NativeApplicationDescriptor [name:platform:version]', () => {
+      expect(() => new NativeApplicationDescriptor('MyNativeAppName', 'android', '1.2.3')).to.not.throw()
+    })
+
+    it('should throw if version is provided but not platform', () => {
+      expect(() => new NativeApplicationDescriptor('MyNativeAppName', null, '1.2.3')).to.throw()
+    })
+
+    it('should throw if name is not provided', () => {
+      expect(() => new NativeApplicationDescriptor(null, 'android', '1.2.3')).to.throw()
+    })
+  })
+
+  describe('name getter', () => {
+    it('should return the native application name', () => {
+      const descriptor = new NativeApplicationDescriptor('MyNativeAppName', 'android', '1.2.3')
+      expect(descriptor.name).to.equal('MyNativeAppName')
+    })
+  })
+
+  describe('platform getter', () => {
+    it('should return the native application platform', () => {
+      const descriptor = new NativeApplicationDescriptor('MyNativeAppName', 'android', '1.2.3')
+      expect(descriptor.platform).to.equal('android')
+    })
+  })
+
+  describe('version getter', () => {
+    it('should return the native application version', () => {
+      const descriptor = new NativeApplicationDescriptor('MyNativeAppName', 'android', '1.2.3')
+      expect(descriptor.version).to.equal('1.2.3')
+    })
+  })
+
+  describe('isComplete getter', () => {
+    it('should return true if the NativeApplicationDescriptor is complete', () => {
+      const descriptor = new NativeApplicationDescriptor('MyNativeAppName', 'android', '1.2.3')
+      expect(descriptor.isComplete).true
+    })
+
+    it('should return false if the NativeApplicationDescriptor is not complete', () => {
+      const descriptor = new NativeApplicationDescriptor('MyNativeAppName', 'android')
+      expect(descriptor.isComplete).false
+    })
+  })
+
+  describe('isPartial getter', () => {
+    it('should return true if the NativeApplicationDescriptor is partial [1]', () => {
+      const descriptor = new NativeApplicationDescriptor('MyNativeAppName', 'android')
+      expect(descriptor.isPartial).true
+    })
+
+    it('should return true if the NativeApplicationDescriptor is partial [2]', () => {
+      const descriptor = new NativeApplicationDescriptor('MyNativeAppName')
+      expect(descriptor.isPartial).true
+    })
+
+    it('should return false if the NativeApplicationDescriptor is not partial', () => {
+      const descriptor = new NativeApplicationDescriptor('MyNativeAppName', 'android', '1.2.3')
+      expect(descriptor.isPartial).false
+    })
+  })
+
+  describe('fromString', () => {
+    it('should work with a complete NativeApplicationDescriptor litteral', () => {
+      const descriptor = NativeApplicationDescriptor.fromString('MyNativeAppName:android:1.2.3')
+      expect(descriptor.name).to.equal('MyNativeAppName')
+      expect(descriptor.platform).to.equal('android')
+      expect(descriptor.version).to.equal('1.2.3')
+    })
+
+    it('should work with a partial NativeApplicationDescriptor litteral [1]', () => {
+      const descriptor = NativeApplicationDescriptor.fromString('MyNativeAppName:android')
+      expect(descriptor.name).to.equal('MyNativeAppName')
+      expect(descriptor.platform).to.equal('android')
+    })
+
+    it('should work with a partial NativeApplicationDescriptor litteral [2]', () => {
+      const descriptor = NativeApplicationDescriptor.fromString('MyNativeAppName')
+      expect(descriptor.name).to.equal('MyNativeAppName')
+    })
+  })
+
+  describe('toString', () => {
+    it('should return the correct string [1]', () => {
+      const descriptor = NativeApplicationDescriptor.fromString('MyNativeAppName:android:1.2.3')
+      expect(descriptor.toString()).to.equal('MyNativeAppName:android:1.2.3')
+    })
+
+    it('should return the correct string [2]', () => {
+      const descriptor = NativeApplicationDescriptor.fromString('MyNativeAppName:android')
+      expect(descriptor.toString()).to.equal('MyNativeAppName:android')
+    })
+
+    it('should return the correct string [3]', () => {
+      const descriptor = NativeApplicationDescriptor.fromString('MyNativeAppName')
+      expect(descriptor.toString()).to.equal('MyNativeAppName')
+    })
+  })
+})


### PR DESCRIPTION
- Remove needless use of `noop` function
- Remove `noop` function and exports from `ern-util`
- Add some guard clauses to NativeApplicationDesccriptor constructor
- Add unit tests for NativeApplicationDescriptor class