### PR TITLE
Remove schema version mismatch ignore from caulronIsActive function

### DIFF
--- a/ern-local-cli/src/lib/Ensure.js
+++ b/ern-local-cli/src/lib/Ensure.js
@@ -259,7 +259,7 @@ export default class Ensure {
   }
 
   static async cauldronIsActive (extraErrorMessage: string = '') {
-    if (!await coreUtils.getCauldronInstance({ignoreSchemaVersionMismatch: true})) {
+    if (!await coreUtils.getCauldronInstance()) {
       throw new Error(`There is no active Cauldron\n${extraErrorMessage}`)
     }
   }


### PR DESCRIPTION
`cauldronIsActive` function will now fail if the Cauldron schema version mismatch