### PR TITLE
Fix BaseGit Cauldron

### DIFF
--- a/ern-cauldron-api/src/BaseGit.js
+++ b/ern-cauldron-api/src/BaseGit.js
@@ -78,7 +78,7 @@ export default class BaseGit implements ITransactional {
       await this._doInitialCommit()
     } else {
       log.debug(`[BaseGit] Fetching from ${GIT_REMOTE_NAME} master`)
-      await this.git.fetchAsync(GIT_REMOTE_NAME, 'master')
+      await this.git.fetchAsync(['--all'])
       await this.git.resetAsync(['--hard', `${GIT_REMOTE_NAME}/master`])
     }
 


### PR DESCRIPTION
It seems like on some systems (Looper VM running CentOS being one where I faced the issue), the `git fetch upstream master` command does not properly work (failing with the following error : `remote: fatal: ambiguous argument 'upstream': unknown revision or path not in the working tree.`.
Might also have noticed the issue a few times in other context.

It is for some reason related to the git CLI invocation itself. The invocation was weird anyway, as a git fetch does not work on a specific branch so to see `master` in the argument was strange in the first place.

Using `git fetch all` is properly working on a looper instance, so it seems like in can properly handle more/all systems.