### PR TITLE
Update CodePush Cauldron structure

### DIFF
--- a/ern-cauldron-api/src/api.js
+++ b/ern-cauldron-api/src/api.js
@@ -109,11 +109,10 @@ export default class CauldronApi {
   async getCodePushEntries (
     nativeApplicationName: string,
     platformName: string,
-    versionName: string) {
+    versionName: string,
+    deploymentName: string) {
     const version = await this.getVersion(nativeApplicationName, platformName, versionName)
-    if (version && version.miniApps) {
-      return version.miniApps.codePush
-    }
+    return version && version.codePush && version.codePush[deploymentName]
   }
 
   async getContainerMiniApps (
@@ -393,10 +392,13 @@ export default class CauldronApi {
     nativeApplicationName: string,
     platformName: string,
     versionName: string,
-    codePushEntry: Array<CauldronCodePushEntry>) {
+    codePushEntry: CauldronCodePushEntry) {
     const version = await this.getVersion(nativeApplicationName, platformName, versionName)
     if (version) {
-      version.miniApps.codePush.push(codePushEntry)
+      const deploymentName = codePushEntry.metadata.deploymentName
+      version.codePush[deploymentName]
+        ? version.codePush[deploymentName].push(codePushEntry)
+        : version.codePush[deploymentName] = [ codePushEntry ]
       await this.commit(`New CodePush OTA update`)
     }
   }

--- a/ern-cauldron-api/src/gitstore.js
+++ b/ern-cauldron-api/src/gitstore.js
@@ -11,7 +11,7 @@ import path from 'path'
 const CAULDRON_FILENAME = 'cauldron.json'
 
 export type CauldronCodePushMetadata = {
-  deploymentName?: string,
+  deploymentName: string,
   isMandatory?: boolean,
   appVersion?: string,
   size?: number,
@@ -28,7 +28,6 @@ export type CauldronCodePushEntry = {
 
 type CauldronMiniApps = {
   container: Array<string>,
-  codePush: Array<CauldronCodePushEntry>
 }
 
 type CauldronNativeAppVersion = {
@@ -39,6 +38,7 @@ type CauldronNativeAppVersion = {
   yarnLocks: Object,
   nativeDeps: Array<string>,
   miniApps: CauldronMiniApps,
+  codePush: Object,
   config?: Object,
   containerVersion: string
 }

--- a/ern-cauldron-api/src/schemas.js
+++ b/ern-cauldron-api/src/schemas.js
@@ -3,8 +3,7 @@
 import Joi from 'joi'
 
 export const miniApps = Joi.object({
-  container: Joi.array().default([]),
-  codePush: Joi.array().default([])
+  container: Joi.array().default([])
 })
 
 export const nativeApplicationVersion = Joi.object({
@@ -15,6 +14,7 @@ export const nativeApplicationVersion = Joi.object({
   yarnLocks: Joi.object().default({}),
   nativeDeps: Joi.array().default([]),
   miniApps: miniApps.default(),
+  codePush: Joi.object().default({}),
   containerVersion: Joi.string().optional() // optional for Backward Compat. Required in ERN 0.5.0
 })
 

--- a/ern-cauldron-api/test/api-test.js
+++ b/ern-cauldron-api/test/api-test.js
@@ -47,9 +47,14 @@ describe('api.js', () => {
   // getCodePushEntries
   // ==========================================================
   describe('getCodePushEntries', () => {
-    it('should return the code push entries', async () => {
-      const entries = await api.getCodePushEntries('test', 'android', '17.7.0')
-      expect(entries).to.be.an('array').of.length(3)
+    it('should return the code push Production entries', async () => {
+      const entries = await api.getCodePushEntries('test', 'android', '17.7.0', 'Production')
+      expect(entries).to.be.an('array').of.length(2)
+    })
+
+    it('should return the code push QA entries', async () => {
+      const entries = await api.getCodePushEntries('test', 'android', '17.7.0', 'QA')
+      expect(entries).to.be.an('array').of.length(1)
     })
 
     it('should return undefined if native application version is not found', async () => {
@@ -62,15 +67,18 @@ describe('api.js', () => {
   // addCodePushEntry
   // ==========================================================
   describe('addCodePushEntry', () => {
-    it('should add the code push entry', async () => {
+    it('should add the code push entry to QA', async () => {
       await api.addCodePushEntry('test', 'android', '17.7.0', codePushNewEntryFixture)
-      const entries = await api.getCodePushEntries('test', 'android', '17.7.0')
-      expect(entries).to.be.an('array').of.length(4)
+      const entries = await api.getCodePushEntries('test', 'android', '17.7.0', 'QA')
+      expect(entries).to.be.an('array').of.length(2)
     })
 
-    it('should return the code push entries', async () => {
-      const entries = await api.getCodePushEntries('test', 'android', '17.7.0')
-      expect(entries).to.be.an('array').of.length(3)
+    it('should add the code push entry to new deployment name', async () => {
+      let modifiedCodePushEntryFixture = Object.assign({}, codePushNewEntryFixture)
+      modifiedCodePushEntryFixture.metadata.deploymentName = 'STAGING'
+      await api.addCodePushEntry('test', 'android', '17.7.0', modifiedCodePushEntryFixture)
+      const entries = await api.getCodePushEntries('test', 'android', '17.7.0', 'STAGING')
+      expect(entries).to.be.an('array').of.length(1)
     })
 
     it('should commit the changes if code push entry was added', async () => {

--- a/ern-cauldron-api/test/fixtures/cauldron-fixture.json
+++ b/ern-cauldron-api/test/fixtures/cauldron-fixture.json
@@ -58,8 +58,10 @@
               "container": [
                 "@test/react-native-foo@4.0.0",
                 "react-native-bar@2.0.0"
-              ],
-              "codePush": [
+              ]
+            },
+            "codePush": {
+              "Production": [
                 {
                   "metadata": {
                     "deploymentName": "Production",
@@ -91,7 +93,9 @@
                     "@test/react-native-foo@4.0.2",
                     "react-native-bar@2.0.2"
                   ]
-                },
+                }
+              ],
+              "QA": [
                 {
                   "metadata": {
                     "deploymentName": "QA",
@@ -126,9 +130,9 @@
               "container": [
                 "@test/react-native-foo@5.0.0",
                 "react-native-bar@3.0.0"
-              ],
-              "codePush": []
-            }
+              ]
+            },
+            "codePush": []
           }
         ]
       }

--- a/ern-core/src/cauldron.js
+++ b/ern-core/src/cauldron.js
@@ -402,25 +402,11 @@ class Cauldron {
       const codePushEntries = await this.cauldron.getCodePushEntries(
         napDescriptor.name,
         napDescriptor.platform,
-        napDescriptor.version)
+        napDescriptor.version,
+        deploymentName)
       if (codePushEntries) {
-        let result = _.chain(codePushEntries)
-          .filter(e => !Array.isArray(e))
-          .filter(e => e.deploymentName === deploymentName)
-          .map(e => e.miniapps)
-          .map(e => Dependency.fromString(e))
-          .last()
-          .value()
-        // Backward compatibility with old structure
-        // To deprecate at some point
-        if (!result) {
-          result = _.chain(codePushEntries)
-            .filter(e => Array.isArray(e))
-            .last()
-            .map(e => Dependency.fromString(e))
-            .value()
-        }
-        return result
+        const lastEntry = _.last(codePushEntries)
+        return _.map(lastEntry.miniapps, e => Dependency.fromString(e))
       }
     } catch (e) {
       log.error(`[getCodePushMiniApps] ${e}`)

--- a/ern-local-cli/src/commands/code-push/release.js
+++ b/ern-local-cli/src/commands/code-push/release.js
@@ -51,7 +51,7 @@ exports.builder = function (yargs: any) {
       describe: 'Percentage of users this release should be immediately available to',
       alias: 'r',
       type: 'number',
-      default: '100'
+      default: 100
     })
     .option('skipConfirmation', {
       describe: 'Skip final confirmation prompt if no compatibility issues are detected',
@@ -80,8 +80,8 @@ exports.handler = async function ({
   deploymentName: string,
   platform: 'android' | 'ios',
   targetBinaryVersion: string,
-  mandatory: boolean,
-  rollout: number,
+  mandatory?: boolean,
+  rollout?: number,
   skipConfirmation?: boolean
 }) {
   if (!descriptor) {

--- a/ern-local-cli/src/lib/publication.js
+++ b/ern-local-cli/src/lib/publication.js
@@ -201,7 +201,7 @@ miniApps: Array<Dependency>, {
   codePushDeploymentName,
   codePushTargetVersionName,
   codePushIsMandatoryRelease = false,
-  codePushRolloutPercentage = 100,
+  codePushRolloutPercentage,
   pathToYarnLock,
   skipConfirmation = false
 }: {
@@ -209,8 +209,8 @@ miniApps: Array<Dependency>, {
   codePushAppName: string,
   codePushDeploymentName: string,
   codePushTargetVersionName: string,
-  codePushIsMandatoryRelease: boolean,
-  codePushRolloutPercentage: number,
+  codePushIsMandatoryRelease?: boolean,
+  codePushRolloutPercentage?: number,
   pathToYarnLock?: string,
   skipConfirmation?: boolean
 } = {}) {

--- a/ern-util/src/CodePushSdk.js
+++ b/ern-util/src/CodePushSdk.js
@@ -37,12 +37,16 @@ export default class CodePushSdk {
     filePath: string,
     targetBinaryVersion: string,
     updateMetadata: CodePushPackageInfo) : Promise<CodePushPackage> {
-    const response = await this._codePush.release(
-        appName,
-        deploymentName,
-        filePath,
-        targetBinaryVersion,
-        updateMetadata)
-    return response.package
+    if (updateMetadata.rollout === 100) {
+      // If rollout is 100% we shouldn't pass it in the HTTP request
+      delete updateMetadata.rollout
+    }
+
+    return this._codePush.release(
+      appName,
+      deploymentName,
+      filePath,
+      targetBinaryVersion,
+      updateMetadata)
   }
 }


### PR DESCRIPTION
- Updates the structure of CodePush updates stored in Cauldron as follow :
  - `codePush` object is now stored directly inside of the native application version object instead of being nested into the `miniapps` object.
  - Instead of storing all CodePush deployments entries in a single array, we now group entries by deployment name (`Production`, `Staging` ...) to make things cleaner and easier to work with from a code perspective.

New format sample :

```json
"codePush": {
  "Staging": [
    {
      "metadata": {
        "deploymentName": "Staging",
        "isMandatory": false,
        "appVersion": "1.0",
        "size": 522946,
        "releaseMethod": "Upload",
        "label": "v7",
        "releasedBy": "lemaireb@gmail.com",
        "rollout": "100"
      },
      "miniapps": [
        "code-push-test-miniapp@0.0.19"
      ]
    },
   {
      "metadata": {
        "deploymentName": "Staging",
        "isMandatory": false,
        "appVersion": "1.0",
        "size": 522947,
        "releaseMethod": "Upload",
        "label": "v8",
        "releasedBy": "lemaireb@gmail.com",
        "rollout": "100"
      },
      "miniapps": [
        "code-push-test-miniapp@0.0.20"
      ]
    }
  ], 
  "Production": [
    {
      "metadata": {
        "deploymentName": "Production",
        "isMandatory": true,
        "appVersion": "1.0",
        "size": 522947,
        "releaseMethod": "Upload",
        "label": "v16",
        "releasedBy": "lemaireb@gmail.com",
        "rollout": "100"
      },
      "miniapps": [
        "code-push-test-miniapp@0.0.20"
      ]
    }
  ]
}
```

- This PR also makes sure that if no CodePush rollout is provided as a command arg, it will default to `100`. If a rollout is set to `100`, we also make sure that we do not pass it to the CodePush SDK release method (otherwise it has some unwanted side effects).