### PR TITLE
 create-api uses --schemaPath to accept initial config

### DIFF
--- a/docs/cli/create-api.md
+++ b/docs/cli/create-api.md
@@ -56,6 +56,10 @@ This example shows how to create a unscoped package named `weather-api`. The API
 `ern create-api weather --scope MyCompany`  
 This example shows how to create a scoped package named `@MyCompany/weather-api`.  
 
+`ern create-api weather --schemaPath schema.json`  
+This example shows how to create a unscoped package named `weather-api`. The API project is located in the new directory named `weather`. The `--schemaPath` option specifies location of file containing pre-existing Swagger schema. 
+
+
 #### Remarks
 
 

--- a/ern-api-gen/src/apigen.js
+++ b/ern-api-gen/src/apigen.js
@@ -29,6 +29,7 @@ const {
  * Refer to normalizeConfig function doc for the list of options
  */
 export async function generateApi (options: Object) {
+  log.error('dasjdsads' ,options)
   let config = normalizeConfig(options)
 
   const outFolder = path.join(process.cwd(), config.moduleName)
@@ -48,7 +49,7 @@ export async function generateApi (options: Object) {
  * @returns {Promise.<void>}
  */
 export async function regenerateCode (options: Object = {}) {
-  const pkg = await validateApiNameAndGetPackageJson(`This is not a properly named API directory. Naming convention is react-native-{name}-api`)
+  const pkg = await validateApiNameAndGetPackageJson('This is not a properly named API directory. Naming convention is react-native-{name}-api')
   const curVersion = pkg.version || '1.0.0' //[default: 1.0.0]
   const pkgName = pkg.name
   let newPluginVer
@@ -96,7 +97,7 @@ export async function regenerateCode (options: Object = {}) {
 }
 
 export async function cleanGenerated (outFolder: string = process.cwd()) {
-  const pkg = await validateApiNameAndGetPackageJson(`This is not a properly named API directory. Naming convention is react-native-{name}-api`)
+  const pkg = await validateApiNameAndGetPackageJson('This is not a properly named API directory. Naming convention is react-native-{name}-api')
 
   shell.rm('-rf', path.join(outFolder, 'javascript'))
   shell.rm('-rf', path.join(outFolder, 'swift'))
@@ -138,7 +139,7 @@ const nextVersion = (curVersion: string, userPluginVer: string) => {
           return ret
         }
       } catch (e) {
-        log.info(`not a valid version:`, userPluginVer)
+        log.info(`not a valid version: ${userPluginVer}`)
       }
     }
   }
@@ -152,7 +153,7 @@ async function _promptForPluginVersion (curVersion: string) {
   }])
   const ret = nextVersion(curVersion, userPluginVer)
   if (ret == null) {
-    log.info(`Sorry, I do not understand your answer`)
+    log.info('Enter valid version number. For more details visit https://github.com/npm/node-semver')
     return _promptForPluginVersion(curVersion)
   }
   return ret

--- a/ern-api-gen/src/apigen.js
+++ b/ern-api-gen/src/apigen.js
@@ -29,7 +29,6 @@ const {
  * Refer to normalizeConfig function doc for the list of options
  */
 export async function generateApi (options: Object) {
-  log.error('dasjdsads' ,options)
   let config = normalizeConfig(options)
 
   const outFolder = path.join(process.cwd(), config.moduleName)

--- a/ern-api-gen/src/generateProject.js
+++ b/ern-api-gen/src/generateProject.js
@@ -1,4 +1,5 @@
 import path from 'path'
+import fs from 'fs'
 import {
   fileUtils,
   ModuleTypes
@@ -103,8 +104,8 @@ export async function generateInitialSchema ({
 }) {
   return shouldGenerateBlankApi
     ? ''
-    : apiSchemaPath
-      ? await fileUtils.readFile(apiSchemaPath)
+    : apiSchemaPath && fs.existsSync(apiSchemaPath)
+      ?  fileUtils.readFile(apiSchemaPath)
       :`
   {
     "swagger": "2.0",

--- a/ern-api-gen/src/generateProject.js
+++ b/ern-api-gen/src/generateProject.js
@@ -92,14 +92,20 @@ export function generatePackageJson ({
   }, null, 2)
 }
 
-export function generateInitialSchema ({
+export async function generateInitialSchema ({
   namespace,
-  shouldGenerateBlankApi
+  shouldGenerateBlankApi,
+  apiSchemaPath
 } : {
   namespace?: string,
-  shouldGenerateBlankApi?: boolean
+  shouldGenerateBlankApi?: boolean,
+  apiSchemaPath: string
 }) {
-  return shouldGenerateBlankApi ? '' : `
+  return shouldGenerateBlankApi
+    ? ''
+    : apiSchemaPath
+      ? await fileUtils.readFile(apiSchemaPath)
+      :`
   {
     "swagger": "2.0",
     "info": {
@@ -218,7 +224,7 @@ export function generateFlowConfig(): string  {
 
 export default async function generateProject (config: Object = {}, outFolder: string) {
   await fileUtils.writeFile(path.join(outFolder, PKG_FILE), generatePackageJson(config))
-  await fileUtils.writeFile(path.join(outFolder, MODEL_FILE), generateInitialSchema(config))
+  await fileUtils.writeFile(path.join(outFolder, MODEL_FILE), await generateInitialSchema(config))
   await fileUtils.writeFile(path.join(outFolder, FLOW_CONFIG_FILE), generateFlowConfig())
   await generateSwagger(config, outFolder)
 }

--- a/ern-local-cli/src/commands/create-api.js
+++ b/ern-local-cli/src/commands/create-api.js
@@ -1,5 +1,6 @@
 // @flow
 
+import fs from 'fs'
 import {
   ApiGen
 } from 'ern-api-gen'
@@ -30,7 +31,7 @@ exports.builder = function (yargs: any) {
     describe: 'Author of library'
   }).option('schemaPath', {
     alias: 'm',
-    describe: 'Path to schema(swagger)'
+    describe: 'Path to pre-existing schema(swagger)'
   }).option('skipNpmCheck', {
     describe: 'Skip the check ensuring package does not already exists in NPM registry',
     type: 'bool'
@@ -61,6 +62,10 @@ exports.handler = async function ({
         name: apiName
       }
     })
+
+    if (schemaPath && !fs.existsSync(schemaPath)) {
+      throw new Error(`Cannot resolve path to ${schemaPath}`)
+    }
 
     if (!utils.checkIfModuleNameContainsSuffix(apiName, ModuleTypes.API)) {
       apiName = await utils.promptUserToUseSuffixModuleName(apiName, ModuleTypes.API)

--- a/ern-local-cli/src/commands/create-api.js
+++ b/ern-local-cli/src/commands/create-api.js
@@ -79,20 +79,20 @@ exports.handler = async function ({
     })
 
     if (!skipNpmCheck && !await utils.performPkgNameConflictCheck(packageName)) {
-      throw new Error(`Aborting command `)
+      throw new Error('Aborting command')
     }
 
     const bridgeDep = await manifest.getNativeDependency(PackagePath.fromString('react-native-electrode-bridge'))
     if (!bridgeDep) {
-      throw new Error(`react-native-electrode-bridge not found in manifest. cannot infer version to use`)
+      throw new Error('react-native-electrode-bridge not found in manifest. cannot infer version to use')
     }
     if (!bridgeDep.version) {
-      throw new Error(`react-native-electrode-bridge version needs to be defined`)
+      throw new Error('react-native-electrode-bridge version needs to be defined')
     }
 
     const reactNative = await manifest.getNativeDependency(PackagePath.fromString('react-native'))
     if (!reactNative) {
-      throw new Error(`react-native-electrode-bridge not found in manifest. cannot infer version to use`)
+      throw new Error('react-native-electrode-bridge not found in manifest. cannot infer version to use')
     }
 
     log.info(`Generating ${apiName} API`)

--- a/ern-util-dev/src/index.js
+++ b/ern-util-dev/src/index.js
@@ -59,7 +59,7 @@ export default function setup (workingCwd = path.join(process.cwd(), 'test'), _d
       prefix: 'ern_test'
     }, (e, _tmpDir, _clean) => {
       if (e) return reject(e)
-      api.log(`tmpDir`, _tmpDir, '\n\n')
+      api.log('tmpDir', _tmpDir, '\n\n')
       tmpDir = _tmpDir
       resolve()
     }))
@@ -199,7 +199,7 @@ ${diffOut}
     has,
     cwd,
     ernTest,
-    fail (message = `This should fail if executed`) {
+    fail (message = 'This should fail if executed') {
       return () => {
         throw new Error(message)
       }


### PR DESCRIPTION
Fixes https://github.com/electrode-io/electrode-native/issues/509

@belemaire Planning to cleanup `shouldGenerateBlankApi` property as it is never used. We do not expose this option any way. Thoughts?