### PR TITLE
Fix manifest scoped plugin config on Windows

### DIFF
--- a/docs/platform-parts/manifest.md
+++ b/docs/platform-parts/manifest.md
@@ -126,6 +126,7 @@ plugins/ern_v0.2.0+/react-native-code-push_v1.17.0+
 plugins/ern_v0.2.0+/react-native-linear-gradient_v2.0.0+
 plugins/ern_v0.2.0+/react-native-maps_v0.13.1+
 plugins/ern_v0.2.0+/react-native-maps_v0.14.0+
+plugins/ern_v0.2.0+/@myscope/react-native-my-module_v1.0.0+
 ```
 
 The naming of these directories includes the minimum version of the plugin that the configuration targets. If a newer version needs a different configuration, a new directory can be created. This is shown in the above example for the `react-native-maps`.


### PR DESCRIPTION
For some obscure historic reason, the configuration of scoped plugins had to be stored in the Manifest in a directory name containing the scope and name of the plugin, delimited by a colon.

For example, for `@myScope/myModule`, the convention was to name the directory as `@myScope:myModule` (excluding the extra version suffix). This is problematic for Windows as the colon `:` character is a reserved one on Windows and cannot be present in the name of directories.

This PR keeps backward compatibility with the old way (`:` delimited), while introducing support for a more proper and natural way of dealing with scoped plugins.

It is now possible in the manifest, to keep scoped plugin configurations in a directory named after the scope, and not as a single name delimited with `:`.

i.e :

**OLD WAY** [Not supported on Windows]

```
├── manifest.json
└── plugins
    └── ern_v0.5.0+
        ├── @myScope:myModuleA_v1.0.0+
        ├── @myScope:myModuleA_v5.0.0+
        ├── @myScope:myModuleB_v1.0.0+
        ├── unscopedModule_v1.0.0+
```

**NEW WAY** [Supported on all platforms]

```
├── manifest.json
└── plugins
    └── ern_v0.5.0+
        ├── @myScope
        │   ├── myModuleA_v1.0.0+
        │   ├── myModuleA_v5.0.0+
        │   ├── myModuleB_v1.0.0+
        ├── unscopedModule_v1.0.0+
```

The new way is the recommended one, as it is supported on all platforms and also more conventional.

Fix https://github.com/electrode-io/electrode-native/issues/510