### PR TITLE
Fix run-android on Windows

### DIFF
--- a/ern-core/src/nativeDependenciesLookup.js
+++ b/ern-core/src/nativeDependenciesLookup.js
@@ -34,7 +34,9 @@ export async function findNativeDependencies (dir: string) : Promise<NativeDepen
   const filteredDirectories = filterDirectories(directoriesWithNativeCode)
 
   for (const nativeDepsDirectory of filteredDirectories) {
-    const r = /^(@.*?\/.*?)\/|^(.*?)\//.exec(nativeDepsDirectory)
+    const r = /^win/.test(process.platform)
+      ? /^(@.*?\\.*?)\\|^(.*?)\\/.exec(nativeDepsDirectory)
+      : /^(@.*?\/.*?)\/|^(.*?)\//.exec(nativeDepsDirectory)
     nativeDependenciesNames.add(r[1] || r[2])
   }
 


### PR DESCRIPTION
Root cause due to a recent refactoring of the native dependencies resolution algorithm, which was not properly implemented for Windows (not properly handling the platform difference in file system path format in regex).

Closes https://github.com/electrode-io/electrode-native/issues/504