### PR TITLE
Improve create-container plugins versions compatibility checks

### DIFF
--- a/ern-local-cli/src/lib/publication.js
+++ b/ern-local-cli/src/lib/publication.js
@@ -54,7 +54,7 @@ export async function runLocalContainerGen (
 miniappPackagesPaths: Array<PackagePath>,
 jsApiImplsPackagePaths: Array<PackagePath>,
 platform: 'android' | 'ios', {
-  outDir = `${Platform.rootDirectory}/containergen`,
+  outDir = path.join(Platform.rootDirectory, 'containergen'),
   extraNativeDependencies = [],
   ignoreRnpmAssets = false
 }: {

--- a/ern-local-cli/src/lib/publication.js
+++ b/ern-local-cli/src/lib/publication.js
@@ -29,6 +29,20 @@ import path from 'path'
 import fs from 'fs'
 import shell from 'shelljs'
 import * as constants from './constants'
+import semver from 'semver'
+
+export function containsVersionMismatch (
+  versions: Array<string>,
+  mismatchLevel: 'major' | 'minor' | 'patch') : boolean {
+  const minVersion = semver.minSatisfying(versions, '*')
+  const maxVersion = semver.maxSatisfying(versions, '*')
+  const majorMismatch = semver.major(maxVersion) !== semver.major(minVersion)
+  const minorMismatch = semver.minor(maxVersion) !== semver.minor(minVersion)
+  const patchMismatch = semver.patch(maxVersion) !== semver.patch(minVersion)
+  return majorMismatch ||
+        (minorMismatch && (mismatchLevel === 'minor' || mismatchLevel === 'patch')) ||
+        (patchMismatch && mismatchLevel === 'patch')
+}
 
 // Run container generator locally, without relying on the Cauldron, given a list of miniapp packages
 // The string used to represent a miniapp package can be anything supported by `yarn add` command

--- a/ern-local-cli/src/lib/publication.js
+++ b/ern-local-cli/src/lib/publication.js
@@ -44,6 +44,39 @@ export function containsVersionMismatch (
         (patchMismatch && mismatchLevel === 'patch')
 }
 
+export function resolvePluginsVersions (
+  plugins: Array<PackagePath>,
+  mismatchLevel: 'major' | 'minor' | 'patch') : {
+  resolved: Array<PackagePath>,
+  pluginsWithMismatchingVersions: Array<string>
+} {
+  let result = {
+    resolved: [],
+    pluginsWithMismatchingVersions: []
+  }
+
+  let pluginsByBasePath = _.groupBy(_.unionBy(plugins, p => p.toString()), 'basePath')
+  for (const basePath of Object.keys(pluginsByBasePath)) {
+    const entry = pluginsByBasePath[basePath]
+    const pluginVersions = _.map(entry, 'version')
+    if (pluginVersions.length > 1) {
+      // If there are multiple versions of the dependency being used across all MiniApps
+      if (containsVersionMismatch(pluginVersions, mismatchLevel)) {
+        // If at least one of the versions major digit differs, deem incompatibility
+        result.pluginsWithMismatchingVersions.push(basePath)
+      } else {
+        // No mismatchLevel version differences, just return the highest version
+        result.resolved.push(_.find(entry, c => c.basePath === basePath && c.version === semver.maxSatisfying(pluginVersions, '*')))
+      }
+    } else {
+      // Only one version is used across all MiniApps, just use this version
+      result.resolved.push(entry[0])
+    }
+  }
+
+  return result
+}
+
 // Run container generator locally, without relying on the Cauldron, given a list of miniapp packages
 // The string used to represent a miniapp package can be anything supported by `yarn add` command
 // For example, the following miniapp strings are all valid

--- a/ern-local-cli/test/publication-test.js
+++ b/ern-local-cli/test/publication-test.js
@@ -96,4 +96,62 @@ describe('lib/publication.js', () => {
       expect(getCodePushSdk).to.throw()
     })
   })
+
+  // ==========================================================
+  // containsVersionMismatch
+  // ==========================================================
+  const versionsWithAMajorMismatch = [ '1.0.0', '2.0.0', '1.0.0' ]
+  const versionsWithAMinorMismatch = [ '1.0.0', '1.1.0', '1.0.0' ]
+  const versionsWithAPatchMismatch = [ '1.0.0', '1.0.1', '1.0.0' ]
+  const versionsWithoutMismatch = [ '1.0.0', '1.0.0', '1.0.0' ]
+
+  describe('containsVersionMismatch', () => {
+    it('should return true if mismatch level is set to major and there is at least one major version mismatch', () => {
+      expect(containsVersionMismatch(versionsWithAMajorMismatch, 'major')).true
+    })
+
+    it('should return false if mismatch level is set to major and there is no major version mismatch [1]', () => {
+      expect(containsVersionMismatch(versionsWithAMinorMismatch, 'major')).false
+    })
+
+    it('should return false if mismatch level is set to major and there is no major version mismatch [2]', () => {
+      expect(containsVersionMismatch(versionsWithAPatchMismatch, 'major')).false
+    })
+
+    it('should return false if mismatch level is set to major and there is no major version mismatch [3]', () => {
+      expect(containsVersionMismatch(versionsWithoutMismatch, 'major')).false
+    })
+
+    it('should return true if mismatch level is set to minor and there is at least one major version mismatch', () => {
+      expect(containsVersionMismatch(versionsWithAMajorMismatch, 'minor')).true
+    })
+
+    it('should return true if mismatch level is set to minor and there is at least one minor version mismatch', () => {
+      expect(containsVersionMismatch(versionsWithAMinorMismatch, 'minor')).true
+    })
+
+    it('should return false if mismatch level is set to minor and there no minor version mismatch [1]', () => {
+      expect(containsVersionMismatch(versionsWithAPatchMismatch, 'minor')).false
+    })
+
+    it('should return false if mismatch level is set to minor and there no minor version mismatch [1]', () => {
+      expect(containsVersionMismatch(versionsWithoutMismatch, 'minor')).false
+    })
+
+    it('should return true if mismatch level is set to patch and there is at least one major version mismatch', () => {
+      expect(containsVersionMismatch(versionsWithAMajorMismatch, 'patch')).true
+    })
+
+    it('should return true if mismatch level is set to patch and there is at least one minor version mismatch', () => {
+      expect(containsVersionMismatch(versionsWithAMinorMismatch, 'patch')).true
+    })
+
+    it('should return true if mismatch level is set to patch and there is at least one patch version mismatch', () => {
+      expect(containsVersionMismatch(versionsWithAPatchMismatch, 'patch')).true
+    })
+
+    it('should return false if mismatch level is set to patch and there is no patch version mismatch', () => {
+      expect(containsVersionMismatch(versionsWithoutMismatch, 'patch')).false
+    })
+  })
 })


### PR DESCRIPTION
This PR adds similar plugins versions compatibility logic to `runLocalContainerGen` as the one used to work with Containers from a Cauldron.

This fixes the `create-container` command, in the case it was used to create a Container with MiniApps provided on the command line (i.e not create a Container from a Caudron descriptor). In that case, the `create-container` command was not running proper compatibility checks for plugins versions. It was too agressive, in the sense that if any plugin versions were mismatching, the command would throw an error. For example, if two MiniApps, MiniAppA and MiniAppB are both using react-native-my-api at two different versions (1.0.0 and 1.1.0 let's say), then the `create-container` would fail (while when adding MiniApps to Cauldron it would succeed and pick the most recent version of the API to be injected in the Container as long as versions don't major differ).

This PR fixes this issue and make sure that for APIs / APIs Implementations and Bridge, if multiple versions are being used across MiniApps, the `create-container` call with succeed and use the latest API / bridge version across MiniApps, as it is done for Cauldron based Containers. For third party native modules the same strict behavior remains (any version difference will fail).