### PR TITLE
refactor create-api command

### DIFF
--- a/docs/cli/create-api-impl.md
+++ b/docs/cli/create-api-impl.md
@@ -41,7 +41,7 @@
 * This option will be stored and reused during container generation to enforce config initialization
 
 `--skipNpmCheck`
-* Skips npm check to see if the package already exists
+* Skip the check ensuring package does not already exists in NPM registry
 * **Default** The value defaults to false. 
 
 `--force/-f`

--- a/docs/cli/create-api.md
+++ b/docs/cli/create-api.md
@@ -6,17 +6,17 @@
 
 #### Syntax
 
-`ern create-api <name>`  
+`ern create-api <apiName>`  
 
 **Arguments**
 
-`<name>`
+`<apiName>`
 
 * The name to use for this API.
 
 **Options**  
 
-`--scope/-n <scope>`
+`--scope/-s <scope>`
 
 * Specify a given npm scope for the API project package  
 
@@ -35,8 +35,8 @@
 * Generate the API using a pre-existing Swagger schema located at the given `schemaPath`  
 * **Default**  If this option is not used the command uses a default starter schema to generate the initial API. You can modify this option at a later time and then regenerate the API using the `ern regen-api` command.  
 
-`--skipNpmCheck/-s`
-* Skips npm check to see if the package already exists
+`--skipNpmCheck`
+* Skip the check ensuring package does not already exists in NPM registry
 * **Default** The value defaults to false. 
 
 #### Examples

--- a/ern-local-cli/src/commands/create-api-impl.js
+++ b/ern-local-cli/src/commands/create-api-impl.js
@@ -46,7 +46,7 @@ exports.builder = function (yargs: any) {
     type: 'bool',
     describe: 'Indicates if this api implementation requires some config during initialization. \nThis option will be stored and reused during container generation to enforce config initialization'
   }).option('skipNpmCheck', {
-    describe: 'skips npm check to see if the package already exists. This is mainly useful when running this command for CI',
+    describe: 'Skip the check ensuring package does not already exists in NPM registry',
     type: 'bool'
   })
   .epilog(utils.epilog(exports))

--- a/ern-local-cli/src/commands/create-api.js
+++ b/ern-local-cli/src/commands/create-api.js
@@ -17,7 +17,7 @@ exports.desc = 'Create a new api'
 
 exports.builder = function (yargs: any) {
   return yargs.option('scope', {
-    alias: 'n',
+    alias: 's',
     describe: 'NPM scope of project'
   }).option('apiVersion', {
     alias: 'a',
@@ -29,8 +29,7 @@ exports.builder = function (yargs: any) {
     alias: 'm',
     describe: 'Path to schema(swagger)'
   }).option('skipNpmCheck', {
-    alias: 's',
-    describe: 'skips npm check to see if the package already exists. This is mainly useful when running this command for CI',
+    describe: 'Skip the check ensuring package does not already exists in NPM registry',
     type: 'bool'
   })
   .epilog(utils.epilog(exports))
@@ -51,6 +50,14 @@ exports.handler = async function ({
   schemaPath?: string,
   skipNpmCheck? : boolean
 }) {
+  // Check if the api name is valid npm package name
+  // https://docs.npmjs.com/files/package.json
+  await utils.logErrorAndExitIfNotSatisfied({
+    isValidNpmPackageName: {
+      name: apiName
+    }
+  })
+
   if (!skipNpmCheck) {
     const continueIfPkgNameExists = await utils.performPkgNameConflictCheck(apiName)
     // If user wants to stop execution if npm package name conflicts


### PR DESCRIPTION
- Reword the description of existing command options
- Remove `-s` alias from `--skipNpmCheck` and move it as the `--scope` alias instead
- Properly check for validity of NPM package name 
