### PR TITLE
Add support for semver versions to code-push commands

### DIFF
--- a/ern-core/src/cauldron.js
+++ b/ern-core/src/cauldron.js
@@ -175,6 +175,21 @@ export class Cauldron {
     }
   }
 
+  async getVersions (napDescriptor: NativeApplicationDescriptor) : Promise<*> {
+    if (!napDescriptor.platform) {
+      throw new Error(`[getVersions] platform must be present in the NativeApplicationDesctiptor`)
+    }
+
+    return this.cauldron.getVersions(
+      napDescriptor.name,
+      napDescriptor.version)
+  }
+
+  async getVersionsNames (napDescriptor: NativeApplicationDescriptor) : Promise<Array<string>> {
+    const versions = await this.getVersions(napDescriptor)
+    return _.map(versions, v => v.name)
+  }
+
   async getNativeDependencies (
     napDescriptor: NativeApplicationDescriptor) : Promise<Array<Dependency>> {
     try {

--- a/ern-local-cli/src/lib/utils.js
+++ b/ern-local-cli/src/lib/utils.js
@@ -730,6 +730,22 @@ async function promptUserToUseSuffixModuleName (moduleName: string, moduleType: 
   return useSuffixedModuleName ? suffixedModuleName : moduleName
 }
 
+async function getDescriptorsMatchingSemVerDescriptor (semVerDescriptor: NativeApplicationDescriptor)
+  : Promise<Array<NativeApplicationDescriptor>> {
+  if (!semVerDescriptor.platform || !semVerDescriptor.version) {
+    throw new Error(`${semVerDescriptor.toString()} descriptor is missing platform and/or version`)
+  }
+  const result = []
+  const versionsNames = await cauldron.getVersionsNames(semVerDescriptor)
+  const versions = _.filter(versionsNames, v => semver.satisfies(v, semVerDescriptor.version))
+  for (const version of versions) {
+    const descriptor = new NativeApplicationDescriptor(semVerDescriptor.name, semVerDescriptor.platform, version)
+    result.push(descriptor)
+  }
+
+  return result
+}
+
 export default {
   getNapDescriptorStringsFromCauldron,
   logErrorAndExitIfNotSatisfied,
@@ -741,5 +757,6 @@ export default {
   doesPackageExistInNpm,
   performPkgNameConflictCheck,
   checkIfModuleNameContainsSuffix,
-  promptUserToUseSuffixModuleName
+  promptUserToUseSuffixModuleName,
+  getDescriptorsMatchingSemVerDescriptor
 }


### PR DESCRIPTION
Closes https://github.com/electrode-io/electrode-native/issues/303

This PR makes it possible to supply target native application versions to `code-push release` and `code-push promote` commands as a semver expression rather than providing all target versions one by one.

