### PR TITLE
Default to maven local publication for publish-container maven publisher

### DIFF
--- a/docs/cli/publish-container.md
+++ b/docs/cli/publish-container.md
@@ -21,7 +21,7 @@
 
 * Specify the Container version to use for publication.
 * The version must be in the format: `x.y.z` where x, y and z are integers. For example `version=1.2.30`.
-* This option is required, there is no default.
+* Defaults to `1.0.0`.
 
 `--publisher/-p <publisher>`
 
@@ -32,13 +32,18 @@
 
 * The publication url to publish the Container to.
 * Can either be the url of a Git repository or a Maven repository (local or remote), depending on the publisher being used.
-* This option is required, there is no default.
+* This option is required for the `git` publisher. For `maven` publisher, it will default to the standard Maven local path (`~/.m2/repository`) if not specified.
 
 `--config/-c <config>`
 
 * Optional publisher configuration provided as JSON.
 * As of this version of Electrode Native, Maven publisher is the only one to expose some extra configuration. 
 * Sample : `--config '{"artifactId":"test-container","groupId":"com.walmartlabs.ern","mavenUser":"user","mavenPasword":"password"}'`
+* Configuration can be omitted or partially provided. The default configuration values used for the Maven publisher are :
+  - artifactId: `local-container`
+  - groupId: `com.walmartlabs.ern`
+  - mavenUser : `undefined`
+  - mavePassword: `undefined`
 
 #### Related commands
 

--- a/ern-container-gen/src/FlowTypes.js
+++ b/ern-container-gen/src/FlowTypes.js
@@ -56,9 +56,11 @@ export type ContainerPublisherConfig = {
 
 export type ContainerMavenPublisherConfig = {
   // Maven Artifact ID to use for publication
-  artifactId: string;
+  // Defaults to 'local-container'
+  artifactId?: string;
   // Maven Group ID to use for publication
-  groupId: string;
+  // Defaults to 'com.walmartlabs.ern'
+  groupId?: string;
   // Maven user name
   // If not specified, by convention, it will use mavenUser from gradle.properties
   mavenUser?: string;

--- a/ern-container-gen/src/publishers/MavenPublisher.js
+++ b/ern-container-gen/src/publishers/MavenPublisher.js
@@ -11,6 +11,7 @@ import {
 import fs from 'fs'
 import path from 'path'
 import tmp from 'tmp'
+import os from 'os'
 const {
   execp
 } = childProcess
@@ -22,7 +23,15 @@ export default class MavenPublisher implements ContainerPublisher {
 
   async publish (config: ContainerPublisherConfig): any {
     if (!config.extra) {
-      throw new Error('Missing extra config for Maven Publisher')
+      config.extra = {}
+    }
+
+    if (!config.extra.artifactId) {
+      config.extra.artifactId = 'local-container'
+    }
+
+    if (!config.extra.groupId) {
+      config.extra.groupId = 'com.walmartlabs.ern'
     }
 
     const artifactId = config.extra.artifactId
@@ -35,7 +44,7 @@ export default class MavenPublisher implements ContainerPublisher {
       MavenUtils.createLocalMavenDirectoryIfDoesNotExist()
     }
 
-    config.url = config.url.replace('file:~', `file:${process.env.HOME || ''}`)
+    config.url = config.url.replace('file:~', `file:${os.homedir() || ''}`)
 
     fs.appendFileSync(path.join(workingDir, 'lib', 'build.gradle'),
   `

--- a/ern-local-cli/src/commands/publish-container.js
+++ b/ern-local-cli/src/commands/publish-container.js
@@ -9,6 +9,8 @@ import {
 } from 'ern-container-gen'
 import utils from '../lib/utils'
 import fs from 'fs'
+import path from 'path'
+import os from 'os'
 
 exports.command = 'publish-container <containerPath>'
 exports.desc = 'Publish a local Container'
@@ -19,7 +21,7 @@ exports.builder = function (yargs: any) {
       type: 'string',
       alias: 'v',
       describe: 'Container version to use for publication',
-      demandOption: true
+      default: '1.0.0'
     })
     .option('publisher', {
       type: 'string',
@@ -31,8 +33,7 @@ exports.builder = function (yargs: any) {
     .option('url', {
       type: 'string',
       alias: 'u',
-      describe: 'The publication url',
-      demandOption: true
+      describe: 'The publication url'
     })
     .option('config', {
       type: 'string',
@@ -56,10 +57,16 @@ exports.handler = async function ({
   config?: string
 } = {}) {
   try {
-    console.log('here')
     await utils.logErrorAndExitIfNotSatisfied({
       isValidContainerVersion: { containerVersion: version }
     })
+
+    // url validation
+    if (!url && publisher === 'git') {
+      throw new Error('url is required when using a git publisher')
+    } else if (!url && publisher === 'maven') {
+      url = `file:${path.join(os.homedir() || '', '.m2', 'repository')}`
+    }
 
     // Container path validation
     if (!fs.existsSync(containerPath)) {


### PR DESCRIPTION
Simplify `publish-container` command for publication to maven local by providing good defaults.

- If `version` is not specified, it will default to `1.0.0`.
- If `url` is not specified, and `maven` publisher is used, the `url` will default to standard maven local path `~/.m2/repository`.
- If maven publisher `config` is not specified, or partially specified, the following default configuration values will be used :
  - artifactId: `local-container`
  - groupId: `com.walmartlabs.ern`

This way, the following verbose command :

`ern publish-container ~/my-android-container --publisher maven --version 1.0.0 --url file:~/.m2/repository --config '{"artifactId":"local-container","groupId":"com.walmartlabs.ern"}'`

Can be simplified as :

`ern publish-container ~/my-android-container --publisher maven`

Close https://github.com/electrode-io/electrode-native/issues/562

