### PR TITLE
Add coveralls support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ else
   ern platform use 1000.0.0;
   node system-tests; 
 fi'
+after_success: 
+- npm run coverage-ci
 notifications:
   slack:
     secure: Ccv7knkrsp4gEQoE/MOqAICq785+G28pJOCsHKJyMRh7SFezT4nOYV0L60gus2JQmi1ap0/rG0GlkmZ1NWQnmhrbcstylPWmCgAM43SMInXxameD8hrbm5dHtJAeq5bsN/Fb8EkW/EFHthKSVgoESqdjvWM7timdg5mCL7ObsADZx30VBZ44rF9nEP7yvwS5LCfmHNakG7R9hbmLBlYoQgYimxEjyCmYoMP2eG+jdfTUWYYJVtW7Mf8BLIdb8jZLX882QXOHNjsIJ96n7gQGyZSozPBU/435+VI8oU3gR00TcYuUuNUKFQHebMNCMA8unRGLy8PZm4TGQgLl0qYSB6nGE0n8gN3pMGQlLP/x8uJOyh0vZXa9lKHhZeFrpXv+RJfUOjtMyYNrD7Ko7wIeqy/lqLkfuPNy0KIND9aAK/Sz/Muo/nx2z7ZWA1n8o//+DgpInt1I6K5KILIYMpu5udrmm+U9HB+WAdB75RmNc7d9uImskcEhbqGKoRwjhTXapX/e95MnTC4p1e2eFCwruvgR/vyclpMgOMQywfab6WlHRqZqLpezgH1PI2o/U7D4NygLPK1W5fAgwFOa5LsyEaU47RUHOwIqr820klL+gfS9+dXqPM3D0PsW1fufOY0859Ba8N11kj53ll1zYi1onWB1zRSLY4XIhjMCqQgah+Y=

--- a/ern-core/test/dummy-test.js
+++ b/ern-core/test/dummy-test.js
@@ -1,0 +1,14 @@
+// 
+// DUMMY TEST JUST FOR ERN-CORE MODULE
+// TO BE ACCOUNTED FOR IN TEST COVERAGE
+// REMOVE THIS FILE AND THIS TEST AS SOON
+// AS A SINGLE REAL ERN-CORE TEST HAS BEEN CREATED
+// AS THIS TEST WON'T LONGER BE NECESSARY
+
+import {
+  expect
+} from 'chai'
+
+it('should succeed', () => {
+  expect(true).to.be.true
+})

--- a/ern-runner-gen/test/dummy-test.js
+++ b/ern-runner-gen/test/dummy-test.js
@@ -1,0 +1,14 @@
+// 
+// DUMMY TEST JUST FOR ERN-CORE MODULE
+// TO BE ACCOUNTED FOR IN TEST COVERAGE
+// REMOVE THIS FILE AND THIS TEST AS SOON
+// AS A SINGLE REAL ERN-CORE TEST HAS BEEN CREATED
+// AS THIS TEST WON'T LONGER BE NECESSARY
+
+import {
+  expect
+} from 'chai'
+
+it('should succeed', () => {
+  expect(true).to.be.true
+})

--- a/ern-util-dev/bin/ern-nyc.js
+++ b/ern-util-dev/bin/ern-nyc.js
@@ -17,7 +17,7 @@ process.argv.push(
   '--instrument=false',
   '--all',
   `--require=${__dirname}/../babelhook-coverage`,
-  '--only="src/"',
+  '--include=src/**/*.js',
   'mocha',
   'test/*-test.js')
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-preset-flow": "^6.23.0",
     "babel-register": "^6.22.0",
     "chai": "^4.1.2",
+    "coveralls": "^3.0.0",
     "dir-compare": "^1.3.0",
     "dirty-chai": "^2.0.1",
     "eslint-plugin-flowtype": "^2.33.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "rebuild": "rimraf ern-*/**/dist && lerna clean --yes && lerna bootstrap --npmClient=yarn",
     "test": "lerna run test",
     "coverage": "lerna run coverage && istanbul-combine -d coverage -p summary -r html $(find ./ern-*/.coverage -type f -name 'coverage-final.json' -maxdepth 3)",
+    "coverage-ci": "lerna run coverage && istanbul-combine -d coverage -p summary -r text-lcov $(find ./ern-*/.coverage -type f -name 'coverage-final.json' -maxdepth 3) | coveralls",
     "standard": "standard",
     "flow": "flow",
     "precommit": "standard && flow",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1318,6 +1318,16 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+coveralls@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.0.0.tgz#22ef730330538080d29b8c151dc9146afde88a99"
+  dependencies:
+    js-yaml "^3.6.1"
+    lcov-parse "^0.0.10"
+    log-driver "^1.2.5"
+    minimist "^1.2.0"
+    request "^2.79.0"
+
 create-error-class@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
@@ -2840,7 +2850,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@3.x, js-yaml@^3.5.1:
+js-yaml@3.x, js-yaml@^3.5.1, js-yaml@^3.6.1:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -2959,6 +2969,10 @@ lcid@^1.0.0:
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
   dependencies:
     invert-kv "^1.0.0"
+
+lcov-parse@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
 
 lerna@2.0.0:
   version "2.0.0"
@@ -3103,6 +3117,10 @@ lodash.without@~4.4.0:
 lodash@^4.0.0, lodash@^4.1.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+log-driver@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
 
 lolex@^1.6.0:
   version "1.6.0"
@@ -4237,6 +4255,33 @@ request@2.81.0, request@~2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
+request@^2.79.0:
+  version "2.83.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.6.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.1"
+    forever-agent "~0.6.1"
+    form-data "~2.3.1"
+    har-validator "~5.0.3"
+    hawk "~6.0.2"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.17"
+    oauth-sign "~0.8.2"
+    performance-now "^2.1.0"
+    qs "~6.5.1"
+    safe-buffer "^5.1.1"
+    stringstream "~0.0.5"
+    tough-cookie "~2.3.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.1.0"
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -4784,7 +4829,7 @@ to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
-tough-cookie@~2.3.0, tough-cookie@~2.3.2:
+tough-cookie@~2.3.0, tough-cookie@~2.3.2, tough-cookie@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
   dependencies:


### PR DESCRIPTION
This PR enables unit tests code coverage script execution on TravisCI and report publication to [coveralls](https://coveralls.io/) service.

- Adds a dependency on [node coveralls](https://github.com/nickmerwin/node-coveralls)
- Create a new npm script `coverage-ci` that does sensibly the same things as the existing `coverage` npm script with the difference that it won't create an `html` report but a `text-lcov` report instead that is piped to `coveralls` binary for publication to `coveralls`.
The `coverage` npm script can still be used locally to generate a local html code coverage report.
- Update Travis build configuration, `.travis.yml`, to run `coverage-ci` script after successful execution of tests.
- Adds initial `test` directory to `ern-core` and `ern-runner-gen` modules that were missing one. Add a dummy test in each of these directories. This way both these modules source files will be properly processed and part of the code coverage report.

Coveralls service has been configured accordingly beforehand and granted access to `electrode-io/electrode-native` repo (required).