### PR TITLE
Fix coverage script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ lerna-debug.*
 **/lerna-debug.*
 **/coverage/**
 **/.nyc_output/**
+**/.coverage/**
 yarn-error.log
 
 # GitBook

--- a/ern-api-gen/resources/es6/babelrc.mustache
+++ b/ern-api-gen/resources/es6/babelrc.mustache
@@ -1,4 +1,4 @@
 {
-    "presets":["es2015"],
+    "presets":["env"],
     "plugins":["transform-class-properties"]
 }

--- a/ern-util-dev/bin/ern-nyc.js
+++ b/ern-util-dev/bin/ern-nyc.js
@@ -1,8 +1,24 @@
 #!/usr/bin/env node
 var fs = require('fs')
+
+process.env['__ERN_TEST__'] = true
+
 if (!fs.existsSync('test')) {
   console.log(`No tests found in ${process.cwd()}/test`)
   process.exit(0)
 }
-process.argv.push('--sourceMap=false', '--reportDir=.coverage', '--instrument=false', '--all', '--include=src/**/*.js', 'mocha', '--compilers', `js:${__dirname}/../babelhook-coverage`, 'test/*-test.js')
+
+process.argv.push(
+  '--sourceMap=false',
+  '--reportDir=.coverage',
+  '--reporter=json',
+  '--reporter=text',
+  '--show-process-tree',
+  '--instrument=false',
+  '--all',
+  `--require=${__dirname}/../babelhook-coverage`,
+  '--only="src/"',
+  'mocha',
+  'test/*-test.js')
+
 require('nyc/bin/nyc')

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "setup-dev": "node setup-dev.js",
     "rebuild": "rimraf ern-*/**/dist && lerna clean --yes && lerna bootstrap --npmClient=yarn",
     "test": "lerna run test",
-    "coverage": "lerna run coverage && istanbul-combine -d coverage -p summary -r lcov -r html $(find ./ern-*/.nyc_output -type f -name '*.json' -maxdepth 3)",
+    "coverage": "lerna run coverage && istanbul-combine -d coverage -p summary -r html $(find ./ern-*/.coverage -type f -name 'coverage-final.json' -maxdepth 3)",
     "standard": "standard",
     "flow": "flow",
     "precommit": "standard && flow",


### PR DESCRIPTION
**Description**

This PR fixes the `coverage` script of Electrode Native.

Running `npm run coverage` from the root directory now properly run `coverage` for all `ern` modules and aggregates the coverage result in a single coverage report.

Upon running `npm run coverage`, a `.coverage` directory (git ignored) will be created in each `ern` module directory. Each of these `.coverage` directory will contain the raw json code coverage report of the module. `istanbul-combine` is then called once all `ern` modules have been processed, and will aggregate all individual json reports and output an html report (that will be located in the `coverage` directory of electrode-native root.

**Things done**

- Fix `nyc` / `istanbul-combine` command line arguments
  - Require our custom `babel-register` mecanism (`babelhook-coverage`) directly in `nyc` process by using the `--require` option of `nyc` (prior to this, the babel hook was called by `mocha` and not `nyc` leading to the `--all` option of `nyc` to not properly work (i.e not reporting files that were not covered at all).
  - Use `--reporter` option for `nyc` to use a `json` reporter (right one for `istanbul-combine` to properly work at the end of the chain). Use a `text` reporter as well (to keep logging coverage report in the console after text execution).
  - Update `istanbul-combine` command line to feed it the correct files to combine (before the command was feeding it raw `istanbul` output files which was leading to improper generated output).

- Set env variable `__ERN_TEST__` as some tests execution are relying on its presence (was done in `ern-mocha` binary already but `ern-mocha` is not executed by `ern-nyc`)

- Add  new`.coverage` directory exclusion to `.gitignore`.
  