### PR TITLE
use semver to list version over 0.xx.0

### DIFF
--- a/ern-local-cli/src/commands/platform/list.js
+++ b/ern-local-cli/src/commands/platform/list.js
@@ -9,6 +9,7 @@ import {
 } from 'ern-util'
 import chalk from 'chalk'
 import utils from '../../lib/utils'
+import semver from 'semver'
 
 const BASE_RELEASE_URL = `https://github.com/electrode-io/electrode-native/releases/tag`
 
@@ -29,7 +30,7 @@ exports.handler = function () {
       // Don't show versions pre 0.7.0 as it was not official public releases
       // Electrode Native initial public release was 0.7.0 so starting from
       // this version
-      if (version < '0.7.0') { continue }
+      if (semver.lt(version, '0.7.0')) { continue }
       if (Platform.isPlatformVersionInstalled(version)) {
         if (Platform.currentVersion === version) {
           log.info(chalk.green(`-> v${version}\t\t`) + chalk.white(`${BASE_RELEASE_URL}/v${version}`))


### PR DESCRIPTION
Fixes https://github.com/electrode-io/electrode-native/issues/377
`ern platform list`
```
 [CURRENT] [INSTALLED] [NOT INSTALLED]
v0.7.0		https://github.com/electrode-io/electrode-native/releases/tag/v0.7.0
v0.8.0		https://github.com/electrode-io/electrode-native/releases/tag/v0.8.0
v0.9.0		https://github.com/electrode-io/electrode-native/releases/tag/v0.9.0
v0.10.0		https://github.com/electrode-io/electrode-native/releases/tag/v0.10.0
v0.10.1		https://github.com/electrode-io/electrode-native/releases/tag/v0.10.1
```