### PR TITLE
[container-gen] Custom Android permissions configuration for native components

### DIFF
--- a/ern-container-gen/src/generators/android/hull/lib/src/main/AndroidManifest.xml
+++ b/ern-container-gen/src/generators/android/hull/lib/src/main/AndroidManifest.xml
@@ -2,6 +2,11 @@
     package="com.walmartlabs.ern.container">
    <uses-permission android:name="android.permission.INTERNET" />
    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+   {{#plugins}}
+   {{#customPermissions}}
+   <uses-permission android:name="{{{.}}}" />
+   {{/customPermissions}}
+   {{/plugins}}
     <application>
       {{#miniApps}}		
        <activity android:name="com.walmartlabs.ern.container.miniapps.{{{pascalCaseName}}}Activity"		

--- a/ern-container-gen/src/generators/android/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeMiniAppActivity.java
+++ b/ern-container-gen/src/generators/android/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeMiniAppActivity.java
@@ -15,10 +15,10 @@ package com.walmartlabs.ern.container;
 
 import android.app.Activity;
 import android.content.Intent;
-import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v4.app.ActivityCompat;
+import android.support.annotation.RequiresApi;
 import android.view.KeyEvent;
 import android.view.MenuItem;
 import android.view.View;
@@ -30,7 +30,6 @@ public class ElectrodeMiniAppActivity extends Activity implements ElectrodeReact
 
     private static final String INITIAL_PROPS = "props";
     private ElectrodeReactActivityDelegate mReactActivityDelegate;
-    private PermissionListener mPermissionListener;
 
     /**
      * Method that helps to pass bundle to react native side.
@@ -118,24 +117,15 @@ public class ElectrodeMiniAppActivity extends Activity implements ElectrodeReact
         finish();
     }
 
-    @Override
-    public int checkPermission(String permission, int pid, int uid) {
-        return PackageManager.PERMISSION_GRANTED;
-    }
-
-    @Override
-    public  int checkSelfPermission(String permission) {
-        return PackageManager.PERMISSION_GRANTED;
-    }
-
+    @RequiresApi(api = Build.VERSION_CODES.M)
     @Override
     public void requestPermissions(String[] permissions, int requestCode, PermissionListener listener) {
-        mPermissionListener = listener;
-        ActivityCompat.requestPermissions(this, permissions, requestCode);
+        mReactActivityDelegate.requestPermissions(permissions, requestCode, listener);
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.M)
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        mPermissionListener.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        mReactActivityDelegate.onRequestPermissionsResult(requestCode, permissions, grantResults);
     }
 }

--- a/ern-container-gen/src/generators/android/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeMiniAppActivity.java
+++ b/ern-container-gen/src/generators/android/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeMiniAppActivity.java
@@ -15,16 +15,22 @@ package com.walmartlabs.ern.container;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v4.app.ActivityCompat;
 import android.view.KeyEvent;
 import android.view.MenuItem;
 import android.view.View;
 
-public class ElectrodeMiniAppActivity extends Activity implements ElectrodeReactActivityDelegate.BackKeyHandler {
+import com.facebook.react.modules.core.PermissionAwareActivity;
+import com.facebook.react.modules.core.PermissionListener;
+
+public class ElectrodeMiniAppActivity extends Activity implements ElectrodeReactActivityDelegate.BackKeyHandler, PermissionAwareActivity {
 
     private static final String INITIAL_PROPS = "props";
     private ElectrodeReactActivityDelegate mReactActivityDelegate;
+    private PermissionListener mPermissionListener;
 
     /**
      * Method that helps to pass bundle to react native side.
@@ -110,5 +116,26 @@ public class ElectrodeMiniAppActivity extends Activity implements ElectrodeReact
     @Override
     public void onBackKey() {
         finish();
+    }
+
+    @Override
+    public int checkPermission(String permission, int pid, int uid) {
+        return PackageManager.PERMISSION_GRANTED;
+    }
+
+    @Override
+    public  int checkSelfPermission(String permission) {
+        return PackageManager.PERMISSION_GRANTED;
+    }
+
+    @Override
+    public void requestPermissions(String[] permissions, int requestCode, PermissionListener listener) {
+        mPermissionListener = listener;
+        ActivityCompat.requestPermissions(this, permissions, requestCode);
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        mPermissionListener.onRequestPermissionsResult(requestCode, permissions, grantResults);
     }
 }

--- a/ern-container-gen/src/utils.js
+++ b/ern-container-gen/src/utils.js
@@ -375,6 +375,11 @@ export async function generatePluginsMustacheViews (
       pluginView.customRepos.push(...pluginConfig.android.repositories)
     }
 
+    pluginView.customPermissions = []
+    if (pluginConfig.android && pluginConfig.android.permissions) {
+      pluginView.customPermissions.push(...pluginConfig.android.permissions)
+    }
+
     if (containerHeader) {
       pluginView.containerHeader = containerHeader
     }


### PR DESCRIPTION
Some third-party native components should have custom Android permissions (eg. `android.permission.CAMERA`) on the container's AndroidManifest.xml, so it should be configurable.

Also, it's good practice to implement react-native's `PermissionAwareActivity` so on newer versions of Android, the user will be prompted to accept it on runtime.