### PR TITLE
Fix doesThrow and doesNotThrow test utils

### DIFF
--- a/ern-cauldron-api/test/CauldronApi-test.js
+++ b/ern-cauldron-api/test/CauldronApi-test.js
@@ -325,7 +325,8 @@ describe('CauldronApi.js', () => {
     })
 
     it('should throw if the native application version does not exists', async () => {
-      assert(await doesThrow(cauldronApi().setCodePushEntries, 'test', 'android', '17.20.0', 'QA', [codePushNewEntryFixture]))
+      const api = cauldronApi()
+      assert(await doesThrow(api.setCodePushEntries, api, 'test', 'android', '17.20.0', 'QA', [codePushNewEntryFixture]))
     })
   })
 
@@ -423,25 +424,37 @@ describe('CauldronApi.js', () => {
   // getConfig
   // ==========================================================
   describe('getConfig', () => {
-    it('should return the native application version config', async () => {
+    it('[get application version config] should return the native application version config', async () => {
       const configObj = await cauldronApi().getConfig({appName:'test', platformName:'android', versionName:'17.7.0'})
       const config = jp.query(fixtures.defaultCauldron, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].config')[0]
       expect(configObj).eql(config)
     })
 
-    it('should return the native application platform config', async () => {
+    it('[get application version config] should return undefined if the native application version does not exist', async () => {
+      const configObj = await cauldronApi().getConfig({appName:'test', platformName:'android', versionName:'17.7.1'})
+      const config = jp.query(fixtures.defaultCauldron, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].config')[0]
+      expect(configObj).undefined
+    })
+
+    it('[get application platform config] should return the native application platform config', async () => {
       const configObj = await cauldronApi().getConfig({appName:'test', platformName:'android'})
       const config = jp.query(fixtures.defaultCauldron, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].config')[0]
       expect(configObj).eql(config)
     })
 
-    it('should return the native application name config', async () => {
+    it('[get application platform config] should return undefined if the native application platform does not exist', async () => {
+      const configObj = await cauldronApi().getConfig({appName:'test', platformName:'none', versionName:'17.7.0'})
+      const config = jp.query(fixtures.defaultCauldron, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].config')[0]
+      expect(configObj).undefined
+    })
+
+    it('[get application config] should return the native application name config', async () => {
       const configObj = await cauldronApi().getConfig({appName:'test'})
       const config = jp.query(fixtures.defaultCauldron, '$.nativeApps[?(@.name=="test")].config')[0]
       expect(configObj).eql(config)
     })
 
-    it('should return undefined if no config exist', async () => {
+    it('[get application config] should return undefined if native application does not exist', async () => {
       const configObj = await cauldronApi().getConfig({appName:'unexisting'})
       expect(configObj).undefined
     })
@@ -478,7 +491,9 @@ describe('CauldronApi.js', () => {
     })
 
     it('should throw if the native application name already exists', async() => {
-      assert(await doesThrow(cauldronApi().createNativeApplication, {name: 'test'}))
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      const api = cauldronApi(tmpFixture)
+      assert(await doesThrow(api.createNativeApplication, api, {name: 'test'}))
     })
   })
 
@@ -502,7 +517,8 @@ describe('CauldronApi.js', () => {
     })
 
     it('should throw if the application name does not exists', async () => {
-      assert(await doesThrow(cauldronApi().removeNativeApplication, 'unexisting'))
+      const api = cauldronApi()
+      assert(await doesThrow(api.removeNativeApplication, api, 'unexisting'))
     })
   })
 
@@ -526,7 +542,8 @@ describe('CauldronApi.js', () => {
     })
 
     it('should throw if the application platform already exists', async () => {
-      assert(await doesThrow(cauldronApi().createPlatform('test', {name:'android'})))
+      const api = cauldronApi()
+      assert(await doesThrow(api.createPlatform, api, 'test', {name:'android'}))
     })
   })
 
@@ -550,11 +567,13 @@ describe('CauldronApi.js', () => {
     })
 
     it('should throw if the application name does not exists', async () => {
-      assert(await doesThrow(cauldronApi().removePlatform, 'unexisting', 'android'))
+      const api = cauldronApi()
+      assert(await doesThrow(api.removePlatform, api, 'unexisting', 'android'))
     })
 
     it('should throw if the application platform does not exists', async () => {
-      assert(await doesThrow(cauldronApi().removePlatform, 'test', 'ios'))
+      const api = cauldronApi()
+      assert(await doesThrow(api.removePlatform, api, 'test', 'ios'))
     })
   })
 
@@ -578,11 +597,13 @@ describe('CauldronApi.js', () => {
     })
 
     it('should throw if the platform does not exist', async () => {
-      assert(await doesThrow(cauldronApi().createVersion('test', 'ios', {name:'17.20.0', ernPlatformVersion:'1.0.0'})))
+      const api = cauldronApi()
+      assert(await doesThrow(api.createVersion, api, 'test', 'ios', {name:'17.20.0', ernPlatformVersion:'1.0.0'}))
     })
 
     it('should throw if the version already exists', async () => {
-      assert(await doesThrow(cauldronApi().createVersion('test', 'android', {name:'17.7.0', ernPlatformVersion:'1.0.0'})))
+      const api = cauldronApi()
+      assert(await doesThrow(api.createVersion, api, 'test', 'android', {name:'17.7.0', ernPlatformVersion:'1.0.0'}))
     })
   })
 
@@ -606,11 +627,13 @@ describe('CauldronApi.js', () => {
     })
 
     it('should throw if the platform name does not exists', async () => {
-      assert(await doesThrow(cauldronApi().removeVersion, 'test', 'unexisting'))
+      const api = cauldronApi()
+      assert(await doesThrow(api.removeVersion, api, 'test', 'unexisting'))
     })
 
     it('should throw if the version does not exists', async () => {
-      assert(await doesThrow(cauldronApi().removePlatform, 'test', 'android', '17.20.0'))
+      const api = cauldronApi()
+      assert(await doesThrow(api.removeVersion, api, 'test', 'android', '17.20.0'))
     })
   })
 
@@ -634,7 +657,8 @@ describe('CauldronApi.js', () => {
     })
 
     it('should throw if the version does not exists', async () => {
-      assert(await doesThrow(cauldronApi().updateVersion, 'test', 'android', '17.20.0', {isReleased: false}))
+      const api = cauldronApi()
+      assert(await doesThrow(api.updateVersion, api, 'test', 'android', '17.20.0', {isReleased: false}))
     })
   })
 
@@ -658,11 +682,13 @@ describe('CauldronApi.js', () => {
     })
 
     it('should throw if the dependency is not found', async () => {
-      assert(await doesThrow(cauldronApi().removeNativeDependency, 'test', 'android', '17.7.0', 'unexisting'))
+      const api = cauldronApi()
+      assert(await doesThrow(api.removeNativeDependency, api, 'test', 'android', '17.7.0', 'unexisting'))
     })
 
     it('should throw if the native application version is not found', async () => {
-      assert(await doesThrow(cauldronApi().removeNativeDependency, 'test', 'android', '17.20.0', 'react-native-electrode-bridge'))
+      const api = cauldronApi()
+      assert(await doesThrow(api.removeNativeDependency, api, 'test', 'android', '17.20.0', 'react-native-electrode-bridge'))
     })
   })
 
@@ -687,11 +713,13 @@ describe('CauldronApi.js', () => {
     })
 
     it('should throw if the dependency is not found', async () => {
-      assert(await doesThrow(cauldronApi().updateNativeDependency, 'test', 'android', '17.7.0', 'unexisting', '1.5.0'))
+      const api = cauldronApi()
+      assert(await doesThrow(api.updateNativeDependency, api, 'test', 'android', '17.7.0', 'unexisting', '1.5.0'))
     })
 
     it('should throw if the native application version is not found', async () => {
-      assert(await doesThrow(cauldronApi().updateNativeDependency, 'test', 'android', '17.20.0', 'react-native-electrode-bridge', '1.5.0'))
+      const api = cauldronApi()
+      assert(await doesThrow(api.updateNativeDependency, api, 'test', 'android', '17.20.0', 'react-native-electrode-bridge', '1.5.0'))
     })
   })
 
@@ -716,11 +744,13 @@ describe('CauldronApi.js', () => {
     })
 
     it('should throw if the miniapp is not found', async () => {
-      assert(await doesThrow(cauldronApi().updateMiniAppVersion, 'test', 'android', '17.7.0',  PackagePath.fromString('react-native-foo@3.0.0')))
+      const api = cauldronApi()
+      assert(await doesThrow(api.updateMiniAppVersion, api, 'test', 'android', '17.7.0',  PackagePath.fromString('react-native-foo@3.0.0')))
     })
 
     it('should throw if the native application version is not found', async () => {
-      assert(await doesThrow(cauldronApi().updateMiniAppVersion, 'test', 'android', '17.20.0',  PackagePath.fromString('react-native-bar@3.0.0')))
+      const api = cauldronApi()
+      assert(await doesThrow(api.updateMiniAppVersion, api, 'test', 'android', '17.20.0',  PackagePath.fromString('react-native-bar@3.0.0')))
     })
   })
 
@@ -764,7 +794,8 @@ describe('CauldronApi.js', () => {
     })
 
     it('should throw if the native application version is not found', async () => {
-      assert(await doesThrow(cauldronApi().updateContainerVersion, 'test', 'android', '17.20.0', '2.0.0'))
+      const api = cauldronApi()
+      assert(await doesThrow(api.updateContainerVersion, api, 'test', 'android', '17.20.0', '2.0.0'))
     })
   })
 
@@ -788,7 +819,8 @@ describe('CauldronApi.js', () => {
     })
 
     it('should throw if the native application version is not found', async () => {
-      assert(await doesThrow(cauldronApi().getContainerVersion, 'test', 'android', '17.20.0'))
+      const api = cauldronApi()
+      assert(await doesThrow(api.getContainerVersion, api, 'test', 'android', '17.20.0'))
     })
   })
 
@@ -812,11 +844,13 @@ describe('CauldronApi.js', () => {
     })
 
     it('should throw if the MiniApp is not found', async () => {
-      assert(await doesThrow(cauldronApi().removeContainerMiniApp, 'test', 'android', '17.7.0', 'unexisting'))
+      const api = cauldronApi()
+      assert(await doesThrow(api.removeContainerMiniApp, api, 'test', 'android', '17.7.0', 'unexisting'))
     })
 
     it('should throw if the native application version is not found', async () => {
-      assert(await doesThrow(cauldronApi().removeContainerMiniApp, 'test', 'android', '17.20.0', 'react-native-bar'))
+      const api = cauldronApi()
+      assert(await doesThrow(api.removeContainerMiniApp, api, 'test', 'android', '17.20.0', 'react-native-bar'))
     })
   })
 
@@ -840,11 +874,13 @@ describe('CauldronApi.js', () => {
     })
 
     it('should throw if the MiniApp already exists', async () => {
-      assert(await doesThrow(cauldronApi().addContainerMiniApp, 'test', 'android', '17.7.0', PackagePath.fromString('react-native-bar@2.0.0')))
+      const api = cauldronApi()
+      assert(await doesThrow(api.addContainerMiniApp, api, 'test', 'android', '17.7.0', PackagePath.fromString('react-native-bar@2.0.0')))
     })
 
     it('should throw if the native application version is not found', async () => {
-      assert(await doesThrow(cauldronApi().addContainerMiniApp, 'test', 'android', '17.20.0', PackagePath.fromString('newMiniApp@1.0.0')))
+      const api = cauldronApi()
+      assert(await doesThrow(api.addContainerMiniApp, api, 'test', 'android', '17.20.0', PackagePath.fromString('newMiniApp@1.0.0')))
     })
   })
 
@@ -868,11 +904,13 @@ describe('CauldronApi.js', () => {
     })
 
     it('should throw if the dependency already exists', async () => {
-      assert(await doesThrow(cauldronApi().createNativeDependency, 'test', 'android', '17.7.0', PackagePath.fromString('react-native-electrode-bridge@1.4.0')))
+      const api = cauldronApi()
+      assert(await doesThrow(api.createNativeDependency, api, 'test', 'android', '17.7.0', PackagePath.fromString('react-native-electrode-bridge@1.4.9')))
     })
 
     it('should throw if the native application version is not found', async () => {
-      assert(await doesThrow(cauldronApi().createNativeDependency, 'test', 'android', '17.20.0', PackagePath.fromString('testDep@1.0.0')))
+      const api = cauldronApi()
+      assert(await doesThrow(api.createNativeDependency, api, 'test', 'android', '17.20.0', PackagePath.fromString('testDep@1.0.0')))
     })
   })
 
@@ -905,7 +943,8 @@ describe('CauldronApi.js', () => {
     })
 
     it('should throw if the native application version is not found', async () => {
-      assert(await doesThrow(cauldronApi().addCodePushEntry, 'test', 'android', '17.20.0',codePushNewEntryFixture))
+      const api = cauldronApi()
+      assert(await doesThrow(api.addCodePushEntry, api, 'test', 'android', '17.20.0',codePushNewEntryFixture))
     })
   })
 
@@ -924,7 +963,8 @@ describe('CauldronApi.js', () => {
     })
 
     it('should throw if the native application version is not found', async () => {
-      assert(await doesThrow(cauldronApi().hasYarnLock, 'test', 'android', '17.20.0', 'Production'))
+      const api = cauldronApi()
+      assert(await doesThrow(api.hasYarnLock, api, 'test', 'android', '17.20.0', 'Production'))
     })
   })
 
@@ -948,7 +988,8 @@ describe('CauldronApi.js', () => {
     })
 
     it('should throw if the native application version is not found', async () => {
-      assert(await doesThrow(cauldronApi().addYarnLock, 'test', 'android', '17.20.0', 'YARN_LOCK_KEY', 'YARN_LOCK_CONTENT'))
+      const api = cauldronApi()
+      assert(await doesThrow(api.addYarnLock, api, 'test', 'android', '17.20.0', 'YARN_LOCK_KEY', 'YARN_LOCK_CONTENT'))
     })
   })
 
@@ -967,7 +1008,8 @@ describe('CauldronApi.js', () => {
     })
 
     it('should throw if the native application version is not found', async () => {
-      assert(await doesThrow(cauldronApi().getYarnLockId, 'test', 'android', '17.20.0', 'Production'))
+      const api = cauldronApi()
+      assert(await doesThrow(api.getYarnLockId, api, 'test', 'android', '17.20.0', 'Production'))
     })
   })
 
@@ -1002,7 +1044,8 @@ describe('CauldronApi.js', () => {
 
     it('should throw if the native application version is not found', async () => {
       const newId = '30bf4eff61586d71fe5d52e31a2cfabcbb31e33e'
-      assert(await doesThrow(cauldronApi().setYarnLockId, 'test', 'android', '17.20.0', 'NewKey', newId))
+      const api = cauldronApi()
+      assert(await doesThrow(api.setYarnLockId, api, 'test', 'android', '17.20.0', 'NewKey', newId))
     })
   })
 
@@ -1012,7 +1055,8 @@ describe('CauldronApi.js', () => {
   describe('getYarnLock', () => {
     it('should throw if the native application version is not found', async () => {
       const newId = '30bf4eff61586d71fe5d52e31a2cfabcbb31e33e'
-      assert(await doesThrow(cauldronApi().getYarnLock, 'test', 'android', '17.20.0', 'Production'))
+      const api = cauldronApi()
+      assert(await doesThrow(api.getYarnLock, api, 'test', 'android', '17.20.0', 'Production'))
     })
   })
 
@@ -1021,7 +1065,8 @@ describe('CauldronApi.js', () => {
   // ==========================================================
   describe('getPathToYarnLock', () => {
     it('should throw if the native application version is not found', async () => {
-      assert(await doesThrow(cauldronApi().getPathToYarnLock, 'test', 'android', '17.20.0', 'Production'))
+      const api = cauldronApi()
+      assert(await doesThrow(api.getPathToYarnLock, api, 'test', 'android', '17.20.0', 'Production'))
     })
   })
 
@@ -1030,7 +1075,8 @@ describe('CauldronApi.js', () => {
   // ==========================================================
   describe('removeYarnLock', () => {
     it('should throw if the native application version is not found', async () => {
-      assert(await doesThrow(cauldronApi().removeYarnLock, 'test', 'android', '17.20.0', 'Production'))
+      const api = cauldronApi()
+      assert(await doesThrow(api.removeYarnLock, api, 'test', 'android', '17.20.0', 'Production'))
     })
   })
 
@@ -1039,7 +1085,8 @@ describe('CauldronApi.js', () => {
   // ==========================================================
   describe('updateYarnLock', () => {
     it('should throw if the native application version is not found', async () => {
-      assert(await doesThrow(cauldronApi().updateYarnLock, 'test', 'android', '17.20.0', 'Production', 'NewLock'))
+      const api = cauldronApi()
+      assert(await doesThrow(api.updateYarnLock, api, 'test', 'android', '17.20.0', 'Production', 'NewLock'))
     })
   })
 
@@ -1065,7 +1112,8 @@ describe('CauldronApi.js', () => {
 
     it('should throw if the native application version is not found', async () => {
       const newId = '30bf4eff61586d71fe5d52e31a2cfabcbb31e33e'
-      assert(await doesThrow(cauldronApi().updateYarnLockId, 'test', 'android', '17.20.0', 'NewKey'))
+      const api = cauldronApi()
+      assert(await doesThrow(api.updateYarnLockId, api, 'test', 'android', '17.20.0', 'NewKey'))
     })
   })
 
@@ -1091,7 +1139,8 @@ describe('CauldronApi.js', () => {
     })
 
     it('should throw if the native application version is not found', async () => {
-      assert(await doesThrow(cauldronApi().setYarnLocks, 'test', 'android', '17.20.0', {"Test":"30bf4eff61586d71fe5d52e31a2cfabcbb31e33e"}))
+      const api = cauldronApi()
+      assert(await doesThrow(api.setYarnLocks, api, 'test', 'android', '17.20.0', {"Test":"30bf4eff61586d71fe5d52e31a2cfabcbb31e33e"}))
     })
   })
 })

--- a/ern-container-gen/test/temp-test.js
+++ b/ern-container-gen/test/temp-test.js
@@ -196,37 +196,37 @@ describe('ern-container-gen utils.js', () => {
   describe('generateMiniAppsComposite [with yarn lock]', () => {
     it('should throw an exception if at least one of the MiniApp path is using a file scheme [1]', async () => {
       const miniApps = [PackagePath.fromString('file:/Code/MiniApp')]
-      assert(await doesThrow(generateMiniAppsComposite, miniApps, tmpOutDir, {pathToYarnLock: 'hello'}), 'No exception was thrown !')
+      assert(await doesThrow(generateMiniAppsComposite, null, miniApps, tmpOutDir, {pathToYarnLock: 'hello'}), 'No exception was thrown !')
     })
 
     it('should throw an exception if at least one of the MiniApp path is using a file scheme [2]', async () => {
       const miniApps = [PackagePath.fromString('MiniAppOne@1.0.0'), PackagePath.fromString('file:/Code/MiniApp')]
-      assert(await doesThrow(generateMiniAppsComposite, miniApps, tmpOutDir, {pathToYarnLock: 'hello'}), 'No exception was thrown !')
+      assert(await doesThrow(generateMiniAppsComposite, null, miniApps, tmpOutDir, {pathToYarnLock: 'hello'}), 'No exception was thrown !')
     })
 
     it('should throw an exception if at least one of the MiniApp path is using a git scheme [1]', async () => {
       const miniApps = [PackagePath.fromString('git://github.com:user/MiniAppRepo')]
-      assert(await doesThrow(generateMiniAppsComposite, miniApps, tmpOutDir, {pathToYarnLock: 'hello'}), 'No exception was thrown !')
+      assert(await doesThrow(generateMiniAppsComposite, null, miniApps, tmpOutDir, {pathToYarnLock: 'hello'}), 'No exception was thrown !')
     })
 
     it('should throw an exception if at least one of the MiniApp path is using a git scheme [2]', async () => {
       const miniApps = [PackagePath.fromString('MiniAppOne@1.0.0'), PackagePath.fromString('git://github.com:user/MiniAppRepo')]
-      assert(await doesThrow(generateMiniAppsComposite, miniApps, tmpOutDir, {pathToYarnLock: 'hello'}), 'No exception was thrown !')
+      assert(await doesThrow(generateMiniAppsComposite, null, miniApps, tmpOutDir, {pathToYarnLock: 'hello'}), 'No exception was thrown !')
     })
 
     it('should throw an exception if one of the MiniApp is not using an explicit version [1]', async () => {
       const miniApps = [PackagePath.fromString('MiniAppOne')]
-      assert(await doesThrow(generateMiniAppsComposite, miniApps, tmpOutDir, {pathToYarnLock: 'hello'}), 'No exception was thrown !')
+      assert(await doesThrow(generateMiniAppsComposite, null, miniApps, tmpOutDir, {pathToYarnLock: 'hello'}), 'No exception was thrown !')
     })
 
     it('should throw an exception if one of the MiniApp is not using an explicit version [1]', async () => {
       const miniApps = [PackagePath.fromString('MiniAppOne'), PackagePath.fromString('MiniAppTwo@1.0.0')]
-      assert(await doesThrow(generateMiniAppsComposite, miniApps, tmpOutDir, {pathToYarnLock: 'hello'}), 'No exception was thrown !')
+      assert(await doesThrow(generateMiniAppsComposite, null, miniApps, tmpOutDir, {pathToYarnLock: 'hello'}), 'No exception was thrown !')
     })
 
     it('should throw an exception if path to yarn.lock does not exists', async () => {
       const miniApps = [PackagePath.fromString('MiniAppOne@1.0.0'), PackagePath.fromString('MiniAppTwo@1.0.0')]
-      assert(await doesThrow(generateMiniAppsComposite, miniApps, tmpOutDir, {pathToYarnLock: path.join(tmpOutDir, 'yarn.lock')}), 'No exception was thrown !')
+      assert(await doesThrow(generateMiniAppsComposite, null, miniApps, tmpOutDir, {pathToYarnLock: path.join(tmpOutDir, 'yarn.lock')}), 'No exception was thrown !')
     })
 
     it('should call yarn install prior to calling yarn add or yarn upgrade for each MiniApp', async () => {

--- a/ern-core/test/CauldronHelper-test.js
+++ b/ern-core/test/CauldronHelper-test.js
@@ -226,7 +226,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.addNativeDependency, 
+        cauldronHelper.addNativeDependency,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'),
         PackagePath.fromString('test@1.0.0')))
     })
@@ -235,7 +236,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.addNativeDependency, 
+        cauldronHelper.addNativeDependency,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'),
         PackagePath.fromString('test@1.0.0')))
     })
@@ -244,7 +246,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.addNativeDependency, 
+        cauldronHelper.addNativeDependency,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('test@1.0.0')))
     })
@@ -265,7 +268,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.removeNativeDependency, 
+        cauldronHelper.removeNativeDependency,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'),
         PackagePath.fromString('test@1.0.0')))
     })
@@ -274,7 +278,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.removeNativeDependency, 
+        cauldronHelper.removeNativeDependency,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'),
         PackagePath.fromString('test@1.0.0')))
     })
@@ -283,7 +288,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.removeNativeDependency, 
+        cauldronHelper.removeNativeDependency,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('test@1.0.0')))
     })
@@ -314,7 +320,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.removeMiniAppFromContainer, 
+        cauldronHelper.removeMiniAppFromContainer,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'),
         PackagePath.fromString('@test/react-native-foo@5.0.0')))
     })
@@ -323,7 +330,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.removeMiniAppFromContainer, 
+        cauldronHelper.removeMiniAppFromContainer,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'),
         PackagePath.fromString('@test/react-native-foo@5.0.0')))
     })
@@ -332,7 +340,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.removeMiniAppFromContainer, 
+        cauldronHelper.removeMiniAppFromContainer,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('@test/react-native-foo@5.0.0')))
     })
@@ -410,7 +419,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.getVersions, 
+        cauldronHelper.getVersions,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test')))
     })
 
@@ -440,7 +450,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.getNativeDependencies, 
+        cauldronHelper.getNativeDependencies,
+        cauldronHelper, 
         NativeApplicationDescriptor.fromString('test:android')))
     })
 
@@ -457,7 +468,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.hasYarnLock, 
+        cauldronHelper.hasYarnLock,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'),
         'Production'))
     })
@@ -466,7 +478,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.hasYarnLock, 
+        cauldronHelper.hasYarnLock,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'),
         'Production'))
     })
@@ -495,7 +508,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.addYarnLock, 
+        cauldronHelper.addYarnLock,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'),
         'Production'))
     })
@@ -504,7 +518,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.addYarnLock, 
+        cauldronHelper.addYarnLock,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'),
         'Production'))
     })
@@ -529,7 +544,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.getYarnLock, 
+        cauldronHelper.getYarnLock,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'),
         'Production'))
     })
@@ -538,7 +554,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.getYarnLock, 
+        cauldronHelper.getYarnLock,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'),
         'Production'))
     })
@@ -574,7 +591,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.getPathToYarnLock, 
+        cauldronHelper.getPathToYarnLock,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'),
         'Production'))
     })
@@ -583,7 +601,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.getPathToYarnLock, 
+        cauldronHelper.getPathToYarnLock,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'),
         'Production'))
     })
@@ -619,7 +638,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.removeYarnLock, 
+        cauldronHelper.removeYarnLock,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'),
         'Production'))
     })
@@ -628,7 +648,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.removeYarnLock, 
+        cauldronHelper.removeYarnLock,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'),
         'Production'))
     })
@@ -660,7 +681,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.updateYarnLock, 
+        cauldronHelper.updateYarnLock,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'),
         'Production',
         '/path/to/yarn.lock'))
@@ -673,7 +695,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.updateYarnLock, 
+        cauldronHelper.updateYarnLock,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'),
         'Production',
         '/path/to/yarn.lock'))
@@ -738,7 +761,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.setYarnLocks, 
+        cauldronHelper.setYarnLocks,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'), { 
         'Foo': '2110ae042d2bf337973c7b60615ba19fe7fb120c', 
         'Bar': '91bf4eff61586d71fe5d52e31a2cfabcbb31e33e'
@@ -749,7 +773,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.setYarnLocks, 
+        cauldronHelper.setYarnLocks,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'), { 
         'Foo': '2110ae042d2bf337973c7b60615ba19fe7fb120c', 
         'Bar': '91bf4eff61586d71fe5d52e31a2cfabcbb31e33e'
@@ -778,7 +803,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.addOrUpdateYarnLock, 
+        cauldronHelper.addOrUpdateYarnLock,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'), 
         'Production',
         '/path/to/yarn.lock'))
@@ -791,7 +817,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.addOrUpdateYarnLock, 
+        cauldronHelper.addOrUpdateYarnLock,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'), 
         'Production',
         '/path/to/yarn.lock'))
@@ -831,7 +858,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.getYarnLockId, 
+        cauldronHelper.getYarnLockId,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'), 
         'Production'))
     })
@@ -840,7 +868,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.getYarnLockId, 
+        cauldronHelper.getYarnLockId,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'), 
         'Production'))
     })
@@ -860,7 +889,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.setYarnLockId, 
+        cauldronHelper.setYarnLockId,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'), 
         'Foo',
         '1111111111111171fe5d52e31a2cfabcbb31e33e'))
@@ -870,7 +900,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.setYarnLockId, 
+        cauldronHelper.setYarnLockId,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'), 
         'Foo',
         '1111111111111171fe5d52e31a2cfabcbb31e33e'))
@@ -893,7 +924,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.updateYarnLockId, 
+        cauldronHelper.updateYarnLockId,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'), 
         'Production',
         '1111111111111171fe5d52e31a2cfabcbb31e33e'))
@@ -903,7 +935,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.updateYarnLockId, 
+        cauldronHelper.updateYarnLockId,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'), 
         'Production',
         '1111111111111171fe5d52e31a2cfabcbb31e33e'))
@@ -926,7 +959,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.getNativeDependency, 
+        cauldronHelper.getNativeDependency,
+        cauldronHelper, 
         NativeApplicationDescriptor.fromString('test:android'), 
         'react-native-electrode-bridge'))
     })
@@ -936,6 +970,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
         cauldronHelper.getNativeDependency, 
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'), 
         'react-native-electrode-bridge'))
     })
@@ -985,6 +1020,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
         cauldronHelper.updateNativeAppDependency, 
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'),
         PackagePath.fromString('react-native-electrode-bridge'),
         '1.5.0'))
@@ -995,6 +1031,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
         cauldronHelper.updateNativeAppDependency, 
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'),
         PackagePath.fromString('react-native-electrode-bridge'),
         '1.5.0'))
@@ -1005,6 +1042,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
         cauldronHelper.updateNativeAppDependency, 
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('react-native-electrode-bridge'),
         '1.5.0'))
@@ -1038,6 +1076,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
         cauldronHelper.getContainerMiniApp, 
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'),
         'react-native-bar'))
     })
@@ -1047,6 +1086,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
         cauldronHelper.getContainerMiniApp, 
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'),
         'react-native-bar'))
     })
@@ -1094,6 +1134,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
         cauldronHelper.getCodePushMiniApps, 
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'),
         'Production'))
     })
@@ -1103,6 +1144,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
         cauldronHelper.getCodePushMiniApps, 
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'),
         'Production'))
     })
@@ -1132,6 +1174,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
         cauldronHelper.getContainerMiniApps, 
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android')))
     })
 
@@ -1140,6 +1183,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
         cauldronHelper.getContainerMiniApps, 
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0')))
     })
 
@@ -1158,6 +1202,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
         cauldronHelper.addCodePushEntry, 
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'),
         codePushMetadataFixtureOne,
         miniAppsFixtureOne))
@@ -1167,7 +1212,8 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.addCodePushEntry, 
+        cauldronHelper.addCodePushEntry,
+        cauldronHelper, 
         NativeApplicationDescriptor.fromString('test:android:0.0.0'),
         codePushMetadataFixtureOne,
         miniAppsFixtureOne))
@@ -1243,6 +1289,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
         cauldronHelper.updateCodePushEntry, 
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'),
         'Production',
         'v17', {
@@ -1255,6 +1302,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
         cauldronHelper.updateCodePushEntry, 
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'),
         'Production',
         'v17',{
@@ -1405,6 +1453,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
         cauldronHelper.updateNativeAppIsReleased, 
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'),
         false))
     })
@@ -1414,6 +1463,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
         cauldronHelper.updateNativeAppIsReleased, 
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'),
         false))
     })
@@ -1435,6 +1485,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
         cauldronHelper.updateContainerVersion,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'),
         '999.0.0'))
     })
@@ -1444,6 +1495,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
         cauldronHelper.updateContainerVersion,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'),
         '999.0.0'))
     })
@@ -1465,6 +1517,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
         cauldronHelper.getContainerVersion,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android')))
     })
 
@@ -1473,6 +1526,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
         cauldronHelper.getContainerVersion,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0')))
     })
 
@@ -1527,6 +1581,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
         cauldronHelper.throwIfNativeApplicationNotInCauldron,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0')))
     })
 
@@ -1535,6 +1590,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesNotThrow(
         cauldronHelper.throwIfNativeApplicationNotInCauldron,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:17.7.0')))
     })
   })
@@ -1545,6 +1601,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
         cauldronHelper.throwIfNativeAppVersionIsReleased,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         'released'))
     })
@@ -1554,6 +1611,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesNotThrow(
         cauldronHelper.throwIfNativeAppVersionIsReleased,
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         'nonreleased'))
     })

--- a/ern-local-cli/test/Ensure-test.js
+++ b/ern-local-cli/test/Ensure-test.js
@@ -103,15 +103,14 @@ describe('Ensure.js', () => {
   describe('napDescritorExistsInCauldron', () => {
     it('should not throw if nap descriptor exists in Cauldron', async () => {
       cauldronHelperStub.getNativeApp.resolves({})
-      assert(await doesNotThrow(Ensure.napDescritorExistsInCauldron, 'testapp:android:1.0.0'))
+      assert(await doesNotThrow(Ensure.napDescritorExistsInCauldron, null, 'testapp:android:1.0.0'))
     })
 
     it('should throw if nap descriptor does not exist in Cauldron', async () => {
       cauldronHelperStub.getNativeApp.resolves(undefined)
-      assert(await doesThrow(Ensure.napDescritorExistsInCauldron, 'testapp:android:1.0.0'))
+      assert(await doesThrow(Ensure.napDescritorExistsInCauldron, null, 'testapp:android:1.0.0'))
     })
   })
-
 
   // ==========================================================
   // publishedToNpm
@@ -119,12 +118,12 @@ describe('Ensure.js', () => {
   describe('publishedToNpm', () => {
     it('should not throw if dependency is published to npm', async () => {
       sandbox.stub(utils, 'isPublishedToNpm').resolves(true)
-      assert(await doesNotThrow(Ensure.publishedToNpm, 'nonpublished@1.0.0'))
+      assert(await doesNotThrow(Ensure.publishedToNpm, null, 'nonpublished@1.0.0'))
     })
 
     it('should throw if dependency is not published to npm', async () => {
       sandbox.stub(utils, 'isPublishedToNpm').resolves(false)
-      assert(await doesThrow(Ensure.publishedToNpm, 'nonpublished@1.0.0'))
+      assert(await doesThrow(Ensure.publishedToNpm, null, 'nonpublished@1.0.0'))
     })
   })
 

--- a/ern-local-cli/test/utils-test.js
+++ b/ern-local-cli/test/utils-test.js
@@ -579,12 +579,12 @@ describe('utils.js', () => {
   describe('getDescriptorsMatchingSemVerDescriptor', () => {
     it('should throw if the descriptor does not contain a platform', async () => {
       const descriptor = NativeApplicationDescriptor.fromString('testapp')
-      assert(await doesThrow(utils.getDescriptorsMatchingSemVerDescriptor, descriptor))
+      assert(await doesThrow(utils.getDescriptorsMatchingSemVerDescriptor, null, descriptor))
     })
 
     it('should throw if the descriptor does not contain a version', async () => {
       const descriptor = NativeApplicationDescriptor.fromString('testapp:android')
-      assert(await doesThrow(utils.getDescriptorsMatchingSemVerDescriptor, descriptor))
+      assert(await doesThrow(utils.getDescriptorsMatchingSemVerDescriptor, null, descriptor))
     })
 
     it('should return an empty array if the semver descriptor does not match any version', async () => {

--- a/ern-util-dev/src/index.js
+++ b/ern-util-dev/src/index.js
@@ -208,20 +208,20 @@ ${diffOut}
   return api
 }
 
-export async function doesThrow (asyncFn, ...args) {
+export async function doesThrow (asyncFn, thisArg, ...args) {
   let threwError = false
   try {
-    await asyncFn(...args)
+    await asyncFn.call(thisArg, ...args)
   } catch (e) {
     threwError = true
   }
   return threwError === true
 }
 
-export async function doesNotThrow (asyncFn, ...args) {
+export async function doesNotThrow (asyncFn, thisArg, ...args) {
   let threwError = false
   try {
-    await asyncFn(...args)
+    await asyncFn.call(thisArg, ...args)
   } catch (e) {
     threwError = true
   }


### PR DESCRIPTION
While looking at coverage reports I noticed that most of the tests ensuring that exceptions are properly thrown were not actually covering any lines in platform code base.

After further investigation, it appeared that the `doesThrow` and `doesNotThrow` function were not properly implemented. The tests were passing as the calls were actually throwing (in the case of `doesThrow`) exceptions, just not the exception thrown from the proper location. All due to missing `this` context for some calls.

This PR fixes this, we should bring test coverage up a little bit.