### PR TITLE
Fix CauldronHelper addNativeApp logic

### DIFF
--- a/ern-core/src/CauldronHelper.js
+++ b/ern-core/src/CauldronHelper.js
@@ -50,13 +50,15 @@ export default class CauldronHelper {
   async addNativeApp (
     napDescriptor: NativeApplicationDescriptor,
     ernPlatformVersion: string = Platform.currentVersion) : Promise<*> {
-    await this.cauldron.createNativeApplication({name: napDescriptor.name})
-    if (napDescriptor.platform) {
+    if (!await this.cauldron.getNativeApplication(napDescriptor.name)) {
+      await this.cauldron.createNativeApplication({name: napDescriptor.name})
+    }
+    if (napDescriptor.platform && !await this.cauldron.getPlatform(napDescriptor.name, napDescriptor.platform)) {
       await this.cauldron.createPlatform(napDescriptor.name, {name: napDescriptor.platform})
-      if (napDescriptor.version) {
-        await this.cauldron.createVersion(
-                    napDescriptor.name, napDescriptor.platform, {name: napDescriptor.version, ernPlatformVersion})
-      }
+    }
+    if (napDescriptor.version && !await this.cauldron.getVersion(napDescriptor.name, napDescriptor.platform, napDescriptor.version)) {
+      await this.cauldron.createVersion(
+        napDescriptor.name, napDescriptor.platform, {name: napDescriptor.version, ernPlatformVersion})
     }
   }
 

--- a/ern-core/test/CauldronHelper-test.js
+++ b/ern-core/test/CauldronHelper-test.js
@@ -1276,7 +1276,6 @@ describe('CauldronHelper.js', () => {
         const codePushEntries = jp.query(fixture, `${testAndroid1770Path}.codePush.Production`)[0]
         expect(codePushEntries).to.be.an('array').of.length(2)
         const updatedEntry = jp.query(codePushEntries,`$[?(@.metadata.label=="v17")]`)[0]
-        console.log(`updatedEntry is ${JSON.stringify(updatedEntry)}`)
 
         expect(updatedEntry.metadata).to.have.property('isDisabled').eql(true)
     })
@@ -1293,7 +1292,6 @@ describe('CauldronHelper.js', () => {
         const codePushEntries = jp.query(fixture, `${testAndroid1770Path}.codePush.Production`)[0]
         expect(codePushEntries).to.be.an('array').of.length(2)
         const updatedEntry = jp.query(codePushEntries,`$[?(@.metadata.label=="v17")]`)[0]
-        console.log(`updatedEntry is ${JSON.stringify(updatedEntry)}`)
 
         expect(updatedEntry.metadata).to.have.property('isMandatory').eql(true)
     })
@@ -1310,7 +1308,6 @@ describe('CauldronHelper.js', () => {
         const codePushEntries = jp.query(fixture, `${testAndroid1770Path}.codePush.Production`)[0]
         expect(codePushEntries).to.be.an('array').of.length(2)
         const updatedEntry = jp.query(codePushEntries,`$[?(@.metadata.label=="v17")]`)[0]
-        console.log(`updatedEntry is ${JSON.stringify(updatedEntry)}`)
 
         expect(updatedEntry.metadata).to.have.property('rollout').eql(10)
     })


### PR DESCRIPTION
Previous PR changed the logic for `CauldronApi` method `createNativeApp` resulting in CI failing during system-tests.

https://travis-ci.org/electrode-io/electrode-native/builds/311695712

This PR fixes the issue.