### PR TITLE
Add a script to regenerate system tests fixtures

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "standard": "standard",
     "flow": "flow",
     "precommit": "node yarn-lock && standard && flow",
-    "postmerge": "node auto-rebuild.js"
+    "postmerge": "node auto-rebuild.js",
+    "regen-fixtures": "node system-tests/regen-fixtures"
   },
   "dependencies": {
     "chalk": "^2.3.0",

--- a/system-tests/fixtures/api/schema.json
+++ b/system-tests/fixtures/api/schema.json
@@ -1,0 +1,162 @@
+{
+	"swagger": "2.0",
+	"info": {
+		"description": "Test schema to demonstrate ComplexAPI ",
+		"title": "Complex Api"
+	},
+	"produces": [
+		"application/json"
+	],
+	"paths": {
+		"/testArrayOfStrings": {
+			"post": {
+				"tags": [
+					"SystemTests"
+				],
+				"operationId": "testArrayOfStrings",
+				"parameters": [{
+					"name": "key",
+					"in": "body",
+					"description": "keys to get setting",
+					"required": true,
+					"schema": {
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					}
+				}],
+				"responses": {
+          "200": {
+            "schema": {
+							"type": "array",
+							"description": "response as an array of Objects",
+							"items": {
+								"$ref": "#/definitions/ERNObject"
+							}
+            }
+          }
+        }
+			}
+		},
+		"/testMultiArgs": {
+			"post": {
+				"tags": [
+						"SystemTests"
+					],
+					"description": "This is a test for multiple arguments.",
+					"operationId": "testMultiArgs",
+					"parameters": [{
+						"name": "key1",
+						"in": "path",
+						"description": "first argument",
+						"required": true,
+						"type": "string"
+		},
+		{
+			"name": "key2",
+			"in": "path",
+			"description": "second argument",
+			"required": true,
+			"type": "integer"
+		}],
+			"responses": {
+				"200": {
+					"description": "set location response",
+					"schema": {
+						"type": "string"
+				}
+			}
+		}
+	}
+},
+"event/testEvent": {
+	"event": {
+		"tags": [
+			"SysteTestEvent"
+		],
+		"operationId": "testEvent",
+		"parameters": [{
+			"name": "buttonId",
+			"in": "path",
+			"description": "id of the button clicked",
+			"required": true,
+				"type": "string"
+		}]
+	}
+}
+	},
+	"definitions": {
+		"NavBarButton": {
+			"properties": {
+				"name": {
+					"type": "string",
+					"description": "Name of button"
+		},
+			"identifier": {
+				"type": "string",
+				"description": "Id of the button"
+		},
+			"showIcon": {
+				"type": "boolean",
+				"description": "Set to true for showing icon"
+		}
+	},
+		"required": [
+			"name",
+			"identifier"
+	]
+},
+    "ERNObject": {
+      "type": "object",
+      "properties": {
+				"name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        },
+        "domain": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "version": {
+          "type": "number",
+          "format": "double"
+        },
+        "expiry": {
+          "type": "number",
+          "format": "long"
+        },
+				"leftButton":{
+					"$ref": "#/definitions/NavBarButton"
+				},
+				"rightButtons": {
+					"type": "array",
+						"items": {
+							"$ref": "#/definitions/NavBarButton"
+										 },
+										 "description": "Right button properties"
+				},
+				"isGuestUser": {
+					"type": "boolean",
+					"description": "specify if user is a guest",
+					"default": false
+				},
+				"mergeType": {
+					"type": "integer",
+					"description": "specify merge type"
+				}
+      },
+			"required": [
+        "name",
+        "version"
+      ]
+    }
+	}
+}

--- a/system-tests/fixtures/constants.js
+++ b/system-tests/fixtures/constants.js
@@ -37,7 +37,7 @@ const pathConstants = {
   pathToIosContainerFixture: path.join(__dirname, 'ios-container'),
   pathToBaseApiFixture: path.join(__dirname, 'api', baseConstants.testApiName),
   pathToComplexApiFixture: path.join(__dirname, 'api', baseConstants.complexApiName),
-  pathToComplexApiSchema: path.join(__dirname, 'api', baseConstants.complexApiName, 'schema.json')
+  pathToComplexApiSchema: path.join(__dirname, 'api', 'schema.json')
 }
 
 module.exports = Object.freeze(Object.assign({}, baseConstants, compositeConstants, pathConstants))

--- a/system-tests/regen-fixtures.js
+++ b/system-tests/regen-fixtures.js
@@ -1,0 +1,86 @@
+const inquirer = require('inquirer')
+const shell = require('shelljs')
+const path = require('path')
+const f = require('./fixtures/constants')
+
+const regenFunctionByFixtureName = {
+  "android-container": regenAndroidContainerFixture,
+  "ios-container": regenIosContainerFixture,
+  "api-impl-js": regenApiImplJsFixture,
+  "api-impl-native": regenApiImplNativeFixture,
+  "ComplexApi": regenComplexApiFixture,
+  "TestApi": regenTestApiFixture
+}
+
+const rootFixturesPath = path.join(__dirname, 'fixtures')
+const rootApiFixturesPath = path.join(rootFixturesPath, 'api')
+const pathsToFixtures = {
+  "android-container": path.join(rootFixturesPath, 'android-container'),
+  "ios-container": path.join(rootFixturesPath, 'ios-container'),
+  "api-impl-js": path.join(rootFixturesPath, 'api-impl-js'),
+  "api-impl-native": path.join(rootFixturesPath, 'api-impl-native'),
+  "ComplexApi": path.join(rootApiFixturesPath, 'ComplexApi'),
+  "TestApi": path.join(rootApiFixturesPath, 'TestApi')
+}
+
+inquirer.prompt([{
+  type: 'checkbox',
+  name: 'userSelectedFixturesToRegen',
+  message: 'Choose one or more system test fixture(s) to regenerate',
+  choices: Object.keys(regenFunctionByFixtureName)
+}]).then(answers => {
+  shell.exec(`ern platform config logLevel trace`)
+  shell.exec(`ern cauldron repo clear`)
+  for (const userSelectedFixtureToRegen of answers.userSelectedFixturesToRegen) {
+    regenFunctionByFixtureName[userSelectedFixtureToRegen]()
+  }
+})
+
+const containerMiniapps = [
+  `${f.movieListMiniAppPgkName}@${f.movieListMiniAppPkgVersion}`,
+  `${f.movieDetailsMiniAppPkgName}@${f.movieDetailsMiniAppPkgVersion}`
+]
+
+function regenAndroidContainerFixture() {
+  logHeader("Regenerating Android Container Fixture")
+  shell.rm('-rf', pathsToFixtures['android-container'])
+  shell.exec(`ern create-container --miniapps ${containerMiniapps.join(' ')} -p android --dependencies react-native-code-push@5.2.1 --out ${pathsToFixtures['android-container']}`)
+}
+
+function regenIosContainerFixture() {
+  logHeader("Regenerating iOS Container Fixture")
+  shell.rm('-rf', pathsToFixtures['ios-container'])
+  shell.exec(`ern create-container --miniapps ${containerMiniapps.join(' ')} -p ios --dependencies react-native-code-push@5.2.1 --out ${pathsToFixtures['ios-container']}`)
+}
+
+function regenApiImplJsFixture() {
+  logHeader("Regenerating JS API Implementation Fixture")
+  shell.rm('-rf', pathsToFixtures['api-impl-js'])
+  shell.exec(`ern create-api-impl ${f.movieApiPkgName} -p ${f.movieApiImplPkgName} --skipNpmCheck --jsOnly --outputDirectory ${pathsToFixtures['api-impl-js']} --force`)
+}
+
+function regenApiImplNativeFixture() {
+  logHeader("Regenerating Native API Implementation Fixture")
+  shell.rm('-rf', pathsToFixtures['api-impl-native'])
+  shell.exec(`ern create-api-impl ${f.movieApiPkgName} -p ${f.movieApiImplPkgName} --skipNpmCheck --nativeOnly --outputDirectory ${pathsToFixtures['api-impl-native']} --force`)
+}
+
+function regenComplexApiFixture() {
+  logHeader("Regenerating Complex API Fixture")
+  shell.rm('-rf', pathsToFixtures['ComplexApi'])
+  shell.cd(rootApiFixturesPath)
+  shell.exec(`ern create-api ${f.complexApiName} -p ${f.testApiPkgName}  --schemaPath ${f.pathToComplexApiSchema} --skipNpmCheck`)
+}
+
+function regenTestApiFixture() {
+  logHeader("Regenerating Test API Fixture")
+  shell.rm('-rf', pathsToFixtures['TestApi'])
+  shell.cd(rootApiFixturesPath)
+  shell.exec(`ern create-api ${f.testApiName} -p ${f.testApiPkgName} --skipNpmCheck`)
+}
+
+function logHeader(message) {
+  console.log("======================================================")
+  console.log(message)
+  console.log("======================================================")
+}


### PR DESCRIPTION
Add a new script `regen-fixtures` to regenerate one or more system test fixture(s).

It can be launched while on dev version of Electrode Native, by running `npm run regen-fixtures` from the root of the Electrode Native workspace, as illustrated below.

One or more fixtures to regenerate can be selected.

This can be used after doing changes to the code generation output of Container or APIs to ensure that system tests will still pass.

```
➜  npm run regen-fixtures

? Choose one or more system test fixture(s) to regenerate (Press <space> to select, <a> to toggle all, <i> to invert selection)
❯◯ android-container
 ◯ ios-container
 ◯ api-impl-js
 ◯ api-impl-native
 ◯ ComplexApi
 ◯ TestApi
```

Close https://github.com/electrode-io/electrode-native/issues/611