### PR TITLE
Internalize imports

### DIFF
--- a/ern-core/src/iosUtil.js
+++ b/ern-core/src/iosUtil.js
@@ -3,11 +3,9 @@ import {
   mustacheUtils,
   shell
 } from 'ern-util'
-import {
-  manifest,
-  handleCopyDirective,
-  utils
-} from 'ern-core'
+import manifest from './Manifest'
+import handleCopyDirective from './handleCopyDirective'
+import utils from './utils'
 import readDir from 'fs-readdir-recursive'
 import path from 'path'
 import xcode from 'xcode-ern'

--- a/ern-util/src/fileUtil.js
+++ b/ern-util/src/fileUtil.js
@@ -1,7 +1,7 @@
 // @flow
 
 import fs from 'fs'
-import { shell } from 'ern-util'
+import shell from './shell'
 
 /**
  * ==============================================================================


### PR DESCRIPTION
* **Problem:** Debugging `ern` CLI commands locally via symlink-ed packages is difficult as certain packages `require` themselves. 
* **Solution:** Change `import`s to reference the modules directly
* **Testing:**
    * Set up for debug development

        ```shell
        ern platform use 0.10.0
        cd <development electrode-native dir>
        npm link
        cd ~/.ern/versions/
        rm -rf 0.10.0/node_modules
        ln -s <development electrode-native dir> node_modules
        ```

        Running `ern --help` should display help output and not explode 💥
    * CI should pass?
