### PR TITLE
Code push improvements

### DIFF
--- a/ern-cauldron-api/src/api.js
+++ b/ern-cauldron-api/src/api.js
@@ -511,6 +511,31 @@ export default class CauldronApi {
     return false
   }
 
+  async getYarnLockId (
+    nativeApplicationName: string,
+    platformName: string,
+    versionName: string,
+    key: string
+  ) : Promise<?string> {
+    const version = await this.getVersion(nativeApplicationName, platformName, versionName)
+
+    return version && version.yarnLocks && version.yarnLocks[key]
+  }
+
+  async setYarnLockId (
+    nativeApplicationName: string,
+    platformName: string,
+    versionName: string,
+    key: string,
+    id: string
+  ) {
+    const version = await this.getVersion(nativeApplicationName, platformName, versionName)
+
+    if (version && version.yarnLocks) {
+      version.yarnLocks[key] = id
+    }
+  }
+
   async getYarnLock (
     nativeApplicationName: string,
     platformName: string,
@@ -574,6 +599,24 @@ export default class CauldronApi {
     }
 
     return false
+  }
+
+  async updateYarnLockId (
+    nativeApplicationName: string,
+    platformName: string,
+    versionName: string,
+    key: string,
+    id: string
+  ) {
+    const version = await this.getVersion(nativeApplicationName, platformName, versionName)
+
+    if (version && version.yarnLocks) {
+      if (version.yarnLocks[key]) {
+        await this._yarnlockStore.removeFile(version.yarnLocks[key])
+      }
+      version.yarnLocks[key] = id
+      await this.commit(`Updated yarn.lock id for ${nativeApplicationName} ${platformName} ${versionName} ${key}`)
+    }
   }
 
   async setYarnLocks (

--- a/ern-cauldron-api/src/gitstore.js
+++ b/ern-cauldron-api/src/gitstore.js
@@ -13,6 +13,7 @@ const CAULDRON_FILENAME = 'cauldron.json'
 export type CauldronCodePushMetadata = {
   deploymentName: string,
   isMandatory?: boolean,
+  isDisabled?: boolean,
   appVersion?: string,
   size?: number,
   releaseMethod?: string,

--- a/ern-core/src/cauldron.js
+++ b/ern-core/src/cauldron.js
@@ -544,6 +544,72 @@ export class Cauldron {
     }
   }
 
+  async updateCodePushEntry (
+    napDescriptor: NativeApplicationDescriptor,
+    deploymentName: string,
+    label: string, {
+      isDisabled,
+      isMandatory,
+      rollout
+    } : {
+      isDisabled?: boolean,
+      isMandatory?: boolean,
+      rollout?: number
+    }) : Promise<*> {
+    this.throwIfPartialNapDescriptor(napDescriptor)
+    await this.throwIfNativeApplicationNotInCauldron(napDescriptor)
+    return this._updateCodePushEntry(
+      napDescriptor,
+      deploymentName,
+      label, {
+        isDisabled,
+        isMandatory,
+        rollout
+      })
+  }
+
+  async _updateCodePushEntry (
+    napDescriptor: NativeApplicationDescriptor,
+    deploymentName: string,
+    label: string, {
+      isDisabled,
+      isMandatory,
+      rollout
+    } : {
+      isDisabled?: boolean,
+      isMandatory?: boolean,
+      rollout?: number
+    }) {
+    try {
+      const codePushEntries = await this.cauldron.getCodePushEntries(
+        napDescriptor.name,
+        napDescriptor.platform,
+        napDescriptor.version,
+        deploymentName)
+      let entry = _.find(codePushEntries, c => c.metadata.label === label)
+      if (entry) {
+        if (isDisabled !== undefined) {
+          entry.metadata.isDisabled = isDisabled
+        }
+        if (isMandatory !== undefined) {
+          entry.metadata.isMandatory = isDisabled
+        }
+        if (rollout !== undefined) {
+          entry.metadata.rollout = rollout
+        }
+        return this.cauldron.setCodePushEntries(
+          napDescriptor.name,
+          napDescriptor.platform,
+          napDescriptor.version,
+          deploymentName,
+          codePushEntries)
+      }
+    } catch (e) {
+      log.error(`[updateCodePushEntry] ${e}`)
+      throw e
+    }
+  }
+
   async addContainerMiniApp (
     napDescriptor: NativeApplicationDescriptor,
     miniApp: Object) : Promise<*> {

--- a/ern-core/src/cauldron.js
+++ b/ern-core/src/cauldron.js
@@ -567,17 +567,21 @@ export class Cauldron {
 
   async getManifestConfig () : Promise<*> {
     const config = await this.cauldron.getConfig()
-    return config ? config.manifest : undefined
+    return config && config.manifest
   }
 
   async getBinaryStoreConfig () : Promise<*> {
     const config = await this.cauldron.getConfig()
-    return config ? config.binaryStore : undefined
+    return config && config.binaryStore
   }
 
-  async getCodePushConfig () : Promise<CodePushConfig | void> {
-    const config = await this.cauldron.getConfig()
-    return config ? config.codePush : undefined
+  async getCodePushConfig (descriptor?: NativeApplicationDescriptor) : Promise<CodePushConfig | void> {
+    const config = await this.cauldron.getConfig({
+      appName: descriptor && descriptor.name,
+      platformName: descriptor && descriptor.platform,
+      versionName: descriptor && descriptor.version
+    })
+    return config && config.codePush
   }
 
   async getConfig (napDescriptor: NativeApplicationDescriptor) : Promise<*> {

--- a/ern-core/src/cauldron.js
+++ b/ern-core/src/cauldron.js
@@ -13,8 +13,14 @@ import type {
 } from 'ern-cauldron-api'
 import Platform from './Platform'
 
+type CodePushVersionModifier = {
+  deploymentName: string,
+  modifier: string
+}
+
 type CodePushConfig = {
-  entriesLimit?: number
+  entriesLimit?: number,
+  versionModifiers?: Array<CodePushVersionModifier>
 }
 
 //

--- a/ern-core/src/cauldron.js
+++ b/ern-core/src/cauldron.js
@@ -332,6 +332,65 @@ export class Cauldron {
     }
   }
 
+  async getYarnLockId (
+    napDescriptor: NativeApplicationDescriptor,
+    key: string
+  ) : Promise<?string> {
+    try {
+      this.throwIfPartialNapDescriptor(napDescriptor)
+      await this.throwIfNativeApplicationNotInCauldron(napDescriptor)
+      return this.cauldron.getYarnLockId(
+        napDescriptor.name,
+        napDescriptor.platform,
+        napDescriptor.version,
+        key)
+    } catch (e) {
+      log.error(`[getYarnLockId] ${e}`)
+      throw e
+    }
+  }
+
+  async setYarnLockId (
+    napDescriptor: NativeApplicationDescriptor,
+    key: string,
+    id: string
+  ) {
+    try {
+      this.throwIfPartialNapDescriptor(napDescriptor)
+      await this.throwIfNativeApplicationNotInCauldron(napDescriptor)
+      return this.cauldron.setYarnLockId(
+        napDescriptor.name,
+        napDescriptor.platform,
+        napDescriptor.version,
+        key,
+        id)
+    } catch (e) {
+      log.error(`[setYarnLockId] ${e}`)
+      throw e
+    }
+  }
+
+  async updateYarnLockId (
+    napDescriptor: NativeApplicationDescriptor,
+    key: string,
+    id: string
+  ) {
+    try {
+      this.throwIfPartialNapDescriptor(napDescriptor)
+      await this.throwIfNativeApplicationNotInCauldron(napDescriptor)
+      return this.cauldron.updateYarnLockId(
+        napDescriptor.name,
+        napDescriptor.platform,
+        napDescriptor.version,
+        key,
+        id
+      )
+    } catch (e) {
+      log.error(`[updateYarnLockId] ${e}`)
+      throw e
+    }
+  }
+
   async getNativeDependency (
     napDescriptor: NativeApplicationDescriptor,
     dependencyName: string,

--- a/ern-local-cli/src/commands/code-push/patch.js
+++ b/ern-local-cli/src/commands/code-push/patch.js
@@ -1,0 +1,106 @@
+// @flow
+
+import {
+  NativeApplicationDescriptor,
+  Utils
+} from 'ern-util'
+import {
+  performCodePushPatch,
+  askUserForCodePushDeploymentName
+} from '../../lib/publication'
+import utils from '../../lib/utils'
+import inquirer from 'inquirer'
+
+exports.command = 'patch'
+exports.desc = 'Patch a CodePush release'
+
+exports.builder = function (yargs: any) {
+  return yargs
+    .option('descriptor', {
+      type: 'string',
+      describe: 'Full native application descriptor from which to promote a release'
+    })
+    .option('deploymentName', {
+      describe: 'Deployment to release the update to',
+      type: 'string'
+    })
+    .option('label', {
+      type: 'string',
+      alias: 'l',
+      describe: 'Label of the release to update'
+    })
+    .option('disabled', {
+      type: 'boolean',
+      alias: 'x',
+      describe: 'Specifies whether this release should be immediately downloadable'
+    })
+    .option('mandatory', {
+      type: 'bool',
+      alias: 'm',
+      describe: 'Specifies whether this release should be considered mandatory',
+      default: false
+    })
+    .option('rollout', {
+      type: 'number',
+      alias: 'r',
+      describe: 'Percentage of users this release should be immediately available to'
+    })
+    .epilog(utils.epilog(exports))
+}
+
+exports.handler = async function ({
+  descriptor,
+  deploymentName,
+  label,
+  disabled,
+  mandatory,
+  rollout
+} : {
+  descriptor?: string,
+  deploymentName?: string,
+  label?: string,
+  disabled?: boolean,
+  mandatory?: boolean,
+  rollout?: number
+}) {
+  if (!descriptor) {
+    descriptor = await utils.askUserToChooseANapDescriptorFromCauldron({ onlyReleasedVersions: true })
+  }
+
+  const napDescriptor = NativeApplicationDescriptor.fromString(descriptor)
+
+  await utils.logErrorAndExitIfNotSatisfied({
+    isCompleteNapDescriptorString: { descriptor },
+    napDescriptorExistInCauldron: {
+      descriptor,
+      extraErrorMessage: 'You cannot CodePush to a non existing native application version.'
+    }
+  })
+
+  try {
+    if (!deploymentName) {
+      deploymentName = await askUserForCodePushDeploymentName(napDescriptor)
+    }
+
+    if (!label) {
+      const { userInputedLabel } = await inquirer.prompt({
+        type: 'input',
+        name: 'userSelectedDeploymentName',
+        message: 'Please enter a label name corresponding to the release entry to patch'
+      })
+
+      label = userInputedLabel
+    }
+
+    await performCodePushPatch(
+      napDescriptor,
+      deploymentName,
+      label, {
+        isDisabled: disabled,
+        isMandatory: mandatory,
+        rollout
+      })
+  } catch (e) {
+    Utils.logErrorAndExitProcess(e)
+  }
+}

--- a/ern-local-cli/src/commands/code-push/promote.js
+++ b/ern-local-cli/src/commands/code-push/promote.js
@@ -1,0 +1,117 @@
+// @flow
+
+import {
+  NativeApplicationDescriptor,
+  Utils
+} from 'ern-util'
+import {
+  performCodePushPromote,
+  askUserForCodePushDeploymentName
+} from '../../lib/publication'
+import utils from '../../lib/utils'
+import _ from 'lodash'
+
+exports.command = 'promote'
+exports.desc = 'Promote a CodePush release to a different deployment environment'
+
+exports.builder = function (yargs: any) {
+  return yargs
+    .option('sourceDescriptor', {
+      type: 'string',
+      describe: 'Full native application descriptor from which to promote a release'
+    })
+    .option('targetDescriptors', {
+      type: 'array',
+      describe: 'One or more native application descriptors matching targeted versions'
+    })
+    .option('sourceDeploymentName', {
+      type: 'string',
+      describe: 'Name of the deployment environment to promote the release from'
+    })
+    .option('targetDeploymentName', {
+      type: 'string',
+      describe: 'Name of the deployment environment to promote the release to'
+    })
+    .option('mandatory', {
+      type: 'bool',
+      alias: 'm',
+      describe: 'Specifies whether this release should be considered mandatory',
+      default: false
+    })
+    .option('rollout', {
+      type: 'number',
+      alias: 'r',
+      describe: 'Percentage of users this release should be immediately available to',
+      default: 100
+    })
+    .epilog(utils.epilog(exports))
+}
+
+exports.handler = async function ({
+  sourceDescriptor,
+  targetDescriptors = [],
+  sourceDeploymentName,
+  targetDeploymentName,
+  platform,
+  mandatory,
+  rollout
+} : {
+  sourceDescriptor?: string,
+  targetDescriptors?: Array<string>,
+  sourceDeploymentName?: string,
+  targetDeploymentName?: string,
+  platform: 'android' | 'ios',
+  mandatory?: boolean,
+  rollout?: number
+}) {
+  if (!sourceDescriptor) {
+    sourceDescriptor = await utils.askUserToChooseANapDescriptorFromCauldron({
+      onlyReleasedVersions: true,
+      message: 'Please select a source native application descriptor'
+    })
+  }
+
+  if (targetDescriptors.length === 0) {
+    targetDescriptors = await utils.askUserToChooseOneOrMoreNapDescriptorFromCauldron({
+      onlyReleasedVersions: true,
+      message: 'Please select one or more target native application descriptor(s)'
+    })
+  }
+
+  const sourceNapDescriptor = NativeApplicationDescriptor.fromString(sourceDescriptor)
+
+  await utils.logErrorAndExitIfNotSatisfied({
+    isCompleteNapDescriptorString: { descriptor: sourceDescriptor },
+    napDescriptorExistInCauldron: {
+      descriptor: targetDescriptors,
+      extraErrorMessage: 'You cannot CodePush to a non existing native application version.'
+    }
+  })
+
+  try {
+    if (!sourceDeploymentName) {
+      sourceDeploymentName = await askUserForCodePushDeploymentName(
+        sourceNapDescriptor,
+        'Please select a source deployment environment')
+    }
+
+    if (!targetDeploymentName) {
+      targetDeploymentName = await askUserForCodePushDeploymentName(
+        sourceNapDescriptor,
+        'Please select a target deployment environment')
+    }
+
+    const targetNapDescriptors = _.map(targetDescriptors, d => NativeApplicationDescriptor.fromString(d))
+
+    await performCodePushPromote(
+      sourceNapDescriptor,
+      targetNapDescriptors,
+      sourceDeploymentName,
+      targetDeploymentName, {
+        mandatory,
+        rollout
+      })
+  } catch (e) {
+    Utils.logErrorAndExitProcess(e)
+  }
+}

--- a/ern-local-cli/src/lib/Ensure.js
+++ b/ern-local-cli/src/lib/Ensure.js
@@ -77,12 +77,16 @@ export default class Ensure {
   }
 
   static async napDescritorExistsInCauldron (
-    napDescriptor: string,
+    napDescriptor: string | Array<string>,
     extraErrorMessage: string = '') {
-    const descriptor = NativeApplicationDescriptor.fromString(napDescriptor)
-    const result = await cauldron.getNativeApp(descriptor)
-    if (!result) {
-      throw new Error(`${descriptor.toString()} descriptor does not exist in Cauldron.\n${extraErrorMessage}`)
+    const descriptors = napDescriptor instanceof Array
+      ? _.map(napDescriptor, d => NativeApplicationDescriptor.fromString(d))
+      : [ NativeApplicationDescriptor.fromString(napDescriptor) ]
+    for (const descriptor of descriptors) {
+      const result = await cauldron.getNativeApp(descriptor)
+      if (!result) {
+        throw new Error(`${descriptor.toString()} descriptor does not exist in Cauldron.\n${extraErrorMessage}`)
+      }
     }
   }
 

--- a/ern-local-cli/src/lib/publication.js
+++ b/ern-local-cli/src/lib/publication.js
@@ -193,6 +193,42 @@ version: string, {
   }
 }
 
+export async function performCodePushPatch (
+  napDescriptor: NativeApplicationDescriptor,
+  deploymentName: string,
+  label: string, {
+    isDisabled,
+    isMandatory,
+    rollout
+  } : {
+    isDisabled?: boolean,
+    isMandatory?: boolean,
+    rollout?: number
+  }) {
+  try {
+    const codePushSdk = getCodePushSdk()
+    const appName = await getCodePushAppName(napDescriptor)
+    await codePushSdk.patch(
+      appName,
+      deploymentName,
+      label, {
+        isDisabled,
+        isMandatory,
+        rollout
+      })
+    await cauldron.updateCodePushEntry(
+      napDescriptor,
+      deploymentName,
+      label, {
+        isDisabled,
+        isMandatory,
+        rollout
+      })
+  } catch (e) {
+    log.error(`[performCodePushPatch] ${e}`)
+    throw e
+  }
+}
 export async function performCodePushOtaUpdate (
 napDescriptor: NativeApplicationDescriptor,
 deploymentName: string,

--- a/ern-local-cli/src/lib/publication.js
+++ b/ern-local-cli/src/lib/publication.js
@@ -214,18 +214,13 @@ miniApps: Array<Dependency>, {
   pathToYarnLock?: string,
   skipConfirmation?: boolean
 } = {}) {
-  const codePushAccessKey = getCodePushAccessKey()
-  if (!codePushAccessKey) {
-    throw new Error('Unable to get the CodePush access key to use')
-  }
-
+  const codePushSdk = getCodePushSdk()
   const plugins = await cauldron.getNativeDependencies(napDescriptor)
   const codePushPlugin = _.find(plugins, p => p.name === 'react-native-code-push')
   if (!codePushPlugin) {
     throw new Error('react-native-code-push plugin is not in native app !')
   }
 
-  const codePushSdk = new CodePushSdk(codePushAccessKey)
   const tmpWorkingDir = tmp.dirSync({ unsafeCleanup: true }).name
 
   let nativeDependenciesVersionAligned = true
@@ -339,6 +334,14 @@ export function getCodePushAccessKey () {
     }
   }
   return codePushAccessKey
+}
+
+export function getCodePushSdk () {
+  const codePushAccessKey = getCodePushAccessKey()
+  if (!codePushAccessKey) {
+    throw new Error('Unable to get the CodePush access key to use')
+  }
+  return new CodePushSdk(codePushAccessKey)
 }
 
 async function askUserToConfirmCodePushPublication (miniAppsToBeCodePushed: Array<Dependency>) : Promise<boolean> {

--- a/ern-local-cli/src/lib/utils.js
+++ b/ern-local-cli/src/lib/utils.js
@@ -290,16 +290,17 @@ async function logErrorAndExitIfNotSatisfied ({
 
 //
 // Inquire user to choose a native application version from the Cauldron, optionally
-// filtered by platform/and or release status and returns them as an array
-// of native application descriptor strings
+// filtered by platform/and or release status and returns the selected one as a string
 async function askUserToChooseANapDescriptorFromCauldron ({
   platform,
   onlyReleasedVersions,
-  onlyNonReleasedVersions
+  onlyNonReleasedVersions,
+  message
 } : {
   platform?: 'ios' | 'android',
   onlyReleasedVersions?: boolean,
-  onlyNonReleasedVersions?: boolean
+  onlyNonReleasedVersions?: boolean,
+  message?: string
 } = {}) : Promise<string> {
   const napDescriptorStrings = await getNapDescriptorStringsFromCauldron({
     platform,
@@ -310,7 +311,7 @@ async function askUserToChooseANapDescriptorFromCauldron ({
   const { userSelectedCompleteNapDescriptor } = await inquirer.prompt([{
     type: 'list',
     name: 'userSelectedCompleteNapDescriptor',
-    message: 'Choose a native application version',
+    message: message || 'Choose a native application version',
     choices: napDescriptorStrings
   }])
 

--- a/ern-local-cli/src/lib/utils.js
+++ b/ern-local-cli/src/lib/utils.js
@@ -318,6 +318,36 @@ async function askUserToChooseANapDescriptorFromCauldron ({
 }
 
 //
+// Inquire user to choose one or more native application version(s) from the Cauldron, optionally
+// filtered by platform/and or release status and returns the selected choices as an array of strings
+async function askUserToChooseOneOrMoreNapDescriptorFromCauldron ({
+  platform,
+  onlyReleasedVersions,
+  onlyNonReleasedVersions,
+  message
+} : {
+  platform?: 'ios' | 'android',
+  onlyReleasedVersions?: boolean,
+  onlyNonReleasedVersions?: boolean,
+  message?: string
+} = {}) : Promise<Array<string>> {
+  const napDescriptorStrings = await getNapDescriptorStringsFromCauldron({
+    platform,
+    onlyReleasedVersions,
+    onlyNonReleasedVersions
+  })
+
+  const { userSelectedCompleteNapDescriptors } = await inquirer.prompt([{
+    type: 'checkbox',
+    name: 'userSelectedCompleteNapDescriptors',
+    message: message || 'Choose a native application version',
+    choices: napDescriptorStrings
+  }])
+
+  return userSelectedCompleteNapDescriptors
+}
+
+//
 // Perform some custom work on a container in Cauldron, provided as a
 // function, that is going to change the state of the container,
 // and regenerate a new container and publish it.
@@ -692,6 +722,7 @@ export default {
   getNapDescriptorStringsFromCauldron,
   logErrorAndExitIfNotSatisfied,
   askUserToChooseANapDescriptorFromCauldron,
+  askUserToChooseOneOrMoreNapDescriptorFromCauldron,
   performContainerStateUpdateInCauldron,
   epilog,
   runMiniApp,

--- a/ern-local-cli/src/lib/utils.js
+++ b/ern-local-cli/src/lib/utils.js
@@ -110,7 +110,7 @@ async function logErrorAndExitIfNotSatisfied ({
     extraErrorMessage?: string
   },
   napDescriptorExistInCauldron?: {
-    descriptor: string,
+    descriptor: string | Array<string>,
     extraErrorMessage?: string
   },
   napDescritorDoesNotExistsInCauldron?: {

--- a/ern-local-cli/test/publication-test.js
+++ b/ern-local-cli/test/publication-test.js
@@ -6,9 +6,9 @@ import {
   expect
 } from 'chai'
 import {
+  getCodePushSdk,
   getCodePushAccessKey
 } from '../src/lib/publication'
-
 
 const ernRcPath = path.join(os.homedir(), '.ern', '.ernrc')
 const codePushConfigPath = path.join(os.homedir(), '.code-push.config')
@@ -66,6 +66,31 @@ describe('lib/publication.js', () => {
         createCwd: false
       })
       expect(getCodePushAccessKey()).to.be.undefined
+    })
+  })
+
+  // ==========================================================
+  // getCodePushSdk
+  // ==========================================================
+  describe('getCodePushSdk', () => {
+    it('should not throw if an access key exists', () => {
+      mockFs({
+        [ernRcPath]: ernRcWithCodePushAccessKey,
+        [codePushConfigPath]: codePushConfigWithoutAccessKey
+      }, {
+        createCwd: false
+      })
+      expect(getCodePushSdk).to.not.throw()
+    })
+
+    it('should throw if no access key exists', () => {
+      mockFs({
+        [ernRcPath]: ernRcWithoutCodePushAccessKey,
+        [codePushConfigPath]: codePushConfigWithoutAccessKey
+      }, {
+        createCwd: false
+      })
+      expect(getCodePushSdk).to.throw()
     })
   })
 })

--- a/ern-util/src/CodePushSdk.js
+++ b/ern-util/src/CodePushSdk.js
@@ -49,4 +49,40 @@ export default class CodePushSdk {
       targetBinaryVersion,
       updateMetadata)
   }
+
+  async promote (
+    appName: string,
+    sourceDeploymentName: string,
+    destinationDeploymentName: string,
+    updateMetadata: CodePushPackageInfo) : Promise<CodePushPackage> {
+    if (updateMetadata.rollout === 100) {
+      // If rollout is 100% we shouldn't pass it in the HTTP request
+      delete updateMetadata.rollout
+    }
+
+    return this._codePush.promote(
+      appName,
+      sourceDeploymentName,
+      destinationDeploymentName,
+      updateMetadata)
+  }
+
+  async patch (
+    appName: string,
+    deploymentName: string,
+    label: string,
+    updateMetadata: CodePushPackageInfo) : Promise<CodePushPackage> {
+    if (updateMetadata.rollout === 100) {
+      // If rollout is 100% we shouldn't pass it in the HTTP request
+      delete updateMetadata.rollout
+    }
+
+    console.log(`patchRelease : ${appName} ${deploymentName} ${label} ${JSON.stringify(updateMetadata)}`)
+
+    return this._codePush.patchRelease(
+      appName,
+      deploymentName,
+      label,
+      updateMetadata)
+  }
 }

--- a/ern-util/src/NativeApplicationDescriptor.js
+++ b/ern-util/src/NativeApplicationDescriptor.js
@@ -40,6 +40,10 @@ export default class NativeApplicationDescriptor {
     return (this._platform === undefined) || (this._version === undefined)
   }
 
+  withoutVersion () : NativeApplicationDescriptor {
+    return new NativeApplicationDescriptor(this.name, this.platform)
+  }
+
   static fromString (napDescriptorLiteral: string) : NativeApplicationDescriptor {
     return new NativeApplicationDescriptor(...napDescriptorLiteral.split(':'))
   }

--- a/ern-util/test/NativeApplicationDescriptor-test.js
+++ b/ern-util/test/NativeApplicationDescriptor-test.js
@@ -112,4 +112,12 @@ describe('NativeApplicationDescriptor', () => {
       expect(descriptor.toString()).to.equal('MyNativeAppName')
     })
   })
+
+  describe('withoutVersion', () => {
+    it('should create a new native application descriptor without the version', () => {
+      const descriptor = NativeApplicationDescriptor.fromString('MyNativeAppName:android:1.2.3')
+      const newDescriptor = descriptor.withoutVersion()
+      expect(newDescriptor.toString()).to.equal('MyNativeAppName:android')
+    })
+  })
 })


### PR DESCRIPTION
Closes https://github.com/electrode-io/electrode-native/issues/340
Closes https://github.com/electrode-io/electrode-native/issues/341

- Add `code-push patch` command
- Add `code-push promote` command
- Introduce new CodePush configuration at the native application platform level.
  - appName : Allow to specify the CodePush application name that is matching the native application stored in the Cauldron. If not specified, the CodePush application name will be the name from the native application descriptor.
  - versionModifiers  : Allow to specify modifiers for the CodePush target application version to use. Modifiers are applied per CodePush deployment name. If no modifier is defined for a given deployment name, then the version used will be the version from the native application descriptor. A modifier is a string that contain the placeholder `$1` which will be replace by the version from the native application descriptor.
Sample configuration :

```json
"config": {
  "codePush": {
    "appName": "CodePushTestMiniApp",
      "versionModifiers": [
        {
          "deploymentName": "QA",
          "modifier": "$1-qa-debug"
        },
        {
          "deploymentName": "Development",
          "modifier": "$1-dev-debug"
        }
      ]
    }
  }
}
```

Some tests have been added part of this PR, more to come.

Documentation for CodePush new commands and CodePush flow overall will be added once all the features part of EPIC https://github.com/electrode-io/electrode-native/issues/342 are completed.