### PR TITLE
Fix upgrade-miniapp command

### DIFF
--- a/ern-core/src/MiniApp.js
+++ b/ern-core/src/MiniApp.js
@@ -358,13 +358,12 @@ Are you sure this is a MiniApp ?`)
     const manifestDependencies = await manifest.getJsAndNativeDependencies(versionToUpgradeTo)
 
     for (const manifestDependency of manifestDependencies) {
-      const nameWithScope = `${manifestDependency.scope ? `@${manifestDependency.scope}/` : ''}${manifestDependency.name}`
-      if (this.packageJson.dependencies[nameWithScope]) {
+      if (this.packageJson.dependencies[manifestDependency.basePath]) {
         const dependencyManifestVersion = manifestDependency.version
-        const localDependencyVersion = this.packageJson.dependencies[nameWithScope]
+        const localDependencyVersion = this.packageJson.dependencies[manifestDependency.basePath]
         if (dependencyManifestVersion !== localDependencyVersion) {
-          log.info(`${nameWithScope} : ${localDependencyVersion} => ${dependencyManifestVersion}`)
-          this.packageJson.dependencies[nameWithScope] = dependencyManifestVersion
+          log.info(`${manifestDependency.basePath} : ${localDependencyVersion} => ${dependencyManifestVersion}`)
+          this.packageJson.dependencies[manifestDependency.basePath] = dependencyManifestVersion
         }
       }
     }


### PR DESCRIPTION
`upgrade-miniapp` command helper function was not properly updated following refactoring to `DependencyPath`, resulting in the function not upgrading any dependency. 

This PR fix the  `upgradeToPlatformVersion` function so that it now properly works again.