### PR TITLE
handle incorrect copy from version value while adding native app

### DIFF
--- a/ern-local-cli/src/commands/cauldron/add/nativeapp.js
+++ b/ern-local-cli/src/commands/cauldron/add/nativeapp.js
@@ -72,6 +72,9 @@ exports.handler = async function ({
           await spin(`Copying data over from latest version ${latestVersionName}`, copyOverPreviousVersionData(napDescriptor, latestVersion, cauldron))
         } else {
           const version = _.find(previousApps.versions, v => v.name === copyFromVersion)
+          if (!version) {
+            throw new Error(`Could not resolve native application version to copy Cauldron data from.\nExamine current value : ${copyFromVersion}`)
+          }
           await spin(`Copying data over from version ${copyFromVersion}`, copyOverPreviousVersionData(napDescriptor, version, cauldron))
         }
       } else if (await askUserCopyPreviousVersionData(latestVersionName)) {

--- a/system-tests.js
+++ b/system-tests.js
@@ -112,6 +112,7 @@ run(`ern cauldron add miniapps ${movieDetailsMiniAppPackageName}@${movieDetailsM
 run(`ern cauldron get nativeapp ${androidNativeApplicationDescriptor}`)
 run(`ern cauldron add miniapps ${movieDetailsMiniAppPackageName}@${movieDetailsMiniAppVersion} -d ${iosNativeApplicationDescriptor}`)
 run(`ern cauldron get nativeapp ${iosNativeApplicationDescriptor}`)
+run(`ern cauldron add nativeapp ${iosNativeApplicationDescriptorNewVersion} -c 1000.1000.1`, { expectedExitCode: 1 })
 run(`ern cauldron add nativeapp ${iosNativeApplicationDescriptorNewVersion} -c latest`)
 run(`ern cauldron add dependencies react-native-code-push@5.1.3-beta -d ${iosNativeApplicationDescriptorNewVersion}`)
 run(`ern cauldron get dependency ${iosNativeApplicationDescriptorNewVersion}`)


### PR DESCRIPTION
Execute 
ern cauldron add nativeapp walmart:android:17.24.0 -c 1000.1000.1
ern cauldron add nativeapp walmart:android:17.24.0 -c appname:android:12.2.2
`TypeError: Cannot read property 'nativeDeps' of undefined`

After Fix 
```
Error: Could not resolve native application version to copy Cauldron data from.
Examine current value : 1000.1000.1```