### PR TITLE
Upgrade code-push version

### DIFF
--- a/ern-util/package.json
+++ b/ern-util/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "bluebird": "^3.5.0",
     "chalk": "^2.3.0",
-    "code-push": "^2.0.3-beta",
+    "code-push": "^2.0.4",
     "console-log-level": "^1.4.0",
     "fs-readdir-recursive": "^1.0.0",
     "inquirer": "^3.0.6",

--- a/ern-util/yarn.lock
+++ b/ern-util/yarn.lock
@@ -268,9 +268,9 @@ co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
 
-code-push@^2.0.3-beta:
-  version "2.0.3-beta"
-  resolved "https://registry.yarnpkg.com/code-push/-/code-push-2.0.3-beta.tgz#0d321cf8243b12b06aae46566c7e71e55b3faa8e"
+code-push@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/code-push/-/code-push-2.0.4.tgz#c0da90a8ca38f97478bf37136c78d066563f4905"
   dependencies:
     q "^1.4.1"
     recursive-fs "0.1.4"


### PR DESCRIPTION
Bump code-push version to [2.1.4](https://github.com/Microsoft/code-push/releases/tag/v2.1.4) to get access to the proper `promote` function implementation.