### PR TITLE
Remove pre-commit deprecated section in platform package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,6 @@
     "precommit": "standard && flow",
     "postmerge": "node auto-rebuild.js"
   },
-  "pre-commit": [
-    "standard",
-    "flow"
-  ],
   "dependencies": {
     "chalk": "^1.1.3",
     "shelljs": "^0.7.6"


### PR DESCRIPTION
This section was associated to `pre-commit` dependency that we are not using anymore in favor of husky.