### PR TITLE
Fix system tests

### DIFF
--- a/system-tests.js
+++ b/system-tests.js
@@ -172,8 +172,6 @@ run(`ern cauldron get config ${iosNativeApplicationDescriptorNewVersion}`)
 run(`ern cauldron add miniapps ${movieDetailsMiniAppPackageName}@${movieDetailsMiniAppVersion} -d ${androidNativeApplicationDescriptor}`, { expectedExitCode: 1 })
 // Non published miniapp
 run(`ern cauldron add miniapps ${packageNotInNpm} -d ${androidNativeApplicationDescriptor}`, { expectedExitCode: 1 })
-// File system miniapp
-run(`ern cauldron add miniapps file:${miniAppPath} -d ${androidNativeApplicationDescriptor}`, { expectedExitCode: 1 })
 
 // Container gen should be successful for the two following commands
 run(`ern create-container --miniapps file:${miniAppPath} -p android -v 1.0.0`)


### PR DESCRIPTION
Due to a recent PR merged to master which makes it possible to add MiniApps to the Cauldron given their git or file system path, one of the system test got broken.

This PR just gets rid of this test (new tests dedicated to git/file MiniApp cauldron tests might be introduced in a future PR, this PR is just fixing the current test suite to unblock daily build)