### PR TITLE
Fix a bug impacting scoped npm packages on Windows

### DIFF
--- a/ern-core/src/nativeDependenciesLookup.js
+++ b/ern-core/src/nativeDependenciesLookup.js
@@ -37,7 +37,11 @@ export async function findNativeDependencies (dir: string) : Promise<NativeDepen
     const r = /^win/.test(process.platform)
       ? /^(@.*?\\.*?)\\|^(.*?)\\/.exec(nativeDepsDirectory)
       : /^(@.*?\/.*?)\/|^(.*?)\//.exec(nativeDepsDirectory)
-    nativeDependenciesNames.add(r[1] || r[2])
+    if (r[1]) {
+      nativeDependenciesNames.add(/^win/.test(process.platform) ? r[1].replace('\\', '/') : r[1])
+    } else {
+      nativeDependenciesNames.add(r[2])
+    }
   }
 
   const result : NativeDependencies = {


### PR DESCRIPTION
This commit fix the issue that was impacting scoped npm packages use with Electrode Native on Windows.
Scope and name of the package were using an invalid delimiter (`\` instead of `/`) on Windows resulting in failure when Electrode Native was trying to yarn add the package(s).

Fixes https://github.com/electrode-io/electrode-native/issues/548