### PR TITLE
Add a way to bypass copy from option of cauldron add nativeapp

### DIFF
--- a/docs/cli/cauldron/add/nativeapp.md
+++ b/docs/cli/cauldron/add/nativeapp.md
@@ -27,7 +27,10 @@
 `--copyFromVersion/-c <version>`
 
 * Copy the data of a native application version stored in the Cauldron.  
-* You can use a specific version, for example `1.2.3`, or you can use `latest` if you want to copy the data from the latest version of the native application.  
+* Possible values for this option are :
+  - A specific version, for example `1.2.3`
+  - `latest` if you want to copy the data from the latest version of the native application
+  - `none` if you don't want any copy from action  
 * The `--copyFromVersion/-c <version>` option also copies the list of native dependencies and MiniApps as well as the container version to the new native application version.  
 * If you use the `--copyFromVersion/-c <version>` option, you do not need to add all MiniApps again after creating a new native application version in the Cauldron.  
 * This option is commonly used.  

--- a/ern-local-cli/src/commands/cauldron/add/nativeapp.js
+++ b/ern-local-cli/src/commands/cauldron/add/nativeapp.js
@@ -69,6 +69,8 @@ exports.handler = async function ({
       if (copyFromVersion) {
         if (copyFromVersion === 'latest') {
           await spin(`Copying data over from latest version ${latestVersionName}`, copyOverPreviousVersionData(napDescriptor, latestVersion, cauldron))
+        } else if (copyFromVersion === 'none') {
+          log.info(`Skipping copy over from previous version as 'none' was specified`)
         } else {
           const version = _.find(previousApps.versions, v => v.name === copyFromVersion)
           if (!version) {


### PR DESCRIPTION
Add new value `none` for `copyFromVersion` of `cauldron add nativeapp`

This can effectively be used to disable interactive mode triggered by the `cauldron add nativeapp` command in case no previous native app version copy is desired (otherwise, the only way to discard copy from was through the interactive prompt, which makes things much more difficult for a CI job)