### PR TITLE
Fix cauldron add nativeapp

### DIFF
--- a/ern-local-cli/src/commands/cauldron/add/nativeapp.js
+++ b/ern-local-cli/src/commands/cauldron/add/nativeapp.js
@@ -61,8 +61,7 @@ exports.handler = async function ({
     }
 
     await spin(`Adding ${descriptor}`, cauldron.addDescriptor(napDescriptor))
-
-    if (previousApps) {
+    if (previousApps && previousApps.versions.length > 0) {
       const latestVersion = _.last(previousApps.versions)
       const latestVersionName = latestVersion.name
 


### PR DESCRIPTION
`cauldron add nativeapp` command was failing with error `An error occurred: Cannot read property 'name' of undefined` when the application name/platform was present in the cauldron but no versions were present. 

Could be reproduced through :

- `ern cauldron add nativeapp newapp:android:1.0.0`
- `ern cauldron del nativeapp newapp:android:1.0.0`
- `ern cauldron add nativeapp newapp:android:1.0.0`

Last command would fail with this error.

This PR fixes this fringe scenario.

Thanks @gmbharath12 for reporting this one.