### PR TITLE
Improvements

### DIFF
--- a/ern-local-cli/src/lib/utils.js
+++ b/ern-local-cli/src/lib/utils.js
@@ -766,6 +766,7 @@ async function getDescriptorsMatchingSemVerDescriptor (semVerDescriptor: NativeA
   const result = []
   const cauldron = await coreUtils.getCauldronInstance()
   const versionsNames = await cauldron.getVersionsNames(semVerDescriptor)
+
   const versions = _.filter(versionsNames, v => semver.satisfies(v, semVerDescriptor.version))
   for (const version of versions) {
     const descriptor = new NativeApplicationDescriptor(semVerDescriptor.name, semVerDescriptor.platform, version)
@@ -773,6 +774,23 @@ async function getDescriptorsMatchingSemVerDescriptor (semVerDescriptor: NativeA
   }
 
   return result
+}
+
+function normalizeVersionsToSemver (versions: Array<string>) : Array<string> {
+  const validSemVerRe = /^\d+\.\d+.\d+.*/
+  const versionMissingPatchRe = /^(\d+\.\d+)(.*)/
+  const versionMissingMinorRe = /^(\d+)(.*)/
+  return _.map(versions, v => {
+    if (validSemVerRe.test(v)) {
+      return v
+    } else {
+      if (versionMissingPatchRe.test(v)) {
+        return v.replace(versionMissingPatchRe, '$1.0$2')
+      } else if (versionMissingMinorRe.test(v)) {
+        return v.replace(versionMissingMinorRe, '$1.0.0$2')
+      }
+    }
+  })
 }
 
 export default {
@@ -787,5 +805,6 @@ export default {
   performPkgNameConflictCheck,
   checkIfModuleNameContainsSuffix,
   promptUserToUseSuffixModuleName,
-  getDescriptorsMatchingSemVerDescriptor
+  getDescriptorsMatchingSemVerDescriptor,
+  normalizeVersionsToSemver
 }

--- a/ern-local-cli/src/lib/utils.js
+++ b/ern-local-cli/src/lib/utils.js
@@ -766,10 +766,12 @@ async function getDescriptorsMatchingSemVerDescriptor (semVerDescriptor: NativeA
   const result = []
   const cauldron = await coreUtils.getCauldronInstance()
   const versionsNames = await cauldron.getVersionsNames(semVerDescriptor)
+  const semVerVersionNames = normalizeVersionsToSemver(versionsNames)
+  const zippedVersions = _.zipWith(versionsNames, semVerVersionNames, (nonSemVer, semVer) => ({nonSemVer, semVer}))
 
-  const versions = _.filter(versionsNames, v => semver.satisfies(v, semVerDescriptor.version))
+  const versions = _.filter(zippedVersions, z => semver.satisfies(z.semVer, semVerDescriptor.version))
   for (const version of versions) {
-    const descriptor = new NativeApplicationDescriptor(semVerDescriptor.name, semVerDescriptor.platform, version)
+    const descriptor = new NativeApplicationDescriptor(semVerDescriptor.name, semVerDescriptor.platform, version.nonSemVer)
     result.push(descriptor)
   }
 

--- a/ern-local-cli/test/utils-test.js
+++ b/ern-local-cli/test/utils-test.js
@@ -47,7 +47,7 @@ describe('utils.js', () => {
     cauldronHelperStub = sandbox.createStubInstance(CauldronHelper)
     cauldronHelperStub.getContainerVersion.resolves('1.0.0')
     cauldronHelperStub.getTopLevelContainerVersion.resolves('1.2.3')
-    cauldronHelperStub.getVersionsNames.resolves(['1.2.3', '1.2.4', '2.0.0'])
+    cauldronHelperStub.getVersionsNames.resolves(['1.2.3', '1.2.4', '2.0.0', '3.0'])
     // Ora stubs
     const oraProto = Object.getPrototypeOf(ora())
     oraFailStub = sandbox.stub()
@@ -539,6 +539,13 @@ describe('utils.js', () => {
       const descriptor = NativeApplicationDescriptor.fromString('testapp:android:2.0.x')
       const result = await utils.getDescriptorsMatchingSemVerDescriptor(descriptor)
       expect(result).to.be.an('array').of.length(1)
+    })
+
+    it('should return the right matched versions [3]', async () => {
+      const descriptor = NativeApplicationDescriptor.fromString('testapp:android:3.0.x')
+      const result = await utils.getDescriptorsMatchingSemVerDescriptor(descriptor)
+      expect(result).to.be.an('array').of.length(1)
+      expect(result[0].version).eql('3.0')
     })
   })
 

--- a/ern-local-cli/test/utils-test.js
+++ b/ern-local-cli/test/utils-test.js
@@ -541,4 +541,25 @@ describe('utils.js', () => {
       expect(result).to.be.an('array').of.length(1)
     })
   })
+
+  describe('normalizeVersionsToSemver', () => {
+    it('should return an array containing the normalized versions', () => {
+      const versions = [ 
+        '1.0.0', 
+        '2.0', 
+        '3', 
+        '1.0.0-beta', 
+        '2.0-beta',
+        '2-beta' ]
+      const result = utils.normalizeVersionsToSemver(versions)
+      expect(result).to.be.an('array').deep.equal([
+        '1.0.0', 
+        '2.0.0', 
+        '3.0.0', 
+        '1.0.0-beta', 
+        '2.0.0-beta',
+        '2.0.0-beta'
+      ])
+    })
+  })
 })


### PR DESCRIPTION
- **Add utility function normalizeVersionsToSemver**
This function can be used to normalize provided versions strings, to make sure that they are semver compliant (i.e the versions needs a minor and patch). Please see the test for reference.

- **Improve getDescriptorsMatchingSemVerDescriptor function**
This is somewhat a bug fix rather than an improvement as this function would fail if provided versions that are not semver compliant (for example for descriptor `walmart:android:17.22`, the version `17.22` is not semver compliant and would have caused the function to throw an error). This improvement makes it that all versions are semver normalized (adding minor and/or patch if missing) before to be processed).
