### PR TITLE
Start command

### DIFF
--- a/ern-local-cli/src/commands/start.js
+++ b/ern-local-cli/src/commands/start.js
@@ -15,7 +15,7 @@ exports.builder = function (yargs: any) {
   return yargs
     .option('descriptor', {
       type: 'string',
-      alias: 'n',
+      alias: 'd',
       describe: 'Full native application selector'
     })
     .option('miniapps', {
@@ -78,7 +78,7 @@ exports.handler = async function ({
       packageName,
       activityName,
       bundleId,
-      extraJsDependencies: _.map(extraJsDependencies, d => PackagePath.fromString(d))
+      extraJsDependencies: _.map(extraJsDependencies, jsDep => PackagePath.fromString(jsDep))
     })
   } catch (e) {
     coreUtils.logErrorAndExitProcess(e)


### PR DESCRIPTION
- Use `d` alias for the descriptor instead of `n` (this is the convention across commands, even the documentation was stating `d` alias for `start` command. No idea why it was moved to `n`).
- Fix the command. The `start` source file was not using flow (and has no tests) and in consequence did not triggered proper typing errors. Added the `// @flow` header and properly refactored code to use new `PackagePath` type instead of former `DependencyPath`.