### PR TITLE
Fix Android generator handling of standalone native API impls

### DIFF
--- a/ern-container-gen/src/generators/android/AndroidGenerator.js
+++ b/ern-container-gen/src/generators/android/AndroidGenerator.js
@@ -170,10 +170,8 @@ export default class AndroidGenerator implements ContainerGenerator {
           throw new Error(`Was not able to download ${plugin.name}`)
         }
 
-        if (plugin.origin === 'npm') {
-          if (await utils.isDependencyNativeApiImpl(plugin.scopedName)) {
-            populateApiImplMustacheView(pluginSourcePath, mustacheView, true)
-          }
+        if (await utils.isDependencyNativeApiImpl(plugin.scopedName)) {
+          populateApiImplMustacheView(pluginSourcePath, mustacheView, true)
         }
 
         const pathToPluginProject = path.join(pluginSourcePath, pluginConfig.android.root)


### PR DESCRIPTION
Because `plugin.origin` was undefined, it was always evaluating the if conditional to false. 
Because we don't yet support non NPM published native dependencies (for ex GIT published) we don't need this check as of now. 

In the context of Walmart, the only native dependency non NPM published (StackTracker) has now been published to NPM, so there is no more issue of executing the code in the if loop for all native dependencies.