### PR TITLE
Fix code-push promote command

### DIFF
--- a/ern-local-cli/src/commands/code-push/promote.js
+++ b/ern-local-cli/src/commands/code-push/promote.js
@@ -100,7 +100,7 @@ exports.handler = async function ({
         message: 'Please select a source native application descriptor'
       })
     } else {
-      await utils.askUserToChooseANapDescriptorFromCauldron({
+      await utils.logErrorAndExitIfNotSatisfied({
         isCompleteNapDescriptorString: {
           descriptor: sourceDescriptor
         }


### PR DESCRIPTION
Seems like a typo (or bad copy/paste) slipped in the code of `code-push promote` command.
This bug was leading to prompting the user to select a source native application descriptor, even if one was explicitly provided to the command through `--sourceNapDescriptor` option (rendering command unusable on CI).