### PR TITLE
Offer dynamic modification of manifest url based on local config

### DIFF
--- a/ern-core/src/Manifest.js
+++ b/ern-core/src/Manifest.js
@@ -13,6 +13,7 @@ import {
   isDependencyApiImpl,
   getCauldronInstance
 } from './utils'
+import config from './config'
 
 export type PluginConfig = {
   android: Object,
@@ -40,10 +41,25 @@ export class Manifest {
     if (!this._overrideManifest && cauldronInstance) {
       const manifestConfig = await cauldronInstance.getManifestConfig()
       if (manifestConfig && manifestConfig.override && manifestConfig.override.url) {
-        this._overrideManifest = new GitManifest(Platform.overrideManifestDirectory, manifestConfig.override.url)
+        const manifestOverrideUrl = this.modifyOverrideManifestUrlIfNeeded(manifestConfig.override.url)
+        this._overrideManifest = new GitManifest(Platform.overrideManifestDirectory, manifestOverrideUrl)
         this._manifestOverrideType = manifestConfig.override.type || 'partial'
       }
     }
+  }
+
+  modifyOverrideManifestUrlIfNeeded (url: string) {
+    // Sample local config :
+    // "overrideManifestUrlModifier": {
+    //   "searchValue": "github.com",
+    //   "replaceValue": "new.github.com"
+    // }
+    const overrideManifestUrlModifier = config.getValue('overrideManifestUrlModifier')
+    if (overrideManifestUrlModifier) {
+      const obj = JSON.parse(overrideManifestUrlModifier)
+      url = url.replace(obj.searchValue, obj.replaceValue)
+    }
+    return url
   }
 
   async getManifestData (platformVersion: string) {


### PR DESCRIPTION
Very Walmart specific right now, but might be useful for users facing similar fringe scenario. Not documenting this one though for now.

This is too solve an issue with our CI systems that require a token part of the git URL to be accessed. However we don't want this token to be part of the URL visible in the Cauldron, for anyone having access to the Cauldron to see. This token is encrypted and stored on the CI machine, and obfuscated during logging on CI, it should therefore be injected in the URL dynamically.

The only way to do this is through a new local configuration object (`overrideManifestUrlModifier`) that contains two properties  `searchValue` and `replaceValue` that will be fed to `String.prototype.replace` to modify the accordingly override manifest url on the fly before using it.

If this config object is not set in the local platform config of a client, the override manifest defined in the cauldron will be used as such without being altered in any way.