### PR TITLE
Run native compatibility checks for code-push promote command

### DIFF
--- a/docs/cli/code-push/promote.md
+++ b/docs/cli/code-push/promote.md
@@ -54,6 +54,11 @@ If no `targetDescriptors` nor a `targetSemVerDescriptor` is specified, the comma
 * Skip confirmation prompts
 * **Default** false
 
+`--force/-f`
+
+* Bypass all compatibility checks and force OTA update through CodePush. **USE AT YOUR OWN RISK**
+* **Default** false
+
 #### Related commands
 
 [code-push release] | Issue a CodePush release 

--- a/ern-core/src/compatibility.js
+++ b/ern-core/src/compatibility.js
@@ -231,6 +231,8 @@ export function getCompatibility (
     //      => INCOMPATIBLE
     if (localDep && localDepVersion &&
       (localDepVersion !== remoteDep.version)) {
+      // Todo : do not infer api or api-impl by looking solely at the suffix as its not mandatory anymore, so
+      // we might get false negatives
       if (localDep.name.endsWith('-api') || localDep.name.endsWith('-api-impl') || (localDep.name === 'react-native-electrode-bridge')) {
         if (semver.major(localDepVersion) === semver.major(remoteDep.version)) {
           result.compatibleNonStrict.push(entry)

--- a/ern-local-cli/src/commands/code-push/promote.js
+++ b/ern-local-cli/src/commands/code-push/promote.js
@@ -48,6 +48,11 @@ exports.builder = function (yargs: any) {
       describe: 'Percentage of users this release should be immediately available to',
       default: 100
     })
+    .option('force', {
+      alias: 'f',
+      type: 'bool',
+      describe: 'Force upgrade (ignore compatibility issues -at your own risks-)'
+    })
     .option('skipConfirmation', {
       describe: 'Skip confirmation prompts',
       alias: 's',
@@ -65,7 +70,8 @@ exports.handler = async function ({
   platform,
   mandatory,
   rollout,
-  skipConfirmation
+  skipConfirmation,
+  force
 } : {
   sourceDescriptor?: string,
   targetDescriptors?: Array<string>,
@@ -75,7 +81,8 @@ exports.handler = async function ({
   platform: 'android' | 'ios',
   mandatory?: boolean,
   rollout?: number,
-  skipConfirmation?: boolean
+  skipConfirmation?: boolean,
+  force?: boolean
 }) {
   try {
     let targetNapDescriptors
@@ -161,6 +168,7 @@ exports.handler = async function ({
       targetNapDescriptors,
       sourceDeploymentName,
       targetDeploymentName, {
+        force,
         mandatory,
         rollout
       })


### PR DESCRIPTION
- Run native dependencies versions compatibility checks for target native application version when using `code-push promote` command. If compatibility checks are failing, the promotion will be aborted (similar to `code-push release`)
- Add the `force` option flag to `code-push promote` command (similar to `code-push release`) which will, if set, discard compatibility checks results and proceed with promotion in any case.

Close https://github.com/electrode-io/electrode-native/issues/451