### PR TITLE
Allow independent ern module test runs

### DIFF
--- a/ern-api-gen/package.json
+++ b/ern-api-gen/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "ern-babel",
-    "test": "cross-env __ERN_TEST__=true ern-mocha",
+    "test": "ern-mocha",
     "coverage": "ern-nyc",
     "prepublish": "npm run build"
   },

--- a/ern-api-impl-gen/package.json
+++ b/ern-api-impl-gen/package.json
@@ -44,7 +44,7 @@
     }
   ],
   "scripts": {
-    "test": "cross-env __ERN_TEST__=true ern-mocha",
+    "test": "ern-mocha",
     "build": "ern-babel",
     "coverage": "ern-nyc",
     "prepublish": "yarn run build"

--- a/ern-cauldron-api/package.json
+++ b/ern-cauldron-api/package.json
@@ -43,7 +43,7 @@
     }
   ],
   "scripts": {
-    "test": "cross-env __ERN_TEST__=true ern-mocha",
+    "test": "ern-mocha",
     "build": "ern-babel",
     "coverage": "ern-nyc",
     "prepublish": "yarn run build"

--- a/ern-container-gen/package.json
+++ b/ern-container-gen/package.json
@@ -45,7 +45,7 @@
   ],
   "scripts": {
     "build": "ern-babel",
-    "test": "cross-env __ERN_TEST__=true ern-mocha",
+    "test": "ern-mocha",
     "coverage": "ern-nyc",
     "prepublish": "yarn run build"
   },

--- a/ern-core/package.json
+++ b/ern-core/package.json
@@ -43,7 +43,7 @@
   ],
   "scripts": {
     "build": "ern-babel",
-    "test": "cross-env __ERN_TEST__=true ern-mocha",
+    "test": "ern-mocha",
     "coverage": "ern-nyc",
     "prepublish": "yarn run build"
   },

--- a/ern-local-cli/package.json
+++ b/ern-local-cli/package.json
@@ -44,7 +44,7 @@
   ],
   "scripts": {
     "build": "ern-babel",
-    "test": "cross-env __ERN_TEST__=true ern-mocha",
+    "test": "ern-mocha",
     "coverage": "ern-nyc",
     "prepublish": "yarn run build",
     "postinstall": "node scripts/postinstall.js"

--- a/ern-runner-gen/package.json
+++ b/ern-runner-gen/package.json
@@ -44,7 +44,7 @@
   ],
   "scripts": {
     "build": "ern-babel",
-    "test": "cross-env __ERN_TEST__=true ern-mocha",
+    "test": "ern-mocha",
     "coverage": "ern-nyc",
     "prepublish": "yarn run build"
   },

--- a/ern-util-dev/bin/ern-mocha.js
+++ b/ern-util-dev/bin/ern-mocha.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+process.env['__ERN_TEST__'] = true
 if (!require('fs').existsSync(require('path').join(process.cwd(), 'test'))) {
   console.log('no tests for project ', process.cwd())
   process.exit(0)

--- a/ern-util-dev/package.json
+++ b/ern-util-dev/package.json
@@ -41,7 +41,7 @@
     }
   ],
   "scripts": {
-    "test": "cross-env __ERN_TEST__=true ./bin/ern-mocha.js"
+    "test": "node bin/ern-mocha.js"
   },
   "dependencies": {
     "babel-polyfill": "^6.23.0",

--- a/ern-util/package.json
+++ b/ern-util/package.json
@@ -42,7 +42,7 @@
   ],
   "scripts": {
     "build": "ern-babel",
-    "test": "cross-env __ERN_TEST__=true ern-mocha",
+    "test": "ern-mocha",
     "coverage": "ern-nyc",
     "prepublish": "yarn run build"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "babel-preset-flow": "^6.23.0",
     "babel-register": "^6.22.0",
     "chai": "^3.5.0",
-    "cross-env": "^3.2.4",
     "dir-compare": "^1.3.0",
     "dirty-chai": "^1.2.2",
     "eslint-plugin-flowtype": "^2.33.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1313,13 +1313,6 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
-cross-env@^3.2.4:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-3.2.4.tgz#9e0585f277864ed421ce756f81a980ff0d698aba"
-  dependencies:
-    cross-spawn "^5.1.0"
-    is-windows "^1.0.0"
-
 cross-spawn@^4:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
@@ -1327,7 +1320,7 @@ cross-spawn@^4:
     lru-cache "^4.0.1"
     which "^1.2.9"
 
-cross-spawn@^5.0.1, cross-spawn@^5.1.0:
+cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
@@ -2733,10 +2726,6 @@ is-typedarray@~1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
-
-is-windows@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.1.tgz#310db70f742d259a16a369202b51af84233310d9"
 
 isarray@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
This PR bring back independent module test run functionality that got lost in a regression. 
It is is now once again possible to run tests of a single `ern` module by running `npm run test` from within the given `ern` module directory.

Quite useful when writing tests for a single `ern` module, avoid having to run all other tests that we don't care about.

`cross-env` dependency was used by the previous methodology, and it was the only usage left of this dependency in Electrode Native. This PR also gets rid of the `cross-env` dependency.