### PR TITLE
move DevSettingsActivity to Android Manifest

### DIFF
--- a/ern-container-gen/hull/android/lib/src/debug/AndroidManifest.xml
+++ b/ern-container-gen/hull/android/lib/src/debug/AndroidManifest.xml
@@ -1,6 +1,0 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.walmartlabs.ern.container">
-    <application>
-        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
-    </application>
-</manifest>

--- a/ern-container-gen/hull/android/lib/src/main/AndroidManifest.xml
+++ b/ern-container-gen/hull/android/lib/src/main/AndroidManifest.xml
@@ -8,5 +8,6 @@
                  android:exported="true">
        </activity>		
        {{/miniApps}}
-   </application>
+       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+    </application>
 </manifest>

--- a/ern-runner-gen/runner-hull/android/app/src/main/AndroidManifest.xml
+++ b/ern-runner-gen/runner-hull/android/app/src/main/AndroidManifest.xml
@@ -19,7 +19,6 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
     </application>
 
 </manifest>


### PR DESCRIPTION
As the `container-gen` performs `bundleRelease` , `DevSettingsActivity` will not be merge with the application manifest. 