### PR TITLE
Update cauldron del nativeapp command

### DIFF
--- a/docs/cli/cauldron/del/nativeapp.md
+++ b/docs/cli/cauldron/del/nativeapp.md
@@ -2,7 +2,7 @@
 
 #### Description
 
-* Remove a native application version from a Cauldron  
+* Remove a native application entry from a Cauldron
 
 #### Syntax
 
@@ -12,7 +12,21 @@
 
 `<descriptor>` 
 
-* A complete native application descriptor representing the native application version to removed from the Cauldron.
+* A partial native application descriptor or a complete native application descriptor representing the native application entry to be removed from the Cauldron.
+
+**Example**  
+
+`ern cauldron del nativeapp TestApp`  
+Remove the native application named `TestApp` from the cauldron.  
+This includes removing all platforms and versions of this native application from the Cauldron.
+
+`ern cauldron del nativeapp TestApp:android`  
+Remove the android platform entry of `TestApp` from the Cauldron.  
+This includes removing all versions entries in Cauldron of `TestApp` for `android` platform, but will other platform versions untouched.
+
+`ern cauldron del nativeapp TestApp:android:1.0.0`  
+Remove version `1.0.0` of the `TestApp` `android` from the Cauldron.  
+All other versions of `TestApp` `android` will remain untouched.
 
 #### Remarks
 

--- a/ern-local-cli/src/commands/cauldron/del/nativeapp.js
+++ b/ern-local-cli/src/commands/cauldron/del/nativeapp.js
@@ -22,7 +22,6 @@ exports.handler = async function ({
     cauldronIsActive: {
       extraErrorMessage: 'A Cauldron must be active in order to use this command'
     },
-    isCompleteNapDescriptorString: { descriptor },
     napDescriptorExistInCauldron: {
       descriptor,
       extraErrorMessahe: 'This command cannot remove a native application version that do not exist in Cauldron.'


### PR DESCRIPTION
Remove the restriction of having to specify a complete native application descriptor for `cauldron del nativeapp` command, so that it is possible -again- to remove all versions of a specific native application platform or to fully remove a native application, along with its platform(s) and version(s) from the Cauldron.