### PR TITLE
Improve native dependencies versions sync in Cauldron

### DIFF
--- a/docs/cli/cauldron/batch.md
+++ b/docs/cli/cauldron/batch.md
@@ -44,8 +44,8 @@
 1) [delDependencies]  
 2) [delMiniapps]  
 3) [updateDependencies]  
-4) [updateMiniapps]  
-5) [addDependencies]  
+4) [addDependencies]  
+5) [updateMiniapps]  
 6) [addMiniapps]
 
 [delDependencies]: del/dependencies.md

--- a/ern-core/src/CauldronHelper.js
+++ b/ern-core/src/CauldronHelper.js
@@ -250,6 +250,60 @@ export default class CauldronHelper {
     return this.cauldron.updateContainerNativeDependencyVersion(napDescriptor, dependencyName, newVersion)
   }
 
+  async syncContainerMiniApps (
+    napDescriptor: NativeApplicationDescriptor,
+    miniappsPackagePath: Array<PackagePath>) : Promise<void> {
+    const cauldronMiniApps = await this.getContainerMiniApps(napDescriptor)
+    // Add MiniApps that are not part of the Container
+    const newMiniApps = _.differenceBy(miniappsPackagePath, cauldronMiniApps, 'basePath')
+    for (const newMiniApp of newMiniApps) {
+      await this.addContainerMiniApp(napDescriptor, newMiniApp)
+    }
+    // Update MiniApps that have a different version
+    for (const cauldronMiniApp of cauldronMiniApps) {
+      const miniapp = _.find(miniappsPackagePath, d => d.basePath === cauldronMiniApp.basePath)
+      if (miniapp && (miniapp.version !== cauldronMiniApp.version)) {
+        await this.updateContainerMiniAppVersion(napDescriptor, miniapp)
+      }
+    }
+  }
+
+  async syncContainerJsApiImpls (
+    napDescriptor: NativeApplicationDescriptor,
+    jsApiImplsPackagePath: Array<PackagePath>) : Promise<void> {
+    const cauldronJsApiImpls = await this.getContainerJsApiImpls(napDescriptor)
+    // Add JS API Impls that are not part of the Container
+    const newJsApiImpls = _.differenceBy(jsApiImplsPackagePath, cauldronJsApiImpls, 'basePath')
+    for (const newJsApiImpl of newJsApiImpls) {
+      await this.addContainerJsApiImpl(napDescriptor, newJsApiImpl)
+    }
+    // Update JS API Impls that have a different version
+    for (const cauldronJsApiImpl of cauldronJsApiImpls) {
+      const jsApiImpl = _.find(jsApiImplsPackagePath, d => d.basePath === cauldronJsApiImpl.basePath)
+      if (jsApiImpl && (jsApiImpl.version !== cauldronJsApiImpl.version)) {
+        await this.updateContainerJsApiImplVersion(napDescriptor, jsApiImpl.basePath, jsApiImpl.version)
+      }
+    }
+  }
+
+  async syncContainerNativeDependencies (
+    napDescriptor: NativeApplicationDescriptor,
+    nativeDependencies: Array<PackagePath>) : Promise<void> {
+    const cauldronNativeDependencies = await this.getNativeDependencies(napDescriptor)
+    // Add native dependencies that are not part of the Container
+    const newNativeDependencies = _.differenceBy(nativeDependencies, cauldronNativeDependencies, 'basePath')
+    for (const newNativeDependency of newNativeDependencies) {
+      await this.addContainerNativeDependency(napDescriptor, newNativeDependency)
+    }
+    // Update native dependencies that have a different version
+    for (const cauldronNativeDependency of cauldronNativeDependencies) {
+      const dep = _.find(nativeDependencies, d => d.basePath === cauldronNativeDependency.basePath)
+      if (dep && (dep.version !== cauldronNativeDependency.version)) {
+        await this.updateContainerNativeDependencyVersion(napDescriptor, dep.basePath, dep.version)
+      }
+    }
+  }
+
   async updateContainerJsApiImplVersion (
     napDescriptor: NativeApplicationDescriptor,
     jsApiImplName: string,

--- a/ern-core/src/index.js
+++ b/ern-core/src/index.js
@@ -37,6 +37,7 @@ import _gitCli from './gitCli'
 import _CodePushSdk from './CodePushSdk'
 import * as _promptUtils from './promptUtils'
 import _createTmpDir from './createTmpDir'
+import * as _nativeDepenciesVersionResolution from './resolveNativeDependenciesVersions'
 
 export const handleCopyDirective = _handleCopyDirective
 export const Platform = _Platform
@@ -73,6 +74,7 @@ export const gitCli = _gitCli
 export const CodePushSdk = _CodePushSdk
 export const promptUtils = _promptUtils
 export const createTmpDir = _createTmpDir
+export const nativeDepenciesVersionResolution = _nativeDepenciesVersionResolution
 
 export default ({
   handleCopyDirective: _handleCopyDirective,
@@ -109,7 +111,8 @@ export default ({
   gitCli: _gitCli,
   CodePushSdk: _CodePushSdk,
   promptUtils: _promptUtils,
-  createTmpDir: _createTmpDir
+  createTmpDir: _createTmpDir,
+  nativeDepenciesVersionResolution: _nativeDepenciesVersionResolution
 })
 
 export type {

--- a/ern-core/src/resolveNativeDependenciesVersions.js
+++ b/ern-core/src/resolveNativeDependenciesVersions.js
@@ -1,0 +1,128 @@
+import semver from 'semver'
+import _ from 'lodash'
+import { PackagePath } from 'ern-core'
+import { NativeDependencies } from './nativeDependenciesLookup'
+import MiniApp from './MiniApp'
+
+export function containsVersionMismatch (
+  versions: Array<string>,
+  mismatchLevel: 'major' | 'minor' | 'patch') : boolean {
+  const minVersion = semver.minSatisfying(versions, '*')
+  const maxVersion = semver.maxSatisfying(versions, '*')
+  const majorMismatch = semver.major(maxVersion) !== semver.major(minVersion)
+  const minorMismatch = semver.minor(maxVersion) !== semver.minor(minVersion)
+  const patchMismatch = semver.patch(maxVersion) !== semver.patch(minVersion)
+  return majorMismatch ||
+        (minorMismatch && (mismatchLevel === 'minor' || mismatchLevel === 'patch')) ||
+        (patchMismatch && mismatchLevel === 'patch')
+}
+
+export function retainHighestVersions (
+  dependenciesA: Array<PackagePath>,
+  dependenciesB: Array<PackagePath>) : Array<PackagePath> {
+  const result : Array<PackagePath> = []
+  const groups = _.groupBy([...dependenciesA, ...dependenciesB], 'basePath')
+  for (const dependencyGroup of Object.values(groups)) {
+    let highestVersionDependency = dependencyGroup[0]
+    if ((dependencyGroup.length > 1) && (semver.gt(dependencyGroup[1].version, dependencyGroup[0].version))) {
+      highestVersionDependency = dependencyGroup[1]
+    }
+    result.push(highestVersionDependency)
+  }
+  return result
+}
+
+export function resolveNativeDependenciesVersionsGivenMismatchLevel (
+  plugins: Array<PackagePath>,
+  mismatchLevel: 'major' | 'minor' | 'patch') : {
+  resolved: Array<PackagePath>,
+  pluginsWithMismatchingVersions: Array<string>
+} {
+  let result = {
+    resolved: [],
+    pluginsWithMismatchingVersions: []
+  }
+
+  let pluginsByBasePath = _.groupBy(_.unionBy(plugins, p => p.toString()), 'basePath')
+  for (const basePath of Object.keys(pluginsByBasePath)) {
+    const entry = pluginsByBasePath[basePath]
+    const pluginVersions = _.map(entry, 'version')
+    if (pluginVersions.length > 1) {
+      // If there are multiple versions of the dependency
+      if (containsVersionMismatch(pluginVersions, mismatchLevel)) {
+        // If at least one of the versions major digit differs, deem incompatibility
+        result.pluginsWithMismatchingVersions.push(basePath)
+      } else {
+        // No mismatchLevel version differences, just return the highest version
+        result.resolved.push(_.find(entry, c => c.basePath === basePath && c.version === semver.maxSatisfying(pluginVersions, '*')))
+      }
+    } else {
+      // Only one version is used across all MiniApps, just use this version
+      result.resolved.push(entry[0])
+    }
+  }
+
+  return result
+}
+
+export function resolveNativeDependenciesVersions (nativeDependenciesArr: Array<NativeDependencies>)
+  : Object {
+  const aggregateNativeDependencies: NativeDependencies = {
+    apis: [],
+    nativeApisImpl: [],
+    thirdPartyInManifest: [],
+    thirdPartyNotInManifest: []
+  }
+
+  // Build a map of all the native dependencies of each of the MiniApps
+  for (const nativeDependencies of nativeDependenciesArr) {
+    // Move react-native-electrode-bridge from nativeModulesInManifest array to nativeApisImpl array
+    // as when it comes to version compatibility checks, react-native-electrode-bridge should be considered
+    // in the same way as APIs and APIs implementations (it's a native module exception)
+    const bridgeDep = _.remove(nativeDependencies.thirdPartyInManifest, d => d.basePath === 'react-native-electrode-bridge')
+    nativeDependencies.nativeApisImpl = nativeDependencies.nativeApisImpl.concat(bridgeDep)
+    aggregateNativeDependencies.apis.push(nativeDependencies.apis)
+    aggregateNativeDependencies.nativeApisImpl.push(nativeDependencies.nativeApisImpl)
+    aggregateNativeDependencies.thirdPartyInManifest.push(nativeDependencies.thirdPartyInManifest)
+    if (aggregateNativeDependencies.thirdPartyNotInManifest.length > 0) {
+      aggregateNativeDependencies.thirdPartyNotInManifest.push(nativeDependencies.thirdPartyNotInManifest)
+    }
+  }
+
+  // Resolve native dependencies versions of APIs / APIs impls
+  let apisAndApiImplsNativeDeps : Array<PackagePath> = []
+  if (aggregateNativeDependencies.apis.length > 0) {
+    apisAndApiImplsNativeDeps.push(_.flatten(aggregateNativeDependencies.apis))
+  }
+  if (aggregateNativeDependencies.nativeApisImpl.length > 0) {
+    apisAndApiImplsNativeDeps.push(_.flatten(aggregateNativeDependencies.nativeApisImpl))
+  }
+  apisAndApiImplsNativeDeps = _.flatten(apisAndApiImplsNativeDeps)
+  const apiAndApiImplsResolvedVersions = resolveNativeDependenciesVersionsGivenMismatchLevel(apisAndApiImplsNativeDeps, 'major')
+
+  // Resolve native dependencies versions third party native modules
+  let thirdPartyNativeModules : Array<PackagePath> = []
+  if (aggregateNativeDependencies.thirdPartyInManifest.length > 0) {
+    thirdPartyNativeModules.push(_.flatten(aggregateNativeDependencies.thirdPartyInManifest))
+  }
+  if (aggregateNativeDependencies.thirdPartyNotInManifest.length > 0) {
+    thirdPartyNativeModules.push(_.flatten(aggregateNativeDependencies.thirdPartyNotInManifest))
+  }
+  thirdPartyNativeModules = _.flatten(thirdPartyNativeModules)
+  const thirdPartyNativeModulesResolvedVersions = resolveNativeDependenciesVersionsGivenMismatchLevel(thirdPartyNativeModules, 'patch')
+
+  return {
+    resolved: [ ...apiAndApiImplsResolvedVersions.resolved, ...thirdPartyNativeModulesResolvedVersions.resolved ],
+    pluginsWithMismatchingVersions: [ ...apiAndApiImplsResolvedVersions.pluginsWithMismatchingVersions, ...thirdPartyNativeModulesResolvedVersions.pluginsWithMismatchingVersions ]
+  }
+}
+
+export async function resolveNativeDependenciesVersionsOfMiniApps (miniapps: Array<MiniApp>) : Promise<Object> {
+  let nativeDependenciesArray = []
+  for (const miniapp of miniapps) {
+    const miniappNativeDependencies = await miniapp.getNativeDependencies()
+    nativeDependenciesArray.push(miniappNativeDependencies)
+  }
+
+  return resolveNativeDependenciesVersions(nativeDependenciesArray)
+}

--- a/ern-core/test/CauldronHelper-test.js
+++ b/ern-core/test/CauldronHelper-test.js
@@ -1114,6 +1114,154 @@ describe('CauldronHelper.js', () => {
     })
   })
 
+  describe('syncContainerNativeDependencies', () => {
+    it('should not update anything if dependencies versions are the same', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      await cauldronHelper.syncContainerNativeDependencies(
+        NativeApplicationDescriptor.fromString('test:android:17.8.0'), [
+          PackagePath.fromString('react-native-electrode-bridge@1.4.9'),
+          PackagePath.fromString('@test/react-native-test-api@0.17.8'),
+          PackagePath.fromString('react-native@0.42.0'),
+          PackagePath.fromString('react-native-code-push@1.17.1-beta')
+        ])
+      const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0]
+      expect(nativeAppVersion.container.nativeDeps).length(4)
+      expect(nativeAppVersion.container.nativeDeps).includes('react-native-electrode-bridge@1.4.9')
+      expect(nativeAppVersion.container.nativeDeps).includes('@test/react-native-test-api@0.17.8')
+      expect(nativeAppVersion.container.nativeDeps).includes('react-native@0.42.0')
+      expect(nativeAppVersion.container.nativeDeps).includes('react-native-code-push@1.17.1-beta')
+    })
+
+    it('should add missing dependencies', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      await cauldronHelper.syncContainerNativeDependencies(
+        NativeApplicationDescriptor.fromString('test:android:17.8.0'), [
+          PackagePath.fromString('react-native-electrode-bridge@1.4.9'),
+          PackagePath.fromString('@test/react-native-test-api@0.17.8'),
+          PackagePath.fromString('react-native@0.42.0'),
+          PackagePath.fromString('react-native-code-push@1.17.1-beta'),
+          PackagePath.fromString('new-dependency@1.0.0')
+        ])
+      const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0]
+      expect(nativeAppVersion.container.nativeDeps).length(5)
+      expect(nativeAppVersion.container.nativeDeps).includes('react-native-electrode-bridge@1.4.9')
+      expect(nativeAppVersion.container.nativeDeps).includes('@test/react-native-test-api@0.17.8')
+      expect(nativeAppVersion.container.nativeDeps).includes('react-native@0.42.0')
+      expect(nativeAppVersion.container.nativeDeps).includes('react-native-code-push@1.17.1-beta')
+      expect(nativeAppVersion.container.nativeDeps).includes('new-dependency@1.0.0')
+    })
+
+    it('should update dependencies with different versions', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      await cauldronHelper.syncContainerNativeDependencies(
+        NativeApplicationDescriptor.fromString('test:android:17.8.0'), [
+          PackagePath.fromString('react-native-electrode-bridge@1.5.0'),
+          PackagePath.fromString('@test/react-native-test-api@0.17.8'),
+          PackagePath.fromString('react-native@0.43.0'),
+          PackagePath.fromString('react-native-code-push@1.17.1-beta')
+        ])
+      const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0]
+      expect(nativeAppVersion.container.nativeDeps).length(4)
+      expect(nativeAppVersion.container.nativeDeps).includes('react-native-electrode-bridge@1.5.0')
+      expect(nativeAppVersion.container.nativeDeps).includes('@test/react-native-test-api@0.17.8')
+      expect(nativeAppVersion.container.nativeDeps).includes('react-native@0.43.0')
+      expect(nativeAppVersion.container.nativeDeps).includes('react-native-code-push@1.17.1-beta')
+    })
+
+    it('should add missing dependencies and update dependencies with different versions', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      await cauldronHelper.syncContainerNativeDependencies(
+        NativeApplicationDescriptor.fromString('test:android:17.8.0'), [
+          PackagePath.fromString('react-native-electrode-bridge@1.5.0'),
+          PackagePath.fromString('@test/react-native-test-api@0.17.8'),
+          PackagePath.fromString('react-native@0.43.0'),
+          PackagePath.fromString('react-native-code-push@1.17.1-beta'),
+          PackagePath.fromString('new-dependency@1.0.0')
+        ])
+      const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0]
+      expect(nativeAppVersion.container.nativeDeps).length(5)
+      expect(nativeAppVersion.container.nativeDeps).includes('react-native-electrode-bridge@1.5.0')
+      expect(nativeAppVersion.container.nativeDeps).includes('@test/react-native-test-api@0.17.8')
+      expect(nativeAppVersion.container.nativeDeps).includes('react-native@0.43.0')
+      expect(nativeAppVersion.container.nativeDeps).includes('react-native-code-push@1.17.1-beta')
+      expect(nativeAppVersion.container.nativeDeps).includes('new-dependency@1.0.0')
+    })
+  })
+
+  describe('syncContainerMiniApps', () => {
+    it('should not update anything if miniapps versions are the same', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      await cauldronHelper.syncContainerMiniApps(
+        NativeApplicationDescriptor.fromString('test:android:17.8.0'), [
+          PackagePath.fromString('@test/react-native-foo@5.0.0'),
+          PackagePath.fromString('react-native-bar@3.0.0'),
+          PackagePath.fromString('git+ssh://git@github.com:electrode-io/gitMiniApp.git#0.0.9')
+        ])
+      const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0]
+      expect(nativeAppVersion.container.miniApps).length(3)
+      expect(nativeAppVersion.container.miniApps).includes('@test/react-native-foo@5.0.0')
+      expect(nativeAppVersion.container.miniApps).includes('react-native-bar@3.0.0')
+      expect(nativeAppVersion.container.miniApps).includes('git+ssh://git@github.com:electrode-io/gitMiniApp.git#0.0.9')
+    })
+
+    it('should add missing miniapps', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      await cauldronHelper.syncContainerMiniApps(
+        NativeApplicationDescriptor.fromString('test:android:17.8.0'), [
+          PackagePath.fromString('@test/react-native-foo@5.0.0'),
+          PackagePath.fromString('react-native-bar@3.0.0'),
+          PackagePath.fromString('git+ssh://git@github.com:electrode-io/gitMiniApp.git#0.0.9'),
+          PackagePath.fromString('new-miniapp@0.0.1')
+        ])
+      const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0]
+      expect(nativeAppVersion.container.miniApps).length(4)
+      expect(nativeAppVersion.container.miniApps).includes('@test/react-native-foo@5.0.0')
+      expect(nativeAppVersion.container.miniApps).includes('react-native-bar@3.0.0')
+      expect(nativeAppVersion.container.miniApps).includes('git+ssh://git@github.com:electrode-io/gitMiniApp.git#0.0.9')
+      expect(nativeAppVersion.container.miniApps).includes('new-miniapp@0.0.1')
+    })
+
+    it('should update miniapps with different versions', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      await cauldronHelper.syncContainerMiniApps(
+        NativeApplicationDescriptor.fromString('test:android:17.8.0'), [
+          PackagePath.fromString('@test/react-native-foo@6.0.0'),
+          PackagePath.fromString('react-native-bar@3.0.0'),
+          PackagePath.fromString('git+ssh://git@github.com:electrode-io/gitMiniApp.git#1.0.0'),
+        ])
+      const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0]
+      expect(nativeAppVersion.container.miniApps).length(3)
+      expect(nativeAppVersion.container.miniApps).includes('@test/react-native-foo@6.0.0')
+      expect(nativeAppVersion.container.miniApps).includes('react-native-bar@3.0.0')
+      expect(nativeAppVersion.container.miniApps).includes('git+ssh://git@github.com:electrode-io/gitMiniApp.git#1.0.0')
+    })
+
+    it('should add missing miniapps and update miniapps with different versions', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      await cauldronHelper.syncContainerMiniApps(
+        NativeApplicationDescriptor.fromString('test:android:17.8.0'), [
+          PackagePath.fromString('@test/react-native-foo@6.0.0'),
+          PackagePath.fromString('react-native-bar@3.0.0'),
+          PackagePath.fromString('git+ssh://git@github.com:electrode-io/gitMiniApp.git#1.0.0'),
+          PackagePath.fromString('new-miniapp@0.0.1')
+        ])
+      const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0]
+      expect(nativeAppVersion.container.miniApps).length(4)
+      expect(nativeAppVersion.container.miniApps).includes('@test/react-native-foo@6.0.0')
+      expect(nativeAppVersion.container.miniApps).includes('react-native-bar@3.0.0')
+      expect(nativeAppVersion.container.miniApps).includes('git+ssh://git@github.com:electrode-io/gitMiniApp.git#1.0.0')
+      expect(nativeAppVersion.container.miniApps).includes('new-miniapp@0.0.1')
+    })
+  })
+
   describe('updateContainerJsApiImplVersion', () => {
     it('should throw if the given native application descriptor is partial', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)

--- a/ern-core/test/resolveNativeDependenciesVersions-test.js
+++ b/ern-core/test/resolveNativeDependenciesVersions-test.js
@@ -1,0 +1,265 @@
+// @flow
+
+import {
+  expect
+} from 'chai'
+import type { NativeDependencies } from '../src/nativeDependenciesLookup'
+import PackagePath from '../src/PackagePath'
+import * as nativeDepenciesVersionResolution from '../src/resolveNativeDependenciesVersions'
+
+// ==========================================================
+// retainHighestVersions
+// ==========================================================
+describe('retainHighestVersion', () => {
+  it('should work as expected', () => {
+    const arrA = [
+      PackagePath.fromString('dependencyA@1.0.0'),
+      PackagePath.fromString('dependencyB@2.0.1'),
+      PackagePath.fromString('dependencyC@1.0.0'),
+      PackagePath.fromString('dependencyD@1.0.0')
+    ]
+
+    const arrB = [
+      PackagePath.fromString('dependencyA@2.0.0'),
+      PackagePath.fromString('dependencyB@2.0.0'),
+      PackagePath.fromString('dependencyC@1.1.0'),
+      PackagePath.fromString('dependencyE@1.0.0'),
+      PackagePath.fromString('dependencyF@3.0.0')
+    ]
+
+    const result = nativeDepenciesVersionResolution.retainHighestVersions(arrA, arrB)
+    const stringifedResult = result.map(p => p.toString())
+    expect(stringifedResult).length(6)
+    expect(stringifedResult).includes('dependencyA@2.0.0')
+    expect(stringifedResult).includes('dependencyB@2.0.1')
+    expect(stringifedResult).includes('dependencyC@1.1.0')
+    expect(stringifedResult).includes('dependencyD@1.0.0')
+    expect(stringifedResult).includes('dependencyE@1.0.0')
+    expect(stringifedResult).includes('dependencyF@3.0.0')
+  })
+})
+
+// ==========================================================
+// resolveNativeDependenciesVersions
+// ==========================================================
+describe('resolveNativeDependenciesVersions', () => {
+  it('should work as expected [different native dependencies]', () => {
+    const fixture = [ 
+      {
+        apis: [ PackagePath.fromString('apiOne@1.0.0'), PackagePath.fromString('apiTwo@1.0.0') ],
+        nativeApisImpl: [ PackagePath.fromString('nativeApiImplOne@1.0.0') ],
+        thirdPartyInManifest: [ PackagePath.fromString('nativeModuleOne@1.0.0') ]
+      }
+    ]
+
+    const result = nativeDepenciesVersionResolution.resolveNativeDependenciesVersions(fixture)
+    expect(result.resolved).length(4)
+    expect(result.pluginsWithMismatchingVersions).empty
+  })
+
+  it('should work as expected [same api with different patch version]', () => {
+    const fixture = [ 
+      {
+        apis: [ PackagePath.fromString('apiOne@1.0.0'), PackagePath.fromString('apiOne@1.0.1') ],
+        nativeApisImpl: [ PackagePath.fromString('nativeApiImplOne@1.0.0') ],
+        thirdPartyInManifest: [ PackagePath.fromString('nativeModuleOne@1.0.0') ]
+      }
+    ]
+
+    const result = nativeDepenciesVersionResolution.resolveNativeDependenciesVersions(fixture)
+    expect(result.resolved).length(3)
+    expect(result.pluginsWithMismatchingVersions).empty
+    const resolvedDepsAsStrings = result.resolved.map(r => r.toString())
+    expect(resolvedDepsAsStrings).includes('apiOne@1.0.1')
+  })
+
+  it('should work as expected [same api with different minor version]', () => {
+    const fixture = [ 
+      {
+        apis: [ PackagePath.fromString('apiOne@1.0.0'), PackagePath.fromString('apiOne@1.1.0') ],
+        nativeApisImpl: [ PackagePath.fromString('nativeApiImplOne@1.0.0') ],
+        thirdPartyInManifest: [ PackagePath.fromString('nativeModuleOne@1.0.0') ]
+      }
+    ]
+
+    const result = nativeDepenciesVersionResolution.resolveNativeDependenciesVersions(fixture)
+    expect(result.resolved).length(3)
+    expect(result.pluginsWithMismatchingVersions).empty
+    const resolvedDepsAsStrings = result.resolved.map(r => r.toString())
+    expect(resolvedDepsAsStrings).includes('apiOne@1.1.0')
+  })
+
+  it('should work as expected [same api with same version]', () => {
+    const fixture = [ 
+      {
+        apis: [ PackagePath.fromString('apiOne@1.0.0'), PackagePath.fromString('apiOne@1.0.0') ],
+        nativeApisImpl: [ PackagePath.fromString('nativeApiImplOne@1.0.0') ],
+        thirdPartyInManifest: [ PackagePath.fromString('nativeModuleOne@1.0.0') ]
+      }
+    ]
+
+    const result = nativeDepenciesVersionResolution.resolveNativeDependenciesVersions(fixture)
+    expect(result.resolved).length(3)
+  })
+
+  it('should work as expected [same api with different major version]', () => {
+    const fixture = [ 
+      {
+        apis: [ PackagePath.fromString('apiOne@1.0.0'), PackagePath.fromString('apiOne@2.0.0') ],
+        nativeApisImpl: [ PackagePath.fromString('nativeApiImplOne@1.0.0') ],
+        thirdPartyInManifest: [ PackagePath.fromString('nativeModuleOne@1.0.0') ]
+      }
+    ]
+
+    const result = nativeDepenciesVersionResolution.resolveNativeDependenciesVersions(fixture)
+    expect(result.resolved).length(2)
+    expect(result.pluginsWithMismatchingVersions).length(1)
+    expect(result.pluginsWithMismatchingVersions).includes('apiOne')
+  })
+
+  it('should work as expected [react-native-electrode-bridge same version]', () => {
+    const fixture = [ 
+      {
+        apis: [ PackagePath.fromString('apiOne@1.0.0') ],
+        nativeApisImpl: [ PackagePath.fromString('nativeApiImplOne@1.0.0') ],
+        thirdPartyInManifest: [
+          PackagePath.fromString('react-native-electrode-bridge@1.0.0'), 
+          PackagePath.fromString('react-native-electrode-bridge@1.0.0')
+        ]
+      }
+    ]
+
+    const result = nativeDepenciesVersionResolution.resolveNativeDependenciesVersions(fixture)
+    expect(result.resolved).length(3)
+    expect(result.pluginsWithMismatchingVersions).length(0)
+  })
+
+  it('should work as expected [react-native-electrode-bridge with different patch version]', () => {
+    const fixture = [ 
+      {
+        apis: [ PackagePath.fromString('apiOne@1.0.0') ],
+        nativeApisImpl: [ PackagePath.fromString('nativeApiImplOne@1.0.0') ],
+        thirdPartyInManifest: [
+          PackagePath.fromString('react-native-electrode-bridge@1.0.0'), 
+          PackagePath.fromString('react-native-electrode-bridge@1.0.1')
+        ]
+      }
+    ]
+
+    const result = nativeDepenciesVersionResolution.resolveNativeDependenciesVersions(fixture)
+    expect(result.resolved).length(3)
+    expect(result.pluginsWithMismatchingVersions).length(0)
+    const resolvedDepsAsStrings = result.resolved.map(r => r.toString())
+    expect(resolvedDepsAsStrings).includes('react-native-electrode-bridge@1.0.1')
+  })
+
+  it('should work as expected [react-native-electrode-bridge with different minor version]', () => {
+    const fixture = [ 
+      {
+        apis: [ PackagePath.fromString('apiOne@1.0.0') ],
+        nativeApisImpl: [ PackagePath.fromString('nativeApiImplOne@1.0.0') ],
+        thirdPartyInManifest: [
+          PackagePath.fromString('react-native-electrode-bridge@1.0.0'), 
+          PackagePath.fromString('react-native-electrode-bridge@1.1.0')
+        ]
+      }
+    ]
+
+    const result = nativeDepenciesVersionResolution.resolveNativeDependenciesVersions(fixture)
+    expect(result.resolved).length(3)
+    expect(result.pluginsWithMismatchingVersions).length(0)
+    const resolvedDepsAsStrings = result.resolved.map(r => r.toString())
+    expect(resolvedDepsAsStrings).includes('react-native-electrode-bridge@1.1.0')
+  })
+
+  it('should work as expected [react-native-electrode-bridge with different major version]', () => {
+    const fixture = [ 
+      {
+        apis: [ PackagePath.fromString('apiOne@1.0.0') ],
+        nativeApisImpl: [ PackagePath.fromString('nativeApiImplOne@1.0.0') ],
+        thirdPartyInManifest: [
+          PackagePath.fromString('react-native-electrode-bridge@1.0.0'), 
+          PackagePath.fromString('react-native-electrode-bridge@2.0.0')
+        ]
+      }
+    ]
+
+    const result = nativeDepenciesVersionResolution.resolveNativeDependenciesVersions(fixture)
+    expect(result.resolved).length(2)
+    expect(result.pluginsWithMismatchingVersions).length(1)
+    expect(result.pluginsWithMismatchingVersions).includes('react-native-electrode-bridge')
+  })
+
+  it('should work as expected [third party native module with same version', () => {
+    const fixture = [ 
+      {
+        apis: [ PackagePath.fromString('apiOne@1.0.0') ],
+        nativeApisImpl: [ PackagePath.fromString('nativeApiImplOne@1.0.0') ],
+        thirdPartyInManifest: [
+          PackagePath.fromString('nativeModuleOne@1.0.0'), 
+          PackagePath.fromString('nativeModuleOne@1.0.0')
+        ]
+      }
+    ]
+
+    const result = nativeDepenciesVersionResolution.resolveNativeDependenciesVersions(fixture)
+    expect(result.resolved).length(3)
+    expect(result.pluginsWithMismatchingVersions).length(0)
+    const resolvedDepsAsStrings = result.resolved.map(r => r.toString())
+    expect(resolvedDepsAsStrings).includes('nativeModuleOne@1.0.0')
+  })
+
+  it('should work as expected [third party native module with different patch version]', () => {
+    const fixture = [ 
+      {
+        apis: [ PackagePath.fromString('apiOne@1.0.0') ],
+        nativeApisImpl: [ PackagePath.fromString('nativeApiImplOne@1.0.0') ],
+        thirdPartyInManifest: [
+          PackagePath.fromString('nativeModuleOne@1.0.0'), 
+          PackagePath.fromString('nativeModuleOne@1.0.1')
+        ]
+      }
+    ]
+
+    const result = nativeDepenciesVersionResolution.resolveNativeDependenciesVersions(fixture)
+    expect(result.resolved).length(2)
+    expect(result.pluginsWithMismatchingVersions).length(1)
+    expect(result.pluginsWithMismatchingVersions).includes('nativeModuleOne')
+  })
+
+  it('should work as expected [third party native module with different minor version]', () => {
+    const fixture = [ 
+      {
+        apis: [ PackagePath.fromString('apiOne@1.0.0') ],
+        nativeApisImpl: [ PackagePath.fromString('nativeApiImplOne@1.0.0') ],
+        thirdPartyInManifest: [
+          PackagePath.fromString('nativeModuleOne@1.0.0'), 
+          PackagePath.fromString('nativeModuleOne@1.1.0')
+        ]
+      }
+    ]
+
+    const result = nativeDepenciesVersionResolution.resolveNativeDependenciesVersions(fixture)
+    expect(result.resolved).length(2)
+    expect(result.pluginsWithMismatchingVersions).length(1)
+    expect(result.pluginsWithMismatchingVersions).includes('nativeModuleOne')
+  })
+
+  it('should work as expected [third party native module with different major version]', () => {
+    const fixture = [ 
+      {
+        apis: [ PackagePath.fromString('apiOne@1.0.0') ],
+        nativeApisImpl: [ PackagePath.fromString('nativeApiImplOne@1.0.0') ],
+        thirdPartyInManifest: [
+          PackagePath.fromString('nativeModuleOne@1.0.0'), 
+          PackagePath.fromString('nativeModuleOne@2.0.0')
+        ]
+      }
+    ]
+
+    const result = nativeDepenciesVersionResolution.resolveNativeDependenciesVersions(fixture)
+    expect(result.resolved).length(2)
+    expect(result.pluginsWithMismatchingVersions).length(1)
+    expect(result.pluginsWithMismatchingVersions).includes('nativeModuleOne')
+  })
+})

--- a/ern-local-cli/src/commands/cauldron/regen-container.js
+++ b/ern-local-cli/src/commands/cauldron/regen-container.js
@@ -1,10 +1,14 @@
 // @flow
 
 import {
+  MiniApp,
+  spin,
   NativeApplicationDescriptor,
-  utils as coreUtils
+  utils as coreUtils,
+  nativeDepenciesVersionResolution as resolver
 } from 'ern-core'
 import utils from '../../lib/utils'
+import _ from 'lodash'
 
 exports.command = 'regen-container'
 exports.desc = 'Triggers the regeneration of a Container from the Cauldron'
@@ -20,6 +24,11 @@ exports.builder = function (yargs: any) {
     type: 'string',
     alias: 'd',
     describe: 'A complete native application descriptor'
+  })
+  .option('force', {
+    alias: 'f',
+    type: 'bool',
+    describe: 'Force regen even if some conflicting native dependencies versions have been found'
   })
   .epilog(utils.epilog(exports))
 }
@@ -56,9 +65,27 @@ exports.handler = async function ({
       }
     })
 
+    const cauldron = await coreUtils.getCauldronInstance()
+    const miniAppsInCauldron = await cauldron.getContainerMiniApps(napDescriptor)
+    const gitMiniAppsInCauldron = _.filter(miniAppsInCauldron, m => m.isGitPath === true)
+
+    // For all MiniApps that are retrieved from git, we need to check if any
+    // of their native dependencies versions have changed (or new one added)
+    // in order to properly update the native dependencies list in the Cauldron
+    let gitMiniAppsObjs = []
+    for (const gitMiniAppInCauldron of gitMiniAppsInCauldron) {
+      const m = await spin(`Retrieving ${gitMiniAppInCauldron.toString()} MiniApp`,
+        MiniApp.fromPackagePath(gitMiniAppInCauldron))
+      gitMiniAppsObjs.push(m)
+    }
+
+    const nativeDependencies = await resolver.resolveNativeDependenciesVersionsOfMiniApps(gitMiniAppsObjs)
+    const cauldronDependencies = await cauldron.getNativeDependencies(napDescriptor)
+    const finalNativeDependencies = resolver.retainHighestVersions(nativeDependencies.resolved, cauldronDependencies)
+
     await utils.performContainerStateUpdateInCauldron(
       async () => {
-        return Promise.resolve()
+        await cauldron.syncContainerNativeDependencies(napDescriptor, finalNativeDependencies)
       },
       napDescriptor,
       `Regenerate Container of ${napDescriptor.toString()} native application`,

--- a/ern-local-cli/src/lib/utils.js
+++ b/ern-local-cli/src/lib/utils.js
@@ -891,6 +891,26 @@ function normalizeVersionsToSemver (versions: Array<string>) : Array<string> {
   })
 }
 
+function logNativeDependenciesConflicts (
+  nativeDependencies: Object, {
+    throwIfConflict
+  } : {
+    throwIfConflict?: boolean
+  } = {}) {
+  const conflictingDependencies = nativeDependencies.pluginsWithMismatchingVersions
+  if (conflictingDependencies.length > 0) {
+    if (!throwIfConflict) {
+      log.warn('=============================================================================')
+      log.warn('The following native dependencies are using different conflicting versions : ')
+      conflictingDependencies.foreach(p => log.warn(`- ${p}`))
+      log.warn('Ignoring due to the use of the --force flag')
+      log.warn('=============================================================================')
+    } else {
+      throw new Error(`Some native dependencies are using conflicting versions : ${conflictingDependencies.join(',')}`)
+    }
+  }
+}
+
 export default {
   getNapDescriptorStringsFromCauldron,
   logErrorAndExitIfNotSatisfied,
@@ -904,5 +924,6 @@ export default {
   checkIfModuleNameContainsSuffix,
   promptUserToUseSuffixModuleName,
   getDescriptorsMatchingSemVerDescriptor,
-  normalizeVersionsToSemver
+  normalizeVersionsToSemver,
+  logNativeDependenciesConflicts
 }

--- a/ern-util-dev/fixtures/default-cauldron-fixture.json
+++ b/ern-util-dev/fixtures/default-cauldron-fixture.json
@@ -152,7 +152,8 @@
               ],
               "miniApps": [
                 "@test/react-native-foo@5.0.0",
-                "react-native-bar@3.0.0"
+                "react-native-bar@3.0.0",
+                "git+ssh://git@github.com:electrode-io/gitMiniApp.git#0.0.9"
               ],
               "jsApiImpls": [
                 "react-native-my-api-impl@1.0.0"


### PR DESCRIPTION
This PR introduces new utility functions and alter the algorithms of the following commands :

```
- cauldron add miniapps
- cauldron update miniapps
- cauldron batch
- cauldron regen-container
```

Without digging into implementation details, the high level change here is regarding proper synchronization of native dependencies stored in the Cauldron for the Container impacted by these commands.

The new algorithm is doing the following :
- List the native dependencies of all the MiniApps that are getting added or updated to/in the Cauldron Container. Also list the native dependencies of all the MiniApps currently in the Container. In a nutshell we just list the native dependencies of all the MiniApps that are going to be listed in the Container once the operation complete.
- For all these native dependencies, we check the one that are conflicting following the rules of Electrode Native (for example a major version diff in an API/API impl or a patch/minor/major diff in a native module). If we find any conflict, we just abort the operation (unless force flag is used, where it will result in just a warning).
- Given that there is no conflicting version (or force flag was used) we just retain the latest version of each dependency from the list of dependencies (we also include all current native dependencies listed in the Container Cauldron).
- This list of native dependencies is now the current list of native dependencies for the Cauldron Container. We then just synchronize the Cauldron, to ensure that it match the list.

This PR close the two following issues :

Close https://github.com/electrode-io/electrode-native/issues/662
Close https://github.com/electrode-io/electrode-native/issues/498