### PR TITLE
Add support for non registry MiniApp paths to Cauldron

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -11,6 +11,21 @@ A partial native application descriptor is a string with format `[nativeAppName]
 - `nativeAppName` : alphanumeric native application name , cannot contain character ':'
 
 ## Electrode Native module name
+
 The Electrode Native module name applies to modules created with Electrode Native cli.
 - Electrode Native recommends module name must only contain upper and/or lower case letters. 
 - `create-miniapp`, `create-api` and `create-api-impl` commands allow passing Electrode Native module name as it's arguments.
+
+## package path
+
+A package path is a string representing the path (local or remote) to a Node Package. In the context of Electrode Native, a few package path formats are supported (as ilustrated by the following samples) :
+
+- `git+ssh://git@github.com:electrode-io/MovieListMiniApp.git`
+- `git+ssh://git@github.com:electrode-io/MovieListMiniApp.git#0.0.9`
+- `https://github.com/electrode-io/MovieListMiniApp.git`
+- `https://github.com/electrode-io/MovieListMiniApp.git#0.0.9`
+- `file:/Users/blemair/Code/MovieListMiniApp`
+- `/Users/blemair/Code/MovieListMiniApp`
+- `movielistminiapp`
+- `movielistminiapp@0.0.9`
+- `@myscope/movielistminiapp@0.0.9`

--- a/docs/cli/cauldron/add/miniapps.md
+++ b/docs/cli/cauldron/add/miniapps.md
@@ -15,9 +15,7 @@
 
 `<miniapps..>`
 
-* One or more MiniApps (delimited by spaces) to add to a target native application version in the Cauldron.
-* You can only add MiniApp versions that have been published to NPM. 
-* You cannot use the `file` or `git` schemes for the MiniApp(s).
+* One or more package path to MiniApps (delimited by spaces) to add to a target native application version in the Cauldron.
 
 **Example**  
 

--- a/docs/cli/cauldron/del/miniapps.md
+++ b/docs/cli/cauldron/del/miniapps.md
@@ -14,7 +14,7 @@
 
 `<miniapps..>`
 
-* One or more MiniApps (delimited by spaces) to remove from a native application version in the Cauldron.
+* One or more package path to MiniApp(s) (delimited by spaces) to remove from a native application version in the Cauldron.
 
 **Options**  
 

--- a/docs/cli/cauldron/update/miniapps.md
+++ b/docs/cli/cauldron/update/miniapps.md
@@ -14,9 +14,7 @@
 
 `<miniapps..>`
 
-* One or more MiniApp(s) (delimited by spaces) to update in a target native application version in the Cauldron.
-* You can only update with MiniApp(s) version(s) that have been published to NPM. 
-* You cannot use the `file` or `git` schemes for the MiniApp(s).
+* One or more package path to MiniApp(s) (delimited by spaces) to update in a target native application version in the Cauldron.
 * The version of each MiniApp is corresponding to the version to update to. 
 
 **Options**  

--- a/ern-core/src/CauldronHelper.js
+++ b/ern-core/src/CauldronHelper.js
@@ -624,7 +624,7 @@ export default class CauldronHelper {
 
   async updateMiniAppVersion (
     napDescriptor: NativeApplicationDescriptor,
-    miniApp: Object) : Promise<*> {
+    miniApp: PackagePath) : Promise<*> {
     this.throwIfPartialNapDescriptor(napDescriptor)
     return this.cauldron.updateMiniAppVersion(
       napDescriptor.name,

--- a/ern-local-cli/src/commands/cauldron/add/miniapps.js
+++ b/ern-local-cli/src/commands/cauldron/add/miniapps.js
@@ -63,17 +63,9 @@ exports.handler = async function ({
         descriptor,
         extraErrorMessage: 'To avoid conflicts with previous versions, you can only use container version newer than the current one'
       } : undefined,
-      noFileSystemPath: {
-        obj: miniapps,
-        extraErrorMessage: 'You cannot provide dependencies using a file scheme path with this command.'
-      },
       napDescriptorExistInCauldron: {
         descriptor,
         extraErrorMessage: 'This command cannot work on a non existing native application version'
-      },
-      publishedToNpm: {
-        obj: miniapps,
-        extraErrorMessage: 'You can only add MiniApps versions that have been published to NPM'
       },
       miniAppNotInNativeApplicationVersionContainer: {
         miniApp: miniapps,
@@ -82,10 +74,7 @@ exports.handler = async function ({
       }
     })
 
-    //
-    // Construct MiniApp objects array
     let miniAppsObjs = []
-    // An array of miniapps strings was provided
     const miniAppsDependencyPaths = _.map(miniapps, m => PackagePath.fromString(m))
     for (const miniAppDependencyPath of miniAppsDependencyPaths) {
       const m = await spin(`Retrieving ${miniAppDependencyPath.toString()} MiniApp`,

--- a/ern-local-cli/src/commands/cauldron/update/miniapps.js
+++ b/ern-local-cli/src/commands/cauldron/update/miniapps.js
@@ -69,14 +69,6 @@ exports.handler = async function ({
         descriptor,
         extraErrorMessage: 'To avoid conflicts with previous versions, you can only use container version newer than the current one'
       } : undefined,
-      noGitOrFilesystemPath: {
-        obj: miniapps,
-        extraErrorMessage: 'You cannot provide dependencies using git or file schme for this command. Only the form miniapp@version is allowed.'
-      },
-      publishedToNpm: {
-        obj: miniapps,
-        extraErrorMessage: 'You can only update MiniApp(s) version(s) with version(s) that have been published to NPM'
-      },
       miniAppIsInNativeApplicationVersionContainer: {
         miniApp: miniapps,
         napDescriptor,


### PR DESCRIPTION
This PR introduce support in Cauldron/Container Generator for non registry based MiniApp paths.
It makes it possible to add non NPM published MiniApps to a Cauldron and properly generate a container out of it. Due to [current yarn bug with the lock file in case of git dependency paths](https://github.com/yarnpkg/yarn/issues/4734), the lock will not be generated, nor used if one of the MiniApp path is git based.

This feature makes it more convenient for development and CI. For example, one can create a native app `MyAppDev:android:1.0.0` in Cauldron and add MiniApps as git paths to this specific native application name/version. All it takes then to regenerate a new Container including all the latest code changes from all MiniApps is just to run `ern cauldron regen-container -d MyAppDev:android:1.0.0` at any time. No need to publish MiniApps to NPM, nor update the Cauldron in any way, to propagate any code changes to a new Container.

closes https://github.com/electrode-io/electrode-native/issues/374
closes https://github.com/electrode-io/electrode-native/issues/445