### PR TITLE
Fix cauldron add publisher command

### DIFF
--- a/ern-core/src/CauldronHelper.js
+++ b/ern-core/src/CauldronHelper.js
@@ -113,15 +113,14 @@ export default class CauldronHelper {
     await this.cauldron.addPublisher(new NativeApplicationDescriptor(nativeAppName, platform), publisherType, url)
   }
 
-  async getNativeAppsForPlatform (platform: string): Promise<Array<string>> {
+  async getNativeAppsForPlatform (platformName: string): Promise<Array<string>> {
     const availableNativeApps = await this.getAllNativeApps()
     const nativeAppsForGivenPlatform = []
     if (availableNativeApps) {
       for (const nativeApp of availableNativeApps) {
         for (const platform of nativeApp.platforms) {
-          if (platform.name === platform) {
+          if (platform.name === platformName) {
             nativeAppsForGivenPlatform.push(nativeApp.name)
-            break
           }
         }
       }


### PR DESCRIPTION
- Fix the command in case no descriptor is explicitly provided as a command option. In that case, the command was failing after selecting the platform with error `An error occurred: Looks like there are no application defined in cauldron for ios`. This was due to naming the argument of `getNativeAppsForPlatform` function as `platform` which was also the name of a local variable used in the function, leading to the issue.

- Remove the break statement so that it does not add the publisher to the first native app returned but in case of multiple native apps present in Cauldron, it will properly ask the user to choose to which native app the publisher should be added to.