### PR TITLE
Docs: "upgrade" to "upgrade-miniapp"

### DIFF
--- a/docs/platform-parts/manifest.md
+++ b/docs/platform-parts/manifest.md
@@ -37,7 +37,7 @@ The Electrode Native manifest repository contains:
 
 Open source MiniApp developers should always use the master manifest. This is the default operating mode of the platform.
 
-To align your native dependencies to a new Electrode Native version, use the `ern upgrade` command. When you align the native dependencies to a new Electrode Native version, your MiniApp will be able to be added to any mobile application using any Electrode Native version.
+To align your native dependencies to a new Electrode Native version, use the `ern upgrade-miniapp` command. When you align the native dependencies to a new Electrode Native version, your MiniApp will be able to be added to any mobile application using any Electrode Native version.
 
 You might also consider using the same version of React Native for your mobile application, for a while, before upgrading to a new version of React Native. Indeed, upgrading (the version of react-native or associated native modules) too frequently might harm your release process because you cannot use CodePush to release updates to versions of your mobile application that have already been released with a different version of React Native.
 


### PR DESCRIPTION
This is 3rd similar typo PR I've written. If I were working at Walmart, I would now write a script to grep all docs and replace $1 with $2, where $1 is upgrade and $2 is upgrade-miniapp. However I don't, so I won't. Most likely I'll start ignoring this case.

Stack Overflow: "Easiest way to recursively find and replace?" https://stackoverflow.com/a/2553702/113079

Beware recursion, since "upgrade" would be found inside "upgrade-miniapp". Maybe search for "upgrade\""