### PR TITLE
Ignore rnpm assets

### DIFF
--- a/docs/cli/create-container.md
+++ b/docs/cli/create-container.md
@@ -44,6 +44,12 @@ You cannot use the Git or file package descriptors for referring to the dependen
 * Specify the output directory where the container generated project should be stored upon creation  
 * **Default**  If this option is not provided, the container is generated in the default platform directory `~/.ern/containergen/out`.
 
+`--ignoreRnpmAssets`
+
+* Inform the Container generator to ignore any rnpm assets optionally declared by MiniApps. This can be used in case you want to keep specific rnpm assets inside the native application itself and not the Container.
+* This flag wil have no effect for a Container generated from a Cauldron as the Container configuration stored in the Cauldron will take precedence.
+* **Default** Do not ignore rnpm assets and package them inside the generated Container.
+
 #### Remarks
 
 * The `ern create-container` command can be used to create a container locally, for development, debugging and experimentation purposes.  

--- a/docs/cli/create-container.md
+++ b/docs/cli/create-container.md
@@ -10,12 +10,6 @@
 
 **Options**  
 
-`--version/-v <version>`
-
-* Specify the version to use for the Container  
-* The version must be in the format: `x.y.z` where x, y and z are integers. For example `version=1.2.30`.
-* **Default**  If you don't provide an explicit version, the default version 1.0.0 is used.  
-
 `--jsOnly/--js`
 
 * Create a JavaScript-only container  

--- a/ern-local-cli/src/commands/create-container.js
+++ b/ern-local-cli/src/commands/create-container.js
@@ -59,6 +59,10 @@ exports.builder = function (yargs: any) {
       alias: 'out',
       describe: 'Directory to output the generated container to'
     })
+    .option('ignoreRnpmAssets', {
+      type: 'bool',
+      describe: 'Ignore rppm assets from the MiniApps'
+    })
     .epilog(utils.epilog(exports))
 }
 
@@ -70,7 +74,8 @@ exports.handler = async function ({
   jsApiImpls = [],
   dependencies = [],
   platform,
-  publicationUrl
+  publicationUrl,
+  ignoreRnpmAssets
 } : {
   descriptor?: string,
   jsOnly?: boolean,
@@ -79,7 +84,8 @@ exports.handler = async function ({
   jsApiImpls: Array<string>,
   dependencies: Array<string>,
   platform?: 'android' | 'ios',
-  publicationUrl?: string
+  publicationUrl?: string,
+  ignoreRnpmAssets?: boolean
 } = {}) {
   let napDescriptor: ?NativeApplicationDescriptor
 
@@ -187,7 +193,8 @@ exports.handler = async function ({
           jsApiImplsPaths,
           platform, {
             outDir,
-            extraNativeDependencies: _.map(dependencies, d => PackagePath.fromString(d))
+            extraNativeDependencies: _.map(dependencies, d => PackagePath.fromString(d)),
+            ignoreRnpmAssets
           }
         ))
       } else if (napDescriptor) {

--- a/ern-local-cli/src/commands/create-container.js
+++ b/ern-local-cli/src/commands/create-container.js
@@ -29,11 +29,6 @@ exports.builder = function (yargs: any) {
       alias: 'd',
       describe: 'Full native application descriptor'
     })
-    .option('version', {
-      type: 'string',
-      alias: 'v',
-      describe: 'Version of the generated container. Default to 1.0.0'
-    })
     .option('jsOnly', {
       type: 'bool',
       alias: 'js',
@@ -59,10 +54,6 @@ exports.builder = function (yargs: any) {
       describe: 'The platform for which to generate the container',
       choices: ['android', 'ios', undefined]
     })
-    .option('containerName', {
-      type: 'string',
-      describe: 'The name to user for the container (usually native application name)'
-    })
     .option('outDir', {
       type: 'string',
       alias: 'out',
@@ -73,32 +64,27 @@ exports.builder = function (yargs: any) {
 
 exports.handler = async function ({
   descriptor,
-  version = '1.0.0',
   jsOnly,
   outDir,
   miniapps,
   jsApiImpls = [],
   dependencies = [],
   platform,
-  containerName,
   publicationUrl
 } : {
   descriptor?: string,
-  version: string,
   jsOnly?: boolean,
   outDir?: string,
   miniapps?: Array<string>,
   jsApiImpls: Array<string>,
   dependencies: Array<string>,
   platform?: 'android' | 'ios',
-  containerName?: string,
   publicationUrl?: string
 } = {}) {
   let napDescriptor: ?NativeApplicationDescriptor
 
   try {
     await utils.logErrorAndExitIfNotSatisfied({
-      isValidContainerVersion: version ? {containerVersion: version} : undefined,
       noGitOrFilesystemPath: {
         obj: dependencies,
         extraErrorMessage: 'You cannot provide dependencies using git or file schme for this command. Only the form miniapp@version is allowed.'
@@ -200,13 +186,11 @@ exports.handler = async function ({
           miniAppsPaths,
           jsApiImplsPaths,
           platform, {
-            version,
-            nativeAppName: containerName,
             outDir,
             extraNativeDependencies: _.map(dependencies, d => PackagePath.fromString(d))
           }
         ))
-      } else if (napDescriptor && version) {
+      } else if (napDescriptor) {
         await runCauldronContainerGen(
           napDescriptor,
           {outDir})

--- a/ern-local-cli/src/lib/publication.js
+++ b/ern-local-cli/src/lib/publication.js
@@ -41,10 +41,12 @@ miniappPackagesPaths: Array<PackagePath>,
 jsApiImplsPackagePaths: Array<PackagePath>,
 platform: 'android' | 'ios', {
   outDir = `${Platform.rootDirectory}/containergen`,
-  extraNativeDependencies = []
+  extraNativeDependencies = [],
+  ignoreRnpmAssets = false
 }: {
   outDir?: string,
-  extraNativeDependencies: Array<PackagePath>
+  extraNativeDependencies: Array<PackagePath>,
+  ignoreRnpmAssets?: boolean
 } = {}) {
   try {
     const nativeDependenciesStrings: Set <string> = new Set()
@@ -90,7 +92,8 @@ platform: 'android' | 'ios', {
       outDir,
       plugins: nativeDependencies,
       pluginsDownloadDir: tmp.dirSync({ unsafeCleanup: true }).name,
-      compositeMiniAppDir: tmp.dirSync({ unsafeCleanup: true }).name
+      compositeMiniAppDir: tmp.dirSync({ unsafeCleanup: true }).name,
+      ignoreRnpmAssets
     }))
   } catch (e) {
     log.error(`runLocalContainerGen failed: ${e}`)


### PR DESCRIPTION
Closes https://github.com/electrode-io/electrode-native/issues/536

Also removes `version` and `containerName` options from the `create-container` command as they are not used any-longer for creating a container (publication specific options. left-overs from past refactoring).