### PR TITLE
Fix travis build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ sudo: enabled
 install:
 - npm install
 script:
-- 'if [ ${TRAVIS_EVENT_TYPE} != "cron" ]; then
+- 'set -ev;
+if [ ${TRAVIS_EVENT_TYPE} != "cron" ]; then
   npm run rebuild;
   npm run standard --version;
   npm run standard;


### PR DESCRIPTION
Fix Travis build bash script by adding `set -ev;` to stop the execution of the script as soon as one one the commands in the script fails (otherwise, even if one of the command fails, the script execution will succeed and turn the build in a false positive).