### PR TITLE
Fix git check for Windows

### DIFF
--- a/ern-local-cli/scripts/postinstall.js
+++ b/ern-local-cli/scripts/postinstall.js
@@ -51,7 +51,7 @@ if (!fs.existsSync(ERN_RC_GLOBAL_FILE_PATH)) {
 
 function isGitInstalled () {
   try {
-    execSync('git --version > /dev/null 2>&1')
+    execSync('git --version')
     return true
   } catch (e) {
     return false


### PR DESCRIPTION
Fix the function `isGitInstalled` for Windows.
The command was done for Linux/Mac in mind, not Windows. On Windows it was throwing an error, leading to impossibility to properly install Electrode Native.