### PR TITLE
Refactor Cauldron

### DIFF
--- a/ern-cauldron-api/src/CauldronApi.js
+++ b/ern-cauldron-api/src/CauldronApi.js
@@ -317,6 +317,9 @@ export default class CauldronApi {
 
   async createNativeApplication (nativeApplication: Object) : Promise<void> {
     const cauldron = await this.getCauldron()
+    if (exists(cauldron.nativeApps, nativeApplication.name)) {
+      throw new Error(`${nativeApplication.name} already exists`)
+    }
     const validatedNativeApplication = await joiValidate(nativeApplication, schemas.nativeApplication)
     cauldron.nativeApps.push(validatedNativeApplication)
     return this.commit(`Create ${nativeApplication.name} native application`)

--- a/ern-cauldron-api/src/FlowTypes.js
+++ b/ern-cauldron-api/src/FlowTypes.js
@@ -26,7 +26,6 @@ export type CauldronContainer = {
 
 export type CauldronNativeAppVersion = {
   name: string,
-  ernPlatormVersion: string,
   isReleased: boolean,
   binary: ?string,
   yarnLocks: Object,

--- a/ern-cauldron-api/src/schemas.js
+++ b/ern-cauldron-api/src/schemas.js
@@ -10,7 +10,6 @@ export const container = Joi.object({
 
 export const nativeApplicationVersion = Joi.object({
   name: Joi.string().required(),
-  ernPlatformVersion: Joi.string().required(),
   isReleased: Joi.boolean().optional().default(false),
   binary: Joi.string().default(null),
   yarnLocks: Joi.object().default({}),

--- a/ern-cauldron-api/test/CauldronApi-test.js
+++ b/ern-cauldron-api/test/CauldronApi-test.js
@@ -7,6 +7,7 @@ import {
 import sinon from 'sinon'
 import fs from 'fs'
 import {
+  NativeApplicationDescriptor,
   PackagePath
 } from 'ern-core'
 import {
@@ -204,14 +205,14 @@ describe('CauldronApi.js', () => {
   // ========================================================== 
   describe('getNativeApplication', () => {
     it('should return the native applications array', async () => {
-      const nativeApp = await cauldronApi().getNativeApplication('test')
+      const nativeApp = await cauldronApi().getNativeApplication(NativeApplicationDescriptor.fromString('test'))
       const nativeAppsObj = jp.query(fixtures.defaultCauldron, '$.nativeApps[?(@.name=="test")]')[0]
       expect(nativeApp).eql(nativeAppsObj)
     })
 
-    it('should return undefined if application name is not found', async () => {
-      const nativeApp = await cauldronApi().getNativeApplication('unexisting')
-      expect(nativeApp).undefined
+    it('should throw if the application name is not found', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getNativeApplication, api, NativeApplicationDescriptor.fromString('unexisting')))
     })
   })
 
@@ -220,13 +221,13 @@ describe('CauldronApi.js', () => {
   // ========================================================== 
   describe('getPlatforms', () => {
     it ('should return the platforms array', async () => {
-      const platforms = await cauldronApi().getPlatforms('test')
+      const platforms = await cauldronApi().getPlatforms(NativeApplicationDescriptor.fromString('test'))
       expect(platforms).to.be.an('array').of.length(1)
     })
 
-    it('should return undefined if no platforms are present', async () => {
-      const platforms = await cauldronApi().getPlatforms('unexisting')
-      expect(platforms).undefined
+    it('should throw if the application name is not found', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getPlatforms, api, NativeApplicationDescriptor.fromString('unexisting')))
     })
   })
 
@@ -235,19 +236,19 @@ describe('CauldronApi.js', () => {
   // ========================================================== 
   describe('getPlatform', () => {
     it('should return the platform object given its name', async () => {
-      const platformObj = await cauldronApi().getPlatform('test', 'android')
+      const platformObj = await cauldronApi().getPlatform(NativeApplicationDescriptor.fromString('test:android'))
       const platform = jp.query(fixtures.defaultCauldron, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")]')[0]
       expect(platform).eql(platformObj)
     })
 
-    it('should return undefined if the platform is not found', async () => {
-      const platform = await cauldronApi().getPlatform('test', 'ios')
-      expect(platform).undefined
+    it('should throw if the platform is not found', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getPlatform, api, NativeApplicationDescriptor.fromString('test:ios')))
     })
 
-    it('should return undefined if the native application is not found', async () => {
-      const platform = await cauldronApi().getPlatform('unexisting', 'android')
-      expect(platform).undefined
+    it('should throw if the native application is not found', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getPlatform, api, NativeApplicationDescriptor.fromString('unexisting:android')))
     })
   })
 
@@ -256,19 +257,19 @@ describe('CauldronApi.js', () => {
   // ========================================================== 
   describe('getVersions', () => {
     it('should return the versions array', async () => {
-      const versionsArr = await cauldronApi().getVersions('test', 'android')
+      const versionsArr = await cauldronApi().getVersions(NativeApplicationDescriptor.fromString('test:android'))
       const versions = jp.query(fixtures.defaultCauldron, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions')[0]
       expect(versionsArr).eql(versions)
     })
 
-    it('should return undefined if the native application platform does not exist', async () => {
-      const versionsArr = await cauldronApi().getVersions('test', 'ios')
-      expect(versionsArr).undefined
+    it('should throw if the native application platform does not exist', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getVersions, api, NativeApplicationDescriptor.fromString('test:ios')))
     })
 
-    it('should return undefined if the native application name does not exist', async () => {
-      const versionsArr = await cauldronApi().getVersions('unexisting', 'android')
-      expect(versionsArr).undefined
+    it('should throw if the native application name does not exist', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getVersions, api, NativeApplicationDescriptor.fromString('unexisting:android')))
     })
   })
 
@@ -277,24 +278,24 @@ describe('CauldronApi.js', () => {
   // ========================================================== 
   describe('getVersion', () => {
     it('should return the version object', async () => {
-      const versionObj = await cauldronApi().getVersion('test', 'android', '17.7.0')
+      const versionObj = await cauldronApi().getVersion(NativeApplicationDescriptor.fromString('test:android:17.7.0'))
       const version = jp.query(fixtures.defaultCauldron, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")]')[0]
       expect(versionObj).eql(version)
     })
 
-    it('should return undefined if the native application version does not exist', async () => {
-      const versionObj = await cauldronApi().getVersion('test', 'android', '0.1.0')
-      expect(versionObj).undefined
+    it('should throw if the native application version does not exist', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getVersion, api, NativeApplicationDescriptor.fromString('test:android:0.1.0')))
     })
 
-    it('should return undefined if the native application platform does not exist', async () => {
-      const versionObj = await cauldronApi().getVersion('test', 'ios', '17.7.0')
-      expect(versionObj).undefined
+    it('should throw if the native application platform does not exist', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getVersion, api, NativeApplicationDescriptor.fromString('test:ios:0.1.0')))
     })
 
-    it('should return undefined if the native application name does not exist', async () => {
-      const versionObj = await cauldronApi().getVersion('unexisting', 'android', '17.7.0')
-      expect(versionObj).undefined
+    it('should throw if the native application name does not exist', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getVersion, api, NativeApplicationDescriptor.fromString('unexisting:android:17.7.0')))
     })
   })
 
@@ -303,33 +304,28 @@ describe('CauldronApi.js', () => {
   // ==========================================================
   describe('getCodePushEntries', () => {
     it('should return the code push Production entries', async () => {
-      const entries = await cauldronApi().getCodePushEntries('test', 'android', '17.7.0', 'Production')
+      const entries = await cauldronApi().getCodePushEntries(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'Production')
       expect(entries).to.be.an('array').of.length(2)
     })
 
     it('should return the code push QA entries', async () => {
-      const entries = await cauldronApi().getCodePushEntries('test', 'android', '17.7.0', 'QA')
+      const entries = await cauldronApi().getCodePushEntries(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'QA')
       expect(entries).to.be.an('array').of.length(1)
     })
 
-    it('should return undefined if deployment name is not found', async () => {
-      const entries = await cauldronApi().getCodePushEntries('test', 'android', '17.7.0', 'unexisting')
-      expect(entries).undefined
+    it('should throw if native application version is not found', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getCodePushEntries, api, NativeApplicationDescriptor.fromString('test:android:1.0.0'), 'QA'))
     })
 
-    it('should return undefined if native application version is not found', async () => {
-      const entries = await cauldronApi().getCodePushEntries('test', 'android', '1.0.0', 'QA')
-      expect(entries).undefined
+    it('should throw if native application platform does not exist', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getCodePushEntries, api, NativeApplicationDescriptor.fromString('test:ios:1.0.0'), 'QA'))
     })
 
-    it('should return undefined if native application platform does not exist', async () => {
-      const entries = await cauldronApi().getCodePushEntries('test', 'unexisting', '17.7.0', 'QA')
-      expect(entries).undefined
-    })
-
-    it('should return undefined if native application name does not exist', async () => {
-      const entries = await cauldronApi().getCodePushEntries('unexisting', 'ios', '17.7.0', 'QA')
-      expect(entries).undefined
+    it('should throw if native application name does not exist', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getCodePushEntries, api, NativeApplicationDescriptor.fromString('unexisting:android:17.7.0'), 'QA'))
     })
   })
 
@@ -339,14 +335,14 @@ describe('CauldronApi.js', () => {
   describe('setCodePushEntries', () => {
     it('should set the code push entries', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).setCodePushEntries('test', 'android', '17.7.0', 'QA', [codePushNewEntryFixture])
+      await cauldronApi(tmpFixture).setCodePushEntries(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'QA', [codePushNewEntryFixture])
       const codePushEntries = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].codePush["QA"]')[0]
       expect(codePushEntries).eql([codePushNewEntryFixture])
     })
 
     it('should throw if the native application version does not exists', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.setCodePushEntries, api, 'test', 'android', '17.20.0', 'QA', [codePushNewEntryFixture]))
+      assert(await doesThrow(api.setCodePushEntries, api, NativeApplicationDescriptor.fromString('test:android:1.0.0'), 'QA', [codePushNewEntryFixture]))
     })
   })
 
@@ -355,23 +351,23 @@ describe('CauldronApi.js', () => {
   // ==========================================================
   describe('getContainerMiniApps', () => {
     it('should return the MiniApps array of a native application version Container', async () => {
-      const containerMiniApps = await cauldronApi().getContainerMiniApps('test', 'android', '17.7.0')
+      const containerMiniApps = await cauldronApi().getContainerMiniApps(NativeApplicationDescriptor.fromString('test:android:17.7.0'))
       expect(containerMiniApps).to.be.an('array').of.length(2)
     })
 
-    it('should return undefined if native application version does not exist', async () => {
-      const containerMiniApps = await cauldronApi().getContainerMiniApps('test', 'android', '0.1.0')
-      expect(containerMiniApps).undefined
+    it('should throw if native application version does not exist', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getContainerMiniApps, api, NativeApplicationDescriptor.fromString('test:android:1.0.0')))
     })
 
-    it('should return undefined if native application platform does not exist', async () => {
-      const containerMiniApps = await cauldronApi().getContainerMiniApps('test', 'unexisting', '17.7.0')
-      expect(containerMiniApps).undefined
+    it('should throw if native application platform does not exist', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getContainerMiniApps, api, NativeApplicationDescriptor.fromString('test:unexisting:17.7.0')))
     })
 
-    it('should return undefined if native application name does not exist', async () => {
-      const containerMiniApps = await cauldronApi().getContainerMiniApps('unexisting', 'android', '17.7.0')
-      expect(containerMiniApps).undefined
+    it('should throw if native application name does not exist', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getContainerMiniApps, api, NativeApplicationDescriptor.fromString('unexisting:android:17.7.0')))
     })
   })
 
@@ -380,58 +376,58 @@ describe('CauldronApi.js', () => {
   // ==========================================================
   describe('getNativeDependencies', () => {
     it('should return the native dependencies of a native application version Container', async () => {
-      const containerDependencies = await cauldronApi().getNativeDependencies('test', 'android', '17.7.0')
+      const containerDependencies = await cauldronApi().getNativeDependencies(NativeApplicationDescriptor.fromString('test:android:17.7.0'))
       expect(containerDependencies).to.be.an('array').of.length(4)
     })
 
-    it('should return an empty array if native application version does not exist', async () => {
-      const containerDependencies = await cauldronApi().getNativeDependencies('test', 'android', '0.1.0')
-      expect(containerDependencies).to.be.an('array').empty
+    it('should throw if native application version does not exist', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getNativeDependencies, api, NativeApplicationDescriptor.fromString('test:android:1.0.0')))
     })
 
-    it('should return an empty array if native application platform does not exist', async () => {
-      const containerDependencies = await cauldronApi().getNativeDependencies('test', 'unexisting', '17.7.0')
-      expect(containerDependencies).to.be.an('array').empty
+    it('should throw if native application platform does not exist', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getNativeDependencies, api, NativeApplicationDescriptor.fromString('test:unexisting:17.7.0')))
     })
 
-    it('should return an empty array if native application name does not exist', async () => {
-      const containerDependencies = await cauldronApi().getNativeDependencies('unexisting', 'android', '17.7.0')
-      expect(containerDependencies).to.be.an('array').empty
+    it('should throw if native application name does not exist', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getNativeDependencies, api, NativeApplicationDescriptor.fromString('unexisting:android:17.7.0')))
     })
   })
 
   // ==========================================================
-  // getJsApiImpls
+  // getContainerJsApiImpls
   // ==========================================================
-  describe('getJsApiImpls', () => {
+  describe('getContainerJsApiImpls', () => {
     it('should throw an error if the native application version does not exist', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.getJsApiImpls, api, 'test', 'android', '17.10.0'))
+      assert(await doesThrow(api.getContainerJsApiImpls, api, NativeApplicationDescriptor.fromString('test:android:1.0.0')))
     })
 
     it('should return the JavaScript API implementations package paths', async () => {
-      const result = await cauldronApi().getJsApiImpls('test', 'android', '17.7.0')
+      const result = await cauldronApi().getContainerJsApiImpls(NativeApplicationDescriptor.fromString('test:android:17.7.0'))
       expect(result).to.be.an('array').of.length(1)
       expect(result[0]).eql('react-native-my-api-impl@1.0.0')
     })
   })
 
   // ==========================================================
-  // getJsApiImpl
+  // getContainerJsApiImpl
   // ==========================================================
-  describe('getJsApiImpl', () => {
+  describe('getContainerJsApiImpl', () => {
     it('should throw an error if the native application version does not exist', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.getJsApiImpl, api, 'test', 'android', '17.10.0', 'react-native-my-api-impl'))
+      assert(await doesThrow(api.getContainerJsApiImpl, api, NativeApplicationDescriptor.fromString('test:android:17.10.0'), 'react-native-my-api-impl'))
     })
 
     it('should return the JavaScript API implementation package path [1]', async () => {
-      const result = await cauldronApi().getJsApiImpl('test', 'android', '17.7.0', 'react-native-my-api-impl')
+      const result = await cauldronApi().getContainerJsApiImpl(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'react-native-my-api-impl')
       expect(result).eql('react-native-my-api-impl@1.0.0')
     })
 
     it('should return the JavaScript API implementation package path [2]', async () => {
-      const result = await cauldronApi().getJsApiImpl('test', 'android', '17.7.0', 'react-native-my-api-impl@1.0.0')
+      const result = await cauldronApi().getContainerJsApiImpl(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'react-native-my-api-impl@1.0.0')
       expect(result).eql('react-native-my-api-impl@1.0.0')
     })
   })
@@ -441,38 +437,38 @@ describe('CauldronApi.js', () => {
   // ==========================================================
   describe('getNativeDependency', () => {
     it('should return the native dependency string if no version is provided', async () => {
-      const dependency = await cauldronApi().getNativeDependency('test', 'android', '17.7.0', 'react-native-electrode-bridge')
+      const dependency = await cauldronApi().getContainerNativeDependency(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'react-native-electrode-bridge')
       expect(dependency).eql('react-native-electrode-bridge@1.4.9')
     })
 
     it('should return the native dependency string if version is provided', async () => {
-      const dependency = await cauldronApi().getNativeDependency('test', 'android', '17.7.0', 'react-native-electrode-bridge@1.4.9')
+      const dependency = await cauldronApi().getContainerNativeDependency(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'react-native-electrode-bridge@1.4.9')
       expect(dependency).eql('react-native-electrode-bridge@1.4.9')
     })
 
-    it('should return undefined if incorrect version is provided', async () => {
-      const dependency = await cauldronApi().getNativeDependency('test', 'android', '17.7.0', 'react-native-electrode-bridge@0.1.0')
-      expect(dependency).undefined
+    it('should throw if incorrect version is provided', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getNativeDependency, api, NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'react-native-electrode-bridge@0.1.0'))
     })
 
-    it('should return undefined if dependency does not exist', async () => {
-      const dependency = await cauldronApi().getNativeDependency('test', 'android', '17.7.0', 'unexisting')
-      expect(dependency).undefined
+    it('should throw if dependency does not exist', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getNativeDependency, api, NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'unexisting'))
     })
 
-    it('should return undefined if native application version does not exist', async () => {
-      const dependency = await cauldronApi().getNativeDependency('test', 'android', '0.1.0', 'react-native-electrode-bridge')
-      expect(dependency).undefined
+    it('should throw if native application version does not exist', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getNativeDependency, api, NativeApplicationDescriptor.fromString('test:android:0.1.0'), 'react-native-electrode-bridge'))
     })
 
-    it('should return undefined if native application platform does not exist', async () => {
-      const dependency = await cauldronApi().getNativeDependency('test', 'unexisting', '17.7.0', 'react-native-electrode-bridge')
-      expect(dependency).undefined
+    it('should throw if native application platform does not exist', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getNativeDependency, api, NativeApplicationDescriptor.fromString('test:unexisting:17.7.0'), 'react-native-electrode-bridge'))
     })
 
-    it('should return undefined if native application name does not exist', async () => {
-      const dependency = await cauldronApi().getNativeDependency('unexisting', 'android', '17.7.0', 'react-native-electrode-bridge')
-      expect(dependency).undefined
+    it('should throw if native application name does not exist', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getNativeDependency, api, NativeApplicationDescriptor.fromString('unexisting:android:17.7.0'), 'react-native-electrode-bridge'))
     })
   })
 
@@ -481,38 +477,36 @@ describe('CauldronApi.js', () => {
   // ==========================================================
   describe('getConfig', () => {
     it('[get application version config] should return the native application version config', async () => {
-      const configObj = await cauldronApi().getConfig({appName:'test', platformName:'android', versionName:'17.7.0'})
+      const configObj = await cauldronApi().getConfig(NativeApplicationDescriptor.fromString('test:android:17.7.0'))
       const config = jp.query(fixtures.defaultCauldron, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].config')[0]
       expect(configObj).eql(config)
     })
 
-    it('[get application version config] should return undefined if the native application version does not exist', async () => {
-      const configObj = await cauldronApi().getConfig({appName:'test', platformName:'android', versionName:'17.7.1'})
-      const config = jp.query(fixtures.defaultCauldron, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].config')[0]
-      expect(configObj).undefined
+    it('[get application version config] should throw if the native application version does not exist', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getConfig, api, NativeApplicationDescriptor.fromString('test:android:1.0.0')))
     })
 
     it('[get application platform config] should return the native application platform config', async () => {
-      const configObj = await cauldronApi().getConfig({appName:'test', platformName:'android'})
+      const configObj = await cauldronApi().getConfig(NativeApplicationDescriptor.fromString('test:android'))
       const config = jp.query(fixtures.defaultCauldron, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].config')[0]
       expect(configObj).eql(config)
     })
 
-    it('[get application platform config] should return undefined if the native application platform does not exist', async () => {
-      const configObj = await cauldronApi().getConfig({appName:'test', platformName:'none', versionName:'17.7.0'})
-      const config = jp.query(fixtures.defaultCauldron, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].config')[0]
-      expect(configObj).undefined
+    it('[get application platform config] should throw if the native application platform does not exist', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getConfig, api, NativeApplicationDescriptor.fromString('test:unexisting')))
     })
 
     it('[get application config] should return the native application name config', async () => {
-      const configObj = await cauldronApi().getConfig({appName:'test'})
+      const configObj = await cauldronApi().getConfig(NativeApplicationDescriptor.fromString('test'))
       const config = jp.query(fixtures.defaultCauldron, '$.nativeApps[?(@.name=="test")].config')[0]
       expect(configObj).eql(config)
     })
 
-    it('[get application config] should return undefined if native application does not exist', async () => {
-      const configObj = await cauldronApi().getConfig({appName:'unexisting'})
-      expect(configObj).undefined
+    it('[get application config] should throw if native application does not exist', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getConfig, api, NativeApplicationDescriptor.fromString('unexisting')))
     })
   })
 
@@ -524,6 +518,58 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       await cauldronApi(tmpFixture).clearCauldron()
       expect(tmpFixture.nativeApps).empty
+    })
+  })
+
+  // ==========================================================
+  // addDescriptor
+  // ==========================================================
+  describe('addDescriptor', () => {
+    it('should add a native application entry', async () => {
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      await cauldronApi(tmpFixture).addDescriptor(NativeApplicationDescriptor.fromString('newapp'))
+      const app = jp.query(tmpFixture, '$.nativeApps[?(@.name=="newapp")]')[0]
+      expect(app).not.undefined
+    })
+
+    it('should add a native application and platform entry', async () => {
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      await cauldronApi(tmpFixture).addDescriptor(NativeApplicationDescriptor.fromString('newapp:android'))
+      const platform = jp.query(tmpFixture, '$.nativeApps[?(@.name=="newapp")].platforms[?(@.name=="android")]')[0]
+      expect(platform).not.undefined
+    })
+
+    it('should add a native application and platform and version entry', async () => {
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      await cauldronApi(tmpFixture).addDescriptor(NativeApplicationDescriptor.fromString('newapp:android:1.0.0'))
+      const platform = jp.query(tmpFixture, '$.nativeApps[?(@.name=="newapp")].platforms[?(@.name=="android")].versions[?(@.name=="1.0.0")]')[0]
+      expect(platform).not.undefined
+    })
+  })
+
+  // ==========================================================
+  // removeDescriptor
+  // ==========================================================
+  describe('removeDescriptor', () => {
+    it('should remove a top level native app', async () => {
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      await cauldronApi(tmpFixture).removeDescriptor(NativeApplicationDescriptor.fromString('test'))
+      const result = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")]')[0]
+      expect(result).undefined
+    })
+
+    it('should remove a native application platform', async () => {
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      await cauldronApi(tmpFixture).removeDescriptor(NativeApplicationDescriptor.fromString('test:android'))
+      const result = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")]')[0]
+      expect(result).undefined
+    })
+
+    it('should remove a native application version', async () => {
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      await cauldronApi(tmpFixture).removeDescriptor(NativeApplicationDescriptor.fromString('test:android:17.7.0'))
+      const result = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")]')[0]
+      expect(result).undefined
     })
   })
 
@@ -559,7 +605,7 @@ describe('CauldronApi.js', () => {
   describe('removeNativeApplication', () => {
     it('should remove the native application given its name', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).removeNativeApplication('test')
+      await cauldronApi(tmpFixture).removeNativeApplication(NativeApplicationDescriptor.fromString('test'))
       const nativeApp = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")]')[0]
       expect(nativeApp).undefined
     })
@@ -568,13 +614,13 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.removeNativeApplication('test')
+      await api.removeNativeApplication(NativeApplicationDescriptor.fromString('test'))
       sinon.assert.calledOnce(commitStub)
     })
 
     it('should throw if the application name does not exists', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.removeNativeApplication, api, 'unexisting'))
+      assert(await doesThrow(api.removeNativeApplication, api, NativeApplicationDescriptor.fromString('unexisting')))
     })
   })
 
@@ -584,7 +630,7 @@ describe('CauldronApi.js', () => {
   describe('createPlatform', () => {
     it('should create the platform object', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).createPlatform('test', {name:'ios'})
+      await cauldronApi(tmpFixture).createPlatform(NativeApplicationDescriptor.fromString('test'), {name:'ios'})
       const platform = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="ios")]')[0]
       expect(platform).not.undefined
     })
@@ -593,13 +639,13 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.createPlatform('test', {name:'ios'})
+      await api.createPlatform(NativeApplicationDescriptor.fromString('test'), {name:'ios'})
       sinon.assert.calledOnce(commitStub)
     })
 
     it('should throw if the application platform already exists', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.createPlatform, api, 'test', {name:'android'}))
+      assert(await doesThrow(api.createPlatform, api, NativeApplicationDescriptor.fromString('test'), {name:'android'}))
     })
   })
 
@@ -609,7 +655,7 @@ describe('CauldronApi.js', () => {
   describe('removePlatform', () => {
     it('should remove the native application platform given its name', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).removePlatform('test', 'android')
+      await cauldronApi(tmpFixture).removePlatform(NativeApplicationDescriptor.fromString('test:android'))
       const platform = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")]')[0]
       expect(platform).undefined
     })
@@ -618,18 +664,18 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.removePlatform('test', 'android')
+      await api.removePlatform(NativeApplicationDescriptor.fromString('test:android'))
       sinon.assert.calledOnce(commitStub)
     })
 
     it('should throw if the application name does not exists', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.removePlatform, api, 'unexisting', 'android'))
+      assert(await doesThrow(api.removePlatform, api, NativeApplicationDescriptor.fromString('unexisting:android')))
     })
 
     it('should throw if the application platform does not exists', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.removePlatform, api, 'test', 'ios'))
+      assert(await doesThrow(api.removePlatform, api, NativeApplicationDescriptor.fromString('test:unexisting')))
     })
   })
 
@@ -639,7 +685,7 @@ describe('CauldronApi.js', () => {
   describe('createVersion', () => {
     it('should create the version object', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).createVersion('test', 'android', {name:'17.20.0', ernPlatformVersion:'1.0.0'})
+      await cauldronApi(tmpFixture).createVersion(NativeApplicationDescriptor.fromString('test:android'), {name:'17.20.0'})
       const version = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.20.0")]')[0]
       expect(version).not.undefined
     })
@@ -648,18 +694,18 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.createVersion('test', 'android', {name:'17.20.0', ernPlatformVersion:'1.0.0'})
+      await api.createVersion(NativeApplicationDescriptor.fromString('test:android'), {name:'17.20.0'})
       sinon.assert.calledOnce(commitStub)
     })
 
     it('should throw if the platform does not exist', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.createVersion, api, 'test', 'ios', {name:'17.20.0', ernPlatformVersion:'1.0.0'}))
+      assert(await doesThrow(api.createVersion, api, NativeApplicationDescriptor.fromString('test:ios'), {name:'17.20.0'}))
     })
 
     it('should throw if the version already exists', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.createVersion, api, 'test', 'android', {name:'17.7.0', ernPlatformVersion:'1.0.0'}))
+      assert(await doesThrow(api.createVersion, api, NativeApplicationDescriptor.fromString('test:android'), {name:'17.7.0'}))
     })
   })
 
@@ -669,7 +715,7 @@ describe('CauldronApi.js', () => {
   describe('removeVersion', () => {
     it('should remove the native application version given its name', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).removeVersion('test', 'android', '17.7.0')
+      await cauldronApi(tmpFixture).removeVersion(NativeApplicationDescriptor.fromString('test:android:17.7.0'))
       const version = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")]')[0]
       expect(version).undefined
     })
@@ -678,18 +724,18 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.removeVersion('test', 'android', '17.7.0')
+      await api.removeVersion(NativeApplicationDescriptor.fromString('test:android:17.7.0'))
       sinon.assert.calledOnce(commitStub)
     })
 
     it('should throw if the platform name does not exists', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.removeVersion, api, 'test', 'unexisting'))
+      assert(await doesThrow(api.removeVersion, api, NativeApplicationDescriptor.fromString('test:unexisting:17.7.0')))
     })
 
     it('should throw if the version does not exists', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.removeVersion, api, 'test', 'android', '17.20.0'))
+      assert(await doesThrow(api.removeVersion, api, NativeApplicationDescriptor.fromString('test:android:1.0.0')))
     })
   })
 
@@ -699,7 +745,7 @@ describe('CauldronApi.js', () => {
   describe('updateVersion', () => {
     it('should perform the update', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).updateVersion('test', 'android', '17.7.0', {isReleased: false})
+      await cauldronApi(tmpFixture).updateVersion(NativeApplicationDescriptor.fromString('test:android:17.7.0'), {isReleased: false})
       const version = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")]')[0]
       expect(version.isReleased).false
     })
@@ -708,23 +754,23 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.updateVersion('test', 'android', '17.7.0', {isReleased: false})
+      await api.updateVersion(NativeApplicationDescriptor.fromString('test:android:17.7.0'), {isReleased: false})
       sinon.assert.calledOnce(commitStub)
     })
 
     it('should throw if the version does not exists', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.updateVersion, api, 'test', 'android', '17.20.0', {isReleased: false}))
+      assert(await doesThrow(api.updateVersion, api, NativeApplicationDescriptor.fromString('test:android:0.1.0'), {isReleased: false}))
     })
   })
 
   // ==========================================================
-  // removeNativeDependency
+  // removeContainerNativeDependency
   // ==========================================================
-  describe('removeNativeDependency', () => {
+  describe('removeContainerNativeDependency', () => {
     it('should remove the native dependency', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).removeNativeDependency('test', 'android', '17.7.0', 'react-native-electrode-bridge')
+      await cauldronApi(tmpFixture).removeContainerNativeDependency(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'react-native-electrode-bridge')
       const dependenciesArr = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].container.nativeDeps')[0]
       expect(dependenciesArr.includes('react-native-electrode-bridge@1.4.9')).false
     })
@@ -733,28 +779,28 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.removeNativeDependency('test', 'android', '17.7.0', 'react-native-electrode-bridge')
+      await api.removeContainerNativeDependency(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'react-native-electrode-bridge')
       sinon.assert.calledOnce(commitStub)
     })
 
     it('should throw if the dependency is not found', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.removeNativeDependency, api, 'test', 'android', '17.7.0', 'unexisting'))
+      assert(await doesThrow(api.removeContainerNativeDependency, api, NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'unexisting'))
     })
 
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.removeNativeDependency, api, 'test', 'android', '17.20.0', 'react-native-electrode-bridge'))
+      assert(await doesThrow(api.removeContainerNativeDependency, api, NativeApplicationDescriptor.fromString('test:android:17.20.0'), 'react-native-electrode-bridge'))
     })
   })
 
   // ==========================================================
-  // updateNativeDependency
+  // updateContainerNativeDependencyVersion
   // ==========================================================
-  describe('updateNativeDependency', () => {
+  describe('updateContainerNativeDependencyVersion', () => {
     it('should update the native dependency', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).updateNativeDependency('test', 'android', '17.7.0', 'react-native-electrode-bridge', '1.5.0')
+      await cauldronApi(tmpFixture).updateContainerNativeDependencyVersion(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'react-native-electrode-bridge', '1.5.0')
       const dependenciesArr = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].container.nativeDeps')[0]
       expect(dependenciesArr.includes('react-native-electrode-bridge@1.4.9')).false
       expect(dependenciesArr.includes('react-native-electrode-bridge@1.5.0')).true
@@ -764,28 +810,28 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.updateNativeDependency('test', 'android', '17.7.0', 'react-native-electrode-bridge', '1.5.0')
+      await api.updateContainerNativeDependencyVersion(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'react-native-electrode-bridge', '1.5.0')
       sinon.assert.calledOnce(commitStub)
     })
 
     it('should throw if the dependency is not found', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.updateNativeDependency, api, 'test', 'android', '17.7.0', 'unexisting', '1.5.0'))
+      assert(await doesThrow(api.updateContainerNativeDependencyVersion, api, NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'unexisting', '1.5.0'))
     })
 
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.updateNativeDependency, api, 'test', 'android', '17.20.0', 'react-native-electrode-bridge', '1.5.0'))
+      assert(await doesThrow(api.updateContainerNativeDependencyVersion, api, NativeApplicationDescriptor.fromString('test:android:17.20.0'), 'react-native-electrode-bridge', '1.5.0'))
     })
   })
 
   // ==========================================================
-  // updateMiniAppVersion
+  // updateContainerMiniAppVersion
   // ==========================================================
-  describe('updateMiniAppVersion', () => {
+  describe('updateContainerMiniAppVersion', () => {
     it('should update the MiniApp version', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).updateMiniAppVersion('test', 'android', '17.7.0', PackagePath.fromString('react-native-bar@3.0.0'))
+      await cauldronApi(tmpFixture).updateContainerMiniAppVersion(NativeApplicationDescriptor.fromString('test:android:17.7.0'), PackagePath.fromString('react-native-bar@3.0.0'))
       const miniAppsArr = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].container.miniApps')[0]
       expect(miniAppsArr.includes('react-native-bar@3.0.0')).true
       expect(miniAppsArr.includes('react-native-bar@2.0.0')).false
@@ -795,18 +841,18 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.updateMiniAppVersion('test', 'android', '17.7.0', PackagePath.fromString('react-native-bar@3.0.0'))
+      await api.updateContainerMiniAppVersion(NativeApplicationDescriptor.fromString('test:android:17.7.0'), PackagePath.fromString('react-native-bar@3.0.0'))
       sinon.assert.calledOnce(commitStub)
     })
 
     it('should throw if the miniapp is not found', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.updateMiniAppVersion, api, 'test', 'android', '17.7.0',  PackagePath.fromString('react-native-foo@3.0.0')))
+      assert(await doesThrow(api.updateContainerMiniAppVersion, api, NativeApplicationDescriptor.fromString('test:android:17.7.0'),  PackagePath.fromString('react-native-foo@3.0.0')))
     })
 
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.updateMiniAppVersion, api, 'test', 'android', '17.20.0',  PackagePath.fromString('react-native-bar@3.0.0')))
+      assert(await doesThrow(api.updateContainerMiniAppVersion, api, NativeApplicationDescriptor.fromString('test:android:17.20.0'),  PackagePath.fromString('react-native-bar@3.0.0')))
     })
   })
 
@@ -816,7 +862,7 @@ describe('CauldronApi.js', () => {
   describe('updateTopLevelContainerVersion', () => {
     it('should update the top level container version', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).updateTopLevelContainerVersion('test', 'android', '2.0.0')
+      await cauldronApi(tmpFixture).updateTopLevelContainerVersion(NativeApplicationDescriptor.fromString('test:android'), '2.0.0')
       const topLevelContainerVersion = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].config.containerGenerator.containerVersion')[0]
       expect(topLevelContainerVersion).eql('2.0.0')
     })
@@ -825,7 +871,7 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.updateTopLevelContainerVersion('test', 'android', '2.0.0')
+      await api.updateTopLevelContainerVersion(NativeApplicationDescriptor.fromString('test:android'), '2.0.0')
       sinon.assert.calledOnce(commitStub)
     })
   })
@@ -836,7 +882,7 @@ describe('CauldronApi.js', () => {
   describe('updateContainerVersion', () => {
     it('should update the container version of the given native application version', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).updateContainerVersion('test', 'android', '17.7.0', '2.0.0')
+      await cauldronApi(tmpFixture).updateContainerVersion(NativeApplicationDescriptor.fromString('test:android:17.7.0'), '2.0.0')
       const topLevelContainerVersion = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].containerVersion')[0]
       expect(topLevelContainerVersion).eql('2.0.0')
     })
@@ -845,13 +891,13 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.updateContainerVersion('test', 'android', '17.7.0', '2.0.0')
+      await api.updateContainerVersion(NativeApplicationDescriptor.fromString('test:android:17.7.0'), '2.0.0')
       sinon.assert.calledOnce(commitStub)
     })
 
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.updateContainerVersion, api, 'test', 'android', '17.20.0', '2.0.0'))
+      assert(await doesThrow(api.updateContainerVersion, api, NativeApplicationDescriptor.fromString('test:android:17.20.0'), '2.0.0'))
     })
   })
 
@@ -860,7 +906,7 @@ describe('CauldronApi.js', () => {
   // ==========================================================
   describe('getTopLevelContainerVersion', () => {
     it('should return the top level container version', async () => {
-      const result = await cauldronApi().getTopLevelContainerVersion('test', 'android')
+      const result = await cauldronApi().getTopLevelContainerVersion(NativeApplicationDescriptor.fromString('test:android'))
       expect(result).eql('1.16.44')
     })
   })
@@ -870,13 +916,13 @@ describe('CauldronApi.js', () => {
   // ==========================================================
   describe('getContainerVersion', () => {
     it('should return the container version of the given native application version', async () => {
-      const result = await cauldronApi().getContainerVersion('test', 'android', '17.7.0')
+      const result = await cauldronApi().getContainerVersion(NativeApplicationDescriptor.fromString('test:android:17.7.0'))
       expect(result).eql('1.16.44')
     })
 
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.getContainerVersion, api, 'test', 'android', '17.20.0'))
+      assert(await doesThrow(api.getContainerVersion, api, NativeApplicationDescriptor.fromString('test:android:17.20.0')))
     })
   })
 
@@ -886,7 +932,7 @@ describe('CauldronApi.js', () => {
   describe('removeContainerMiniApp', () => {
     it('should remove the MiniApp from the container of the native application version', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).removeContainerMiniApp('test', 'android', '17.7.0', 'react-native-bar')
+      await cauldronApi(tmpFixture).removeContainerMiniApp(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'react-native-bar')
       const miniAppsArr = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].container.miniApps')[0]
       expect(miniAppsArr.includes('react-native-bare@2.0.0')).false
     })
@@ -895,18 +941,18 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.removeContainerMiniApp('test', 'android', '17.7.0', 'react-native-bar')
+      await api.removeContainerMiniApp(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'react-native-bar')
       sinon.assert.calledOnce(commitStub)
     })
 
     it('should throw if the MiniApp is not found', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.removeContainerMiniApp, api, 'test', 'android', '17.7.0', 'unexisting'))
+      assert(await doesThrow(api.removeContainerMiniApp, api, NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'unexisting'))
     })
 
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.removeContainerMiniApp, api, 'test', 'android', '17.20.0', 'react-native-bar'))
+      assert(await doesThrow(api.removeContainerMiniApp, api, NativeApplicationDescriptor.fromString('test:android:17.20.0'), 'react-native-bar'))
     })
   })
 
@@ -916,7 +962,7 @@ describe('CauldronApi.js', () => {
   describe('addContainerMiniApp', () => {
     it('should add the MiniApp to the container of the native application version', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).addContainerMiniApp('test', 'android', '17.7.0', PackagePath.fromString('newMiniApp@1.0.0'))
+      await cauldronApi(tmpFixture).addContainerMiniApp(NativeApplicationDescriptor.fromString('test:android:17.7.0'), PackagePath.fromString('newMiniApp@1.0.0'))
       const miniAppsArr = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].container.miniApps')[0]
       expect(miniAppsArr.includes('newMiniApp@1.0.0')).true
     })
@@ -925,28 +971,28 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.addContainerMiniApp('test', 'android', '17.7.0', PackagePath.fromString('newMiniApp@1.0.0'))
+      await api.addContainerMiniApp(NativeApplicationDescriptor.fromString('test:android:17.7.0'), PackagePath.fromString('newMiniApp@1.0.0'))
       sinon.assert.calledOnce(commitStub)
     })
 
     it('should throw if the MiniApp already exists', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.addContainerMiniApp, api, 'test', 'android', '17.7.0', PackagePath.fromString('react-native-bar@2.0.0')))
+      assert(await doesThrow(api.addContainerMiniApp, api, NativeApplicationDescriptor.fromString('test:android:17.7.0'), PackagePath.fromString('react-native-bar@2.0.0')))
     })
 
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.addContainerMiniApp, api, 'test', 'android', '17.20.0', PackagePath.fromString('newMiniApp@1.0.0')))
+      assert(await doesThrow(api.addContainerMiniApp, api, NativeApplicationDescriptor.fromString('test:android:17.20.0'), PackagePath.fromString('newMiniApp@1.0.0')))
     })
   })
 
   // ==========================================================
-  // createNativeDependency
+  // addContainerNativeDependency
   // ==========================================================
-  describe('createNativeDependency', () => {
+  describe('addContainerNativeDependency', () => {
     it('should add the native dependency to the container of the native application version', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).createNativeDependency('test', 'android', '17.7.0', PackagePath.fromString('testDep@1.0.0'))
+      await cauldronApi(tmpFixture).addContainerNativeDependency(NativeApplicationDescriptor.fromString('test:android:17.7.0'), PackagePath.fromString('testDep@1.0.0'))
       const dependenciesArr = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].container.nativeDeps')[0]
       expect(dependenciesArr.includes('testDep@1.0.0')).true
     })
@@ -955,118 +1001,118 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.createNativeDependency('test', 'android', '17.7.0', PackagePath.fromString('testDep@1.0.0'))
+      await api.addContainerNativeDependency(NativeApplicationDescriptor.fromString('test:android:17.7.0'), PackagePath.fromString('testDep@1.0.0'))
       sinon.assert.calledOnce(commitStub)
     })
 
     it('should throw if the dependency already exists', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.createNativeDependency, api, 'test', 'android', '17.7.0', PackagePath.fromString('react-native-electrode-bridge@1.4.9')))
+      assert(await doesThrow(api.addContainerNativeDependency, api, NativeApplicationDescriptor.fromString('test:android:17.7.0'), PackagePath.fromString('react-native-electrode-bridge@1.4.9')))
     })
 
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.createNativeDependency, api, 'test', 'android', '17.20.0', PackagePath.fromString('testDep@1.0.0')))
+      assert(await doesThrow(api.addContainerNativeDependency, api, NativeApplicationDescriptor.fromString('test:android:17.20.0'), PackagePath.fromString('testDep@1.0.0')))
     })
   })
 
   // ==========================================================
-  // addJsApiImpl
+  // addContainerJsApiImpl
   // ==========================================================
-  describe('addJsApiImpl', () => {
+  describe('addContainerJsApiImpl', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.addJsApiImpl, api, 'test', 'android', '17.20.0', PackagePath.fromString('react-native-new-js-api-impl@1.0.0')))
+      assert(await doesThrow(api.addContainerJsApiImpl, api, NativeApplicationDescriptor.fromString('test:android:17.20.0'), PackagePath.fromString('react-native-new-js-api-impl@1.0.0')))
     })
 
     it('should throw if the js api impl already exists', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.addJsApiImpl, api, 'test', 'android', '17.7.0', PackagePath.fromString('react-native-my-api-impl@1.0.0')))
+      assert(await doesThrow(api.addContainerJsApiImpl, api, NativeApplicationDescriptor.fromString('test:android:17.7.0'), PackagePath.fromString('react-native-my-api-impl@1.0.0')))
     })
 
     it('should commit the document store', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.addJsApiImpl('test', 'android', '17.7.0', PackagePath.fromString('react-native-new-js-api-impl@1.0.0'))
+      await api.addContainerJsApiImpl(NativeApplicationDescriptor.fromString('test:android:17.7.0'), PackagePath.fromString('react-native-new-js-api-impl@1.0.0'))
       sinon.assert.calledOnce(commitStub)
     })
 
     it('should add the JS API impl to the container of the native application version', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).addJsApiImpl('test', 'android', '17.7.0', PackagePath.fromString('react-native-new-js-api-impl@1.0.0'))
+      await cauldronApi(tmpFixture).addContainerJsApiImpl(NativeApplicationDescriptor.fromString('test:android:17.7.0'), PackagePath.fromString('react-native-new-js-api-impl@1.0.0'))
       const dependenciesArr = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].container.jsApiImpls')[0]
       expect(dependenciesArr.includes('react-native-new-js-api-impl@1.0.0')).true
     })
   })
 
   // ==========================================================
-  // removeJsApiImpl
+  // removeContainerJsApiImpl
   // ==========================================================
-  describe('removeJsApiImpl', () => {
+  describe('removeContainerJsApiImpl', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.removeJsApiImpl, api, 'test', 'android', '17.20.0', 'react-native-my-api-impl@1.0.0'))
+      assert(await doesThrow(api.removeContainerJsApiImpl, api, NativeApplicationDescriptor.fromString('test:android:17.20.0'), 'react-native-my-api-impl@1.0.0'))
     })
 
     it('should throw if the js api impl is not found [1]', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.removeJsApiImpl, api, 'test', 'android', '17.7.0', 'react-native-unknown-api-impl'))
+      assert(await doesThrow(api.removeContainerJsApiImpl, api, NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'react-native-unknown-api-impl'))
     })
 
     it('should throw if the js api impl is not found [2]', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.removeJsApiImpl, api, 'test', 'android', '17.7.0', 'react-native-unknown-api-impl@1.0.0'))
+      assert(await doesThrow(api.removeContainerJsApiImpl, api, NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'react-native-unknown-api-impl@1.0.0'))
     })
 
     it('should commit the document store', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.removeJsApiImpl('test', 'android', '17.7.0', 'react-native-my-api-impl@1.0.0')
+      await api.removeContainerJsApiImpl(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'react-native-my-api-impl@1.0.0')
       sinon.assert.calledOnce(commitStub)
     })
 
     it('should remove the JS API impl from the container of the native application version [1]', async() => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).removeJsApiImpl('test', 'android', '17.7.0', 'react-native-my-api-impl')
+      await cauldronApi(tmpFixture).removeContainerJsApiImpl(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'react-native-my-api-impl')
       const dependenciesArr = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].container.jsApiImpls')[0]
       expect(dependenciesArr).not.includes('react-native-my-api-impl@1.0.0')
     })
 
     it('should remove the JS API impl from the container of the native application version [2]', async() => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).removeJsApiImpl('test', 'android', '17.7.0', 'react-native-my-api-impl@1.0.0')
+      await cauldronApi(tmpFixture).removeContainerJsApiImpl(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'react-native-my-api-impl@1.0.0')
       const dependenciesArr = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].container.jsApiImpls')[0]
       expect(dependenciesArr).not.includes('react-native-my-api-impl@1.0.0')
     })
   })
 
   // ==========================================================
-  // updateJsApiImpl
+  // updateContainerJsApiImplVersion
   // ==========================================================
-  describe('updateJsApiImpl', () => {
+  describe('updateContainerJsApiImplVersion', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.updateJsApiImpl, api, 'test', 'android', '17.20.0', 'react-native-my-api-impl', '2.0.0'))
+      assert(await doesThrow(api.updateContainerJsApiImplVersion, api, NativeApplicationDescriptor.fromString('test:android:17.20.0'), 'react-native-my-api-impl', '2.0.0'))
     })
 
     it('should throw if the js api impl is not found', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.updateJsApiImpl, api, 'test', 'android', '17.7.0', 'react-native-unknown-api-impl', '1.0.0'))
+      assert(await doesThrow(api.updateContainerJsApiImplVersion, api, NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'react-native-unknown-api-impl', '1.0.0'))
     })
 
     it('should commit the document store', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.updateJsApiImpl('test', 'android', '17.7.0', 'react-native-my-api-impl', '2.0.0')
+      await api.updateContainerJsApiImplVersion(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'react-native-my-api-impl', '2.0.0')
       sinon.assert.calledOnce(commitStub)
     })
 
     it('should update the JS API impl version', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).updateJsApiImpl('test', 'android', '17.7.0', 'react-native-my-api-impl', '2.0.0')
+      await cauldronApi(tmpFixture).updateContainerJsApiImplVersion(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'react-native-my-api-impl', '2.0.0')
       const dependenciesArr = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].container.jsApiImpls')[0]
       expect(dependenciesArr).includes('react-native-my-api-impl@2.0.0')
     })
@@ -1078,7 +1124,7 @@ describe('CauldronApi.js', () => {
   describe('addCodePushEntry', () => {
     it('should add the code push entry to QA', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).addCodePushEntry('test', 'android', '17.7.0', codePushNewEntryFixture)
+      await cauldronApi(tmpFixture).addCodePushEntry(NativeApplicationDescriptor.fromString('test:android:17.7.0'), codePushNewEntryFixture)
       const entries = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].codePush["QA"]')[0]
       expect(entries).to.be.an('array').of.length(2)
     })
@@ -1087,7 +1133,7 @@ describe('CauldronApi.js', () => {
       let modifiedCodePushEntryFixture = Object.assign({}, codePushNewEntryFixture)
       modifiedCodePushEntryFixture.metadata.deploymentName = 'STAGING'
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).addCodePushEntry('test', 'android', '17.7.0', modifiedCodePushEntryFixture)
+      await cauldronApi(tmpFixture).addCodePushEntry(NativeApplicationDescriptor.fromString('test:android:17.7.0'), modifiedCodePushEntryFixture)
       const entries = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].codePush["STAGING"]')[0]
       expect(entries).to.be.an('array').of.length(1)
     })
@@ -1096,13 +1142,13 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.addCodePushEntry('test', 'android', '17.7.0', codePushNewEntryFixture)
+      await api.addCodePushEntry(NativeApplicationDescriptor.fromString('test:android:17.7.0'), codePushNewEntryFixture)
       sinon.assert.calledOnce(commitStub)
     })
 
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.addCodePushEntry, api, 'test', 'android', '17.20.0',codePushNewEntryFixture))
+      assert(await doesThrow(api.addCodePushEntry, api, NativeApplicationDescriptor.fromString('test:android:17.20.0'),codePushNewEntryFixture))
     })
   })
 
@@ -1111,18 +1157,18 @@ describe('CauldronApi.js', () => {
   // ==========================================================
   describe('hasYarnLock', () => {
     it('should return true if the native application version has the given yarn lock key', async () => {
-      const hasYarnLock = await cauldronApi().hasYarnLock('test', 'android', '17.7.0', 'Production')
+      const hasYarnLock = await cauldronApi().hasYarnLock(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'Production')
       expect(hasYarnLock).to.be.true
     })
 
     it('should return false if the native application version does not have the given yarn lock key', async () => {
-      const hasYarnLock = await cauldronApi().hasYarnLock('test', 'android', '17.7.0', 'UnexistingKey')
+      const hasYarnLock = await cauldronApi().hasYarnLock(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'Unexisting')
       expect(hasYarnLock).to.be.false
     })
 
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.hasYarnLock, api, 'test', 'android', '17.20.0', 'Production'))
+      assert(await doesThrow(api.hasYarnLock, api, 'test', NativeApplicationDescriptor.fromString('test:android:17.20.0'), 'Production'))
     })
   })
 
@@ -1132,7 +1178,7 @@ describe('CauldronApi.js', () => {
   describe('addYarnLock', () => {
     it('should properly add the yarn lock', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).addYarnLock('test', 'android', '17.7.0', 'YARN_LOCK_KEY', 'YARN_LOCK_CONTENT')
+      await cauldronApi(tmpFixture).addYarnLock(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'YARN_LOCK_KEY', 'YARN_LOCK_CONTENT')
       const entry = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].yarnLocks["YARN_LOCK_KEY"]')[0]
       expect(entry).not.undefined
     })
@@ -1141,13 +1187,13 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.addYarnLock('test', 'android', '17.7.0', 'YARN_LOCK_KEY', 'YARN_LOCK_CONTENT')
+      await api.addYarnLock(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'YARN_LOCK_KEY', 'YARN_LOCK_CONTENT')
       sinon.assert.calledOnce(commitStub)
     })
 
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.addYarnLock, api, 'test', 'android', '17.20.0', 'YARN_LOCK_KEY', 'YARN_LOCK_CONTENT'))
+      assert(await doesThrow(api.addYarnLock, api, NativeApplicationDescriptor.fromString('test:android:17.20.0'), 'YARN_LOCK_KEY', 'YARN_LOCK_CONTENT'))
     })
   })
 
@@ -1156,18 +1202,18 @@ describe('CauldronApi.js', () => {
   // ==========================================================
   describe('getYarnLockId', () => {
     it('should properly return the yarn lock id if it exists', async () => {
-      const id = await cauldronApi().getYarnLockId('test', 'android', '17.7.0', 'Production')
+      const id = await cauldronApi().getYarnLockId(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'Production')
       expect(id).eql('91bf4eff61586d71fe5d52e31a2cfabcbb31e33e')
     })
 
     it('should return undefined if the yarn lock key does not exists', async () => {
-      const id = await cauldronApi().getYarnLockId('test', 'android', '17.7.0', 'UnknownKey')
+      const id = await cauldronApi().getYarnLockId(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'UnknownKey')
       expect(id).undefined
     })
 
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.getYarnLockId, api, 'test', 'android', '17.20.0', 'Production'))
+      assert(await doesThrow(api.getYarnLockId, api, NativeApplicationDescriptor.fromString('test:android:17.20.0'), 'Production'))
     })
   })
 
@@ -1178,7 +1224,7 @@ describe('CauldronApi.js', () => {
     it('should properly set the yarn lock id of an existing key', async () => {
       const newId = '30bf4eff61586d71fe5d52e31a2cfabcbb31e33e'
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).setYarnLockId('test', 'android', '17.7.0', 'Production', newId)
+      await cauldronApi(tmpFixture).setYarnLockId(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'Production', newId)
       const entry = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].yarnLocks["Production"]')[0]
       expect(entry).eql(newId)
     })
@@ -1186,7 +1232,7 @@ describe('CauldronApi.js', () => {
     it('should properly set the yarn lock id of an unexisting key', async () => {
       const newId = '30bf4eff61586d71fe5d52e31a2cfabcbb31e33e'
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).setYarnLockId('test', 'android', '17.7.0', 'NewKey', newId)
+      await cauldronApi(tmpFixture).setYarnLockId(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'NewKey', newId)
       const entry = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].yarnLocks["NewKey"]')[0]
       expect(entry).eql(newId)
     })
@@ -1196,14 +1242,14 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.setYarnLockId('test', 'android', '17.7.0', 'NewKey', newId)
+      await api.setYarnLockId(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'NewKey', newId)
       sinon.assert.calledOnce(commitStub)
     })
 
     it('should throw if the native application version is not found', async () => {
       const newId = '30bf4eff61586d71fe5d52e31a2cfabcbb31e33e'
       const api = cauldronApi()
-      assert(await doesThrow(api.setYarnLockId, api, 'test', 'android', '17.20.0', 'NewKey', newId))
+      assert(await doesThrow(api.setYarnLockId, api, NativeApplicationDescriptor.fromString('test:android:17.20.0'), 'NewKey', newId))
     })
   })
 
@@ -1214,7 +1260,7 @@ describe('CauldronApi.js', () => {
     it('should throw if the native application version is not found', async () => {
       const newId = '30bf4eff61586d71fe5d52e31a2cfabcbb31e33e'
       const api = cauldronApi()
-      assert(await doesThrow(api.getYarnLock, api, 'test', 'android', '17.20.0', 'Production'))
+      assert(await doesThrow(api.getYarnLock, api, NativeApplicationDescriptor.fromString('test:android:17.20.0'), 'Production'))
     })
   })
 
@@ -1224,7 +1270,7 @@ describe('CauldronApi.js', () => {
   describe('getPathToYarnLock', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.getPathToYarnLock, api, 'test', 'android', '17.20.0', 'Production'))
+      assert(await doesThrow(api.getPathToYarnLock, api, NativeApplicationDescriptor.fromString('test:android:17.20.0'), 'Production'))
     })
   })
 
@@ -1234,7 +1280,7 @@ describe('CauldronApi.js', () => {
   describe('removeYarnLock', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.removeYarnLock, api, 'test', 'android', '17.20.0', 'Production'))
+      assert(await doesThrow(api.removeYarnLock, api, NativeApplicationDescriptor.fromString('test:android:17.20.0'), 'Production'))
     })
   })
 
@@ -1244,7 +1290,7 @@ describe('CauldronApi.js', () => {
   describe('updateYarnLock', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.updateYarnLock, api, 'test', 'android', '17.20.0', 'Production', 'NewLock'))
+      assert(await doesThrow(api.updateYarnLock, api, NativeApplicationDescriptor.fromString('test:android:17.20.0'), 'Production', 'NewLock'))
     })
   })
 
@@ -1255,23 +1301,23 @@ describe('CauldronApi.js', () => {
     it('should properly update the yarn lock id of an existing key', async () => {
       const newId = '30bf4eff61586d71fe5d52e31a2cfabcbb31e33e'
       const api = cauldronApi()
-      await api.updateYarnLockId('test', 'android', '17.7.0', 'Production', newId)
-      const id = await api.getYarnLockId('test', 'android', '17.7.0', 'Production')
+      await api.updateYarnLockId(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'Production', newId)
+      const id = await api.getYarnLockId(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'Production')
       expect(id).eql(newId)
     })
 
     it('should properly set the yarn lock id of an unexisting key', async () => {
       const newId = '30bf4eff61586d71fe5d52e31a2cfabcbb31e33e'
       const api = cauldronApi()
-      await api.updateYarnLockId('test', 'android', '17.7.0', 'NewKey', newId)
-      const id = await api.getYarnLockId('test', 'android', '17.7.0', 'NewKey')
+      await api.updateYarnLockId(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'NewKey', newId)
+      const id = await api.getYarnLockId(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'NewKey')
       expect(id).eql(newId)
     })
 
     it('should throw if the native application version is not found', async () => {
       const newId = '30bf4eff61586d71fe5d52e31a2cfabcbb31e33e'
       const api = cauldronApi()
-      assert(await doesThrow(api.updateYarnLockId, api, 'test', 'android', '17.20.0', 'NewKey'))
+      assert(await doesThrow(api.updateYarnLockId, api, NativeApplicationDescriptor.fromString('test:android:17.20.0'), 'NewKey'))
     })
   })
 
@@ -1282,7 +1328,7 @@ describe('CauldronApi.js', () => {
     it('should set the yarn locks', async () => {
       const yarnLocks = { test: '30bf4eff61586d71fe5d52e31a2cfabcbb31e33e' }
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).setYarnLocks('test', 'android', '17.7.0', yarnLocks)
+      await cauldronApi(tmpFixture).setYarnLocks(NativeApplicationDescriptor.fromString('test:android:17.7.0'), yarnLocks)
       const yarnLocksObj = jp.query(tmpFixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].yarnLocks')[0]
       expect(yarnLocksObj).eql(yarnLocks)
     })
@@ -1292,13 +1338,36 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.setYarnLocks('test', 'android', '17.7.0', yarnLocks)
+      await api.setYarnLocks(NativeApplicationDescriptor.fromString('test:android:17.7.0'), yarnLocks)
       sinon.assert.calledOnce(commitStub)
     })
 
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.setYarnLocks, api, 'test', 'android', '17.20.0', {"Test":"30bf4eff61586d71fe5d52e31a2cfabcbb31e33e"}))
+      assert(await doesThrow(api.setYarnLocks, api, NativeApplicationDescriptor.fromString('test:android:17.20.0'), {"Test":"30bf4eff61586d71fe5d52e31a2cfabcbb31e33e"}))
+    })
+  })
+
+  // ==========================================================
+  // throwIfPartialNapDescriptor
+  // ==========================================================
+  describe('throwIfPartialNapDescriptor', () => {
+    it('should throw if provided a partial native application descriptor [1]', () => {
+      expect(() => { cauldronApi().throwIfPartialNapDescriptor(
+        NativeApplicationDescriptor.fromString('test')
+      )}).to.throw()
+    })
+
+    it('should throw if provided a partial native application descriptor [2]', () => {
+      expect(() => { cauldronApi().throwIfPartialNapDescriptor(
+        NativeApplicationDescriptor.fromString('test:android')
+      )}).to.throw()
+    })
+
+    it('should not throw if provided a complete native application descriptor', () => {
+      expect(() => { cauldronApi().throwIfPartialNapDescriptor(
+        NativeApplicationDescriptor.fromString('test:android:17.70')
+      )}).to.not.throw()
     })
   })
 })

--- a/ern-core/src/MiniApp.js
+++ b/ern-core/src/MiniApp.js
@@ -392,7 +392,7 @@ with "ern" : { "version" : "${this.packageJson.ernPlatformVersion}" } instead`)
       if (!cauldronInstance) {
         throw new Error('No Cauldron is active')
       }
-      const nativeApp = await cauldronInstance.getNativeApp(napDescriptor)
+      const nativeApp = await cauldronInstance.getDescriptor(napDescriptor)
 
        // If this is not a forced add, we run quite some checks beforehand
       if (!force) {
@@ -435,8 +435,10 @@ with "ern" : { "version" : "${this.packageJson.ernPlatformVersion}" } instead`)
         // If local native dependency already exists at same version in cauldron,
         // we then don't need to add it or update it
         const localNativeDependencyString = localNativeDependency.basePath
-        const remoteDependency =
-                    await cauldronInstance.getNativeDependency(napDescriptor, localNativeDependencyString, { convertToObject: true })
+        let remoteDependency
+        if (await cauldronInstance.isNativeDependencyInContainer(napDescriptor, localNativeDependencyString)) {
+          remoteDependency = await cauldronInstance.getContainerNativeDependency(napDescriptor, localNativeDependencyString)
+        }
 
         if (!localNativeDependency.version) {
           throw new Error('local dependency does not have a version. This should not happen')
@@ -447,18 +449,18 @@ with "ern" : { "version" : "${this.packageJson.ernPlatformVersion}" } instead`)
         // This does not apply to other third party native dependencies (anyway in that case the code should not react this
         // point as compatibility checks would have failed unless force flag is used)
         if (remoteDependency && remoteDependency.version && (remoteDependency.version < localNativeDependency.version)) {
-          await cauldronInstance.updateNativeAppDependency(napDescriptor, localNativeDependencyString, localNativeDependency.version)
+          await cauldronInstance.updateContainerNativeDependencyVersion(napDescriptor, localNativeDependencyString, localNativeDependency.version)
         } else if (!remoteDependency) {
-          await cauldronInstance.addNativeDependency(napDescriptor, localNativeDependency)
+          await cauldronInstance.addContainerNativeDependency(napDescriptor, localNativeDependency)
         }
       }
 
-      const currentMiniAppEntryInContainer =
-                await cauldronInstance.getContainerMiniApp(napDescriptor, this._packagePath.basePath)
+      const isMiniAppInContainer =
+                await cauldronInstance.isMiniAppInContainer(napDescriptor, this._packagePath.basePath)
 
-      if (currentMiniAppEntryInContainer && !nativeApp.isReleased) {
-        await cauldronInstance.updateMiniAppVersion(napDescriptor, this._packagePath)
-      } else if (!currentMiniAppEntryInContainer && !nativeApp.isReleased) {
+      if (isMiniAppInContainer && !nativeApp.isReleased) {
+        await cauldronInstance.updateContainerMiniAppVersion(napDescriptor, this._packagePath)
+      } else if (!isMiniAppInContainer && !nativeApp.isReleased) {
         await cauldronInstance.addContainerMiniApp(napDescriptor, this._packagePath)
       } else {
         log.error('not supported')

--- a/ern-core/test/CauldronHelper-test.js
+++ b/ern-core/test/CauldronHelper-test.js
@@ -129,108 +129,56 @@ describe('CauldronHelper.js', () => {
     })
   })
 
-  describe('addNativeApp', () => {
-    it('should create a native application entry', async () => {
-      const fixture = cloneFixture(fixtures.emptyCauldron)
-      const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.addNativeApp(NativeApplicationDescriptor.fromString('myapp'))
-      expect(fixture.nativeApps).to.be.an('array').of.length(1)
-      expect(fixture.nativeApps[0].name).eql('myapp')
-    })
-
-    it('should create a native application and platform entry', async () => {
-      const fixture = cloneFixture(fixtures.emptyCauldron)
-      const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.addNativeApp(NativeApplicationDescriptor.fromString('myapp:android'))
-      expect(fixture.nativeApps[0].platforms).to.be.an('array').of.length(1)
-      expect(fixture.nativeApps[0].platforms[0].name).eql('android')
-    })
-
-    it('should create a native application and platform and version entry', async () => {
-      const fixture = cloneFixture(fixtures.emptyCauldron)
-      const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.addNativeApp(NativeApplicationDescriptor.fromString('myapp:android:1.0.0'), '0.10.0')
-      expect(fixture.nativeApps[0].platforms[0].versions).to.be.an('array').of.length(1)
-      expect(fixture.nativeApps[0].platforms[0].versions[0].name).eql('1.0.0')
-    })
-  })
-
-  describe('removeNativeApp', () => {
-    it('should remove a top level native app', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron)
-      const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.removeNativeApp(NativeApplicationDescriptor.fromString('test'))
-      const result = jp.query(fixture, '$.nativeApps[?(@.name=="test")]')[0]
-      expect(result).to.be.undefined
-    })
-
-    it('should remove a native application platform', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron)
-      const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.removeNativeApp(NativeApplicationDescriptor.fromString('test:android'))
-      const result = jp.query(fixture, '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")]')[0]
-      expect(result).to.be.undefined
-    })
-
-    it('should remove a native application version', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron)
-      const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.removeNativeApp(NativeApplicationDescriptor.fromString('test:android:17.7.0'))
-      const result = jp.query(fixture, testAndroid1770Path)[0]
-      expect(result).to.be.undefined
-    })
-  })
-
-  describe('isNativeApplicationInCauldron', () => {
+  describe('isDescriptorInCauldron', () => {
     it('should return true when querying an existing top level native app', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      const result = await cauldronHelper.isNativeApplicationInCauldron(NativeApplicationDescriptor.fromString('test'))
+      const result = await cauldronHelper.isDescriptorInCauldron(NativeApplicationDescriptor.fromString('test'))
       expect(result).true
     })
 
     it('should return false when querying a non existing top level native app', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      const result = await cauldronHelper.isNativeApplicationInCauldron(NativeApplicationDescriptor.fromString('foo'))
+      const result = await cauldronHelper.isDescriptorInCauldron(NativeApplicationDescriptor.fromString('foo'))
       expect(result).false
     })
 
     it('should return true when querying an existing top level native app platform', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      const result = await cauldronHelper.isNativeApplicationInCauldron(NativeApplicationDescriptor.fromString('test:android'))
+      const result = await cauldronHelper.isDescriptorInCauldron(NativeApplicationDescriptor.fromString('test:android'))
       expect(result).true
     })
 
     it('should return false when querying a non existing top level native app platform', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      const result = await cauldronHelper.isNativeApplicationInCauldron(NativeApplicationDescriptor.fromString('test:foo'))
+      const result = await cauldronHelper.isDescriptorInCauldron(NativeApplicationDescriptor.fromString('test:foo'))
       expect(result).false
     })
 
     it('should return true when querying an existing top level native app version', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      const result = await cauldronHelper.isNativeApplicationInCauldron(NativeApplicationDescriptor.fromString('test:android:17.7.0'))
+      const result = await cauldronHelper.isDescriptorInCauldron(NativeApplicationDescriptor.fromString('test:android:17.7.0'))
       expect(result).true
     })
 
     it('should return false when querying a non existing top level native app version', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      const result = await cauldronHelper.isNativeApplicationInCauldron(NativeApplicationDescriptor.fromString('test:android:0.0.0'))
+      const result = await cauldronHelper.isDescriptorInCauldron(NativeApplicationDescriptor.fromString('test:android:0.0.0'))
       expect(result).false
     })
   })
 
-  describe('addNativeDependency', () => {
+  describe('addContainerNativeDependency', () => {
     it('should throw if the given native application descriptor is partial', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.addNativeDependency,
+        cauldronHelper.addContainerNativeDependency,
         cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'),
         PackagePath.fromString('test@1.0.0')))
@@ -240,7 +188,7 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.addNativeDependency,
+        cauldronHelper.addContainerNativeDependency,
         cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'),
         PackagePath.fromString('test@1.0.0')))
@@ -250,7 +198,7 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.addNativeDependency,
+        cauldronHelper.addContainerNativeDependency,
         cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('test@1.0.0')))
@@ -259,7 +207,7 @@ describe('CauldronHelper.js', () => {
     it('should add the dependency to the native application version', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.addNativeDependency(
+      await cauldronHelper.addContainerNativeDependency(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString('test@1.0.0'))
       const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0]
@@ -309,12 +257,12 @@ describe('CauldronHelper.js', () => {
     })
   })
 
-  describe('removeNativeDependency', () => {
+  describe('removeContainerNativeDependency', () => {
     it('should throw if the given native application descriptor is partial', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.removeNativeDependency,
+        cauldronHelper.removeContainerNativeDependency,
         cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'),
         PackagePath.fromString('test@1.0.0')))
@@ -324,7 +272,7 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.removeNativeDependency,
+        cauldronHelper.removeContainerNativeDependency,
         cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'),
         PackagePath.fromString('test@1.0.0')))
@@ -334,7 +282,7 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.removeNativeDependency,
+        cauldronHelper.removeContainerNativeDependency,
         cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('test@1.0.0')))
@@ -343,7 +291,7 @@ describe('CauldronHelper.js', () => {
     it('should remove the dependency from the native application version [1]', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.removeNativeDependency(
+      await cauldronHelper.removeContainerNativeDependency(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString('react-native-electrode-bridge@1.4.9'))
       const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0]
@@ -353,7 +301,7 @@ describe('CauldronHelper.js', () => {
     it('should remove the dependency from the native application version [2]', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.removeNativeDependency(
+      await cauldronHelper.removeContainerNativeDependency(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString('react-native-electrode-bridge'))
       const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0]
@@ -361,12 +309,12 @@ describe('CauldronHelper.js', () => {
     })
   })
 
-  describe('removeMiniAppFromContainer', () => {
+  describe('removeContainerMiniApp', () => {
     it('should throw if the given native application descriptor is partial', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.removeMiniAppFromContainer,
+        cauldronHelper.removeContainerMiniApp,
         cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'),
         PackagePath.fromString('@test/react-native-foo@5.0.0')))
@@ -376,7 +324,7 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.removeMiniAppFromContainer,
+        cauldronHelper.removeContainerMiniApp,
         cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'),
         PackagePath.fromString('@test/react-native-foo@5.0.0')))
@@ -386,7 +334,7 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.removeMiniAppFromContainer,
+        cauldronHelper.removeContainerMiniApp,
         cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('@test/react-native-foo@5.0.0')))
@@ -395,7 +343,7 @@ describe('CauldronHelper.js', () => {
     it('should remove the miniapp from the native application version [1]', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.removeMiniAppFromContainer(
+      await cauldronHelper.removeContainerMiniApp(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString('@test/react-native-foo@5.0.0'))
       const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0]
@@ -405,7 +353,7 @@ describe('CauldronHelper.js', () => {
     it('should remove the miniapp from the native application version [2]', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.removeMiniAppFromContainer(
+      await cauldronHelper.removeContainerMiniApp(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString('@test/react-native-foo'))
       const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0]
@@ -413,12 +361,12 @@ describe('CauldronHelper.js', () => {
     })
   })
 
-  describe('removeJsApiImplFromContainer', () => {
+  describe('removeContainerJsApiImpl', () => {
     it('should throw if the given native application descriptor is partial', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.removeJsApiImplFromContainer,
+        cauldronHelper.removeContainerJsApiImpl,
         cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'),
         PackagePath.fromString('react-native-my-api-impl@1.0.0')))
@@ -428,7 +376,7 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.removeJsApiImplFromContainer,
+        cauldronHelper.removeContainerJsApiImpl,
         cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'),
         PackagePath.fromString('react-native-my-api-impl@1.0.0')))
@@ -438,7 +386,7 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.removeJsApiImplFromContainer,
+        cauldronHelper.removeContainerJsApiImpl,
         cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('react-native-my-api-impl@1.0.0')))
@@ -447,7 +395,7 @@ describe('CauldronHelper.js', () => {
     it('should remove the miniapp from the native application version [1]', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.removeJsApiImplFromContainer(
+      await cauldronHelper.removeContainerJsApiImpl(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString('react-native-my-api-impl@1.0.0'))
       const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0]
@@ -457,7 +405,7 @@ describe('CauldronHelper.js', () => {
     it('should remove the miniapp from the native application version [2]', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.removeJsApiImplFromContainer(
+      await cauldronHelper.removeContainerJsApiImpl(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString('react-native-my-api-impl'))
       const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0]
@@ -465,48 +413,54 @@ describe('CauldronHelper.js', () => {
     })
   })
 
-  describe('getNativeApp', () => {
-    it('should return undefined if no top level application is found', async () => {
+  describe('getDescriptor', () => {
+    it('should throw if no top level application is found', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      const result = await cauldronHelper.getNativeApp(NativeApplicationDescriptor.fromString('foo'))
-      expect(result).undefined
+      assert(doesThrow(
+        cauldronHelper.getDescriptor,
+        cauldronHelper,
+        NativeApplicationDescriptor.fromString('foo')))
     })
 
     it('should return a top level native app', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      const result = await cauldronHelper.getNativeApp(NativeApplicationDescriptor.fromString('test'))
+      const result = await cauldronHelper.getDescriptor(NativeApplicationDescriptor.fromString('test'))
       expect(result).to.be.an('object')
       expect(result.name).eql('test')
     })
 
-    it('should return undefined if no application platform is found', async () => {
+    it('should throw if no application platform is found', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      const result = await cauldronHelper.getNativeApp(NativeApplicationDescriptor.fromString('test:foo'))
-      expect(result).undefined
+      assert(doesThrow(
+        cauldronHelper.getDescriptor,
+        cauldronHelper,
+        NativeApplicationDescriptor.fromString('test:foo')))
     })
 
     it('should return a native app platform', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      const result = await cauldronHelper.getNativeApp(NativeApplicationDescriptor.fromString('test:android'))
+      const result = await cauldronHelper.getDescriptor(NativeApplicationDescriptor.fromString('test:android'))
       expect(result).to.be.an('object')
       expect(result.name).eql('android')
     })
 
-    it('should return undefined if no application version is found', async () => {
+    it('should throw if no application version is found', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      const result = await cauldronHelper.getNativeApp(NativeApplicationDescriptor.fromString('test:android:0.0.0'))
-      expect(result).undefined
+      assert(doesThrow(
+        cauldronHelper.getDescriptor,
+        cauldronHelper,
+        NativeApplicationDescriptor.fromString('test:android:0.0.0')))
     })
 
     it('should return a native app version', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      const result = await cauldronHelper.getNativeApp(NativeApplicationDescriptor.fromString('test:android:17.7.0'))
+      const result = await cauldronHelper.getDescriptor(NativeApplicationDescriptor.fromString('test:android:17.7.0'))
       expect(result).to.be.an('object')
       expect(result.name).eql('17.7.0')
     })
@@ -1073,28 +1027,30 @@ describe('CauldronHelper.js', () => {
         'react-native-electrode-bridge'))
     })
 
-    it('should return undefined if the dependency was not found [1]', async () => {
+    it('should throw if the dependency was not found [1]', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      const result = await cauldronHelper.getNativeDependency(
+      assert(doesThrow(
+        cauldronHelper.getNativeDependency, 
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:17.7.0'), 
-        'foo')
-      expect(result).undefined
+        'foo'))
     })
 
-    it('should return undefined if the dependency was not found [1]', async () => {
+    it('should throw if the dependency was not found [2]', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      const result = await cauldronHelper.getNativeDependency(
+      assert(doesThrow(
+        cauldronHelper.getNativeDependency, 
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:17.7.0'), 
-        'react-native-electrode-bridge@0.0.1')
-      expect(result).undefined
+        'react-native-electrode-bridge@0.0.1'))
     })
 
     it('should return the dependency [1]', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      const result = await cauldronHelper.getNativeDependency(
+      const result = await cauldronHelper.getContainerNativeDependency(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'), 
         'react-native-electrode-bridge')
       expect(result).not.undefined
@@ -1104,7 +1060,7 @@ describe('CauldronHelper.js', () => {
     it('should return the dependency [2]', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      const result = await cauldronHelper.getNativeDependency(
+      const result = await cauldronHelper.getContainerNativeDependency(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'), 
         'react-native-electrode-bridge@1.4.9')
       expect(result).not.undefined
@@ -1112,12 +1068,12 @@ describe('CauldronHelper.js', () => {
     })
   })
 
-  describe('updateNativeAppDependency', () => {
+  describe('updateContainerNativeDependencyVersion', () => {
     it('should throw if the given native application descriptor is partial', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.updateNativeAppDependency, 
+        cauldronHelper.updateContainerNativeDependencyVersion, 
         cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'),
         PackagePath.fromString('react-native-electrode-bridge'),
@@ -1128,7 +1084,7 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.updateNativeAppDependency, 
+        cauldronHelper.updateContainerNativeDependencyVersion, 
         cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'),
         PackagePath.fromString('react-native-electrode-bridge'),
@@ -1139,7 +1095,7 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.updateNativeAppDependency, 
+        cauldronHelper.updateContainerNativeDependencyVersion, 
         cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('react-native-electrode-bridge'),
@@ -1149,7 +1105,7 @@ describe('CauldronHelper.js', () => {
     it('should update the native dependency version', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.updateNativeAppDependency(
+      await cauldronHelper.updateContainerNativeDependencyVersion(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         'react-native-electrode-bridge',
         '1.5.0')
@@ -1159,12 +1115,12 @@ describe('CauldronHelper.js', () => {
     })
   })
 
-  describe('updateContainerJsApiImpl', () => {
+  describe('updateContainerJsApiImplVersion', () => {
     it('should throw if the given native application descriptor is partial', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.updateContainerJsApiImpl, 
+        cauldronHelper.updateContainerJsApiImplVersion, 
         cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android'),
         'react-native-my-api-impl',
@@ -1175,7 +1131,7 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.updateContainerJsApiImpl, 
+        cauldronHelper.updateContainerJsApiImplVersion, 
         cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:0.0.0'),
         'react-native-my-api-impl',
@@ -1186,7 +1142,7 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(doesThrow(
-        cauldronHelper.updateContainerJsApiImpl, 
+        cauldronHelper.updateContainerJsApiImplVersion, 
         cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         'react-native-my-api-impl',
@@ -1196,7 +1152,7 @@ describe('CauldronHelper.js', () => {
     it('should update the native dependency version', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.updateContainerJsApiImpl(
+      await cauldronHelper.updateContainerJsApiImplVersion(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         'react-native-my-api-impl',
         '1.5.0')
@@ -1264,13 +1220,14 @@ describe('CauldronHelper.js', () => {
         PackagePath.fromString('react-native-my-api-impl')))
     })
 
-    it('should return undefined if the JS API impl was not found', async () => {
+    it('should throw if the JS API impl was not found', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      const result = await cauldronHelper.getContainerJsApiImpl(
+      assert(doesThrow(
+        cauldronHelper.getContainerJsApiImpl, 
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
-        PackagePath.fromString('foo@1.0.0'))
-      expect(result).undefined
+        PackagePath.fromString('foo@1.0.0')))
     })
 
     it('should return the JS API impl [1]', async () => {
@@ -1313,22 +1270,24 @@ describe('CauldronHelper.js', () => {
         'react-native-bar'))
     })
 
-    it('should return undefined if the MiniApp was not found [1]', async () => {
+    it('should throw if the MiniApp was not found [1]', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      const result = await cauldronHelper.getContainerMiniApp(
+      assert(doesThrow(
+        cauldronHelper.getContainerMiniApp, 
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
-        'foo@1.0.0')
-      expect(result).undefined
+        'foo@1.0.0'))
     })
 
-    it('should return undefined if the MiniApp was not found [2]', async () => {
+    it('should throw if the MiniApp was not found [2]', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      const result = await cauldronHelper.getContainerMiniApp(
+      assert(doesThrow(
+        cauldronHelper.getContainerMiniApp, 
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
-        'react-native-bar@0.0.1')
-      expect(result).undefined
+        'react-native-bar@0.0.1'))
     })
 
     it('should return the MiniApp [1]', async () => {
@@ -1371,13 +1330,14 @@ describe('CauldronHelper.js', () => {
         'Production'))
     })
 
-    it('should return undefined if no JS API impls were CodePushed', async () => {
+    it('should throw if deployment does not exist', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      const result = await cauldronHelper.getCodePushJsApiImpls(
+      assert(doesThrow(
+        cauldronHelper.getCodePushJsApiImpls, 
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
-        'Foo')
-      expect(result).undefined
+        'Foo'))
     })
 
     it('should return the CodePushed JS API impls', async () => {
@@ -1411,13 +1371,14 @@ describe('CauldronHelper.js', () => {
         'Production'))
     })
 
-    it('should return undefined if no MiniApps were CodePushed', async () => {
+    it('should throw if deployment does not exist', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      const result = await cauldronHelper.getCodePushMiniApps(
+      assert(doesThrow(
+        cauldronHelper.getCodePushMiniApps, 
+        cauldronHelper,
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
-        'Foo')
-      expect(result).undefined
+        'Foo'))
     })
 
     it('should return the CodePushed MiniApps', async () => {
@@ -1630,12 +1591,13 @@ describe('CauldronHelper.js', () => {
       expect(result).not.undefined
     })
 
-    it('should return undefined if it does not find the container generator config', async () => {
+    it('should throw if the native application does not exist', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      const result = await cauldronHelper.getContainerGeneratorConfig(
-        NativeApplicationDescriptor.fromString('toto:android'))
-      expect(result).undefined
+      assert(doesThrow(
+        cauldronHelper.getContainerGeneratorConfig, 
+        cauldronHelper,
+        NativeApplicationDescriptor.fromString('toto:android')))
     })
   })
 
@@ -1808,32 +1770,6 @@ describe('CauldronHelper.js', () => {
       const result = await cauldronHelper.getTopLevelContainerVersion(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'))
       expect(result).equal('1.16.44')
-    })
-  })
-
-  describe('throwIfPartialNapDescriptor', () => {
-    it('should throw if provided a partial native application descriptor [1]', () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron)
-      const cauldronHelper = createCauldronHelper(fixture)
-      expect(() => { cauldronHelper.throwIfPartialNapDescriptor(
-        NativeApplicationDescriptor.fromString('test')
-      )}).to.throw()
-    })
-
-    it('should throw if provided a partial native application descriptor [2]', () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron)
-      const cauldronHelper = createCauldronHelper(fixture)
-      expect(() => { cauldronHelper.throwIfPartialNapDescriptor(
-        NativeApplicationDescriptor.fromString('test:android')
-      )}).to.throw()
-    })
-
-    it('should not throw if provided a complete native application descriptor', () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron)
-      const cauldronHelper = createCauldronHelper(fixture)
-      expect(() => { cauldronHelper.throwIfPartialNapDescriptor(
-        NativeApplicationDescriptor.fromString('test:android:17.70')
-      )}).to.not.throw()
     })
   })
 

--- a/ern-local-cli/src/commands/cauldron/add/dependencies.js
+++ b/ern-local-cli/src/commands/cauldron/add/dependencies.js
@@ -86,7 +86,7 @@ exports.handler = async function ({
       async () => {
         for (const dependencyObj of dependenciesObjs) {
           // Add the dependency to Cauldron
-          await cauldron.addNativeDependency(napDescriptor, dependencyObj)
+          await cauldron.addContainerNativeDependency(napDescriptor, dependencyObj)
           cauldronCommitMessage.push(`- Add ${dependencyObj.toString()} native dependency`)
         }
       },

--- a/ern-local-cli/src/commands/cauldron/batch.js
+++ b/ern-local-cli/src/commands/cauldron/batch.js
@@ -168,17 +168,17 @@ exports.handler = async function ({
     await utils.performContainerStateUpdateInCauldron(async () => {
       // Del Dependencies
       for (const delDependencyObj of delDependenciesObjs) {
-        await cauldron.removeNativeDependency(napDescriptor, delDependencyObj)
+        await cauldron.removeContainerNativeDependency(napDescriptor, delDependencyObj)
         cauldronCommitMessage.push(`- Remove ${delDependencyObj.toString()} native dependency`)
       }
       // Del MiniApps
       for (const delMiniAppAsDep of delMiniAppsAsDeps) {
-        await cauldron.removeMiniAppFromContainer(napDescriptor, delMiniAppAsDep)
+        await cauldron.removeContainerMiniApp(napDescriptor, delMiniAppAsDep)
         cauldronCommitMessage.push(`- Remove ${delMiniAppAsDep.toString()} MiniApp`)
       }
       // Update Dependencies
       for (const updateDependencyObj of updateDependenciesObjs) {
-        await cauldron.updateNativeAppDependency(
+        await cauldron.updateContainerNativeDependencyVersion(
           napDescriptor,
           updateDependencyObj.basePath,
           updateDependencyObj.version)
@@ -193,7 +193,7 @@ exports.handler = async function ({
       // Add Dependencies
       for (const addDependencyObj of addDependenciesObjs) {
         // Add the dependency to Cauldron
-        await cauldron.addNativeDependency(napDescriptor, addDependencyObj)
+        await cauldron.addContainerNativeDependency(napDescriptor, addDependencyObj)
         cauldronCommitMessage.push(`-Add ${addDependencyObj.toString()} native dependency`)
       }
       // Add MiniApps

--- a/ern-local-cli/src/commands/cauldron/del/dependencies.js
+++ b/ern-local-cli/src/commands/cauldron/del/dependencies.js
@@ -92,7 +92,7 @@ exports.handler = async function ({
     await utils.performContainerStateUpdateInCauldron(
       async () => {
         for (const dependencyObj: PackagePath of dependenciesObjs) {
-          await cauldron.removeNativeDependency(napDescriptor, dependencyObj)
+          await cauldron.removeContainerNativeDependency(napDescriptor, dependencyObj)
           cauldronCommitMessage.push(`- Remove ${dependencyObj.toString()} native dependency`)
         }
       },

--- a/ern-local-cli/src/commands/cauldron/del/jsapiimpls.js
+++ b/ern-local-cli/src/commands/cauldron/del/jsapiimpls.js
@@ -70,7 +70,7 @@ exports.handler = async function ({
     await utils.performContainerStateUpdateInCauldron(
       async () => {
         for (const jsApiImpl of jsapiimpls) {
-          await cauldron.removeJsApiImplFromContainer(napDescriptor, PackagePath.fromString(jsApiImpl))
+          await cauldron.removeContainerJsApiImpl(napDescriptor, PackagePath.fromString(jsApiImpl))
           cauldronCommitMessage.push(`- Remove ${jsApiImpl} JS API implementation`)
         }
       },

--- a/ern-local-cli/src/commands/cauldron/del/miniapps.js
+++ b/ern-local-cli/src/commands/cauldron/del/miniapps.js
@@ -84,7 +84,7 @@ exports.handler = async function ({
     await utils.performContainerStateUpdateInCauldron(
       async () => {
         for (const miniAppAsDep of miniAppsAsDeps) {
-          await cauldron.removeMiniAppFromContainer(napDescriptor, miniAppAsDep)
+          await cauldron.removeContainerMiniApp(napDescriptor, miniAppAsDep)
           cauldronCommitMessage.push(`- Remove ${miniAppAsDep.toString()} MiniApp`)
         }
       },

--- a/ern-local-cli/src/commands/cauldron/del/nativeapp.js
+++ b/ern-local-cli/src/commands/cauldron/del/nativeapp.js
@@ -24,13 +24,13 @@ exports.handler = async function ({
     },
     napDescriptorExistInCauldron: {
       descriptor,
-      extraErrorMessahe: 'This command cannot remove a native application version that do not exist in Cauldron.'
+      extraErrorMessage: 'This command cannot remove a native application version that do not exist in Cauldron.'
     }
   })
 
   try {
     const cauldron = await coreUtils.getCauldronInstance()
-    await cauldron.removeNativeApp(NativeApplicationDescriptor.fromString(descriptor))
+    await cauldron.removeDescriptor(NativeApplicationDescriptor.fromString(descriptor))
   } catch (e) {
     coreUtils.logErrorAndExitProcess(e)
   }

--- a/ern-local-cli/src/commands/cauldron/get/nativeapp.js
+++ b/ern-local-cli/src/commands/cauldron/get/nativeapp.js
@@ -30,7 +30,7 @@ exports.handler = async function ({
       const napDescriptors = await utils.getNapDescriptorStringsFromCauldron()
       napDescriptors.forEach(n => log.info(n))
     } else {
-      const nativeApp = await cauldron.getNativeApp(NativeApplicationDescriptor.fromString(descriptor))
+      const nativeApp = await cauldron.getDescriptor(NativeApplicationDescriptor.fromString(descriptor))
       log.info(JSON.stringify(nativeApp, null, 1))
     }
   } catch (e) {

--- a/ern-local-cli/src/commands/cauldron/update/dependencies.js
+++ b/ern-local-cli/src/commands/cauldron/update/dependencies.js
@@ -86,7 +86,7 @@ exports.handler = async function ({
     await utils.performContainerStateUpdateInCauldron(
       async () => {
         for (const dependencyObj of dependenciesObjs) {
-          await cauldron.updateNativeAppDependency(
+          await cauldron.updateContainerNativeDependencyVersion(
             napDescriptor,
             dependencyObj.basePath,
             dependencyObj.version)

--- a/ern-local-cli/src/commands/cauldron/update/jsapiimpls.js
+++ b/ern-local-cli/src/commands/cauldron/update/jsapiimpls.js
@@ -77,7 +77,7 @@ exports.handler = async function ({
             log.error(`Will not update ${jsApiImplPackagePath.toString()} as it does not specify a version`)
             continue
           }
-          await cauldron.updateContainerJsApiImpl(
+          await cauldron.updateContainerJsApiImplVersion(
             napDescriptor,
             jsApiImplPackagePath.basePath,
             jsApiImplPackagePath.version)

--- a/ern-local-cli/src/lib/Ensure.js
+++ b/ern-local-cli/src/lib/Ensure.js
@@ -47,7 +47,7 @@ export default class Ensure {
     extraErrorMessage: string = '') {
     const cauldron = await coreUtils.getCauldronInstance()
     const cauldronContainerVersion = await cauldron.getTopLevelContainerVersion(NativeApplicationDescriptor.fromString(napDescriptor))
-    if (!semver.gt(containerVersion, cauldronContainerVersion)) {
+    if (cauldronContainerVersion && !semver.gt(containerVersion, cauldronContainerVersion)) {
       throw new Error(`Container version ${containerVersion} is older than ${cauldronContainerVersion}\n${extraErrorMessage}`)
     }
   }
@@ -93,7 +93,7 @@ export default class Ensure {
       ? _.map(napDescriptor, d => NativeApplicationDescriptor.fromString(d))
       : [ NativeApplicationDescriptor.fromString(napDescriptor) ]
     for (const descriptor of descriptors) {
-      const result = await cauldron.getNativeApp(descriptor)
+      const result = await cauldron.isDescriptorInCauldron(descriptor)
       if (!result) {
         throw new Error(`${descriptor.toString()} descriptor does not exist in Cauldron.\n${extraErrorMessage}`)
       }
@@ -114,8 +114,7 @@ export default class Ensure {
     extraErrorMessage: string = '') {
     const cauldron = await coreUtils.getCauldronInstance()
     const descriptor = NativeApplicationDescriptor.fromString(napDescriptor)
-    const result = await cauldron.getNativeApp(descriptor)
-    if (result) {
+    if (await cauldron.isDescriptorInCauldron(descriptor)) {
       throw new Error(`${descriptor.toString()} descriptor exist in Cauldron.\n${extraErrorMessage}`)
     }
   }
@@ -140,7 +139,7 @@ export default class Ensure {
     const miniAppsStrings = obj instanceof Array ? obj : [ obj ]
     for (const miniAppString of miniAppsStrings) {
       const basePathMiniAppString = PackagePath.fromString(miniAppString).basePath
-      if (await cauldron.getContainerMiniApp(napDescriptor, basePathMiniAppString)) {
+      if (await cauldron.isMiniAppInContainer(napDescriptor, basePathMiniAppString)) {
         throw new Error(`${basePathMiniAppString} MiniApp exists in ${napDescriptor.toString()}.\n${extraErrorMessage}`)
       }
     }
@@ -155,7 +154,7 @@ export default class Ensure {
     const dependenciesStrings = obj instanceof Array ? obj : [ obj ]
     for (const dependencyString of dependenciesStrings) {
       const unversionedDependencyString = PackagePath.fromString(dependencyString).basePath
-      if (await cauldron.getNativeDependency(napDescriptor, unversionedDependencyString)) {
+      if (await cauldron.isNativeDependencyInContainer(napDescriptor, unversionedDependencyString)) {
         throw new Error(`${unversionedDependencyString} dependency exists in ${napDescriptor.toString()}.\n${extraErrorMessage}`)
       }
     }
@@ -170,7 +169,7 @@ export default class Ensure {
     const miniAppsStrings = obj instanceof Array ? obj : [ obj ]
     for (const miniAppString of miniAppsStrings) {
       const basePathMiniAppString = PackagePath.fromString(miniAppString).basePath
-      if (!await cauldron.getContainerMiniApp(napDescriptor, basePathMiniAppString)) {
+      if (!await cauldron.isMiniAppInContainer(napDescriptor, basePathMiniAppString)) {
         throw new Error(`${basePathMiniAppString} MiniApp does not exist in ${napDescriptor.toString()}.\n${extraErrorMessage}`)
       }
     }
@@ -185,7 +184,7 @@ export default class Ensure {
     const dependenciesStrings = obj instanceof Array ? obj : [ obj ]
     for (const dependencyString of dependenciesStrings) {
       const unversionedDependencyString = PackagePath.fromString(dependencyString).basePath
-      if (!await cauldron.getNativeDependency(napDescriptor, unversionedDependencyString)) {
+      if (!await cauldron.getContainerNativeDependency(napDescriptor, unversionedDependencyString)) {
         throw new Error(`${unversionedDependencyString} does not exists in ${napDescriptor.toString()}.\n${extraErrorMessage}`)
       }
     }
@@ -219,7 +218,7 @@ export default class Ensure {
     await this.dependencyIsInNativeApplicationVersionContainer(obj, napDescriptor)
     const dependenciesStrings = obj instanceof Array ? obj : [ obj ]
     for (const dependencyString of dependenciesStrings) {
-      const dependencyFromCauldron = await cauldron.getNativeDependency(napDescriptor,
+      const dependencyFromCauldron = await cauldron.getContainerNativeDependency(napDescriptor,
         PackagePath.fromString(dependencyString).basePath)
       if (dependencyFromCauldron && dependencyFromCauldron.version === PackagePath.fromString(dependencyString).version) {
         throw new Error(`${PackagePath.fromString(dependencyString).basePath} is already at version ${dependencyFromCauldron.version || 'undefined'} in ${napDescriptor.toString()}.\n${extraErrorMessage}`)

--- a/ern-local-cli/src/lib/publication.js
+++ b/ern-local-cli/src/lib/publication.js
@@ -532,7 +532,7 @@ export async function askUserForCodePushDeploymentName (napDescriptor: NativeApp
   const cauldron = await coreUtils.getCauldronInstance()
   const config = await cauldron.getConfig(napDescriptor)
   const hasCodePushDeploymentsConfig = config && config.codePush && config.codePush.deployments
-  const choices = hasCodePushDeploymentsConfig ? config.codePush.deployments : undefined
+  const choices = hasCodePushDeploymentsConfig ? config && config.codePush.deployments : undefined
 
   const { userSelectedDeploymentName } = await inquirer.prompt({
     type: choices ? 'list' : 'input',

--- a/ern-local-cli/test/Ensure-test.js
+++ b/ern-local-cli/test/Ensure-test.js
@@ -102,12 +102,12 @@ describe('Ensure.js', () => {
   // ==========================================================
   describe('napDescritorExistsInCauldron', () => {
     it('should not throw if nap descriptor exists in Cauldron', async () => {
-      cauldronHelperStub.getNativeApp.resolves({})
+      cauldronHelperStub.isDescriptorInCauldron.resolves(true)
       assert(await doesNotThrow(Ensure.napDescritorExistsInCauldron, null, 'testapp:android:1.0.0'))
     })
 
     it('should throw if nap descriptor does not exist in Cauldron', async () => {
-      cauldronHelperStub.getNativeApp.resolves(undefined)
+      cauldronHelperStub.isDescriptorInCauldron.resolves(false)
       assert(await doesThrow(Ensure.napDescritorExistsInCauldron, null, 'testapp:android:1.0.0'))
     })
   })


### PR DESCRIPTION
- Add proper typing (flow) throughout all of `CauldronApi` and `CauldronHelper`
- Throw exceptions in Cauldron API functions for most of the `get` methods in case what is accessed does not exist in Cauldron (instead of returning `undefined`)
- Move `throwIfPartialNapDescriptor` from `CauldronHelper` to `CauldronApi`
- Improve / normalize commit messages
- Lighten CauldronHelper logic. Idea is to get rid of `CauldronHelper` extra logic as much as possible when it is just used as a proxy to `CauldronApi` methods (1 to 1 mapping). `CauldronHelper` should ideally just be an additional layer on top of the `CauldronApi` offering some functions that orchestrate calls to the `CauldronApi`. Going toward this direction.