### PR TITLE
Improve Container MavenPublisher

### DIFF
--- a/ern-container-gen/src/FlowTypes.js
+++ b/ern-container-gen/src/FlowTypes.js
@@ -57,6 +57,12 @@ export type ContainerMavenPublisherConfig = {
   artifactId: string;
   // Maven Group ID to use for publication
   groupId: string;
+  // Maven user name
+  // If not specified, by convention, it will use mavenUser from gradle.properties
+  mavenUser?: string;
+  // Maven password
+  // If not specified, by convention, it will use mavenPassword from gradle.properties
+  mavenPassword?: string;
 }
 
 export interface ContainerPublisher {

--- a/ern-container-gen/src/publishers/MavenPublisher.js
+++ b/ern-container-gen/src/publishers/MavenPublisher.js
@@ -55,7 +55,9 @@ export default class MavenPublisher implements ContainerPublisher {
               pom.version = '${config.containerVersion}'
               pom.artifactId = '${artifactId}'
               pom.groupId = '${groupId}'
-              ${MavenUtils.targetRepositoryGradleStatement(config.url)}
+              ${MavenUtils.targetRepositoryGradleStatement(config.url, {
+                mavenUser: config.extra && config.extra.mavenUser, mavenPassword: config.extra && config.extra.mavenPassword
+              })}
           }
       }
   }

--- a/ern-core/src/MavenUtils.js
+++ b/ern-core/src/MavenUtils.js
@@ -22,13 +22,21 @@ export default class MavenUtils {
    * @param mavenRepositoryUrl
    * @returns {string}
    */
-  static targetRepositoryGradleStatement (mavenRepositoryUrl: string): ?string {
+  static targetRepositoryGradleStatement (mavenRepositoryUrl: string, {
+    mavenUser,
+    mavenPassword
+  } : {
+    mavenUser?: string,
+    mavenPassword?: string
+  } = {}): ?string {
     const repoType = this.mavenRepositoryType(mavenRepositoryUrl)
     if (repoType === 'file') {
       // Replace \ by \\ for Windows
       return `repository(url: "${mavenRepositoryUrl.replace(/\\/g, '\\\\')}")`
     } else if (repoType === 'http') {
-      return `repository(url: "${mavenRepositoryUrl}") { authentication(userName: mavenUser, password: mavenPassword) }`
+      mavenUser = mavenUser ? `'${mavenUser}'` : 'mavenUser'
+      mavenPassword = mavenPassword ? `'${mavenPassword}'` : 'mavenPassword'
+      return `repository(url: "${mavenRepositoryUrl}") { authentication(userName: ${mavenUser}, password: ${mavenPassword}) }`
     }
   }
 

--- a/ern-local-cli/src/lib/utils.js
+++ b/ern-local-cli/src/lib/utils.js
@@ -454,7 +454,9 @@ async function performContainerStateUpdateInCauldron (
               url: publisherFromCauldron.url,
               extra: {
                 artifactId: `${napDescriptor.name}-ern-container`,
-                groupId: 'com.walmartlabs.ern'
+                groupId: 'com.walmartlabs.ern',
+                mavenUser: publisherFromCauldron.mavenUser,
+                mavenPassword: publisherFromCauldron.mavenPassword
               }
             })
             break


### PR DESCRIPTION
Just to make it possible to explicitly provide Maven user name and password as part of the MavenPublisher configuration, instead of relying on the ones stored in `gradle.properties`.