### PR TITLE
Fix extra dependencies handling for local container generation

### DIFF
--- a/ern-local-cli/src/lib/publication.js
+++ b/ern-local-cli/src/lib/publication.js
@@ -147,7 +147,8 @@ platform: 'android' | 'ios', {
       outDir,
       plugins: [
         ...apiAndApiImplsResolvedVersions.resolved,
-        ...nativeModulesResolvedVersions.resolved ],
+        ...nativeModulesResolvedVersions.resolved,
+        ...extraNativeDependencies ],
       pluginsDownloadDir: tmp.dirSync({ unsafeCleanup: true }).name,
       compositeMiniAppDir: tmp.dirSync({ unsafeCleanup: true }).name,
       ignoreRnpmAssets


### PR DESCRIPTION
`extraNativeDependencies` provided to `runLocalContainerGen` function were not used at all. 
This was leading to extra dependencies provided to `create-container` command through the `--dependencies` option, not being added to the generated Container.

This PR fixes that.
