### PR TITLE
Show error if ERN platform version not found

### DIFF
--- a/global-cli/src/index.js
+++ b/global-cli/src/index.js
@@ -149,10 +149,16 @@ function runLocalCli () {
 
   const ernRc = JSON.parse(fs.readFileSync(ernRcPath, 'utf-8'))
 
+  let ernPlatformPath
   if ((ernRc.platformVersion === '1000') || (ernRc.platformVersion === '1000.0.0')) {
-    require(`${ERN_VERSIONS_CACHE_PATH}/${ernRc.platformVersion}/ern-local-cli/src/index.dev.js`)
+    ernPlatformPath = `${ERN_VERSIONS_CACHE_PATH}/${ernRc.platformVersion}/ern-local-cli/src/index.dev.js`
   } else {
-    require(`${ERN_VERSIONS_CACHE_PATH}/${ernRc.platformVersion}/node_modules/ern-local-cli/src/index.prod.js`)
+    ernPlatformPath = `${ERN_VERSIONS_CACHE_PATH}/${ernRc.platformVersion}/node_modules/ern-local-cli/src/index.prod.js`
+  }
+  try {
+    require(ernPlatformPath)
+  } catch (e) {
+    console.error(`cannot find ${ernPlatformPath}`)
   }
 }
 


### PR DESCRIPTION
Mainly for your information, took a long time to debug. Figured it out only, when writing this bug report.

**PROBLEM**: I'm trying to uninstall and reinstall Electrode Native, both seem successful. However something is referring to old install. What else do I need to reset...

My build script:

```bash
echo "=== STEP 0"
whoami
pwd

# === Setup ERN

# MUST have log level  trace to fix this error:
# runCauldronContainerGen failed: TypeError: this.stream.clearLine is not a function
# "It is due to Ora (the JS library we use to display spinners during commands execution)
# that doesn't properly work in certain CI envs."
export  ERN_LOG_LEVEL=trace

echo "=== STEP 1"
npm uninstall -g electrode-native && ern

echo "=== STEP 1a"
npm install -g electrode-native && ern

echo "=== STEP 2"
# --- electrode-native/system-tests/system-tests.js
# Trace log level should be set to trace to ensure that `ora` 
# gets disabled as it can lead to issues on CI env
#ern platform config logLevel trace

echo "=== STEP 3"
```

My build error:

```bash
17:28:05 === STEP 0
17:28:05 jenkins
17:28:05 /Users/jenkins/jenkins/workspace/bacon-ci-android-build
17:28:05 === STEP 1
17:28:06 removed 93 packages in 0.796s
17:28:06 /var/folders/95/xlfqlj515b1b_py1hry21sr00000gn/T/jenkins8917781206425641990.sh: line 15: ern: command not found
17:28:06 === STEP 1a
17:28:10 /usr/local/bin/ern -> /usr/local/lib/node_modules/electrode-native/bin/ern.js
17:28:10 + electrode-native@1.0.13
17:28:10 added 93 packages from 32 contributors in 3.57s
17:28:10 module.js:545
17:28:10     throw err;
17:28:10     ^
17:28:10 
17:28:10 Error: Cannot find module '/Users/jenkins/.ern/versions/0.12.2/node_modules/ern-local-cli/src/index.prod.js'
17:28:10     at Function.Module._resolveFilename (module.js:543:15)
17:28:10     at Function.Module._load (module.js:470:25)
17:28:10     at Module.require (module.js:593:17)
17:28:10     at require (internal/module.js:11:18)
17:28:10     at runLocalCli (/usr/local/lib/node_modules/electrode-native/src/index.js:155:5)
17:28:10     at Object.<anonymous> (/usr/local/lib/node_modules/electrode-native/src/index.js:45:3)
17:28:10     at Module._compile (module.js:649:30)
17:28:10     at Object.Module._extensions..js (module.js:660:10)
17:28:10     at Module.load (module.js:561:32)
17:28:10     at tryModuleLoad (module.js:501:12)
17:28:10 === STEP 2
```

I also tried this, no change:

```bash
watchman watch-del-all
rm -rf node_modules
rm -rf $TMPDIR/react-*
rm -rf $TMPDIR/haste-map-react-native-packager-*
yarn --reset-cache
```

**QUICK FIX:**

I have local .ernrc file under version control, which defined used platform as 0.12.2 - which obviously did not exist, since by default ern installs only latest version (currently 0.14.2).

Remove this row from .ernrc file (as soon as there's someone else at the office to approve my PR)

```bash
  "platformVersion": "0.12.2",
```

**SOLUTION:**

Maybe code in file https://github.com/electrode-io/electrode-native/blob/master/global-cli/src/index.js `function runLocalCli` could be patched with something like this...