### PR TITLE
Fix a bug in performCodePushOtaUpdate

### DIFF
--- a/ern-local-cli/src/lib/publication.js
+++ b/ern-local-cli/src/lib/publication.js
@@ -422,7 +422,7 @@ miniApps: Array<Dependency>, {
     const codePushResponse: CodePushPackage = await spin('Releasing bundle through CodePush', codePushSdk.releaseReact(
       appName,
       deploymentName,
-      bundleOutputPath,
+      bundleOutputDirectory,
       targetVersionName, {
         isMandatory: codePushIsMandatoryRelease,
         rollout: codePushRolloutPercentage


### PR DESCRIPTION
Fix wrong path used for CodePush release that was leading to releasing only the bundle but not the assets.