### PR TITLE
Code push promote label

### DIFF
--- a/docs/cli/code-push/promote.md
+++ b/docs/cli/code-push/promote.md
@@ -59,6 +59,11 @@ If no `targetDescriptors` nor a `targetSemVerDescriptor` is specified, the comma
 * Bypass all compatibility checks and force OTA update through CodePush. **USE AT YOUR OWN RISK**
 * **Default** false
 
+`--label/-l`
+
+* Promote the release matching this specific label. 
+* **Default** The latest release matching sourceDescriptor/sourceDeploymentName pair will be promoted.
+
 #### Related commands
 
 [code-push release] | Issue a CodePush release 

--- a/ern-cauldron-api/src/FlowTypes.js
+++ b/ern-cauldron-api/src/FlowTypes.js
@@ -9,7 +9,8 @@ export type CauldronCodePushMetadata = {
   releaseMethod?: string,
   label?: string,
   releasedBy?: string,
-  rollout?: number
+  rollout?: number,
+  promotedFromLabel?: string
 }
 
 export type CauldronCodePushEntry = {

--- a/ern-core/test/CauldronHelper-test.js
+++ b/ern-core/test/CauldronHelper-test.js
@@ -1349,6 +1349,58 @@ describe('CauldronHelper.js', () => {
     })
   })
 
+  describe('getCodePushEntry', () => {
+    it('should throw if the given native application descriptor is partial', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      assert(await doesThrow(
+        cauldronHelper.getCodePushEntry, 
+        cauldronHelper,
+        NativeApplicationDescriptor.fromString('test:android'),
+        'Production'))
+    })
+
+    it('should throw if the given native application descriptor is not in Cauldron', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      assert(await doesThrow(
+        cauldronHelper.getCodePushEntry, 
+        cauldronHelper,
+        NativeApplicationDescriptor.fromString('test:android:0.0.0'),
+        'Production'))
+    })
+
+    it('should throw if the label does not exist', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      assert(await doesThrow(
+        cauldronHelper.getCodePushEntry, 
+        cauldronHelper,
+        NativeApplicationDescriptor.fromString('test:android:17.7.0'),
+        'Production', { label: 'v0' }))
+    })
+
+    it('should return the latest CodePushed entry if label is ommited', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      const result = await cauldronHelper.getCodePushEntry(
+        NativeApplicationDescriptor.fromString('test:android:17.7.0'),
+        'Production')
+      expect(result).not.undefined
+      expect(result.metadata.label).eql('v17')
+    })
+
+    it('should return the CodePushed entry matching label', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      const result = await cauldronHelper.getCodePushEntry(
+        NativeApplicationDescriptor.fromString('test:android:17.7.0'),
+        'Production', { label: 'v16' })
+        expect(result).not.undefined
+        expect(result.metadata.label).eql('v16')
+    })
+  })
+
   describe('getCodePushMiniApps', () => {
     it('should throw if the given native application descriptor is partial', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
@@ -1380,13 +1432,32 @@ describe('CauldronHelper.js', () => {
         'Foo'))
     })
 
-    it('should return the CodePushed MiniApps', async () => {
+    it('should return the latest CodePushed MiniApps if label is ommited', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       const result = await cauldronHelper.getCodePushMiniApps(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         'Production')
       expect(result).to.be.an('array').of.length(2)
+    })
+
+    it('should return the CodePushed MiniApps matching label', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      const result = await cauldronHelper.getCodePushMiniApps(
+        NativeApplicationDescriptor.fromString('test:android:17.7.0'),
+        'Production', { label: 'v16' })
+      expect(result).to.be.an('array').of.length(3)
+    })
+
+    it('should throw if the label does not exist', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      assert(await doesThrow(
+        cauldronHelper.getCodePushMiniApps, 
+        cauldronHelper,
+        NativeApplicationDescriptor.fromString('test:android:17.7.0'),
+        'Production', { label: 'v0' }))
     })
   })
 

--- a/ern-local-cli/src/commands/code-push/promote.js
+++ b/ern-local-cli/src/commands/code-push/promote.js
@@ -58,6 +58,11 @@ exports.builder = function (yargs: any) {
       alias: 's',
       type: 'bool'
     })
+    .option('label', {
+      alias: 'l',
+      type: 'string',
+      describe: 'Promote the release matching this label. If omitted, the latest release of sourceDescriptor/sourceDeploymentName pair will be promoted.'
+    })
     .epilog(utils.epilog(exports))
 }
 
@@ -71,7 +76,8 @@ exports.handler = async function ({
   mandatory,
   rollout,
   skipConfirmation,
-  force
+  force,
+  label
 } : {
   sourceDescriptor?: string,
   targetDescriptors?: Array<string>,
@@ -82,7 +88,8 @@ exports.handler = async function ({
   mandatory?: boolean,
   rollout?: number,
   skipConfirmation?: boolean,
-  force?: boolean
+  force?: boolean,
+  label?: string
 }) {
   try {
     let targetNapDescriptors
@@ -170,7 +177,8 @@ exports.handler = async function ({
       targetDeploymentName, {
         force,
         mandatory,
-        rollout
+        rollout,
+        label
       })
   } catch (e) {
     coreUtils.logErrorAndExitProcess(e)

--- a/ern-util-dev/fixtures/default-cauldron-fixture.json
+++ b/ern-util-dev/fixtures/default-cauldron-fixture.json
@@ -90,7 +90,8 @@
                   },
                   "miniapps": [
                     "@test/react-native-foo@4.0.2",
-                    "react-native-bar@2.0.1"
+                    "react-native-bar@2.0.1",
+                    "react-native-abc@1.0.0"
                   ],
                   "jsApiImpls": []
                 },
@@ -122,7 +123,7 @@
                     "appVersion": "17.7",
                     "size": 522938,
                     "releaseMethod": "Upload",
-                    "label": "v17",
+                    "label": "v18",
                     "releasedBy": "test@gmail.com",
                     "rollout": "100"
                   },


### PR DESCRIPTION
- Add `--label/-l` option to `code-push promote` command to allow promotion of a release matching a specific label (if option is omitted, will fall back to current behavior of promoting latest release for the given source descriptor / deployment).

- Add `promotedFromLabel` field to the `metadata`object stored in the Cauldron for each promoted release. This is helpful to know which source label is associated to a given promotion entry.

Closes https://github.com/electrode-io/electrode-native/issues/638