### PR TITLE
Code push release related fixes

### DIFF
--- a/ern-local-cli/src/commands/code-push/release.js
+++ b/ern-local-cli/src/commands/code-push/release.js
@@ -24,7 +24,8 @@ exports.builder = function (yargs: any) {
   return yargs
     .option('descriptors', {
       alias: 'd',
-      describe: 'Full native application descriptors (target native application versions for the push)'
+      describe: 'Full native application descriptors (target native application versions for the push)',
+      type: 'array'
     })
     .option('semVerDescriptor', {
       describe: 'A native application descriptor using a semver expression for the version'

--- a/ern-local-cli/src/lib/publication.js
+++ b/ern-local-cli/src/lib/publication.js
@@ -335,6 +335,7 @@ miniApps: Array<Dependency>, {
     const codePushSdk = getCodePushSdk()
     var cauldron = await coreUtils.getCauldronInstance()
     const plugins = await cauldron.getNativeDependencies(napDescriptor)
+    await cauldron.beginTransaction()
     const codePushPlugin = _.find(plugins, p => p.name === 'react-native-code-push')
     if (!codePushPlugin) {
       throw new Error('react-native-code-push plugin is not in native app !')


### PR DESCRIPTION
- Fix a bug that was causing `code-push release` command to fail, because the provided descriptor(s) were handled as strings instead of an array.
- Fix a bug that was causing a `code-push release` command to create atomic Cauldron commits and log an error to the terminal, failing to commit the transaction, due to the fact that no Cauldron transaction was initiated in the first place.