### PR TITLE
Perform full cleanup of Container generator directories before generation

### DIFF
--- a/ern-container-gen/src/generators/android/AndroidGenerator.js
+++ b/ern-container-gen/src/generators/android/AndroidGenerator.js
@@ -42,19 +42,19 @@ export default class AndroidGenerator implements ContainerGenerator {
     if (!fs.existsSync(config.outDir)) {
       shell.mkdir('-p', config.outDir)
     } else {
-      shell.rm('-rf', path.join(config.outDir, '*'))
+      shell.rm('-rf', path.join(config.outDir, '{.*,*}'))
     }
 
     if (!fs.existsSync(config.compositeMiniAppDir)) {
       shell.mkdir('-p', config.compositeMiniAppDir)
     } else {
-      shell.rm('-rf', path.join(config.compositeMiniAppDir, '*'))
+      shell.rm('-rf', path.join(config.compositeMiniAppDir, '{.*,*}'))
     }
 
     if (!fs.existsSync(config.pluginsDownloadDir)) {
       shell.mkdir('-p', config.pluginsDownloadDir)
     } else {
-      shell.rm('-rf', path.join(config.pluginsDownloadDir, '*'))
+      shell.rm('-rf', path.join(config.pluginsDownloadDir, '{.*,*}'))
     }
   }
 

--- a/ern-container-gen/src/generators/ios/IosGenerator.js
+++ b/ern-container-gen/src/generators/ios/IosGenerator.js
@@ -41,19 +41,19 @@ export default class IosGenerator implements ContainerGenerator {
     if (!fs.existsSync(config.outDir)) {
       shell.mkdir('-p', config.outDir)
     } else {
-      shell.rm('-rf', path.join(config.outDir, '*'))
+      shell.rm('-rf', path.join(config.outDir, '{.*,*}'))
     }
 
     if (!fs.existsSync(config.compositeMiniAppDir)) {
       shell.mkdir('-p', config.compositeMiniAppDir)
     } else {
-      shell.rm('-rf', path.join(config.compositeMiniAppDir, '*'))
+      shell.rm('-rf', path.join(config.compositeMiniAppDir, '{.*,*}'))
     }
 
     if (!fs.existsSync(config.pluginsDownloadDir)) {
       shell.mkdir('-p', config.pluginsDownloadDir)
     } else {
-      shell.rm('-rf', path.join(config.pluginsDownloadDir, '*'))
+      shell.rm('-rf', path.join(config.pluginsDownloadDir, '{.*,*}'))
     }
   }
 


### PR DESCRIPTION
Android and iOS generator were not completely properly cleaning the directories used for generation, before starting a new Container generation.

Hidden files (prefixed by `.`) were not removed part of this cleanup, and because of this, Container generation or publication could fail under some circumstances.

This commit ensure that all container generator directories are fully cleaned of all files, including hidden ones.