### PR TITLE
create-api-impl now supports options `packageName` , `scope`

### DIFF
--- a/docs/cli/create-api-impl.md
+++ b/docs/cli/create-api-impl.md
@@ -23,7 +23,13 @@
 
 `--jsOnly/-j`
 
-* Generate an implementation skeleton project for a JavaScript implementation of the API  
+* Generate an implementation skeleton project for a JavaScript implementation of the API
+  
+`--packageName/-p`
+* Name to use for the apiImpl NPM package
+
+`--scope/-s`
+* Scope to use for the apiImpl NPM package
 
 `--outputDirectory/-o <directory>`
 
@@ -34,7 +40,7 @@
 * Indicates if this api implementation requires some config during initialization.
 * This option will be stored and reused during container generation to enforce config initialization
 
-`--skipNpmCheck/-s`
+`--skipNpmCheck`
 * Skips npm check to see if the package already exists
 * **Default** The value defaults to false. 
 
@@ -45,8 +51,17 @@
 
 #### Examples
 
-`ern create-api-impl react-native-weather-api`  
+`ern create-api-impl react-native-weather-api`
 This example shows how to create an API skeleton project named `react-native-weather-api-impl`.
+
+`ern create-api-impl react-native-weather-api -p my-weather-api-impl`
+
+This example shows how to create an API skeleton project named `my-weather-api-impl`.
+
+`ern create-api-impl react-native-weather-api -p my-weather-api-impl -s org`
+
+This example shows how to create an API skeleton project named `@org/my-weather-api-impl`.
+
 
 #### Remarks
 

--- a/docs/cli/create-api-impl.md
+++ b/docs/cli/create-api-impl.md
@@ -7,11 +7,11 @@
 
 #### Syntax
 
-`ern create-api-impl <api>`  
+`ern create-api-impl <apiName>`  
 
 **Arguments**
 
-`<api>`
+`<apiName>`
 
 * The package descriptor of the API for which to create an API implementation project
 

--- a/ern-api-impl-gen/src/ApiImpl.js
+++ b/ern-api-impl-gen/src/ApiImpl.js
@@ -15,10 +15,9 @@ import {
 import path from 'path'
 import ApiImplGen from './generators/ApiImplGen'
 
-const API_NAME_RE = /([^/]*)$/
-
 export default async function generateApiImpl ({
   apiDependency,
+  apiImplPkgName,
   outputDirectory,
   nativeOnly,
   forceGenerate,
@@ -27,6 +26,7 @@ export default async function generateApiImpl ({
   paths
 } : {
   apiDependency: Dependency,
+  apiImplPkgName: string,
   outputDirectory: string,
   nativeOnly: boolean,
   forceGenerate?: boolean,
@@ -40,10 +40,9 @@ export default async function generateApiImpl ({
   }
 } = {}) {
   log.debug('Entering generate API IMPL')
-
   try {
     // get the directory to output the generated project.
-    paths.outDirectory = outputDirectory = formOutputDirectoryName(apiDependency, outputDirectory)
+    paths.outDirectory = outputDirectory = formOutputDirectoryName(apiImplPkgName, outputDirectory)
     await createOutputDirectory(outputDirectory, forceGenerate)
     await createNodePackage(outputDirectory, apiDependency, nativeOnly, hasConfig)
 
@@ -113,11 +112,10 @@ function createPluginsDownloadDirectory (pluginsDownloadPath: string) {
   shell.mkdir('-p', pluginsDownloadPath)
 }
 
-function formOutputDirectoryName (apiDependency: Dependency, outputDirectoryPath: string) {
-  let apiName = API_NAME_RE.exec(apiDependency.name)[1]
+function formOutputDirectoryName (apiImplPkgName: string, outputDirectoryPath: string) {
   return outputDirectoryPath
-    ? path.join(outputDirectoryPath, `${apiName}-impl`)
-    : path.join(process.cwd(), `${apiName}-impl`)
+    ? path.join(outputDirectoryPath, apiImplPkgName)
+    : path.join(process.cwd(), apiImplPkgName)
 }
 
 function getPlatforms (nativeOnly: boolean): Array<string> {

--- a/ern-container-gen/src/generators/android/AndroidGenerator.js
+++ b/ern-container-gen/src/generators/android/AndroidGenerator.js
@@ -163,7 +163,7 @@ export default class AndroidGenerator implements ContainerGenerator {
           throw new Error(`Was not able to download ${plugin.name}`)
         }
 
-        if (utils.isDependencyApiImpl(plugin.name)) {
+        if (await utils.isDependencyApiImpl(plugin.name)) {
           this.populateApiImplMustacheView(pluginSourcePath, mustacheView)
         }
 

--- a/ern-core/src/MiniApp.js
+++ b/ern-core/src/MiniApp.js
@@ -270,7 +270,7 @@ Are you sure this is a MiniApp ?`)
           log.debug(`One or more native dependencies identified: ${JSON.stringify(nativeDependencies)}`)
           for (let dep: Dependency of nativeDependencies) {
             if (Dependency.same(dep.withoutVersion(), dependency, {ignoreVersion: true})) {
-              if (utils.isDependencyApiOrApiImpl(dep.name)) {
+              if (await utils.isDependencyApiOrApiImpl(dep.name)) {
                 log.debug(`This is an api or api-impl`)
                 log.warn(`${dep.toString()} is not declared in the Manifest. You might consider adding it.`)
                 finalDependency = dep

--- a/ern-core/src/utils.js
+++ b/ern-core/src/utils.js
@@ -96,7 +96,7 @@ export function getDefaultPackageNameForModule (moduleName: string, moduleType: 
   }
 }
 
-export function isDependencyApiOrApiImpl (dependencyName: string): boolean {
+export async function isDependencyApiOrApiImpl (dependencyName: string): Promise<boolean> {
   return (isDependencyApi(dependencyName) || isDependencyApiImpl(dependencyName))
 }
 
@@ -104,8 +104,13 @@ export function isDependencyApi (dependencyName: string): boolean {
   return (/^.*react-native-.+-api$/.test(dependencyName))
 }
 
-export function isDependencyApiImpl (dependencyName: string): boolean {
-  return (/^.*react-native-.+-api-impl$/.test(dependencyName))
+export async function isDependencyApiImpl (dependencyName: string): Promise<boolean> {
+  // for api-impl using default name minimize the await time
+  if (/^.*react-native-.+-api-impl$/.test(dependencyName)) {
+    return true
+  }
+  const depInfo = await yarn.info(DependencyPath.fromString(dependencyName), {field: 'ern 2> /dev/null', json: true})
+  return (depInfo.data && [`${ModuleTypes.NATIVE_API_IMPL}`, `${ModuleTypes.JS_API_IMPL}`].indexOf(depInfo.data.moduleType) > -1)
 }
 
 /**

--- a/ern-core/src/utils.js
+++ b/ern-core/src/utils.js
@@ -88,9 +88,9 @@ export function getDefaultPackageNameForModule (moduleName: string, moduleType: 
     case ModuleTypes.API:
       return basePackageName.concat('-api')
     case ModuleTypes.JS_API_IMPL:
-      return basePackageName.concat('js-api-impl')
+      return basePackageName.concat('-js-api-impl')
     case ModuleTypes.NATIVE_API_IMPL:
-      return basePackageName.concat('native-api-impl')
+      return basePackageName.concat('-native-api-impl')
     default:
       throw new Error(`Unsupported module type : ${moduleType}`)
   }

--- a/ern-local-cli/src/commands/create-api-impl.js
+++ b/ern-local-cli/src/commands/create-api-impl.js
@@ -42,6 +42,9 @@ exports.builder = function (yargs: any) {
     alias: 's',
     describe: 'skips npm check to see if the package already exists. This is mainly useful when running this command for CI',
     type: 'bool'
+  }).option('apiImplName', {
+    alias: 'n',
+    describe: 'Specify the name of the api implementation to use'
   })
   .epilog(cliUtils.epilog(exports))
 }
@@ -56,7 +59,8 @@ exports.handler = async function ({
   force,
   outputDirectory,
   hasConfig,
-  skipNpmCheck
+  skipNpmCheck,
+  apiImplName
 } : {
   api: string,
   nativeOnly: boolean,
@@ -64,7 +68,8 @@ exports.handler = async function ({
   force: boolean,
   outputDirectory: string,
   hasConfig: boolean,
-  skipNpmCheck?: boolean
+  skipNpmCheck?: boolean,
+  apiImplName?: string
 }) {
   try {
     // Fixes https://github.com/electrode-io/electrode-native/issues/265
@@ -73,13 +78,13 @@ exports.handler = async function ({
     }
 
     const apiDep = Dependency.fromPath(DependencyPath.fromString(api))
-    const apiImplName = `${apiDep.name}-impl`
+    const implPkgName = `${apiDep.name}-impl`
 
     // Skip npm check code execution
     if (!skipNpmCheck) {
       // check if the packageName for specified {apiName}-impl exists
       // Extend the command to ack the scope in the name
-      const continueIfPkgNameExists = await cliUtils.performPkgNameConflictCheck(apiImplName)
+      const continueIfPkgNameExists = await cliUtils.performPkgNameConflictCheck(implPkgName)
       // If user wants to stop execution if npm package name conflicts
       if (!continueIfPkgNameExists) {
         return

--- a/ern-local-cli/src/commands/create-api-impl.js
+++ b/ern-local-cli/src/commands/create-api-impl.js
@@ -31,10 +31,10 @@ exports.builder = function (yargs: any) {
     describe: 'Generate js project with proper dependencies (Implementation of the API has to be written in js'
   }).option('packageName', {
     alias: 'p',
-    describe: 'Name to use for the ApiImpl NPM package'
+    describe: 'Name to use for the apiImpl NPM package'
   }).option('scope', {
     alias: 's',
-    describe: 'Scope to use for the ApiImpl NPM package'
+    describe: 'Scope to use for the apiImpl NPM package'
   }).option('force', {
     alias: 'f',
     type: 'bool',

--- a/ern-local-cli/src/commands/create-api-impl.js
+++ b/ern-local-cli/src/commands/create-api-impl.js
@@ -1,8 +1,9 @@
 // @flow
 
 import {
-  utils,
-  Platform
+  utils as core,
+  Platform,
+  ModuleTypes
 } from 'ern-core'
 import {
   generateApiImpl
@@ -12,11 +13,11 @@ import {
   DependencyPath,
   Utils
 } from 'ern-util'
-import cliUtils from '../lib/utils'
+import utils from '../lib/utils'
 import inquirer from 'inquirer'
 import path from 'path'
 
-exports.command = 'create-api-impl <api>'
+exports.command = 'create-api-impl <apiName>'
 exports.desc = 'Commands to generate API implementation skeleton.'
 
 exports.builder = function (yargs: any) {
@@ -28,6 +29,12 @@ exports.builder = function (yargs: any) {
     alias: 'j',
     type: 'bool',
     describe: 'Generate js project with proper dependencies (Implementation of the API has to be written in js'
+  }).option('packageName', {
+    alias: 'p',
+    describe: 'Name to use for the ApiImpl NPM package'
+  }).option('scope', {
+    alias: 's',
+    describe: 'Scope to use for the ApiImpl NPM package'
   }).option('force', {
     alias: 'f',
     type: 'bool',
@@ -39,70 +46,51 @@ exports.builder = function (yargs: any) {
     type: 'bool',
     describe: 'Indicates if this api implementation requires some config during initialization. \nThis option will be stored and reused during container generation to enforce config initialization'
   }).option('skipNpmCheck', {
-    alias: 's',
     describe: 'skips npm check to see if the package already exists. This is mainly useful when running this command for CI',
     type: 'bool'
-  }).option('apiImplPkgName', {
-    alias: 'a',
-    describe: 'Specify the name of the api implementation to use'
   })
-  .epilog(cliUtils.epilog(exports))
+  .epilog(utils.epilog(exports))
 }
 
 const WORKING_DIRECTORY = path.join(Platform.rootDirectory, 'api-impl-gen')
 const PLUGIN_DIRECTORY = path.join(WORKING_DIRECTORY, 'plugins')
 
 exports.handler = async function ({
-  api,
+  apiName,
   nativeOnly,
   jsOnly,
+  packageName,
+  scope,
   force,
   outputDirectory,
   hasConfig,
-  skipNpmCheck,
-  apiImplPkgName
+  skipNpmCheck
 } : {
-  api: string,
+  apiName: string,
   nativeOnly: boolean,
   jsOnly: boolean,
+  packageName?: string,
+  scope?: string,
   force: boolean,
   outputDirectory: string,
   hasConfig: boolean,
-  skipNpmCheck?: boolean,
-  apiImplPkgName?: string
+  skipNpmCheck?: boolean
 }) {
   try {
-    const apiDep = Dependency.fromPath(DependencyPath.fromString(api))
-    if (!apiImplPkgName) {
-      apiImplPkgName = `${apiDep.name}-impl`
-    }
+    const apiDep = Dependency.fromPath(DependencyPath.fromString(apiName))
     // pre conditions
-    await cliUtils.logErrorAndExitIfNotSatisfied({
+    await utils.logErrorAndExitIfNotSatisfied({
       noGitOrFilesystemPath: {
-        obj: api
+        obj: apiName
       },
       publishedToNpm: {
-        obj: api,
-        extraErrorMessage: `Couldn't find package ${api} to generate the api implementation`
-      },
-      isValidNpmPackageName: {
-        name: apiImplPkgName,
-        extraErrorMessage: `${apiImplPkgName} is not a valid npm package name`
+        obj: apiName,
+        extraErrorMessage: `Couldn't find package ${apiName} to generate the api implementation`
       }
     })
-    // Skip npm check code execution
-    if (!skipNpmCheck) {
-      // check if the packageName for specified {apiName}-impl exists
-      // Extend the command to ack the scope in the name
-      const continueIfPkgNameExists = await cliUtils.performPkgNameConflictCheck(apiImplPkgName)
-      // If user wants to stop execution if npm package name conflicts
-      if (!continueIfPkgNameExists) {
-        return
-      }
-    }
 
-    log.info(`Generating API implementation for ${api}`)
-    let reactNativeVersion = await utils.reactNativeManifestVersion()
+    log.info(`Generating API implementation for ${apiName}`)
+    let reactNativeVersion = await core.reactNativeManifestVersion()
     log.debug(`Will generate api implementation using react native version: ${reactNativeVersion}`)
 
     if (jsOnly && nativeOnly) {
@@ -113,9 +101,39 @@ exports.handler = async function ({
     if (!jsOnly && !nativeOnly) {
       nativeOnly = await promptPlatformSelection()
     }
+
+    // Construct the package name
+    if (packageName) {
+      packageName = scope ? `@${scope}/${packageName}` : packageName
+    } else {
+      packageName = core.getDefaultPackageNameForModule(
+        scope ? `@${scope}/${apiDep.name}` : apiDep.name,
+        nativeOnly ? ModuleTypes.NATIVE_API_IMPL : ModuleTypes.JS_API_IMPL)
+    }
+
+    // Check if packageName is valid
+    await utils.logErrorAndExitIfNotSatisfied({
+      isValidNpmPackageName: {
+        name: packageName,
+        extraErrorMessage: `${packageName} is not a valid npm package name`
+      }
+    })
+
+    const apiImplDep = Dependency.fromPath(DependencyPath.fromString(packageName))
+    // Skip npm check code execution
+    if (!skipNpmCheck) {
+      // check if the packageName for specified {apiName}-impl exists
+      // Extend the command to ack the scope in the name
+      const continueIfPkgNameExists = await utils.performPkgNameConflictCheck(packageName)
+      // If user wants to stop execution if npm package name conflicts
+      if (!continueIfPkgNameExists) {
+        return
+      }
+    }
+
     await generateApiImpl({
       apiDependency: apiDep,
-      apiImplPkgName,
+      apiImplDependency: apiImplDep,
       outputDirectory,
       nativeOnly,
       forceGenerate: force,


### PR DESCRIPTION
Closes https://github.com/electrode-io/electrode-native/issues/254

- [x] Add new option to `create-api-impl` command to pass name of api implementation (completely replacing the convention). If user provide `test-api-implementation`, it will use this name as such.
- [x] support `scope`
- [x] Update logic in `ern-api-impl-gen` accordingly
- [x] Update platform logic where needed to not rely on naming to detect API implementation module, but on the data we store in `ern` object in package.json of the module (indicating the type of `ern` module)
- [x] Update `create-api-impl` command documentation

* create-api-impl now supports passing `packageName` , `scope`
* underlying logic is adapted
* documentation is updated