### PR TITLE
Add a list of all NS*UsageDescription to ErnRunner

### DIFF
--- a/ern-runner-gen/runner-hull/ios/ErnRunner/Info.plist
+++ b/ern-runner-gen/runner-hull/ios/ErnRunner/Info.plist
@@ -48,5 +48,39 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NFCReaderUsageDescription</key>
+	<string>ErnRunner is requesting NFC Reader access.</string>
+	<key>NSAppleMusicUsageDescription</key>
+	<string>ErnRunner is requesting media library access.</string>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>ErnRunner is requesting bluetooth access.</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>ErnRunner is requesting calendar access.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>ErnRunner is requesting camera access.</string>
+	<key>NSContactsUsageDescription</key>
+	<string>ErnRunner is requesting contacts access.</string>
+	<key>NSFaceIDUsageDescription</key>
+	<string>ErnRunner is requesting FaceID access.</string>
+	<key>NSHealthShareUsageDescription</key>
+	<string>ErnRunner is requesting health data access.</string>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>ErnRunner is requesting health data write access.</string>
+	<key>NSHomeKitUsageDescription</key>
+	<string>ErnRunner is requesting HomeKit access.</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>ErnRunner is requesting location access at all times.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>ErnRunner is requesting location access.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>ErnRunner is requesting microphone access.</string>
+	<key>NSMotionUsageDescription</key>
+	<string>ErnRunner is requesting accelerometer access.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>ErnRunner is requesting photo library write access.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>ErnRunner is requesting photo library access.</string>
+	<key>NSRemindersUsageDescription</key>
+	<string>ErnRunner is requesting reminders access.</string>
 </dict>
 </plist>


### PR DESCRIPTION
So it won't crash when a plugin tries to use some native feature. See [CocoaKeys](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html) for more info.

As iOS doesn't have a manifest merger feature like Android (Info.plist modifications on framework won't reflect on app), we need to add `NS*UsageDescription` keys to ErnRunner Info.plist (and later, manually on the main app).