### PR TITLE
Fix Android container config passing

### DIFF
--- a/ern-container-gen/src/generators/android/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactContainer.java
+++ b/ern-container-gen/src/generators/android/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactContainer.java
@@ -127,7 +127,6 @@ public class ElectrodeReactContainer {
             {{/apiImplementations}}
      ) {
         if (sElectrodeReactNativeHost == null) {
-            sElectrodeReactNativeHost = new ElectrodeReactNativeHost(application);
 
             // ReactNative general config
 
@@ -137,6 +136,8 @@ public class ElectrodeReactContainer {
             if (reactContainerConfig.okHttpClient != null) {
                 OkHttpClientProvider.replaceOkHttpClient(reactContainerConfig.okHttpClient);
             }
+
+            sElectrodeReactNativeHost = new ElectrodeReactNativeHost(application);
 
             askForOverlayPermissionIfDebug(application);
 


### PR DESCRIPTION
* **Problem:** `ElectrodeReactContainer.Config` settings aren’t honored
* **Solution:** Ensure the `isReactNativeDeveloperSupport` property is set _before_ `ElectrodeReactNativeHost` instantiation reads the value.
* **Testing:** Need help!