### PR TITLE
Remove improper log

### DIFF
--- a/ern-container-gen/src/utils.js
+++ b/ern-container-gen/src/utils.js
@@ -33,7 +33,6 @@ export async function bundleMiniApps (
 
     let miniAppsPaths : Array<PackagePath> = []
     for (const miniapp of miniapps) {
-      log.debug(`[bundleMiniApps] MiniApp is not local. Using package path ${miniapp.packageDescriptor} for ${miniapp.name}`)
       miniAppsPaths.push(miniapp.packagePath)
     }
 


### PR DESCRIPTION
Remove a log that was left-over from a previous refactoring and now misleading/incorrect.