### PR TITLE
Use copy-files options of Babel

### DIFF
--- a/ern-util-dev/bin/ern-babel.js
+++ b/ern-util-dev/bin/ern-babel.js
@@ -16,6 +16,7 @@ process.argv.push(babelRc.plugins.join(','))
 process.argv.push('src')
 process.argv.push('--out-dir')
 process.argv.push('dist')
+process.argv.push('--copy-files')
 
 console.log('running babel with', process.argv.slice(2))
 require('babel-cli/lib/babel')


### PR DESCRIPTION
Fix [system tests failure](https://travis-ci.org/electrode-io/electrode-native/builds/328930441#L6960) of past few days on CI.

Because we relocated the container generators hulls inside the `src` folder, these hull files were not properly copied over to the distibution (dist) folder during Babel transpilation. Due to the fact that non dev (release) versions of `ern` are using the distribution directory, the Container generator was unable to locate the missing hulls, leading in a system tests failure on CI but not on local dev version.

To fix this issue, this PR informs Babel CLI, through the [copy-files](https://babeljs.io/docs/usage/cli/#babel-copy-files) option, to copy over all files from `src` to the `dist` folder, and not just source (transpiled) files. 
