### PR TITLE
Code push custom server

### DIFF
--- a/ern-core/src/CodePushSdk.js
+++ b/ern-core/src/CodePushSdk.js
@@ -22,13 +22,20 @@ export type CodePushReleaseInfo = {
   /* generated */ uploadTime: number;
 };
 
+export type CodePushInitConfig = {
+  accessKey: string,
+  customHeaders?: {[headerName: string]: string},
+  customServerUrl?: string,
+  proxy?: string
+}
+
 export type CodePushPackage = CodePushPackageInfo & CodePushReleaseInfo;
 
 export default class CodePushSdk {
   _codePush: any
 
-  constructor (accessKey: string) {
-    this._codePush = new CodePush(accessKey)
+  constructor (initConfig: CodePushInitConfig) {
+    this._codePush = new CodePush(initConfig.accessKey, initConfig.customHeaders, initConfig.customServerUrl, initConfig.proxy)
   }
 
   async releaseReact (

--- a/ern-core/src/index.js
+++ b/ern-core/src/index.js
@@ -117,5 +117,6 @@ export default ({
 
 export type {
   CodePushPackageInfo,
-  CodePushPackage
+  CodePushPackage,
+  CodePushInitConfig
 } from './CodePushSdk'

--- a/ern-local-cli/src/lib/publication.js
+++ b/ern-local-cli/src/lib/publication.js
@@ -20,7 +20,8 @@ import {
   reactnative
 } from 'ern-core'
 import type {
-  CodePushPackage
+  CodePushPackage,
+  CodePushInitConfig
 } from 'ern-core'
 
 import inquirer from 'inquirer'
@@ -546,21 +547,28 @@ async function getCodePushAppName (
   return result
 }
 
-export function getCodePushAccessKey () {
+export function getCodePushInitConfig (): CodePushInitConfig {
   const codePushConfigFilePath = path.join(process.env.LOCALAPPDATA || process.env.HOME || '', '.code-push.config')
+  var codePushInitConfig: CodePushInitConfig
   if (fs.existsSync(codePushConfigFilePath)) {
-    return JSON.parse(fs.readFileSync(codePushConfigFilePath, 'utf-8')).accessKey
+    codePushInitConfig = JSON.parse(fs.readFileSync(codePushConfigFilePath, 'utf-8'))
   } else {
-    return config.getValue('codePushAccessKey')
+    codePushInitConfig = {
+      'accessKey': config.getValue('codePushAccessKey'),
+      'customHeaders': config.getValue('codePushCustomHeaders'),
+      'customServerUrl': config.getValue('codePushCustomServerUrl'),
+      'proxy': config.getValue('codePushproxy')
+    }
   }
+  return codePushInitConfig
 }
 
 export function getCodePushSdk () {
-  const codePushAccessKey = getCodePushAccessKey()
-  if (!codePushAccessKey) {
-    throw new Error('Unable to get the CodePush access key to use')
+  const codePushInitConfig = getCodePushInitConfig()
+  if (!codePushInitConfig || !codePushInitConfig.accessKey) {
+    throw new Error('Unable to get the CodePush config to use')
   }
-  return new CodePushSdk(codePushAccessKey)
+  return new CodePushSdk(codePushInitConfig)
 }
 
 async function askUserToConfirmCodePushPublication (

--- a/ern-local-cli/test/publication-test.js
+++ b/ern-local-cli/test/publication-test.js
@@ -12,7 +12,7 @@ import {
 } from 'ern-core'
 import {
   getCodePushSdk,
-  getCodePushAccessKey,
+  getCodePushInitConfig,
   containsVersionMismatch,
   resolvePluginsVersions
 } from '../src/lib/publication'
@@ -36,7 +36,7 @@ describe('lib/publication.js', () => {
   // ==========================================================
   // getCodePushAccessKey
   // ==========================================================
-  describe('getCodePushAccessKey', () => {
+  describe('getCodePushInitConfig', () => {
     it('should return the access key from code push config if keys are present in both config files', () => {
       mockFs({
         [ernRcPath]: ernRcWithCodePushAccessKey,
@@ -44,7 +44,7 @@ describe('lib/publication.js', () => {
       }, {
         createCwd: false
       })
-      expect(getCodePushAccessKey()).to.be.equal(codePushConfigAccessKey)
+      expect(getCodePushInitConfig().accessKey).to.be.equal(codePushConfigAccessKey)
     })
 
     it('should return the access key from code push config if key is not present in .ernrc', () => {
@@ -54,7 +54,7 @@ describe('lib/publication.js', () => {
       }, {
         createCwd: false
       })
-      expect(getCodePushAccessKey()).to.be.equal(codePushConfigAccessKey)
+      expect(getCodePushInitConfig().accessKey).to.be.equal(codePushConfigAccessKey)
     })
 
     it('should return undefined if key is not found in .ernrc nor in .code-push.config', () => {
@@ -64,7 +64,7 @@ describe('lib/publication.js', () => {
       }, {
         createCwd: false
       })
-      expect(getCodePushAccessKey()).to.be.undefined
+      expect(getCodePushInitConfig().accessKey).to.be.undefined
     })
 
     it('should return undefined if key is not found in .ernrc and .code-push.config does not exist', () => {
@@ -73,7 +73,7 @@ describe('lib/publication.js', () => {
       }, {
         createCwd: false
       })
-      expect(getCodePushAccessKey()).to.be.undefined
+      expect(getCodePushInitConfig().accessKey).to.be.undefined
     })
   })
 


### PR DESCRIPTION
This PR adds the ability to pass custom configs to codePush SDK. Allowing you to specify your serverUrl for the OTA. 