### PR TITLE
Fix a bug in create-container command

### DIFF
--- a/ern-container-gen/src/utils.js
+++ b/ern-container-gen/src/utils.js
@@ -137,6 +137,7 @@ export async function generateMiniAppsComposite (
   } else {
     // No yarn.lock path was provided, just add miniapps one by one
     log.debug('[generateMiniAppsComposite] no yarn lock provided')
+    await yarn.init()
     for (const miniappPath of miniappsPaths) {
       await yarn.add(miniappPath)
     }


### PR DESCRIPTION
Fix `Error: ENOENT, no such file or directory 'package.json'` that was thrown by `ern create-container` command under a certain condition.

This error was happening in case some directory in the parent directories tree of the container generated output directory, was containing a Node Application (a package.json present). In that case, yarn (and npm) behavior is to add the packages at this level (parent directory) and not current directory from where `yarn add` command is being run. Calling `yarn init` from the generated container output directory, before executing `yarn add` commands, ensure that the package.json will be created in the directory from which `yarn add` commands are getting called, thus solving the issue.