### PR TITLE
create-api interpolates irrelevant variable

### DIFF
--- a/ern-local-cli/src/commands/create-api.js
+++ b/ern-local-cli/src/commands/create-api.js
@@ -69,7 +69,7 @@ exports.handler = async function ({
     return log.error(`react-native not found in manifest. cannot infer version to use`)
   }
 
-  log.info(`Generating ${apiName} API ${ApiGen}`)
+  log.info(`Generating ${apiName} API`)
   try {
     await ApiGen.generateApi({
       bridgeVersion: `${bridgeDep.version}`,


### PR DESCRIPTION
`ern create-api react-native-ernmovie-api -s` 

`Generating react-native-ernmovie-api API [object Object]` 
