### PR TITLE
Fix system tests

### DIFF
--- a/system-tests.js
+++ b/system-tests.js
@@ -178,11 +178,11 @@ run(`ern cauldron add miniapps ${movieDetailsMiniAppPackageName}@${movieDetailsM
 run(`ern cauldron add miniapps ${packageNotInNpm} -d ${androidNativeApplicationDescriptor}`, { expectedExitCode: 1 })
 
 // Container gen should be successful for the two following commands
-run(`ern create-container --miniapps file:${miniAppPath} -p android -v 1.0.0`)
-run(`ern create-container --miniapps file:${miniAppPath} -p ios -v 1.0.0`)
+run(`ern create-container --miniapps file:${miniAppPath} -p android`)
+run(`ern create-container --miniapps file:${miniAppPath} -p ios`)
 
-run(`ern create-container --miniapps file:${miniAppPath} ${movieListMiniAppPackageName}@${movieListMiniAppVersion} -p android -v 1.0.0`)
-run(`ern create-container --miniapps file:${miniAppPath} ${movieListMiniAppPackageName}@${movieListMiniAppVersion} -p ios -v 1.0.0`)
+run(`ern create-container --miniapps file:${miniAppPath} ${movieListMiniAppPackageName}@${movieListMiniAppVersion} -p android`)
+run(`ern create-container --miniapps file:${miniAppPath} ${movieListMiniAppPackageName}@${movieListMiniAppVersion} -p ios`)
 
 const androidContainerOutDir = tmp.dirSync({ unsafeCleanup: true }).name
 run(`ern create-container --descriptor ${androidNativeApplicationDescriptor} --out ${androidContainerOutDir}`)


### PR DESCRIPTION
`--version/-v` option was removed from `create-container` command as it is not needed any longer. This commit removes the option from system tests calls to `create-container`.