### PR TITLE
Add iphone X safelayout support for ERNRunner

### DIFF
--- a/ern-runner-gen/runner-hull/ios/ErnRunner/ViewController.m
+++ b/ern-runner-gen/runner-hull/ios/ErnRunner/ViewController.m
@@ -19,6 +19,7 @@
 #import <ElectrodeContainer/ElectrodeContainer.h>
 
 @interface ViewController ()
+@property(nonatomic, weak) IBOutlet UIView *rnView;
 @end
 
 @implementation ViewController
@@ -31,6 +32,19 @@
     [[ElectrodeReactNative sharedInstance] miniAppWithName:MainMiniAppName properties:nil];
     viewController.view.frame = [UIScreen mainScreen].bounds;
     [self.view addSubview:viewController.view];
+
+
+    self.rnView = viewController.view;
+    self.rnView.frame = [UIScreen mainScreen].bounds;
+    [self.view addSubview:self.rnView];
+    [self.view layoutIfNeeded];
+}
+
+- (void) viewDidLayoutSubviews {
+    [super viewDidLayoutSubviews];
+    if (@available(iOS 11.0, *)){
+        self.rnView.frame = self.view.safeAreaLayoutGuide.layoutFrame;
+    }
 }
 
 - (void)didReceiveMemoryWarning {


### PR DESCRIPTION
![screen shot 2017-12-18 at 2 21 16 pm](https://user-images.githubusercontent.com/31863333/34131148-4b825330-e3ff-11e7-9ab0-21fe5ea67695.png)

Adapt to iphone x screen when running on iOS version 11 for ErnRunner. 