### PR TITLE
create-api command passes wrong property name downstream for --schema

### DIFF
--- a/ern-local-cli/src/commands/create-api.js
+++ b/ern-local-cli/src/commands/create-api.js
@@ -107,7 +107,7 @@ exports.handler = async function ({
       reactNativeVersion: reactNative.version,
       name: apiName,
       npmScope: scope,
-      modelSchemaPath: schemaPath,
+      apiSchemaPath: schemaPath,
       apiVersion: apiVersion,
       apiAuthor: apiAuthor,
       packageName: packageName


### PR DESCRIPTION
Fixes #509 

map the property name to the one used to normalize config.