### PR TITLE
Update Info.plist of iOS Runner

### DIFF
--- a/ern-runner-gen/runner-hull/ios/ErnRunner/Info.plist
+++ b/ern-runner-gen/runner-hull/ios/ErnRunner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
Set `UIViewControllerBasedStatusBarAppearance` to `false` so that `RCTStatusBarManager` does not cause a red screen when used in some standalone MiniApps.