### PR TITLE
add jcenter publisher support.

### DIFF
--- a/ern-container-gen/src/index.js
+++ b/ern-container-gen/src/index.js
@@ -5,19 +5,22 @@ import _IosGenerator from './generators/ios/IosGenerator'
 import _AndroidGenerator from './generators/android/AndroidGenerator'
 import _GitHubPublisher from './publishers/GithubPublisher'
 import _MavenPublisher from './publishers/MavenPublisher'
+import _JcenterPublisher from './publishers/JcenterPublisher'
 
 export const AndroidGenerator = _AndroidGenerator
 export const IosGenerator = _IosGenerator
 export const generateMiniAppsComposite = _generateMiniAppsComposite
 export const MavenPublisher = _MavenPublisher
 export const GitHubPublisher = _GitHubPublisher
+export const JcenterPublisher = _JcenterPublisher
 
 export default ({
   AndroidGenerator: _AndroidGenerator,
   IosGenerator: _IosGenerator,
   generateMiniAppsComposite: _generateMiniAppsComposite,
   MavenPublisher: _MavenPublisher,
-  GitHubPublisher: _GitHubPublisher
+  GitHubPublisher: _GitHubPublisher,
+  JcenterPublisher: _JcenterPublisher
 })
 
 export type {

--- a/ern-container-gen/src/publishers/JcenterPublisher.js
+++ b/ern-container-gen/src/publishers/JcenterPublisher.js
@@ -1,0 +1,84 @@
+// @flow
+import type {
+  ContainerPublisher,
+  ContainerPublisherConfig
+} from '../FlowTypes'
+import {
+  shell,
+  mustacheUtils,
+  childProcess
+} from 'ern-core'
+import fs from 'fs'
+import path from 'path'
+import tmp from 'tmp'
+const {
+  execp
+} = childProcess
+
+export default class JcenterPublisher implements ContainerPublisher {
+  get name (): string {
+    return 'jcenter'
+  }
+  async publish (config: ContainerPublisherConfig): any {
+    if (!config.extra) {
+      throw new Error('Missing params(artifactId, groupId)')
+    }
+
+    if (!config.extra.artifactId) {
+      throw new Error('artifactId')
+    }
+
+    if (!config.extra.groupId) {
+      throw new Error('groupId')
+    }
+
+    const mustacheConfig = {}
+
+    mustacheConfig.artifactId = config.extra.artifactId
+    mustacheConfig.groupId = config.extra.groupId
+    mustacheConfig.containerVersion = config.containerVersion
+
+    const workingDir = tmp.dirSync({
+      unsafeCleanup: true
+    }).name
+    shell.cp('-Rf', path.join(config.containerPath, '{.*,*}'), workingDir)
+
+    fs.appendFileSync(path.join(workingDir, 'lib', 'build.gradle'),
+      `
+    task androidSourcesJar(type: Jar) {
+      classifier = 'sources'
+      from android.sourceSets.main.java.srcDirs
+      include '**/*.java'
+    }
+    
+    artifacts {
+        archives androidSourcesJar
+    }
+    apply from: 'jcenter-publish.gradle'
+    `)
+
+    fs.appendFileSync(path.join(workingDir, 'build.gradle'),
+      `buildscript {
+      dependencies {
+          classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
+      }
+    }`)
+
+    shell.cp(path.join(__dirname, 'supplements', 'jcenter-publish.gradle'), path.join(workingDir, 'lib'))
+    mustacheUtils.mustacheRenderToOutputFileUsingTemplateFile(path.join(workingDir, 'lib', 'jcenter-publish.gradle'), mustacheConfig, path.join(workingDir, 'lib', 'jcenter-publish.gradle'))
+
+    try {
+      log.debug('[=== Starting build and jcenter publication ===]')
+      shell.pushd(workingDir)
+      await this.buildAndUploadArchive()
+      log.debug('[=== Completed build and publication of the module ===]')
+    } finally {
+      shell.popd()
+    }
+  }
+  async buildAndUploadArchive (): Promise < * > {
+    const gradlew = /^win/.test(process.platform) ? 'gradlew' : './gradlew'
+    await execp(`${gradlew} build`)
+    return execp(`${gradlew} bintrayUpload`)
+  }
+}

--- a/ern-container-gen/src/publishers/supplements/jcenter-publish.gradle
+++ b/ern-container-gen/src/publishers/supplements/jcenter-publish.gradle
@@ -1,0 +1,61 @@
+apply plugin: 'maven-publish'
+apply plugin: 'com.jfrog.bintray'
+
+version '{{{containerVersion}}}'
+def aId = '{{{artifactId}}}'
+def gId  = '{{{groupId}}}'
+
+artifacts {
+    archives androidSourcesJar
+}
+
+publishing {
+    publications {
+        Production(MavenPublication) {
+            artifact androidSourcesJar
+            artifact("$buildDir/outputs/aar/lib-release.aar")
+            groupId gId
+            artifactId aId
+            version this.version
+
+            pom.withXml {
+                def dependenciesNode = asNode().appendNode('dependencies')
+
+                // Iterate over the implementation dependencies (we don't want the test ones), adding a <dependency> node for each
+                configurations.implementation.allDependencies.each {
+                    // Ensure dependencies such as fileTree are not included.
+                    if (it.name != 'unspecified') {
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        dependencyNode.appendNode('groupId', it.group)
+                        dependencyNode.appendNode('artifactId', it.name)
+                        dependencyNode.appendNode('version', it.version)
+                    }
+                }
+            }
+        }
+    }
+}
+
+bintray {
+    user = bintrayUser
+    key = bintrayApiKey
+    publications = ['Production']
+    configurations = ['archives']
+    override = false
+    pkg {
+        repo = bintrayRepo
+        name = aId
+        description = "Container that holds the MiniApps, APIs and other native dependencies."
+        publish = true
+        licenses = ['Apache-2.0']
+        vcsUrl = bintrayVcsUrl
+        dryRun = false
+        publicDownloadNumbers = true
+        version {
+            name = this.version
+            desc = "${aId} ${this.version}"
+            released  = new Date()
+            vcsTag = this.version
+        }
+    }
+}

--- a/ern-local-cli/src/lib/utils.js
+++ b/ern-local-cli/src/lib/utils.js
@@ -21,7 +21,8 @@ import {
 } from 'ern-runner-gen'
 import {
   MavenPublisher,
-  GitHubPublisher
+  GitHubPublisher,
+  JcenterPublisher
 } from 'ern-container-gen'
 import {
   runLocalContainerGen,
@@ -457,6 +458,17 @@ async function performContainerStateUpdateInCauldron (
                 groupId: 'com.walmartlabs.ern',
                 mavenUser: publisherFromCauldron.mavenUser,
                 mavenPassword: publisherFromCauldron.mavenPassword
+              }
+            })
+            break
+          case 'jcenter':
+            await new JcenterPublisher().publish({
+              containerPath: outDir,
+              containerVersion: cauldronContainerVersion,
+              url: '',
+              extra: {
+                artifactId: `${napDescriptor.name}-ern-container`,
+                groupId: 'com.walmartlabs.ern'
               }
             })
             break


### PR DESCRIPTION
close #490

Support for Jcenter publisher in the cauldron. You can add the following entry inside your cauldron publisher config to enable this feature. 

```
 "config": {
    "containerGenerator": {
      "containerVersion": "1.0.62",
      "publishers": [ 
        {
          "name": "jcenter"
        }
      ]
    }
  }
```

Once added, make sure to include the following details in your gradle.properties file to have the aar files published to your bintray repository. 

```
bintrayUser=<your-bintray-username>
bintrayApiKey=<your-bintray-apikey>
bintrayRepo=<your-bintray-repo-name>
bintrayVcsUrl=<your-project-repo-url>
```
