### PR TITLE
Docs: platform api doc to link to commands

### DIFF
--- a/docs/platform-parts/apis.md
+++ b/docs/platform-parts/apis.md
@@ -66,11 +66,15 @@ Generated standalone API implementations have the following naming convention: `
 
 ### Related commands
 
-- `ern create-api`  
+- [ern create-api]  
 Creates (generates) a new API project based on a Swagger schema
 
-- `ern regen-api`  
+- [ern regen-api]  
 Regenerates an existing API project following Swagger schema updates
 
-- `ern create-api-impl`  
+- [ern create-api-impl]  
 Creates (generates) a new API implementation project (native or JS)
+
+[ern create-api]: ../cli/create-api.md
+[ern regen-api]: ../cli/regen-api.md
+[ern create-api-impl]: ../cli/create-api-impl.md


### PR DESCRIPTION
SUGGESTION:

I like links in documentation, but e.g. this doc is missing them. Maybe you left them out on purpose, because you believe it's better to guide users through "learn the platform basics first" pipeline, before they might get lost into command details and be even more confused.

Anyway, I like links. No problem, if you feel this PR does not improve anything and close it.