### PR TITLE
Manifest documentation fixes

### DIFF
--- a/docs/platform-parts/manifest.md
+++ b/docs/platform-parts/manifest.md
@@ -23,7 +23,7 @@ The Electrode Native platform guarantees that any MiniApp targeting a given Elec
 The Electrode Native platform stores its master manifest in a GitHub repository, [electrode-native-manifest](https://github.com/electrode-io/electrode-native-manifest/blob/master/manifest.json).  
 By default, Electrode Native uses the master manifest. For more advanced use cases, it is possible to override the master manifest as described later in this documentation.
 
-In order to update the manifest at any time, it is stored in a Git repository. This allows for addding new supported dependencies for an Electrode Native version at any time, without having to wait for the next Electrode Native main version to be released.
+In order to update the manifest at any time, it is stored in a Git repository. This allows for adding new supported dependencies for an Electrode Native version at any time, without having to wait for the next Electrode Native main version to be released.
 
 For any Electrode Native version defined in the master manifest:
 * We can add new native dependencies support.  

--- a/docs/platform-parts/manifest.md
+++ b/docs/platform-parts/manifest.md
@@ -53,9 +53,9 @@ You can override the master manifest with your own manifest file:
 
 To override a manifest:
 
-1) Create your own manifest repository on GitHub (you can fork this [starter manifest](https://github.com/electrode-io/electrode-native-starter-manifest)).
-2) Create a manifest override configuration in your cauldron--so that it is correctly applied to all users of this cauldron.
-3) Update and maintain your manifest as needed, over time.
+1. Create your own manifest repository on GitHub (you can fork this [starter manifest](https://github.com/electrode-io/electrode-native-starter-manifest)).
+2. Create a manifest override configuration in your cauldron--so that it is correctly applied to all users of this cauldron.
+3. Update and maintain your manifest as needed, over time.
 
 The following example shows a configuration that includes a manifest override.
 


### PR DESCRIPTION
#### Problem

Typo and list formatting problem on the [manifest docs](http://www.electrode.io/site/docs/introduction.html):

![before](https://user-images.githubusercontent.com/1858316/32510772-84bb4004-c3a6-11e7-9188-8b9c24d79bc6.jpg)

#### Solution

Fix typo, reformat list:

![after](https://user-images.githubusercontent.com/1858316/32510778-87fc6180-c3a6-11e7-8373-97b973e1d1a4.jpg)
