### PR TITLE
Clean all dist directories as part of rebuild script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "setup-dev": "node setup-dev.js",
-    "rebuild": "lerna clean --yes && lerna bootstrap --npmClient=yarn",
+    "rebuild": "rm -rf **/dist && lerna clean --yes && lerna bootstrap --npmClient=yarn",
     "test": "lerna run test",
     "coverage": "lerna run coverage && istanbul-combine -d coverage -p summary -r lcov -r html $(find ./ern-*/.nyc_output -type f -name '*.json' -maxdepth 3)",
     "standard": "standard",


### PR DESCRIPTION
Electrode Native platform `rebuild` script was not properly cleaning up ern modules `dist` directories, resulting in some deleted `src` files in ern modules to remain in the `dist` directories.

The `rebuild` script will now remove all `dist` folders from ern modules before proceeding with lerna clean/bootstrap (that in part regenerates the `dist` folders).