### PR TITLE
Improve system-tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,11 @@ script:
 - npm run flow version
 - npm run flow
 - npm run test
+- 'if [ ${TRAVIS_EVENT_TYPE} != "cron" ]; then
+    npm install -g electrode-native && ern;
+    node setup-dev;
+    node system-tests;
+fi'
 notifications:
   slack:
     secure: Ccv7knkrsp4gEQoE/MOqAICq785+G28pJOCsHKJyMRh7SFezT4nOYV0L60gus2JQmi1ap0/rG0GlkmZ1NWQnmhrbcstylPWmCgAM43SMInXxameD8hrbm5dHtJAeq5bsN/Fb8EkW/EFHthKSVgoESqdjvWM7timdg5mCL7ObsADZx30VBZ44rF9nEP7yvwS5LCfmHNakG7R9hbmLBlYoQgYimxEjyCmYoMP2eG+jdfTUWYYJVtW7Mf8BLIdb8jZLX882QXOHNjsIJ96n7gQGyZSozPBU/435+VI8oU3gR00TcYuUuNUKFQHebMNCMA8unRGLy8PZm4TGQgLl0qYSB6nGE0n8gN3pMGQlLP/x8uJOyh0vZXa9lKHhZeFrpXv+RJfUOjtMyYNrD7Ko7wIeqy/lqLkfuPNy0KIND9aAK/Sz/Muo/nx2z7ZWA1n8o//+DgpInt1I6K5KILIYMpu5udrmm+U9HB+WAdB75RmNc7d9uImskcEhbqGKoRwjhTXapX/e95MnTC4p1e2eFCwruvgR/vyclpMgOMQywfab6WlHRqZqLpezgH1PI2o/U7D4NygLPK1W5fAgwFOa5LsyEaU47RUHOwIqr820klL+gfS9+dXqPM3D0PsW1fufOY0859Ba8N11kj53ll1zYi1onWB1zRSLY4XIhjMCqQgah+Y=

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,19 @@ sudo: enabled
 install:
 - npm install
 script:
-- npm run rebuild
-- npm run standard --version
-- npm run standard
-- npm run flow version
-- npm run flow
-- npm run test
 - 'if [ ${TRAVIS_EVENT_TYPE} != "cron" ]; then
-    npm install -g electrode-native && ern;
-    node setup-dev;
-    node system-tests;
+  npm run rebuild;
+  npm run standard --version;
+  npm run standard;
+  npm run flow version;
+  npm run flow;
+  npm run test;
+else
+  npm install -g electrode-native;
+  ern;
+  node setup-dev;
+  ern platform use 1000.0.0;
+  node system-tests; 
 fi'
 notifications:
   slack:

--- a/ern-api-gen/src/apigen.js
+++ b/ern-api-gen/src/apigen.js
@@ -43,11 +43,6 @@ export async function generateApi (options: Object) {
 }
 
 /**
- * If updatePlugin is specified it will not attempt to update the version.
- * It'll just do its job.
- *
- * Otherwise it will try to get the next version.
- *
  * @param options
  * @returns {Promise.<void>}
  */
@@ -56,8 +51,8 @@ export async function regenerateCode (options: Object = {}) {
   const curVersion = pkg.version || '0.0.1'
   const pkgName = pkg.name
   let newPluginVer
-  if (options.updatePlugin) {
-    newPluginVer = nextVersion(curVersion, options.updatePlugin)
+  if (options.skipVersion) {
+    newPluginVer = curVersion
   } else {
     newPluginVer = semver.inc(curVersion, 'minor')
     const {confirmPluginVer} = await inquirer.prompt([{
@@ -136,7 +131,7 @@ async function readPackage () {
 }
 
 const nextVersion = (curVersion: string, userPluginVer: string) => {
-  switch ((userPluginVer + '').toLowerCase()) {
+  switch (userPluginVer.toLowerCase()) {
     case 'same':
     case 'no':
     case 'q':

--- a/ern-container-gen/src/generators/android/AndroidGenerator.js
+++ b/ern-container-gen/src/generators/android/AndroidGenerator.js
@@ -115,7 +115,7 @@ export default class AndroidGenerator implements ContainerGenerator {
         this.copyRnpmAssets(miniapps, paths)
       }
 
-      if (mavenPublisher) {
+      if (mavenPublisher && !process.env['SYSTEM_TESTS']) {
         await mavenPublisher.publish({workingDir: paths.outDirectory, moduleName: `lib`})
         log.debug(`Published com.walmartlabs.ern:${nativeAppName}-ern-container:${containerVersion}`)
         log.debug(`To ${mavenPublisher.url}`)

--- a/ern-local-cli/src/commands/regen-api.js
+++ b/ern-local-cli/src/commands/regen-api.js
@@ -17,9 +17,9 @@ exports.desc = 'Regenerates an existing api'
 
 exports.builder = function (yargs: any) {
   return yargs
-    .option('updatePlugin', {
-      alias: 'u',
-      describe: 'Update plugin version'
+    .option('skipVersion', {
+      alias: 's',
+      describe: 'Do not update API version and do not publish'
     })
     .option('bridgeVersion', {
       alias: 'b',
@@ -29,10 +29,10 @@ exports.builder = function (yargs: any) {
 }
 
 exports.handler = async function ({
-  updatePlugin,
+  skipVersion,
   bridgeVersion
 } : {
-  updatePlugin: boolean,
+  skipVersion: boolean,
   bridgeVersion: string
 } = {}) {
   try {
@@ -44,7 +44,7 @@ exports.handler = async function ({
       bridgeVersion = bridgeDep.version
     }
 
-    return ApiGen.regenerateCode({bridgeVersion, updatePlugin})
+    await ApiGen.regenerateCode({bridgeVersion, skipVersion})
   } catch (e) {
     Utils.logErrorAndExitProcess(e)
   }

--- a/system-tests.js
+++ b/system-tests.js
@@ -5,7 +5,6 @@ const path = require('path')
 const workingDirectoryPath = tmp.dirSync({ unsafeCleanup: true }).name
 const info = chalk.bold.blue
 
-const gitHubPesonalToken = 'c8c36f576ef24273c0ffb0c90e512caea0f21c25'
 const gitUserName = 'ernplatformtest'
 const gitPassword = 'ernplatformtest12345'
 const gitHubCauldronRepositoryName = `cauldron-system-tests-${getRandomInt(0, 1000)}`
@@ -47,7 +46,7 @@ function afterAll () {
   console.log('===========================================================================')
   console.log(info('Cleaning up test env'))
   console.log(info(`Removing GitHub repository (${gitHubCauldronRepositoryName})`))
-  shell.exec(`curl -u ernplatformtest:${gitHubPesonalToken} -X DELETE https://api.github.com/repos/${gitUserName}/${gitHubCauldronRepositoryName}`)
+  shell.exec(`curl -u ${gitUserName}:${gitPassword} -X DELETE https://api.github.com/repos/${gitUserName}/${gitHubCauldronRepositoryName}`)
   console.log(info('Deactivating current Cauldron'))
   shell.exec('ern cauldron repo clear')
   console.log(info('Removing Cauldron alias'))
@@ -59,7 +58,7 @@ console.log(info(`Entering temporary working directory : ${workingDirectoryPath}
 process.chdir(workingDirectoryPath)
 
 console.log(info(`Creating GitHub repository (${gitHubCauldronRepositoryName})`))
-run(`curl -u ernplatformtest:${gitHubPesonalToken} -d '{"name": "${gitHubCauldronRepositoryName}"}' https://api.github.com/user/repos`)
+run(`curl -u ${gitUserName}:${gitPassword} -d '{"name": "${gitHubCauldronRepositoryName}"}' https://api.github.com/user/repos`)
 
 run('ern --hide-banner')
 run('ern --log-level trace')

--- a/system-tests.js
+++ b/system-tests.js
@@ -5,53 +5,78 @@ const path = require('path')
 const workingDirectoryPath = tmp.dirSync({ unsafeCleanup: true }).name
 const info = chalk.bold.blue
 
-const gitHubPesonalToken = `32207e94b79acaeb8bc7e82bcd0cd0c29ac0437f`
-const gitUserName = `ernplatformtest`
-const gitPassword = `ernplatformtest12345`
-const gitHubCauldronRepositoryName = `cauldron-system-tests`
-const cauldronName = `cauldron-automation`
-const miniAppName = `MiniAppSystemTest`
-const apiName = `TestApi`
-const nativeApplicationName = `system-test-app`
+const gitHubPesonalToken = 'c8c36f576ef24273c0ffb0c90e512caea0f21c25'
+const gitUserName = 'ernplatformtest'
+const gitPassword = 'ernplatformtest12345'
+const gitHubCauldronRepositoryName = `cauldron-system-tests-${getRandomInt(0, 1000)}`
+const cauldronName = 'cauldron-automation'
+const miniAppName = 'MiniAppSystemTest'
+const apiName = 'TestApi'
+const nativeApplicationName = 'system-test-app'
 const nativeApplicationVersion = '1.0.0'
 const androidNativeApplicationDescriptor = `${nativeApplicationName}:android:${nativeApplicationVersion}`
 const iosNativeApplicationDescriptor = `${nativeApplicationName}:ios:${nativeApplicationVersion}`
-const movieListMiniAppVersion = '0.0.4'
-const movieDetailsMiniAppVersion = '0.0.3'
+const movieListMiniAppVersion = '0.0.7'
+const movieDetailsMiniAppVersion = '0.0.6'
 const movieApi = 'react-native-ernmovie-api'
 
-function run (command) {
+process.env['SYSTEM_TESTS'] = 'true'
+
+function getRandomInt (min, max) {
+  min = Math.ceil(min)
+  max = Math.floor(max)
+  return Math.floor(Math.random() * (max - min)) + min
+}
+
+function run (command, {
+  expectedExitCode = 0
+} = {}) {
   console.log('===========================================================================')
-  console.log(`${chalk.bold.red(`Running`)} ${chalk.bold.blue(`${command}`)}`)
-  if (shell.exec(command).code !== 0) {
-    console.log(`${chalk.bold.red(`!!!TEST FAILED!!! `)} ${chalk.bold.blue(`${command}`)}`)
+  console.log(`${chalk.bold.red('Running')} ${chalk.bold.blue(`${command}`)}`)
+  const exitCode = shell.exec(command).code
+  if (exitCode !== expectedExitCode) {
+    console.log(`${chalk.bold.red('!!! TEST FAILED !!! ')} ${chalk.bold.blue(`${command}`)}`)
+    console.log(`Expected exit code ${expectedExitCode} but command exited with code ${exitCode}`)
+    afterAll()
     shell.exit(1)
   }
   console.log('===========================================================================')
 }
 
+function afterAll () {
+  console.log('===========================================================================')
+  console.log(info('Cleaning up test env'))
+  console.log(info(`Removing GitHub repository (${gitHubCauldronRepositoryName})`))
+  shell.exec(`curl -u ernplatformtest:${gitHubPesonalToken} -X DELETE https://api.github.com/repos/${gitUserName}/${gitHubCauldronRepositoryName}`)
+  console.log(info('Deactivating current Cauldron'))
+  shell.exec('ern cauldron repo clear')
+  console.log(info('Removing Cauldron alias'))
+  shell.exec(`ern cauldron repo remove ${cauldronName}`)
+  console.log('===========================================================================')
+}
+
 console.log(info(`Entering temporary working directory : ${workingDirectoryPath}`))
-process.chdir(`${workingDirectoryPath}`)
+process.chdir(workingDirectoryPath)
 
 console.log(info(`Creating GitHub repository (${gitHubCauldronRepositoryName})`))
 run(`curl -u ernplatformtest:${gitHubPesonalToken} -d '{"name": "${gitHubCauldronRepositoryName}"}' https://api.github.com/user/repos`)
 
-run(`ern --hide-banner`)
-run(`ern --log-level debug`)
+run('ern --hide-banner')
+run('ern --log-level trace')
 
 // Cauldron repo
-run(`ern cauldron repo clear`)
+run('ern cauldron repo clear')
 run(`ern cauldron repo add ${cauldronName} https://${gitUserName}:${gitPassword}@github.com/${gitUserName}/${gitHubCauldronRepositoryName}.git --current=false`)
 run(`ern cauldron repo use ${cauldronName}`)
-run(`ern cauldron repo current`)
-run(`ern cauldron repo list`)
+run('ern cauldron repo current')
+run('ern cauldron repo list')
 
 // Miniapp commands
 run(`ern create-miniapp ${miniAppName} --skipNpmCheck=true`)
-const miniAppPath = path.join(process.cwd(), `${miniAppName}`)
+const miniAppPath = path.join(process.cwd(), miniAppName)
 console.log(info(`Entering ${miniAppPath}`))
 process.chdir(miniAppPath)
-run(`ern add react-native-electrode-bridge`)
+run('ern add react-native-electrode-bridge')
 
 // Cauldron access commands
 run(`ern cauldron add nativeapp ${androidNativeApplicationDescriptor}`)
@@ -68,11 +93,11 @@ run(`ern cauldron add miniapps moviedetailsminiapp@${movieDetailsMiniAppVersion}
 run(`ern cauldron get nativeapp ${iosNativeApplicationDescriptor}`)
 
 // Already existing miniapp
-run(`ern cauldron add miniapps moviedetailsminiapp@${movieDetailsMiniAppVersion} -d ${androidNativeApplicationDescriptor}`)
+run(`ern cauldron add miniapps moviedetailsminiapp@${movieDetailsMiniAppVersion} -d ${androidNativeApplicationDescriptor}`, { expectedExitCode: 1 })
 // Non published miniapp
-run(`ern cauldron add miniapps ewkljrlwjerjlwjrl@0.0.3 -d ${androidNativeApplicationDescriptor}`)
+run(`ern cauldron add miniapps ewkljrlwjerjlwjrl@0.0.3 -d ${androidNativeApplicationDescriptor}`, { expectedExitCode: 1 })
 // File system miniapp
-run(`ern cauldron add miniapps file:${miniAppPath} -d ${androidNativeApplicationDescriptor}`)
+run(`ern cauldron add miniapps file:${miniAppPath} -d ${androidNativeApplicationDescriptor}`, { expectedExitCode: 1 })
 
 // Container gen should be successful for the two following commands
 run(`ern create-container --miniapps file:${miniAppPath} -p android -v 1.0.0`)
@@ -84,15 +109,15 @@ run(`ern create-container --miniapps file:${miniAppPath} movielistminiapp@${movi
 run(`ern create-container --descriptor ${androidNativeApplicationDescriptor}`)
 run(`ern create-container --descriptor ${iosNativeApplicationDescriptor}`)
 
-run(`ern why ern react-native-ernmovie-api ${androidNativeApplicationDescriptor}`)
+run(`ern why react-native-ernmovie-api ${androidNativeApplicationDescriptor}`)
 
 // Del dependency should fail because its still used by MovieListMiniApp
-run(`ern cauldron del dependencies react-native-ernmovie-api -d ${androidNativeApplicationDescriptor}`)
+run(`ern cauldron del dependencies react-native-ernmovie-api -d ${androidNativeApplicationDescriptor}`, { expectedExitCode: 1 })
 
 // Del miniapp
-run(`ern cauldron del miniapps moviedetailsminiapp-d ${androidNativeApplicationDescriptor}`)
+run(`ern cauldron del miniapps movielistminiapp -d ${androidNativeApplicationDescriptor}`)
 
-// Del dependency should succeed
+// Del dependency should now succeed
 run(`ern cauldron del dependencies react-native-ernmovie-api -d ${androidNativeApplicationDescriptor}`)
 run(`ern cauldron get nativeapp ${androidNativeApplicationDescriptor}`)
 
@@ -103,23 +128,19 @@ run(`ern create-api ${apiName}`)
 const apiPath = path.join(process.cwd(), `react-native-${apiName}-api`)
 console.log(info(`Entering ${apiPath}`))
 process.chdir(apiPath)
-run(`ern regen-api --updatePlugin=true`)
+run('ern regen-api --skipVersion')
 
 // api-impl
 run(`ern create-api-impl ${movieApi} --skipNpmCheck=true --nativeOnly=true --force=true`)
 const apiImplPath = path.join(process.cwd(), `${movieApi}-impl`)
 console.log(info(`Entering ${apiImplPath}`))
 process.chdir(apiImplPath)
-run(`ern regen-api-impl`)
+run('ern regen-api-impl')
 
 // Platform commands
-run(`ern platform current`)
-run(`ern platform list`)
-run(`ern platform plugins list`)
-run(`ern platform plugins search react-native`)
+run('ern platform current')
+run('ern platform list')
+run('ern platform plugins list')
+run('ern platform plugins search react-native')
 
-console.log(info(`Removing GitHub repository (${gitHubCauldronRepositoryName})`))
-run(`curl -u ernplatformtest:${gitHubPesonalToken} -X DELETE https://api.github.com/repos/${gitUserName}/${gitHubCauldronRepositoryName}`)
-
-run(`ern cauldron repo clear`)
-run(`ern cauldron repo remove ${cauldronName}`)
+afterAll()


### PR DESCRIPTION
- Rename updatePlugin option in regen-api to skipVersion and update logic accordingly.
- Set process environment variable SYSTEM_TESTS during system tests execution. 
- AndroidGenerator is making use of this to disable Container maven publication during tests (as we are using a NodeJs environment on Travis which does not come with Android SDK). This is temporary.
- Fix ApiImplGitHubGenerator to avoid system test failure due to thrown error.
Improve system tests
- Update .travis.yml file to run system tests as a cron job (daily)