### PR TITLE
Add cauldron default directory to Platform class

### DIFF
--- a/ern-core/src/Platform.js
+++ b/ern-core/src/Platform.js
@@ -19,6 +19,10 @@ export default class Platform {
     return path.join(HOME_DIRECTORY, '.ern')
   }
 
+  static get cauldronDirectory () : string {
+    return path.join(this.rootDirectory, 'cauldron')
+  }
+
   static get masterManifestDirectory () : string {
     return path.join(this.rootDirectory, 'ern-master-manifest')
   }

--- a/ern-local-cli/src/commands/cauldron/repo/add.js
+++ b/ern-local-cli/src/commands/cauldron/repo/add.js
@@ -59,6 +59,6 @@ exports.handler = function ({
 
 function useCauldronRepository (alias: string) {
   ernConfig.setValue('cauldronRepoInUse', alias)
-  shell.rm('-rf', `${Platform.rootDirectory}/cauldron`)
+  shell.rm('-rf', Platform.cauldronDirectory)
   log.info(`${alias} Cauldron is now activated`)
 }

--- a/ern-local-cli/src/commands/cauldron/repo/clear.js
+++ b/ern-local-cli/src/commands/cauldron/repo/clear.js
@@ -22,7 +22,7 @@ exports.handler = function ({
 }) {
   try {
     ernConfig.setValue('cauldronRepoInUse', undefined)
-    shell.rm('-rf', `${Platform.rootDirectory}/cauldron`)
+    shell.rm('-rf', Platform.cauldronDirectory)
     log.info(`Done.`)
   } catch (e) {
     coreUtils.logErrorAndExitProcess(e)

--- a/ern-local-cli/src/commands/cauldron/repo/use.js
+++ b/ern-local-cli/src/commands/cauldron/repo/use.js
@@ -29,7 +29,7 @@ exports.handler = function ({
       throw new Error(`No Cauldron repository exists with ${alias} alias`)
     }
     ernConfig.setValue('cauldronRepoInUse', alias)
-    shell.rm('-rf', `${Platform.rootDirectory}/cauldron`)
+    shell.rm('-rf', Platform.cauldronDirectory)
     log.info(`${alias} Cauldron is now in use`)
   } catch (e) {
     coreUtils.logErrorAndExitProcess(e)


### PR DESCRIPTION
- Remove improper hardcoding of path as a string (instead of using `path` module)
- Centralize default cauldron directory path in `Platform` class along with other platform related paths