### PR TITLE
Add options to run-android and run-ios documentation

### DIFF
--- a/docs/cli/run-android.md
+++ b/docs/cli/run-android.md
@@ -7,9 +7,23 @@
 
 **Options**  
 
-`ern run-android <miniapp>`
+`--dev [true|false]`
+* Enable or disable React Native dev support
 
-* Launch a specified MiniApp in the Runner application  
+`--miniapps/m`
+* One or more MiniApps to combine in the Runner Container
+
+`--dependencies, --deps`
+* One or more native dependencies to add to the Runner Container
+
+`--descriptor, -d`
+* complete native application descriptor
+
+`--mainMiniAppName`
+* Name of the MiniApp to launch when starting the Runner application
+
+`--usePreviousEmulator/-u`
+* Use the previously selected emulator to avoid prompt
 
 #### Remarks
 * You can launch the MiniApp located in the current working directory or on a connected Android device or running emulator if available. If a connected Android device is not available, the command prompts you to select an emulator to launch from the list of installed emulator images.  

--- a/docs/cli/run-ios.md
+++ b/docs/cli/run-ios.md
@@ -7,9 +7,23 @@
 
 **Options**  
 
-`ern run-ios <miniapp>`
-
-* Launch a specified MiniApp in the Runner application  
+ `--dev [true|false]`
+ * Enable or disable React Native dev support
+ 
+ `--miniapps/m`
+ * One or more MiniApps to combine in the Runner Container
+ 
+ `--dependencies, --deps`
+ * One or more native dependencies to add to the Runner Container
+ 
+ `--descriptor, -d`
+ * complete native application descriptor
+ 
+ `--mainMiniAppName`
+ * Name of the MiniApp to launch when starting the Runner application
+ 
+ `--usePreviousEmulator/-u`
+ * Use the previously selected emulator to avoid prompt
 
 #### Remarks
 * You can launch the MiniApp located in the current working directory or on a connected iOS device or running emulator if available. If a connected iOS device is not available, the command prompts you to select an emulator to launch from the list of installed emulator images.  


### PR DESCRIPTION
Update the documentation to match the current state of `run-android` and `run-ios` commands