### PR TITLE
Add example to GLOSSARY for ElectrodeNative module name. 

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,20 +1,21 @@
 ## complete native application descriptor
 
-A complete native application descriptor is a string with format `[nativeAppName]:[platform]:[version]` 
+A complete native application descriptor is a string with format `[nativeAppName]:[platform]:[version]`
 - `nativeAppName` : alphanumeric native application name , cannot contain character ':'
 - `platform` : one of `android` or `ios`
 - `version` : alphanumeric , cannot contain character ':'
 
 ## partial native application descriptor
 
-A partial native application descriptor is a string with format `[nativeAppName]`, `platform` and `version` can remain optional. 
+A partial native application descriptor is a string with format `[nativeAppName]`, `platform` and `version` can remain optional.
 - `nativeAppName` : alphanumeric native application name , cannot contain character ':'
 
 ## Electrode Native module name
 
 The Electrode Native module name applies to modules created with Electrode Native cli.
-- Electrode Native recommends module name must only contain upper and/or lower case letters. 
+- Electrode Native recommends module name must only contain upper and/or lower case letters.
 - `create-miniapp`, `create-api` and `create-api-impl` commands allow passing Electrode Native module name as it's arguments.
+   For example, `ern create-miniapp Mymovie`, `ern create-api ReactNativeMymovie` will create `MymovieMiniApp` and `react-native-mymovie-api` respectively.
 
 ## package path
 

--- a/ern-local-cli/src/lib/Ensure.js
+++ b/ern-local-cli/src/lib/Ensure.js
@@ -15,7 +15,7 @@ export default class Ensure {
     name: string,
     extraErrorMessage: string = '') {
     if (!coreUtils.isValidElectrodeNativeModuleName(name)) {
-      const errorMessage = `${name} is not a valid Electrode Native module name\n${extraErrorMessage}`
+      const errorMessage = `${name} is not a valid Electrode Native module name\nCheck GLOSSARY section of doc for "Electrode Native module name" naming rules\n${extraErrorMessage}`
       throw new Error(errorMessage)
     }
   }


### PR DESCRIPTION
Add an explicit sentence to indicate "ElectrodeNative module name" is a GLOSSARY. The original message doesn't show it's a defined glossary in electrode doc. Thus, it takes user's time to figure out why it's a not valid module name. 