### PR TITLE
Cauldron transactional commits

### DIFF
--- a/ern-cauldron-api/src/api.js
+++ b/ern-cauldron-api/src/api.js
@@ -48,9 +48,9 @@ export default class CauldronApi {
     await this._yarnlockStore.discardTransaction()
   }
 
-  async commitTransaction () {
-    await this._db.commitTransaction()
-    await this._yarnlockStore.commitTransaction()
+  async commitTransaction (message: string | Array<string>) {
+    await this._db.commitTransaction(message)
+    await this._yarnlockStore.commitTransaction(message)
   }
 
   // =====================================================================================

--- a/ern-cauldron-api/src/base-git.js
+++ b/ern-cauldron-api/src/base-git.js
@@ -57,11 +57,12 @@ export default class BaseGit {
     this._pendingTransaction = false
   }
 
-  async commitTransaction () {
+  async commitTransaction (message: string | Array<string>) {
     if (!this._pendingTransaction) {
       throw new Error('No pending transaction to commit')
     }
 
+    await this.git.commitAsync(message)
     await this.push()
     this._pendingTransaction = false
   }

--- a/ern-cauldron-api/src/filestore.js
+++ b/ern-cauldron-api/src/filestore.js
@@ -39,8 +39,8 @@ export default class FileStore extends BaseGit {
     const pathToFile = path.resolve(storeDirectoryPath, identifier)
     await writeFile(pathToFile, content, {flag: 'w'})
     await this.git.addAsync(pathToFile)
-    await this.git.commitAsync(`[added file] ${identifier}`)
     if (!this._pendingTransaction) {
+      await this.git.commitAsync(`[added file] ${identifier}`)
       await this.push()
     }
   }
@@ -84,8 +84,8 @@ export default class FileStore extends BaseGit {
     await this.sync()
     if (fs.existsSync(this.pathToFile(filename))) {
       await this.git.rmAsync(this.pathToFile(filename))
-      await this.git.commitAsync(`[removed file] ${filename}`)
       if (!this._pendingTransaction) {
+        await this.git.commitAsync(`[removed file] ${filename}`)
         await this.push()
       }
       return true

--- a/ern-cauldron-api/src/gitstore.js
+++ b/ern-cauldron-api/src/gitstore.js
@@ -63,8 +63,8 @@ export default class GitStore extends BaseGit {
   async commit (message: string = 'Commit') {
     await writeJSON(this._jsonPath, this.cauldron)
     await this.git.addAsync(CAULDRON_FILENAME)
-    await this.git.commitAsync(message)
     if (!this._pendingTransaction) {
+      await this.git.commitAsync(message)
       await this.push()
     }
   }

--- a/ern-core/src/cauldron.js
+++ b/ern-core/src/cauldron.js
@@ -36,8 +36,8 @@ class Cauldron {
     return this.cauldron.discardTransaction()
   }
 
-  async commitTransaction () {
-    return this.cauldron.commitTransaction()
+  async commitTransaction (message: string | Array<string>) {
+    return this.cauldron.commitTransaction(message)
   }
 
   async addNativeApp (

--- a/ern-local-cli/src/commands/cauldron/add/dependencies.js
+++ b/ern-local-cli/src/commands/cauldron/add/dependencies.js
@@ -77,13 +77,24 @@ exports.handler = async function ({
 
   const dependenciesObjs = _.map(dependencies, d => Dependency.fromString(d))
 
+  const cauldronCommitMessage = [
+    `${dependencies.length === 1
+      ? `Add ${dependencies[0]} native dependency to ${napDescriptor.toString()}`
+      : `Add multiple native dependencies to ${napDescriptor.toString()}`}`
+  ]
+
   try {
-    await utils.performContainerStateUpdateInCauldron(async () => {
-      for (const dependencyObj of dependenciesObjs) {
-        // Add the dependency to Cauldron
-        await cauldron.addNativeDependency(napDescriptor, dependencyObj)
-      }
-    }, napDescriptor, { containerVersion })
+    await utils.performContainerStateUpdateInCauldron(
+      async () => {
+        for (const dependencyObj of dependenciesObjs) {
+          // Add the dependency to Cauldron
+          await cauldron.addNativeDependency(napDescriptor, dependencyObj)
+          cauldronCommitMessage.push(`- Add ${dependencyObj.toString()} native dependency`)
+        }
+      },
+      napDescriptor,
+      cauldronCommitMessage,
+      { containerVersion })
     log.info(`Dependency(ies) was/were succesfully added to ${napDescriptor.toString()} !`)
   } catch (e) {
     log.error(`An error happened while trying to add a dependency to ${napDescriptor.toString()}`)

--- a/ern-local-cli/src/commands/cauldron/add/miniapps.js
+++ b/ern-local-cli/src/commands/cauldron/add/miniapps.js
@@ -94,13 +94,24 @@ exports.handler = async function ({
     miniAppsObjs.push(m)
   }
 
+  const cauldronCommitMessage = [
+    `${miniapps.length === 1
+      ? `Add ${miniapps[0]} MiniApp to ${napDescriptor.toString()}`
+      : `Add multiple MiniApps to ${napDescriptor.toString()}`}`
+  ]
+
   try {
-    await utils.performContainerStateUpdateInCauldron(async () => {
-      for (const miniAppObj of miniAppsObjs) {
-        // Add the MiniApp (and all it's dependencies if needed) to Cauldron
-        await miniAppObj.addToNativeAppInCauldron(napDescriptor, force)
-      }
-    }, napDescriptor, { containerVersion })
+    await utils.performContainerStateUpdateInCauldron(
+      async () => {
+        for (const miniAppObj of miniAppsObjs) {
+          // Add the MiniApp (and all it's dependencies if needed) to Cauldron
+          await miniAppObj.addToNativeAppInCauldron(napDescriptor, force)
+          cauldronCommitMessage.push(`- Add ${miniAppObj.packageDescriptor} MiniApp`)
+        }
+      },
+      napDescriptor,
+      cauldronCommitMessage,
+      { containerVersion })
     log.debug(`MiniApp(s) was/were succesfully added to ${napDescriptor.toString()} in the Cauldron !`)
   } catch (e) {
     log.error(`An error occured while trying to add MiniApp(s) to Cauldron`)

--- a/ern-local-cli/src/commands/cauldron/add/nativeapp.js
+++ b/ern-local-cli/src/commands/cauldron/add/nativeapp.js
@@ -76,7 +76,7 @@ exports.handler = async function ({
       }
     }
 
-    await spin(`Updating Cauldron`, cauldron.commitTransaction())
+    await spin(`Updating Cauldron`, cauldron.commitTransaction(`Add ${napDescriptor.toString()} native application`))
     log.info(`${napDescriptor.toString()} was succesfuly added to the Cauldron`)
   } catch (e) {
     log.error(`An error occured while trying to add the native app to the Cauldron: ${e.message}`)

--- a/ern-local-cli/src/commands/cauldron/del/dependencies.js
+++ b/ern-local-cli/src/commands/cauldron/del/dependencies.js
@@ -84,12 +84,23 @@ exports.handler = async function ({
 
   const dependenciesObjs = _.map(dependencies, d => Dependency.fromString(d))
 
+  const cauldronCommitMessage = [
+    `${dependencies.length === 1
+      ? `Remove ${dependencies[0]} native dependency from ${napDescriptor.toString()}`
+      : `Remove multiple native dependencies from ${napDescriptor.toString()}`}`
+  ]
+
   try {
-    await utils.performContainerStateUpdateInCauldron(async () => {
-      for (const dependencyObj of dependenciesObjs) {
-        await cauldron.removeNativeDependency(napDescriptor, dependencyObj)
-      }
-    }, napDescriptor, { containerVersion })
+    await utils.performContainerStateUpdateInCauldron(
+      async () => {
+        for (const dependencyObj of dependenciesObjs) {
+          await cauldron.removeNativeDependency(napDescriptor, dependencyObj)
+          cauldronCommitMessage.push(`- Remove ${dependencyObj.toString()} native dependency`)
+        }
+      },
+      napDescriptor,
+      cauldronCommitMessage,
+      { containerVersion })
     log.info(`Dependency(ies) was/were succesfully removed from ${napDescriptor.toString()}`)
   } catch (e) {
     log.error(`An error happened while trying to remove dependency(ies) from ${napDescriptor.toString()}`)

--- a/ern-local-cli/src/commands/cauldron/del/miniapps.js
+++ b/ern-local-cli/src/commands/cauldron/del/miniapps.js
@@ -76,12 +76,23 @@ exports.handler = async function ({
 
   const miniAppsAsDeps = _.map(miniapps, m => Dependency.fromString(m))
 
+  const cauldronCommitMessage = [
+    `${miniapps.length === 1
+      ? `Remove ${miniapps[0]} MiniApp from ${napDescriptor.toString()}`
+      : `Remove multiple MiniApps from ${napDescriptor.toString()}`}`
+  ]
+
   try {
-    await utils.performContainerStateUpdateInCauldron(async () => {
-      for (const miniAppAsDep of miniAppsAsDeps) {
-        await cauldron.removeMiniAppFromContainer(napDescriptor, miniAppAsDep)
-      }
-    }, napDescriptor, { containerVersion })
+    await utils.performContainerStateUpdateInCauldron(
+      async () => {
+        for (const miniAppAsDep of miniAppsAsDeps) {
+          await cauldron.removeMiniAppFromContainer(napDescriptor, miniAppAsDep)
+          cauldronCommitMessage.push(`- Remove ${miniAppAsDep.toString()} MiniApp`)
+        }
+      },
+      napDescriptor,
+      cauldronCommitMessage,
+      { containerVersion })
     log.debug(`MiniApp(s) was/were succesfully removed from ${napDescriptor.toString()}`)
   } catch (e) {
     log.error(`An error happened while trying to remove MiniApp(s) from ${napDescriptor.toString()}`)

--- a/ern-local-cli/src/commands/cauldron/regen-container.js
+++ b/ern-local-cli/src/commands/cauldron/regen-container.js
@@ -56,9 +56,13 @@ exports.handler = async function ({
   })
 
   try {
-    await utils.performContainerStateUpdateInCauldron(async () => {
-      return Promise.resolve()
-    }, napDescriptor, { containerVersion })
+    await utils.performContainerStateUpdateInCauldron(
+      async () => {
+        return Promise.resolve()
+      },
+      napDescriptor,
+      `Regenerate Container of ${napDescriptor.toString()} native application`,
+      { containerVersion })
     log.debug(`Container was succesfully regenerated !`)
   } catch (e) {
     log.error(`An error occured while trying to regenerate the container : ${e.message}`)

--- a/ern-local-cli/src/commands/cauldron/update/dependencies.js
+++ b/ern-local-cli/src/commands/cauldron/update/dependencies.js
@@ -78,15 +78,26 @@ exports.handler = async function ({
     }
   })
 
+  const cauldronCommitMessage = [
+    `${dependenciesObjs.length === 1
+      ? `Update ${dependenciesObjs[0].withoutVersion().toString()} native dependency version in v${napDescriptor.toString()}`
+      : `Update multiple native dependencies versions in ${napDescriptor.toString()}`}`
+  ]
+
   try {
-    await utils.performContainerStateUpdateInCauldron(async () => {
-      for (const dependencyObj of dependenciesObjs) {
-        await cauldron.updateNativeAppDependency(
-          napDescriptor,
-          dependencyObj.withoutVersion().toString(),
-          dependencyObj.version)
-      }
-    }, napDescriptor, { containerVersion })
+    await utils.performContainerStateUpdateInCauldron(
+      async () => {
+        for (const dependencyObj of dependenciesObjs) {
+          await cauldron.updateNativeAppDependency(
+            napDescriptor,
+            dependencyObj.withoutVersion().toString(),
+            dependencyObj.version)
+          cauldronCommitMessage.push(`- Update ${dependencyObj.withoutVersion().toString()} native dependency to v${dependencyObj.version}`)
+        }
+      },
+      napDescriptor,
+      cauldronCommitMessage,
+      { containerVersion })
     log.info(`Dependency(ies) was/were succesfully updated in ${napDescriptor.toString()}`)
   } catch (e) {
     log.error(`An error happened while trying to update dependency(ies) in ${napDescriptor.toString()}`)

--- a/ern-local-cli/src/commands/cauldron/update/miniapps.js
+++ b/ern-local-cli/src/commands/cauldron/update/miniapps.js
@@ -100,13 +100,24 @@ exports.handler = async function ({
     miniAppsObjs.push(m)
   }
 
+  const cauldronCommitMessage = [
+    `${miniapps.length === 1
+      ? `Update ${miniapps[0]} MiniApp version in ${napDescriptor.toString()}`
+      : `Update multiple MiniApps versions in ${napDescriptor.toString()}`}`
+  ]
+
   try {
-    await utils.performContainerStateUpdateInCauldron(async() => {
-      for (const miniAppObj of miniAppsObjs) {
-        // Add the MiniApp (and all it's dependencies if needed) to Cauldron
-        await miniAppObj.addToNativeAppInCauldron(napDescriptor, force)
-      }
-    }, napDescriptor, { containerVersion })
+    await utils.performContainerStateUpdateInCauldron(
+      async() => {
+        for (const miniAppObj of miniAppsObjs) {
+          // Add the MiniApp (and all it's dependencies if needed) to Cauldron
+          await miniAppObj.addToNativeAppInCauldron(napDescriptor, force)
+          cauldronCommitMessage.push(`- Update ${miniAppObj.name} MiniApp version to v${miniAppObj.version}`)
+        }
+      },
+      napDescriptor,
+      cauldronCommitMessage,
+      { containerVersion })
     log.info(`MiniApp(s) version(s) was/were succesfully updated for ${napDescriptor.toString()} in Cauldron !`)
   } catch (e) {
     log.error(`An error occured while trying to update MiniApp(s) version(s) in Cauldron`)

--- a/ern-local-cli/src/lib/utils.js
+++ b/ern-local-cli/src/lib/utils.js
@@ -300,7 +300,8 @@ async function askUserToChooseANapDescriptorFromCauldron ({
 // If any part of this function fails, the Cauldron will not get updated
 async function performContainerStateUpdateInCauldron (
   stateUpdateFunc: () => Promise<*>,
-  napDescriptor: NativeApplicationDescriptor, {
+  napDescriptor: NativeApplicationDescriptor,
+  commitMessage: string | Array<string>, {
   containerVersion
 } : {
   containerVersion?: string
@@ -336,7 +337,7 @@ async function performContainerStateUpdateInCauldron (
     await cauldron.updateContainerVersion(napDescriptor, cauldronContainerVersion)
 
     // Commit Cauldron transaction
-    await spin(`Updating Cauldron`, cauldron.commitTransaction())
+    await spin(`Updating Cauldron`, cauldron.commitTransaction(commitMessage))
 
     log.debug(`Published new container version ${cauldronContainerVersion} for ${napDescriptor.toString()}`)
   } catch (e) {

--- a/ern-local-cli/test/utils-test.js
+++ b/ern-local-cli/test/utils-test.js
@@ -247,7 +247,7 @@ describe('utils.js', () => {
 
     it('should uppdate container version with provided one', async () => {
       await utils.performContainerStateUpdateInCauldron(() => Promise.resolve(true), 
-      napDescriptor , { containerVersion: '1.0.0' })
+      napDescriptor , 'commit message', { containerVersion: '1.0.0' })
       sinon.assert.calledWith(updateContainerVersionStub, 
         napDescriptor,
         '1.0.0')
@@ -268,14 +268,14 @@ describe('utils.js', () => {
 
     it('should call state update function during the transaction', async () => {
       const stateUpdateFunc = sinon.stub().resolves(true)
-      await utils.performContainerStateUpdateInCauldron(stateUpdateFunc, napDescriptor)
+      await utils.performContainerStateUpdateInCauldron(stateUpdateFunc, napDescriptor, 'commit message')
       sinon.assert.callOrder(beginTransactionStub, stateUpdateFunc, commitTransactionStub)
     })
 
     it('should discard transaction if an error happens during the transaction', async () => {
       const stateUpdateFunc = sinon.stub().rejects(new Error('boum'))
       try {
-        await utils.performContainerStateUpdateInCauldron(stateUpdateFunc, napDescriptor)
+        await utils.performContainerStateUpdateInCauldron(stateUpdateFunc, napDescriptor, 'commit message')
       } catch (e) {}
       sinon.assert.calledOnce(discardTransactionStub)
       sinon.assert.notCalled(commitTransactionStub)
@@ -285,7 +285,7 @@ describe('utils.js', () => {
       const stateUpdateFunc = sinon.stub().rejects(new Error('boum'))
       let hasRethrowError = false
       try {
-        await utils.performContainerStateUpdateInCauldron(stateUpdateFunc, napDescriptor)
+        await utils.performContainerStateUpdateInCauldron(stateUpdateFunc, napDescriptor, 'commit message')
       } catch (e) {
         if (e.message === 'boum') { hasRethrowError = true }
       }


### PR DESCRIPTION
Closes https://github.com/electrode-io/electrode-native/issues/227

Since Cauldron transactional support has been introduced, it does not make a lot of sense to keep individual atomic git commit messages for Cauldron in the context of a transaction.

Indeed, for example, adding a MiniApp to a native application is a Cauldron transaction, results in 4 individual commits messages (adding the miniapp, remove previous yarn lock, add new yarn lock, bump container version). This is a bit confusing and too verbose when reviewing a Cauldron git commit history.

This PR refactors Cauldron client so that it does not perform atomic commits during a transaction, but rather issue a single commit when calling `commitTransaction` method.

The `commitTransaction` method now takes the final commit message as a parameter.

All transactions currently done through `ern` commands (add/remove/update MiniApp(s) and/or native dependency(ies), batch command, add native app command) have been updated part of this PR  so that these commands will result in a single commit, along with a clean and concise commit message that can span on multiple lines for some commands that perform multiple operations.

For example, using a dev Cauldron and running 

`ern cauldron del miniapps @walmart/react-native-cart@4.0.25 @walmart/react-native-thankyou@2.0.27 @walmart/RNEasyReturns@0.0.56 -d testbinary:android:17.19.0`

 now results in the following single commit message :

```
Remove multiple MiniApps from testbinary:android:17.19.0

- Remove @walmart/react-native-cart@4.0.25 MiniApp
- Remove @walmart/react-native-thankyou@2.0.27 MiniApp
- Remove @walmart/RNEasyReturns@0.0.56 MiniApp
```
