### PR TITLE
Fix manifest platform version filtering

### DIFF
--- a/ern-core/src/GitManifest.js
+++ b/ern-core/src/GitManifest.js
@@ -106,7 +106,7 @@ export default class GitManifest {
 
   getPluginsConfigurationDirectories (maxVersion: string = Platform.currentVersion) : Array<string> {
     return _(fs.readdirSync(path.join(this._repoAbsoluteLocalPath, 'plugins')))
-            .filter(d => ERN_VERSION_DIRECTORY_RE.test(d) && ERN_VERSION_DIRECTORY_RE.exec(d)[1] <= maxVersion)
+            .filter(d => ERN_VERSION_DIRECTORY_RE.test(d) && semver.lte(ERN_VERSION_DIRECTORY_RE.exec(d)[1], maxVersion))
             .map(d => path.join(this._repoAbsoluteLocalPath, 'plugins', d))
             .value()
   }


### PR DESCRIPTION
Fixes https://github.com/electrode-io/electrode-native/issues/317

Fix a bug that has already been there but only surfaced with platform version `0.10.0`.
Code was working fine for previous versions `v0.8.0`, `v0.9.0` or even `v1000.0.0` as the version comparison statement was properly evaluated to `true` for the following :

```js
'0.5.0' <= '0.9.0'  // true
'0.5.0' <= '1000.0.0' // true
```

However for `v0.10.0` the string comparison was returning false, leading to the bug.

```js
'0.5.0' <= '0.10.0' // false
```

**Fix :** Do not use string comparison when comparing versions but rather rely on `semver` lib that has proper logic to compare versions.