### PR TITLE
Windows fixes

### DIFF
--- a/ern-core/src/android.js
+++ b/ern-core/src/android.js
@@ -9,6 +9,7 @@ import {
   execp,
   spawnp
 } from './childProcess'
+import os from 'os'
 
 // ==============================================================================
 // Misc utilities
@@ -253,7 +254,7 @@ export function launchAndroidActivityDetached (
 // Utility method to list all available android avd images (emulator images)
 export async function getAndroidAvds () {
   const stdout = await execp(`${androidEmulatorPath()} -list-avds`)
-  return stdout.toString().trim().split('\n')
+  return stdout.toString().trim().split(os.EOL)
 }
 
 // Utility method to query what device instances are connected to the adb server
@@ -265,7 +266,7 @@ export async function getDevices (): Promise<Array<string>> {
     * daemon not running. starting it now at tcp:5037 *
     * daemon started successfully *
   */
-  let stdOutArr = stdout.toString().trim().split('\n')
+  let stdOutArr = stdout.toString().trim().split(os.EOL)
   // remove stdout 'List of devices attached' (position 0)
   // and remove stdout related to daemon
   return stdOutArr.filter((entry, i) => i > 0 && !entry.includes('* daemon'))

--- a/ern-core/test/CauldronHelper-test.js
+++ b/ern-core/test/CauldronHelper-test.js
@@ -22,7 +22,6 @@ import {
 import jp from 'jsonpath'
 import path from 'path'
 import mockFs from 'mock-fs'
-import { nativeApplication } from '../../ern-cauldron-api/dist/schemas';
 
 const codePushEntryFixtureOne =  {
   metadata: {

--- a/ern-core/test/fixtures/common.js
+++ b/ern-core/test/fixtures/common.js
@@ -1,3 +1,4 @@
+import os from 'os'
 export const pkgNameNotInNpm = 'zxc-pkg-not-in-npm-bnm'
 export const pkgName = 'chai'
 export const pkgNameWithVersion = 'chai@4.1.2'
@@ -10,7 +11,7 @@ export const oneAvdList = ['Nexus6API23M']
 export const oneAvd = 'Nexus6API23M'
 export const activityName = 'ChaiActivity'
 export const projectPath = 'projectPath'
-export const getDeviceResult = 'emulator-5554\tdevice\n8XV7N16516003608\tdevice'
+export const getDeviceResult = `emulator-5554\tdevice${os.EOL}8XV7N16516003608\tdevice`
 export const oneUdid = 'A1213FE6-BDA8-424B-972C-4EA0480C3497'
 
 export const validElectrodeNativeModuleNames = [


### PR DESCRIPTION
Working on making sure that all unit and system tests are passing on Windows to be able to run them consistently before each release.

`ern-core` tests were failing due to an invalid import statement in one of the tests (which for some reason was not causing any issue on Mac/Linux).

Also, 2 android related tests were failing due to the line terminator being encoded differently on Windows (`\r\n` v.s `\n`).

This PR fixes both issues, `ern-core` tests are now passing on Windows.

