### PR TITLE
Erroring

### DIFF
--- a/ern-container-gen/src/generators/android/AndroidGenerator.js
+++ b/ern-container-gen/src/generators/android/AndroidGenerator.js
@@ -97,7 +97,7 @@ export default class AndroidGenerator implements ContainerGenerator {
 
           shell.rm('-rf', `${paths.outDirectory}/*`)
         } catch (e) {
-          Utils.logErrorAndExitProcess('Container generation Failed while cloning the repo. \n Check to see if the entered URL is correct')
+          Utils.logErrorAndExitProcess(new Error('Container generation Failed while cloning the repo. \n Check to see if the entered URL is correct'))
         }
       }
 

--- a/ern-core/src/Platform.js
+++ b/ern-core/src/Platform.js
@@ -96,7 +96,7 @@ export default class Platform {
         execSync(`npm install ${ERN_LOCAL_CLI_PACKAGE}@${version} --exact`, { cwd: pathToVersion })
       }
     } catch (e) {
-      console.log('Soemthing went wrong during installation. Performing clean up.')
+      log.error('Something went wrong during installation. Performing clean up.')
       shell.rm('-rf', pathToVersion)
       throw e
     }

--- a/ern-local-cli/src/commands/add.js
+++ b/ern-local-cli/src/commands/add.js
@@ -4,7 +4,8 @@ import {
   MiniApp
 } from 'ern-core'
 import {
-  Dependency
+  Dependency,
+  Utils
 } from 'ern-util'
 import utils from '../lib/utils'
 
@@ -43,6 +44,6 @@ exports.handler = async function ({
       await MiniApp.fromCurrentPath().addDependency(Dependency.fromString(pkg), {dev, peer})
     }
   } catch (e) {
-    log.error(`${e}`)
+    Utils.logErrorAndExitProcess(e)
   }
 }

--- a/ern-local-cli/src/commands/cauldron/add/dependencies.js
+++ b/ern-local-cli/src/commands/cauldron/add/dependencies.js
@@ -2,7 +2,8 @@
 
 import {
   Dependency,
-  NativeApplicationDescriptor
+  NativeApplicationDescriptor,
+  Utils
 } from 'ern-util'
 import {
   cauldron
@@ -97,6 +98,6 @@ exports.handler = async function ({
       { containerVersion })
     log.info(`Dependency(ies) was/were succesfully added to ${napDescriptor.toString()} !`)
   } catch (e) {
-    log.error(`An error happened while trying to add a dependency to ${napDescriptor.toString()}`)
+    Utils.logErrorAndExitProcess(e)
   }
 }

--- a/ern-local-cli/src/commands/cauldron/add/miniapps.js
+++ b/ern-local-cli/src/commands/cauldron/add/miniapps.js
@@ -6,7 +6,8 @@ import {
 import {
   DependencyPath,
   NativeApplicationDescriptor,
-  spin
+  spin,
+  Utils
 } from 'ern-util'
 import utils from '../../../lib/utils'
 import _ from 'lodash'
@@ -112,8 +113,8 @@ exports.handler = async function ({
       napDescriptor,
       cauldronCommitMessage,
       { containerVersion })
-    log.debug(`MiniApp(s) was/were succesfully added to ${napDescriptor.toString()} in the Cauldron !`)
+    log.debug(`MiniApp(s) was/were succesfully added to ${napDescriptor.toString()} in the Cauldron`)
   } catch (e) {
-    log.error(`An error occured while trying to add MiniApp(s) to Cauldron`)
+    Utils.logErrorAndExitProcess(e)
   }
 }

--- a/ern-local-cli/src/commands/cauldron/add/nativeapp.js
+++ b/ern-local-cli/src/commands/cauldron/add/nativeapp.js
@@ -3,7 +3,8 @@
 import {
   Dependency,
   NativeApplicationDescriptor,
-  spin
+  spin,
+  Utils
 } from 'ern-util'
 import {
   cauldron
@@ -79,8 +80,8 @@ exports.handler = async function ({
     await spin(`Updating Cauldron`, cauldron.commitTransaction(`Add ${napDescriptor.toString()} native application`))
     log.info(`${napDescriptor.toString()} was succesfuly added to the Cauldron`)
   } catch (e) {
-    log.error(`An error occured while trying to add the native app to the Cauldron: ${e.message}`)
     await cauldron.discardTransaction()
+    Utils.logErrorAndExitProcess(e)
   }
 }
 

--- a/ern-local-cli/src/commands/cauldron/batch.js
+++ b/ern-local-cli/src/commands/cauldron/batch.js
@@ -3,7 +3,8 @@
 import {
   Dependency,
   DependencyPath,
-  NativeApplicationDescriptor
+  NativeApplicationDescriptor,
+  Utils
 } from 'ern-util'
 import {
   cauldron,
@@ -207,6 +208,6 @@ exports.handler = async function ({
     { containerVersion })
     log.info(`Operations were succesfully performed for ${napDescriptor.toString()}`)
   } catch (e) {
-    log.error(`An error happened while trying to remove dependency(ies) from ${napDescriptor.toString()}`)
+    Utils.logErrorAndExitProcess(e)
   }
 }

--- a/ern-local-cli/src/commands/cauldron/del/dependencies.js
+++ b/ern-local-cli/src/commands/cauldron/del/dependencies.js
@@ -2,7 +2,8 @@
 
 import {
   Dependency,
-  NativeApplicationDescriptor
+  NativeApplicationDescriptor,
+  Utils
 } from 'ern-util'
 import {
   cauldron
@@ -103,6 +104,6 @@ exports.handler = async function ({
       { containerVersion })
     log.info(`Dependency(ies) was/were succesfully removed from ${napDescriptor.toString()}`)
   } catch (e) {
-    log.error(`An error happened while trying to remove dependency(ies) from ${napDescriptor.toString()}`)
+    Utils.logErrorAndExitProcess(e)
   }
 }

--- a/ern-local-cli/src/commands/cauldron/del/miniapps.js
+++ b/ern-local-cli/src/commands/cauldron/del/miniapps.js
@@ -2,7 +2,8 @@
 
 import {
   NativeApplicationDescriptor,
-  Dependency
+  Dependency,
+  Utils
 } from 'ern-util'
 import {
   cauldron
@@ -95,6 +96,6 @@ exports.handler = async function ({
       { containerVersion })
     log.debug(`MiniApp(s) was/were succesfully removed from ${napDescriptor.toString()}`)
   } catch (e) {
-    log.error(`An error happened while trying to remove MiniApp(s) from ${napDescriptor.toString()}`)
+    Utils.logErrorAndExitProcess(e)
   }
 }

--- a/ern-local-cli/src/commands/cauldron/del/nativeapp.js
+++ b/ern-local-cli/src/commands/cauldron/del/nativeapp.js
@@ -1,7 +1,8 @@
 // @flow
 
 import {
-  NativeApplicationDescriptor
+  NativeApplicationDescriptor,
+  Utils
 } from 'ern-util'
 import {
   cauldron
@@ -31,5 +32,9 @@ exports.handler = async function ({
     }
   })
 
-  await cauldron.removeNativeApp(NativeApplicationDescriptor.fromString(descriptor))
+  try {
+    await cauldron.removeNativeApp(NativeApplicationDescriptor.fromString(descriptor))
+  } catch (e) {
+    Utils.logErrorAndExitProcess(e)
+  }
 }

--- a/ern-local-cli/src/commands/cauldron/get/config.js
+++ b/ern-local-cli/src/commands/cauldron/get/config.js
@@ -1,7 +1,8 @@
 // @flow
 
 import {
-  NativeApplicationDescriptor
+  NativeApplicationDescriptor,
+  Utils
 } from 'ern-util'
 import {
   cauldron
@@ -26,6 +27,10 @@ exports.handler = async function ({
     }
   })
 
-  const config = await cauldron.getConfig(NativeApplicationDescriptor.fromString(descriptor))
-  log.info(JSON.stringify(config, null, 2))
+  try {
+    const config = await cauldron.getConfig(NativeApplicationDescriptor.fromString(descriptor))
+    log.info(JSON.stringify(config, null, 2))
+  } catch (e) {
+    Utils.logErrorAndExitProcess(e)
+  }
 }

--- a/ern-local-cli/src/commands/cauldron/get/dependency.js
+++ b/ern-local-cli/src/commands/cauldron/get/dependency.js
@@ -1,7 +1,8 @@
 // @flow
 
 import {
-  NativeApplicationDescriptor
+  NativeApplicationDescriptor,
+  Utils
 } from 'ern-util'
 import {
   cauldron
@@ -31,9 +32,13 @@ exports.handler = async function ({
     }
   })
 
-  const napDescriptor = NativeApplicationDescriptor.fromString(descriptor)
-  const dependencies = await cauldron.getNativeDependencies(napDescriptor)
-  for (const dependency of dependencies) {
-    log.info(dependency.toString())
+  try {
+    const napDescriptor = NativeApplicationDescriptor.fromString(descriptor)
+    const dependencies = await cauldron.getNativeDependencies(napDescriptor)
+    for (const dependency of dependencies) {
+      log.info(dependency.toString())
+    }
+  } catch (e) {
+    Utils.logErrorAndExitProcess(e)
   }
 }

--- a/ern-local-cli/src/commands/cauldron/get/nativeapp.js
+++ b/ern-local-cli/src/commands/cauldron/get/nativeapp.js
@@ -1,7 +1,8 @@
 // @flow
 
 import {
-  NativeApplicationDescriptor
+  NativeApplicationDescriptor,
+  Utils
 } from 'ern-util'
 import {
   cauldron
@@ -31,6 +32,10 @@ exports.handler = async function ({
     }
   })
 
-  const nativeApp = await cauldron.getNativeApp(NativeApplicationDescriptor.fromString(descriptor))
-  log.info(JSON.stringify(nativeApp, null, 1))
+  try {
+    const nativeApp = await cauldron.getNativeApp(NativeApplicationDescriptor.fromString(descriptor))
+    log.info(JSON.stringify(nativeApp, null, 1))
+  } catch (e) {
+    Utils.logErrorAndExitProcess(e)
+  }
 }

--- a/ern-local-cli/src/commands/cauldron/regen-container.js
+++ b/ern-local-cli/src/commands/cauldron/regen-container.js
@@ -1,7 +1,8 @@
 // @flow
 
 import {
-  NativeApplicationDescriptor
+  NativeApplicationDescriptor,
+  Utils
 } from 'ern-util'
 import utils from '../../lib/utils'
 
@@ -65,6 +66,6 @@ exports.handler = async function ({
       { containerVersion })
     log.debug(`Container was succesfully regenerated !`)
   } catch (e) {
-    log.error(`An error occured while trying to regenerate the container : ${e.message}`)
+    Utils.logErrorAndExitProcess(e)
   }
 }

--- a/ern-local-cli/src/commands/cauldron/repo/add.js
+++ b/ern-local-cli/src/commands/cauldron/repo/add.js
@@ -5,7 +5,8 @@ import {
 } from 'ern-core'
 import {
   config as ernConfig,
-  shell
+  shell,
+  Utils
 } from 'ern-util'
 import inquirer from 'inquirer'
 import utils from '../../../lib/utils'
@@ -32,25 +33,29 @@ exports.handler = function ({
   url: string,
   current: boolean,
 }) {
-  let cauldronRepositories = ernConfig.getValue('cauldronRepositories', {})
-  if (cauldronRepositories[alias]) {
-    return console.log(`A Cauldron repository is already associated to ${alias} alias`)
-  }
-  cauldronRepositories[alias] = url
-  ernConfig.setValue('cauldronRepositories', cauldronRepositories)
-  console.log(`Added Cauldron repository ${url} with alias ${alias}`)
-  if (current) {
-    useCauldronRepository(alias)
-  } else if (!(current === false)) {
-    inquirer.prompt([{
-      type: 'confirm',
-      name: 'current',
-      message: `Set ${alias} as the current Cauldron repository`
-    }]).then(answers => {
-      if (answers.current) {
-        useCauldronRepository(alias)
-      }
-    })
+  try {
+    let cauldronRepositories = ernConfig.getValue('cauldronRepositories', {})
+    if (cauldronRepositories[alias]) {
+      return console.log(`A Cauldron repository is already associated to ${alias} alias`)
+    }
+    cauldronRepositories[alias] = url
+    ernConfig.setValue('cauldronRepositories', cauldronRepositories)
+    console.log(`Added Cauldron repository ${url} with alias ${alias}`)
+    if (current) {
+      useCauldronRepository(alias)
+    } else if (!(current === false)) {
+      inquirer.prompt([{
+        type: 'confirm',
+        name: 'current',
+        message: `Set ${alias} as the current Cauldron repository`
+      }]).then(answers => {
+        if (answers.current) {
+          useCauldronRepository(alias)
+        }
+      })
+    }
+  } catch (e) {
+    Utils.logErrorAndExitProcess(e)
   }
 }
 

--- a/ern-local-cli/src/commands/cauldron/repo/add.js
+++ b/ern-local-cli/src/commands/cauldron/repo/add.js
@@ -36,11 +36,11 @@ exports.handler = function ({
   try {
     let cauldronRepositories = ernConfig.getValue('cauldronRepositories', {})
     if (cauldronRepositories[alias]) {
-      return console.log(`A Cauldron repository is already associated to ${alias} alias`)
+      throw new Error(`A Cauldron repository is already associated to ${alias} alias`)
     }
     cauldronRepositories[alias] = url
     ernConfig.setValue('cauldronRepositories', cauldronRepositories)
-    console.log(`Added Cauldron repository ${url} with alias ${alias}`)
+    log.info(`Added Cauldron repository ${url} with alias ${alias}`)
     if (current) {
       useCauldronRepository(alias)
     } else if (!(current === false)) {

--- a/ern-local-cli/src/commands/cauldron/repo/clear.js
+++ b/ern-local-cli/src/commands/cauldron/repo/clear.js
@@ -5,7 +5,8 @@ import {
 } from 'ern-core'
 import {
   config as ernConfig,
-  shell
+  shell,
+  Utils
 } from 'ern-util'
 import utils from '../../../lib/utils'
 
@@ -21,7 +22,11 @@ exports.handler = function ({
 } : {
   alias: string
 }) {
-  ernConfig.setValue('cauldronRepoInUse', undefined)
-  shell.rm('-rf', `${Platform.rootDirectory}/cauldron`)
-  log.info(`Done.`)
+  try {
+    ernConfig.setValue('cauldronRepoInUse', undefined)
+    shell.rm('-rf', `${Platform.rootDirectory}/cauldron`)
+    log.info(`Done.`)
+  } catch (e) {
+    Utils.logErrorAndExitProcess(e)
+  }
 }

--- a/ern-local-cli/src/commands/cauldron/repo/current.js
+++ b/ern-local-cli/src/commands/cauldron/repo/current.js
@@ -1,7 +1,8 @@
 // @flow
 
 import {
-  config as ernConfig
+  config as ernConfig,
+  Utils
 } from 'ern-util'
 import utils from '../../../lib/utils'
 
@@ -13,10 +14,14 @@ exports.builder = function (yargs: any) {
 }
 
 exports.handler = function () {
-  const cauldronRepoInUse = ernConfig.getValue('cauldronRepoInUse')
-  if (!cauldronRepoInUse) {
-    return console.log(`No Cauldron repository is in use yet`)
+  try {
+    const cauldronRepoInUse = ernConfig.getValue('cauldronRepoInUse')
+    if (!cauldronRepoInUse) {
+      return console.log(`No Cauldron repository is in use yet`)
+    }
+    const cauldronRepositories = ernConfig.getValue('cauldronRepositories')
+    console.log(`${cauldronRepoInUse} [${cauldronRepositories[cauldronRepoInUse]}]`)
+  } catch (e) {
+    Utils.logErrorAndExitProcess(e)
   }
-  const cauldronRepositories = ernConfig.getValue('cauldronRepositories')
-  console.log(`${cauldronRepoInUse} [${cauldronRepositories[cauldronRepoInUse]}]`)
 }

--- a/ern-local-cli/src/commands/cauldron/repo/current.js
+++ b/ern-local-cli/src/commands/cauldron/repo/current.js
@@ -17,10 +17,10 @@ exports.handler = function () {
   try {
     const cauldronRepoInUse = ernConfig.getValue('cauldronRepoInUse')
     if (!cauldronRepoInUse) {
-      return console.log(`No Cauldron repository is in use yet`)
+      throw new Error(`No Cauldron repository is in use yet`)
     }
     const cauldronRepositories = ernConfig.getValue('cauldronRepositories')
-    console.log(`${cauldronRepoInUse} [${cauldronRepositories[cauldronRepoInUse]}]`)
+    log.info(`${cauldronRepoInUse} [${cauldronRepositories[cauldronRepoInUse]}]`)
   } catch (e) {
     Utils.logErrorAndExitProcess(e)
   }

--- a/ern-local-cli/src/commands/cauldron/repo/list.js
+++ b/ern-local-cli/src/commands/cauldron/repo/list.js
@@ -1,7 +1,8 @@
 // @flow
 
 import {
-  config as ernConfig
+  config as ernConfig,
+  Utils
 } from 'ern-util'
 import utils from '../../../lib/utils'
 
@@ -13,11 +14,15 @@ exports.builder = function (yargs: any) {
 }
 
 exports.handler = function () {
-  const cauldronRepositories = ernConfig.getValue('cauldronRepositories')
-  if (!cauldronRepositories) {
-    return console.log('No Cauldron repositories have been added yet')
+  try {
+    const cauldronRepositories = ernConfig.getValue('cauldronRepositories')
+    if (!cauldronRepositories) {
+      return console.log('No Cauldron repositories have been added yet')
+    }
+    console.log('[Cauldron Repositories]')
+    Object.keys(cauldronRepositories).forEach(alias =>
+        console.log(`${alias} -> ${cauldronRepositories[alias]}`))
+  } catch (e) {
+    Utils.logErrorAndExitProcess(e)
   }
-  console.log('[Cauldron Repositories]')
-  Object.keys(cauldronRepositories).forEach(alias =>
-      console.log(`${alias} -> ${cauldronRepositories[alias]}`))
 }

--- a/ern-local-cli/src/commands/cauldron/repo/list.js
+++ b/ern-local-cli/src/commands/cauldron/repo/list.js
@@ -17,11 +17,11 @@ exports.handler = function () {
   try {
     const cauldronRepositories = ernConfig.getValue('cauldronRepositories')
     if (!cauldronRepositories) {
-      return console.log('No Cauldron repositories have been added yet')
+      throw new Error('No Cauldron repositories have been added yet')
     }
-    console.log('[Cauldron Repositories]')
+    log.info('[Cauldron Repositories]')
     Object.keys(cauldronRepositories).forEach(alias =>
-        console.log(`${alias} -> ${cauldronRepositories[alias]}`))
+      log.info(`${alias} -> ${cauldronRepositories[alias]}`))
   } catch (e) {
     Utils.logErrorAndExitProcess(e)
   }

--- a/ern-local-cli/src/commands/cauldron/repo/remove.js
+++ b/ern-local-cli/src/commands/cauldron/repo/remove.js
@@ -1,7 +1,8 @@
 // @flow
 
 import {
-  config as ernConfig
+  config as ernConfig,
+  Utils
 } from 'ern-util'
 import utils from '../../../lib/utils'
 
@@ -17,19 +18,23 @@ exports.handler = function ({
 } : {
   alias: string
 }) {
-  let cauldronRepositories = ernConfig.getValue('cauldronRepositories')
-  if (!cauldronRepositories) {
-    return console.log('No Cauldron repositories have been added yet')
-  }
-  if (!cauldronRepositories[alias]) {
-    return console.log(`No Cauldron repository exists with ${alias} alias`)
-  }
-  delete cauldronRepositories[alias]
-  ernConfig.setValue('cauldronRepositories', cauldronRepositories)
-  console.log(`Removed Cauldron repository exists with alias ${alias}`)
-  const cauldronRepoInUse = ernConfig.getValue('cauldronRepoInUse')
-  if (cauldronRepoInUse === alias) {
-    ernConfig.setValue('cauldronRepoInUse', null)
-    console.log(`This Cauldron repository was the currently activated one. No more current repo !`)
+  try {
+    let cauldronRepositories = ernConfig.getValue('cauldronRepositories')
+    if (!cauldronRepositories) {
+      return console.log('No Cauldron repositories have been added yet')
+    }
+    if (!cauldronRepositories[alias]) {
+      return console.log(`No Cauldron repository exists with ${alias} alias`)
+    }
+    delete cauldronRepositories[alias]
+    ernConfig.setValue('cauldronRepositories', cauldronRepositories)
+    console.log(`Removed Cauldron repository exists with alias ${alias}`)
+    const cauldronRepoInUse = ernConfig.getValue('cauldronRepoInUse')
+    if (cauldronRepoInUse === alias) {
+      ernConfig.setValue('cauldronRepoInUse', null)
+      console.log(`This Cauldron repository was the currently activated one. No more current repo !`)
+    }
+  } catch (e) {
+    Utils.logErrorAndExitProcess(e)
   }
 }

--- a/ern-local-cli/src/commands/cauldron/repo/remove.js
+++ b/ern-local-cli/src/commands/cauldron/repo/remove.js
@@ -21,18 +21,18 @@ exports.handler = function ({
   try {
     let cauldronRepositories = ernConfig.getValue('cauldronRepositories')
     if (!cauldronRepositories) {
-      return console.log('No Cauldron repositories have been added yet')
+      throw new Error('No Cauldron repositories have been added yet')
     }
     if (!cauldronRepositories[alias]) {
-      return console.log(`No Cauldron repository exists with ${alias} alias`)
+      throw new Error(`No Cauldron repository exists with ${alias} alias`)
     }
     delete cauldronRepositories[alias]
     ernConfig.setValue('cauldronRepositories', cauldronRepositories)
-    console.log(`Removed Cauldron repository exists with alias ${alias}`)
+    log.info(`Removed Cauldron repository exists with alias ${alias}`)
     const cauldronRepoInUse = ernConfig.getValue('cauldronRepoInUse')
     if (cauldronRepoInUse === alias) {
       ernConfig.setValue('cauldronRepoInUse', null)
-      console.log(`This Cauldron repository was the currently activated one. No more current repo !`)
+      log.info(`This Cauldron repository was the currently activated one. No more current repo !`)
     }
   } catch (e) {
     Utils.logErrorAndExitProcess(e)

--- a/ern-local-cli/src/commands/cauldron/repo/use.js
+++ b/ern-local-cli/src/commands/cauldron/repo/use.js
@@ -5,7 +5,8 @@ import {
 } from 'ern-core'
 import {
   config as ernConfig,
-  shell
+  shell,
+  Utils
 } from 'ern-util'
 import utils from '../../../lib/utils'
 
@@ -21,14 +22,18 @@ exports.handler = function ({
 } : {
   alias: string
 }) {
-  let cauldronRepositories = ernConfig.getValue('cauldronRepositories')
-  if (!cauldronRepositories) {
-    return console.log('No Cauldron repositories have been added yet')
+  try {
+    let cauldronRepositories = ernConfig.getValue('cauldronRepositories')
+    if (!cauldronRepositories) {
+      return console.log('No Cauldron repositories have been added yet')
+    }
+    if (!cauldronRepositories[alias]) {
+      return console.log(`No Cauldron repository exists with ${alias} alias`)
+    }
+    ernConfig.setValue('cauldronRepoInUse', alias)
+    shell.rm('-rf', `${Platform.rootDirectory}/cauldron`)
+    console.log(`${alias} Cauldron is now in use`)
+  } catch (e) {
+    Utils.logErrorAndExitProcess(e)
   }
-  if (!cauldronRepositories[alias]) {
-    return console.log(`No Cauldron repository exists with ${alias} alias`)
-  }
-  ernConfig.setValue('cauldronRepoInUse', alias)
-  shell.rm('-rf', `${Platform.rootDirectory}/cauldron`)
-  console.log(`${alias} Cauldron is now in use`)
 }

--- a/ern-local-cli/src/commands/cauldron/repo/use.js
+++ b/ern-local-cli/src/commands/cauldron/repo/use.js
@@ -25,14 +25,14 @@ exports.handler = function ({
   try {
     let cauldronRepositories = ernConfig.getValue('cauldronRepositories')
     if (!cauldronRepositories) {
-      return console.log('No Cauldron repositories have been added yet')
+      throw new Error('No Cauldron repositories have been added yet')
     }
     if (!cauldronRepositories[alias]) {
-      return console.log(`No Cauldron repository exists with ${alias} alias`)
+      throw new Error(`No Cauldron repository exists with ${alias} alias`)
     }
     ernConfig.setValue('cauldronRepoInUse', alias)
     shell.rm('-rf', `${Platform.rootDirectory}/cauldron`)
-    console.log(`${alias} Cauldron is now in use`)
+    log.info(`${alias} Cauldron is now in use`)
   } catch (e) {
     Utils.logErrorAndExitProcess(e)
   }

--- a/ern-local-cli/src/commands/cauldron/update/dependencies.js
+++ b/ern-local-cli/src/commands/cauldron/update/dependencies.js
@@ -2,7 +2,8 @@
 
 import {
   Dependency,
-  NativeApplicationDescriptor
+  NativeApplicationDescriptor,
+  Utils
 } from 'ern-util'
 import {
   cauldron
@@ -100,6 +101,6 @@ exports.handler = async function ({
       { containerVersion })
     log.info(`Dependency(ies) was/were succesfully updated in ${napDescriptor.toString()}`)
   } catch (e) {
-    log.error(`An error happened while trying to update dependency(ies) in ${napDescriptor.toString()}`)
+    Utils.logErrorAndExitProcess(e)
   }
 }

--- a/ern-local-cli/src/commands/cauldron/update/miniapps.js
+++ b/ern-local-cli/src/commands/cauldron/update/miniapps.js
@@ -6,7 +6,8 @@ import {
 import {
   DependencyPath,
   NativeApplicationDescriptor,
-  spin
+  spin,
+  Utils
 } from 'ern-util'
 import utils from '../../../lib/utils'
 import _ from 'lodash'
@@ -120,6 +121,6 @@ exports.handler = async function ({
       { containerVersion })
     log.info(`MiniApp(s) version(s) was/were succesfully updated for ${napDescriptor.toString()} in Cauldron !`)
   } catch (e) {
-    log.error(`An error occured while trying to update MiniApp(s) version(s) in Cauldron`)
+    Utils.logErrorAndExitProcess(e)
   }
 }

--- a/ern-local-cli/src/commands/cauldron/update/nativeapp.js
+++ b/ern-local-cli/src/commands/cauldron/update/nativeapp.js
@@ -1,7 +1,8 @@
 // @flow
 
 import {
-  NativeApplicationDescriptor
+  NativeApplicationDescriptor,
+  Utils
 } from 'ern-util'
 import {
   cauldron
@@ -29,17 +30,21 @@ exports.handler = async function ({
   descriptor: string,
   isReleased: boolean
 }) {
-  await utils.logErrorAndExitIfNotSatisfied({
-    cauldronIsActive: {
-      extraErrorMessage: 'A Cauldron must be active in order to use this command'
-    },
-    isCompleteNapDescriptorString: { descriptor },
-    napDescriptorExistInCauldron: {
-      descriptor,
-      extraErrorMessage: 'You cannot update the release status of a non existing native application version'
-    }
-  })
+  try {
+    await utils.logErrorAndExitIfNotSatisfied({
+      cauldronIsActive: {
+        extraErrorMessage: 'A Cauldron must be active in order to use this command'
+      },
+      isCompleteNapDescriptorString: { descriptor },
+      napDescriptorExistInCauldron: {
+        descriptor,
+        extraErrorMessage: 'You cannot update the release status of a non existing native application version'
+      }
+    })
 
-  const napDescriptor = NativeApplicationDescriptor.fromString(descriptor)
-  cauldron.updateNativeAppIsReleased(napDescriptor, isReleased)
+    const napDescriptor = NativeApplicationDescriptor.fromString(descriptor)
+    cauldron.updateNativeAppIsReleased(napDescriptor, isReleased)
+  } catch (e) {
+    Utils.logErrorAndExitProcess(e)
+  }
 }

--- a/ern-local-cli/src/commands/code-push.js
+++ b/ern-local-cli/src/commands/code-push.js
@@ -2,7 +2,8 @@
 
 import {
   Dependency,
-  NativeApplicationDescriptor
+  NativeApplicationDescriptor,
+  Utils
 } from 'ern-util'
 import {
   cauldron
@@ -108,18 +109,22 @@ exports.handler = async function ({
     }
   })
 
-  const pathToYarnLock = await cauldron.getPathToYarnLock(napDescriptor)
-  await performCodePushOtaUpdate(
-    napDescriptor,
-    _.map(miniapps, Dependency.fromString), {
-      force: force,
-      codePushAppName: appName,
-      codePushDeploymentName: deploymentName,
-      codePushPlatformName: platform,
-      codePushTargetVersionName: targetBinaryVersion,
-      codePushIsMandatoryRelease: mandatory,
-      codePushRolloutPercentage: rollout,
-      pathToYarnLock: pathToYarnLock || undefined,
-      skipConfirmation
-    })
+  try {
+    const pathToYarnLock = await cauldron.getPathToYarnLock(napDescriptor)
+    await performCodePushOtaUpdate(
+      napDescriptor,
+      _.map(miniapps, Dependency.fromString), {
+        force: force,
+        codePushAppName: appName,
+        codePushDeploymentName: deploymentName,
+        codePushPlatformName: platform,
+        codePushTargetVersionName: targetBinaryVersion,
+        codePushIsMandatoryRelease: mandatory,
+        codePushRolloutPercentage: rollout,
+        pathToYarnLock: pathToYarnLock || undefined,
+        skipConfirmation
+      })
+  } catch (e) {
+    Utils.logErrorAndExitProcess(e)
+  }
 }

--- a/ern-local-cli/src/commands/compat-check.js
+++ b/ern-local-cli/src/commands/compat-check.js
@@ -2,7 +2,8 @@
 
 import {
   DependencyPath,
-  NativeApplicationDescriptor
+  NativeApplicationDescriptor,
+  Utils
 } from 'ern-util'
 import {
   compatibility,
@@ -36,29 +37,33 @@ exports.handler = async function ({
   descriptor?: string,
   miniapps: Array<string>
 } = {}) {
-  if (!miniapp && miniapps.length === 0) {
-    try {
-      miniapps.push(MiniApp.fromCurrentPath().packageDescriptor)
-    } catch (e) {
-      return log.error(e.message)
+  try {
+    if (!miniapp && miniapps.length === 0) {
+      try {
+        miniapps.push(MiniApp.fromCurrentPath().packageDescriptor)
+      } catch (e) {
+        return log.error(e.message)
+      }
+    } else if (miniapp && miniapps.length === 0) {
+      miniapps.push(miniapp)
     }
-  } else if (miniapp && miniapps.length === 0) {
-    miniapps.push(miniapp)
-  }
 
-  if (!descriptor) {
-    descriptor = await utils.askUserToChooseANapDescriptorFromCauldron()
-  }
-  const napDescriptor = NativeApplicationDescriptor.fromString(descriptor)
+    if (!descriptor) {
+      descriptor = await utils.askUserToChooseANapDescriptorFromCauldron()
+    }
+    const napDescriptor = NativeApplicationDescriptor.fromString(descriptor)
 
-  await utils.logErrorAndExitIfNotSatisfied({
-    isCompleteNapDescriptorString: {descriptor}
-  })
+    await utils.logErrorAndExitIfNotSatisfied({
+      isCompleteNapDescriptorString: {descriptor}
+    })
 
-  for (const miniappPath of miniapps) {
-    const miniapp = await MiniApp.fromPackagePath(DependencyPath.fromString(miniappPath))
-    log.info(`=> ${miniapp.name}`)
-    await compatibility.checkCompatibilityWithNativeApp(
-      miniapp, napDescriptor.name, napDescriptor.platform, napDescriptor.version)
+    for (const miniappPath of miniapps) {
+      const miniapp = await MiniApp.fromPackagePath(DependencyPath.fromString(miniappPath))
+      log.info(`=> ${miniapp.name}`)
+      await compatibility.checkCompatibilityWithNativeApp(
+        miniapp, napDescriptor.name, napDescriptor.platform, napDescriptor.version)
+    }
+  } catch (e) {
+    Utils.logErrorAndExitProcess(e)
   }
 }

--- a/ern-local-cli/src/commands/create-api-impl.js
+++ b/ern-local-cli/src/commands/create-api-impl.js
@@ -9,7 +9,8 @@ import {
 } from 'ern-api-impl-gen'
 import {
   Dependency,
-  DependencyPath
+  DependencyPath,
+  Utils
 } from 'ern-util'
 import cliUtils from '../lib/utils'
 import inquirer from 'inquirer'
@@ -108,7 +109,7 @@ exports.handler = async function ({
     })
     log.info('Success!')
   } catch (e) {
-    log.error(`${e} \n\nAPI implementation generation failed.`)
+    Utils.logErrorAndExitProcess(e)
   }
 }
 

--- a/ern-local-cli/src/commands/create-api.js
+++ b/ern-local-cli/src/commands/create-api.js
@@ -7,7 +7,8 @@ import {
   manifest
 } from 'ern-core'
 import {
-  Dependency
+  Dependency,
+  Utils
 } from 'ern-util'
 import utils from '../lib/utils'
 
@@ -76,7 +77,6 @@ exports.handler = async function ({
     })
     log.info('Success!')
   } catch (e) {
-    log.error('Command failed.')
-    process.exit(1)
+    Utils.logErrorAndExitProcess(e)
   }
 }

--- a/ern-local-cli/src/commands/create-miniapp.js
+++ b/ern-local-cli/src/commands/create-miniapp.js
@@ -4,6 +4,9 @@ import {
   MiniApp,
   utils as core
 } from 'ern-core'
+import {
+  Utils
+} from 'ern-util'
 import utils from '../lib/utils'
 import chalk from 'chalk'
 import inquirer from 'inquirer'
@@ -83,7 +86,7 @@ exports.handler = async function ({
     log.info(chalk.white(`    > ern run-ios`))
     log.info(`================================================`)
   } catch (e) {
-    log.error(e.message)
+    Utils.logErrorAndExitProcess(e)
   }
 }
 

--- a/ern-local-cli/src/commands/link.js
+++ b/ern-local-cli/src/commands/link.js
@@ -3,6 +3,9 @@
 import {
   MiniApp
 } from 'ern-core'
+import {
+  Utils
+} from 'ern-util'
 import utils from '../lib/utils'
 
 exports.command = 'link'
@@ -16,6 +19,6 @@ exports.handler = async function () {
   try {
     MiniApp.fromCurrentPath().link()
   } catch (e) {
-    log.error(`${e}`)
+    Utils.logErrorAndExitProcess(e)
   }
 }

--- a/ern-local-cli/src/commands/platform/config.js
+++ b/ern-local-cli/src/commands/platform/config.js
@@ -1,7 +1,8 @@
 // @flow
 
 import {
-  config as ernConfig
+  config as ernConfig,
+  Utils
 } from 'ern-util'
 import utils from '../../lib/utils'
 
@@ -19,9 +20,13 @@ exports.handler = function ({
   key: string,
   value?: string
 }) {
-  if (value) {
-    ernConfig.setValue(key, value)
-  } else {
-    log.info(`${key}: ${ernConfig.getValue(key)}`)
+  try {
+    if (value) {
+      ernConfig.setValue(key, value)
+    } else {
+      log.info(`${key}: ${ernConfig.getValue(key)}`)
+    }
+  } catch (e) {
+    Utils.logErrorAndExitProcess(e)
   }
 }

--- a/ern-local-cli/src/commands/platform/current.js
+++ b/ern-local-cli/src/commands/platform/current.js
@@ -3,6 +3,9 @@
 import {
   Platform
 } from 'ern-core'
+import {
+  Utils
+} from 'ern-util'
 import utils from '../../lib/utils'
 
 exports.command = 'current'
@@ -13,5 +16,9 @@ exports.builder = function (yargs: any) {
 }
 
 exports.handler = function () {
-  log.info(`Platform version : v${Platform.currentVersion}`)
+  try {
+    log.info(`Platform version : v${Platform.currentVersion}`)
+  } catch (e) {
+    Utils.logErrorAndExitProcess(e)
+  }
 }

--- a/ern-local-cli/src/commands/platform/install.js
+++ b/ern-local-cli/src/commands/platform/install.js
@@ -3,6 +3,9 @@
 import {
   Platform
 } from 'ern-core'
+import {
+  Utils
+} from 'ern-util'
 import utils from '../../lib/utils'
 
 exports.command = 'install <version>'
@@ -20,6 +23,6 @@ exports.handler = function ({
   try {
     Platform.installPlatform(version.toString().replace('v', ''))
   } catch (e) {
-    log.error(e)
+    Utils.logErrorAndExitProcess(e)
   }
 }

--- a/ern-local-cli/src/commands/platform/list.js
+++ b/ern-local-cli/src/commands/platform/list.js
@@ -4,7 +4,8 @@ import {
   Platform
 } from 'ern-core'
 import {
-  tagOneLine
+  tagOneLine,
+  Utils
 } from 'ern-util'
 import chalk from 'chalk'
 import utils from '../../lib/utils'
@@ -19,23 +20,27 @@ exports.builder = function (yargs: any) {
 }
 
 exports.handler = function () {
-  log.info(tagOneLine`
+  try {
+    log.info(tagOneLine`
     ${chalk.green('[CURRENT]')}
     ${chalk.yellow('[INSTALLED]')}
     ${chalk.gray('[NOT INSTALLED]')}`)
-  for (const version of Platform.versions) {
-    // Don't show versions pre 0.7.0 as it was not official public releases
-    // Electrode Native initial public release was 0.7.0 so starting from
-    // this version
-    if (version < '0.7.0') { continue }
-    if (Platform.isPlatformVersionInstalled(version)) {
-      if (Platform.currentVersion === version) {
-        log.info(chalk.green(`-> v${version}\t\t`) + chalk.white(`${BASE_RELEASE_URL}/v${version}`))
+    for (const version of Platform.versions) {
+      // Don't show versions pre 0.7.0 as it was not official public releases
+      // Electrode Native initial public release was 0.7.0 so starting from
+      // this version
+      if (version < '0.7.0') { continue }
+      if (Platform.isPlatformVersionInstalled(version)) {
+        if (Platform.currentVersion === version) {
+          log.info(chalk.green(`-> v${version}\t\t`) + chalk.white(`${BASE_RELEASE_URL}/v${version}`))
+        } else {
+          log.info(chalk.yellow(`v${version}\t\t`) + chalk.white(`${BASE_RELEASE_URL}/v${version}`))
+        }
       } else {
-        log.info(chalk.yellow(`v${version}\t\t`) + chalk.white(`${BASE_RELEASE_URL}/v${version}`))
+        log.info(chalk.gray(`v${version}\t\t`) + chalk.white(`${BASE_RELEASE_URL}/v${version}`))
       }
-    } else {
-      log.info(chalk.gray(`v${version}\t\t`) + chalk.white(`${BASE_RELEASE_URL}/v${version}`))
     }
+  } catch (e) {
+    Utils.logErrorAndExitProcess(e)
   }
 }

--- a/ern-local-cli/src/commands/platform/plugins/list.js
+++ b/ern-local-cli/src/commands/platform/plugins/list.js
@@ -4,6 +4,9 @@ import {
   manifest,
   Platform
 } from 'ern-core'
+import {
+  Utils
+} from 'ern-util'
 import utils from '../../../lib/utils'
 
 import chalk from 'chalk'
@@ -26,23 +29,27 @@ exports.handler = async function ({
 } : {
   platformVersion?: string
 }) {
-  const plugins = await manifest.getNativeDependencies(platformVersion)
+  try {
+    const plugins = await manifest.getNativeDependencies(platformVersion)
 
-  log.info(`Platform v${platformVersion} suports the following plugins`)
-  var table = new Table({
-    head: [
-      chalk.cyan('Scope'),
-      chalk.cyan('Name'),
-      chalk.cyan('Version')
-    ],
-    colWidths: [10, 40, 16]
-  })
-  for (const plugin of plugins) {
-    table.push([
-      plugin.scope ? plugin.scope : '',
-      plugin.name,
-      plugin.version
-    ])
+    log.info(`Platform v${platformVersion} suports the following plugins`)
+    var table = new Table({
+      head: [
+        chalk.cyan('Scope'),
+        chalk.cyan('Name'),
+        chalk.cyan('Version')
+      ],
+      colWidths: [10, 40, 16]
+    })
+    for (const plugin of plugins) {
+      table.push([
+        plugin.scope ? plugin.scope : '',
+        plugin.name,
+        plugin.version
+      ])
+    }
+    console.log(table.toString())
+  } catch (e) {
+    Utils.logErrorAndExitProcess(e)
   }
-  console.log(table.toString())
 }

--- a/ern-local-cli/src/commands/platform/plugins/list.js
+++ b/ern-local-cli/src/commands/platform/plugins/list.js
@@ -48,7 +48,7 @@ exports.handler = async function ({
         plugin.version
       ])
     }
-    console.log(table.toString())
+    log.info(table.toString())
   } catch (e) {
     Utils.logErrorAndExitProcess(e)
   }

--- a/ern-local-cli/src/commands/platform/plugins/search.js
+++ b/ern-local-cli/src/commands/platform/plugins/search.js
@@ -38,7 +38,7 @@ exports.handler = async function ({
     }
 
     const scopeStr = `${plugin.scope ? `${plugin.scope}@` : ''}`
-    console.log(`${chalk.gray(scopeStr)}${chalk.yellow(plugin.name)}@${chalk.magenta(plugin.version)}`)
+    log.info(`${chalk.gray(scopeStr)}${chalk.yellow(plugin.name)}@${chalk.magenta(plugin.version)}`)
   } catch (e) {
     Utils.logErrorAndExitProcess(e)
   }

--- a/ern-local-cli/src/commands/platform/plugins/search.js
+++ b/ern-local-cli/src/commands/platform/plugins/search.js
@@ -5,7 +5,8 @@ import {
   Platform
 } from 'ern-core'
 import {
-  Dependency
+  Dependency,
+  Utils
 } from 'ern-util'
 import utils from '../../../lib/utils'
 
@@ -30,11 +31,15 @@ exports.handler = async function ({
   name: string,
   platformVersion?: string
 }) {
-  const plugin = await manifest.getNativeDependency(Dependency.fromString(name), platformVersion)
-  if (!plugin) {
-    return log.warn(`No plugin named ${name} was found for platform version $platformVersion}`)
-  }
+  try {
+    const plugin = await manifest.getNativeDependency(Dependency.fromString(name), platformVersion)
+    if (!plugin) {
+      return log.warn(`No plugin named ${name} was found for platform version $platformVersion}`)
+    }
 
-  const scopeStr = `${plugin.scope ? `${plugin.scope}@` : ''}`
-  console.log(`${chalk.gray(scopeStr)}${chalk.yellow(plugin.name)}@${chalk.magenta(plugin.version)}`)
+    const scopeStr = `${plugin.scope ? `${plugin.scope}@` : ''}`
+    console.log(`${chalk.gray(scopeStr)}${chalk.yellow(plugin.name)}@${chalk.magenta(plugin.version)}`)
+  } catch (e) {
+    Utils.logErrorAndExitProcess(e)
+  }
 }

--- a/ern-local-cli/src/commands/platform/uninstall.js
+++ b/ern-local-cli/src/commands/platform/uninstall.js
@@ -3,6 +3,9 @@
 import {
   Platform
 } from 'ern-core'
+import {
+  Utils
+} from 'ern-util'
 import utils from '../../lib/utils'
 
 exports.command = 'uninstall <version>'
@@ -20,6 +23,6 @@ exports.handler = function ({
   try {
     Platform.uninstallPlatform(version.toString().replace('v', ''))
   } catch (e) {
-    log.error(e)
+    Utils.logErrorAndExitProcess(e)
   }
 }

--- a/ern-local-cli/src/commands/platform/use.js
+++ b/ern-local-cli/src/commands/platform/use.js
@@ -3,6 +3,9 @@
 import {
   Platform
 } from 'ern-core'
+import {
+  Utils
+} from 'ern-util'
 import utils from '../../lib/utils'
 
 exports.command = 'use <version>'
@@ -20,6 +23,6 @@ exports.handler = function ({
   try {
     Platform.switchToVersion(version.toString().replace('v', ''))
   } catch (e) {
-    log.error(e.message)
+    Utils.logErrorAndExitProcess(e)
   }
 }

--- a/ern-local-cli/src/commands/regen-api-impl.js
+++ b/ern-local-cli/src/commands/regen-api-impl.js
@@ -9,10 +9,10 @@ import {
   utils,
   yarn
 } from 'ern-core'
-
 import {
   fileUtils,
-  Dependency
+  Dependency,
+  Utils
 } from 'ern-util'
 import cliUtils from '../lib/utils'
 import path from 'path'
@@ -36,6 +36,8 @@ const ERROR_MSG_NOT_IN_IMPL = 'api-regen-impl can only be run inside an implemen
 const WORKING_DIRECTORY = path.join(Platform.rootDirectory, `api-impl-gen`)
 const PLUGIN_DIRECTORY = path.join(WORKING_DIRECTORY, 'plugins')
 
+// TOO MUCH LOGIC IN THE COMMAND ITSELF
+// TO REFACTOR TO EXTRACT LOGIC OUT OF THE COMMAND FOR REUSABILITY
 exports.handler = async function
   ({
      apiVersion,
@@ -79,7 +81,7 @@ exports.handler = async function
     })
     log.info('Successfully regenerated api implementation!')
   } catch (e) {
-    log.error(`${e} ApiImpl regeneration failed.`)
+    Utils.logErrorAndExitProcess(e)
   }
 
   async function readPackageJson (): Object {

--- a/ern-local-cli/src/commands/regen-api.js
+++ b/ern-local-cli/src/commands/regen-api.js
@@ -7,7 +7,8 @@ import {
   manifest
 } from 'ern-core'
 import {
-  Dependency
+  Dependency,
+  Utils
 } from 'ern-util'
 import utils from '../lib/utils'
 
@@ -34,13 +35,17 @@ exports.handler = async function ({
   updatePlugin: boolean,
   bridgeVersion: string
 } = {}) {
-  if (!bridgeVersion) {
-    const bridgeDep = await manifest.getNativeDependency(Dependency.fromString('react-native-electrode-bridge'))
-    if (!bridgeDep) {
-      return log.error(`react-native-electrode-bridge not found in manifest. please provide explicit version`)
+  try {
+    if (!bridgeVersion) {
+      const bridgeDep = await manifest.getNativeDependency(Dependency.fromString('react-native-electrode-bridge'))
+      if (!bridgeDep) {
+        return log.error(`react-native-electrode-bridge not found in manifest. please provide explicit version`)
+      }
+      bridgeVersion = bridgeDep.version
     }
-    bridgeVersion = bridgeDep.version
-  }
 
-  return ApiGen.regenerateCode({bridgeVersion, updatePlugin})
+    return ApiGen.regenerateCode({bridgeVersion, updatePlugin})
+  } catch (e) {
+    Utils.logErrorAndExitProcess(e)
+  }
 }

--- a/ern-local-cli/src/commands/run-android.js
+++ b/ern-local-cli/src/commands/run-android.js
@@ -1,7 +1,10 @@
 // @flow
 
 import utils from '../lib/utils'
-import { config as ernConfig } from 'ern-util'
+import {
+  config as ernConfig,
+  Utils
+} from 'ern-util'
 
 exports.command = 'run-android'
 exports.desc = 'Run one or more MiniApps in the Android Runner application'
@@ -54,14 +57,14 @@ exports.handler = async function ({
   dev?: boolean,
   usePreviousEmulator?: boolean
 }) {
-  let emulatorConfig = ernConfig.getValue('emulatorConfig', {
-    android: {usePreviousEmulator: false, emulatorName: ''},
-    ios: {usePreviousEmulator: false, simulatorUdid: ''}
-  })
-  usePreviousEmulator ? emulatorConfig.android.usePreviousEmulator = true : emulatorConfig.android.usePreviousEmulator = false
-  ernConfig.setValue('emulatorConfig', emulatorConfig)
-
   try {
+    let emulatorConfig = ernConfig.getValue('emulatorConfig', {
+      android: {usePreviousEmulator: false, emulatorName: ''},
+      ios: {usePreviousEmulator: false, simulatorUdid: ''}
+    })
+    usePreviousEmulator ? emulatorConfig.android.usePreviousEmulator = true : emulatorConfig.android.usePreviousEmulator = false
+    ernConfig.setValue('emulatorConfig', emulatorConfig)
+
     await utils.runMiniApp('android', {
       mainMiniAppName,
       miniapps,
@@ -71,6 +74,6 @@ exports.handler = async function ({
     })
     process.exit(0)
   } catch (e) {
-    log.error(`${e}`)
+    Utils.logErrorAndExitProcess(e)
   }
 }

--- a/ern-local-cli/src/commands/run-ios.js
+++ b/ern-local-cli/src/commands/run-ios.js
@@ -1,7 +1,10 @@
 // @flow
 
 import utils from '../lib/utils'
-import { config as ernConfig } from 'ern-util'
+import {
+  config as ernConfig,
+  Utils
+} from 'ern-util'
 
 exports.command = 'run-ios'
 exports.desc = 'Run one or more MiniApps in the iOS Runner application'
@@ -54,18 +57,18 @@ exports.handler = async function ({
   dev?: boolean,
   usePreviousEmulator?: boolean
 }) {
-  if (process.platform !== 'darwin') {
-    return log.error('This command can only be used on Mac OS X')
-  }
-
-  let emulatorConfig = ernConfig.getValue('emulatorConfig', {
-    android: {usePreviousEmulator: false, emulatorName: ''},
-    ios: {usePreviousEmulator: false, simulatorUdid: ''}
-  })
-  usePreviousEmulator ? emulatorConfig.ios.usePreviousEmulator = true : emulatorConfig.ios.usePreviousEmulator = false
-  ernConfig.setValue('emulatorConfig', emulatorConfig)
-
   try {
+    if (process.platform !== 'darwin') {
+      return log.error('This command can only be used on Mac OS X')
+    }
+
+    let emulatorConfig = ernConfig.getValue('emulatorConfig', {
+      android: {usePreviousEmulator: false, emulatorName: ''},
+      ios: {usePreviousEmulator: false, simulatorUdid: ''}
+    })
+    usePreviousEmulator ? emulatorConfig.ios.usePreviousEmulator = true : emulatorConfig.ios.usePreviousEmulator = false
+    ernConfig.setValue('emulatorConfig', emulatorConfig)
+
     await utils.runMiniApp('ios', {
       mainMiniAppName,
       miniapps,
@@ -74,6 +77,6 @@ exports.handler = async function ({
       dev
     })
   } catch (e) {
-    log.error(`${e}`)
+    Utils.logErrorAndExitProcess(e)
   }
 }

--- a/ern-local-cli/src/commands/start.js
+++ b/ern-local-cli/src/commands/start.js
@@ -4,7 +4,8 @@ import utils from '../lib/utils'
 import start from '../lib/start'
 import _ from 'lodash'
 import {
-  DependencyPath
+  DependencyPath,
+  Utils
 } from 'ern-util'
 
 exports.command = 'start'
@@ -80,6 +81,6 @@ exports.handler = async function ({
       extraJsDependencies: _.map(extraJsDependencies, d => DependencyPath.fromString(d))
     })
   } catch (e) {
-    log.error(e.message)
+    Utils.logErrorAndExitProcess(e)
   }
 }

--- a/ern-local-cli/src/commands/unlink.js
+++ b/ern-local-cli/src/commands/unlink.js
@@ -3,6 +3,9 @@
 import {
   MiniApp
 } from 'ern-core'
+import {
+  Utils
+} from 'ern-util'
 import utils from '../lib/utils'
 
 exports.command = 'unlink'
@@ -16,6 +19,6 @@ exports.handler = async function () {
   try {
     MiniApp.fromCurrentPath().unlink()
   } catch (e) {
-    log.error(`${e}`)
+    Utils.logErrorAndExitProcess(e)
   }
 }

--- a/ern-local-cli/src/commands/upgrade-miniapp.js
+++ b/ern-local-cli/src/commands/upgrade-miniapp.js
@@ -4,6 +4,9 @@ import {
   MiniApp,
   Platform
 } from 'ern-core'
+import {
+  Utils
+} from 'ern-util'
 import utils from '../lib/utils'
 
 exports.command = 'upgrade-miniapp'
@@ -31,6 +34,6 @@ exports.handler = function ({
     const versionWithoutPrefix = version.toString().replace('v', '')
     miniApp.upgradeToPlatformVersion(versionWithoutPrefix)
   } catch (e) {
-    log.error(e.message)
+    Utils.logErrorAndExitProcess(e)
   }
 }

--- a/ern-local-cli/src/commands/why.js
+++ b/ern-local-cli/src/commands/why.js
@@ -6,7 +6,8 @@ import {
 } from 'ern-core'
 import {
   Dependency,
-  NativeApplicationDescriptor
+  NativeApplicationDescriptor,
+  Utils
 } from 'ern-util'
 import _ from 'lodash'
 import utils from '../lib/utils'
@@ -25,17 +26,21 @@ exports.handler = async function ({
   dependency: string,
   completeNapDescriptor: string
 }) {
-  const napDescriptor = NativeApplicationDescriptor.fromString(completeNapDescriptor)
-  const miniApps = await cauldron.getContainerMiniApps(napDescriptor)
-  const miniAppsPaths = _.map(miniApps, m => m.path)
-  log.info(`This might take a while. The more MiniApps, the longer.`)
-  const result = await dependencyLookup.getMiniAppsUsingNativeDependency(miniAppsPaths, Dependency.fromString(dependency))
-  if (!result || result.length === 0) {
-    log.info(`${dependency} dependency is not directly used by any MiniApps`)
-  } else {
-    log.info(`The following MiniApp(s) are using ${dependency} dependency :`)
-    for (const miniApp of result) {
-      log.info(`=> ${miniApp.name}`)
+  try {
+    const napDescriptor = NativeApplicationDescriptor.fromString(completeNapDescriptor)
+    const miniApps = await cauldron.getContainerMiniApps(napDescriptor)
+    const miniAppsPaths = _.map(miniApps, m => m.path)
+    log.info(`This might take a while. The more MiniApps, the longer.`)
+    const result = await dependencyLookup.getMiniAppsUsingNativeDependency(miniAppsPaths, Dependency.fromString(dependency))
+    if (!result || result.length === 0) {
+      log.info(`${dependency} dependency is not directly used by any MiniApps`)
+    } else {
+      log.info(`The following MiniApp(s) are using ${dependency} dependency :`)
+      for (const miniApp of result) {
+        log.info(`=> ${miniApp.name}`)
+      }
     }
+  } catch (e) {
+    Utils.logErrorAndExitProcess(e)
   }
 }

--- a/ern-util/src/utils.js
+++ b/ern-util/src/utils.js
@@ -1,8 +1,7 @@
-import chalk from 'chalk'
-
 export default class Utils {
-  static logErrorAndExitProcess (message: string) {
-    log.error(chalk.red(message))
-    process.exit(1)
+  static logErrorAndExitProcess (e: Error, code?: number = 1) {
+    log.error(`An error hapenned : ${e.message}`)
+    log.debug(e)
+    process.exit(code)
   }
 }


### PR DESCRIPTION
- Lightly refactor ern-util `logErrorAndExitProcess` so that it takes an `Error` instead of a message as well as an exit code (default to 1). Log error message (just the Error instance message) and also log debug the error instance to get more details in debug log level.
- Refactor all commands to use `logErrorAndExitProcess` in the same way.