### PR TITLE
Force authentication details to be part of an https cauldron url

### DIFF
--- a/docs/cli/cauldron/repo/add.md
+++ b/docs/cli/cauldron/repo/add.md
@@ -17,6 +17,7 @@
 `<url>`
 
 * HTTPS or SSH url to the Cauldron git repository
+* For HTTPS urls, the username and password (or token) must be specified in the URL (valid formats are `https://[username]:[password]@[repourl` or `https://[token]@[repourl]`).
 * By default, the `master` branch of the repository will be used. If you need to use a different branch, you can set the branch name you want to use, by appending it at the end of the url using the `#[branch-name]` format (second example below illustrate this).
 
 **Options**  

--- a/ern-local-cli/src/commands/cauldron/repo/add.js
+++ b/ern-local-cli/src/commands/cauldron/repo/add.js
@@ -22,6 +22,8 @@ exports.builder = function (yargs: any) {
     .epilog(utils.epilog(exports))
 }
 
+const supportedGitHttpsSchemeRe = /(^https:\/\/.+:.+@.+$)|(^https:\/\/.+@.+$)/
+
 exports.handler = function ({
   alias,
   url,
@@ -32,6 +34,15 @@ exports.handler = function ({
   current: boolean,
 }) {
   try {
+    if (url.startsWith('https')) {
+      if (!supportedGitHttpsSchemeRe.test(url)) {
+        throw new Error(`Cauldron https urls have to be formatted as : 
+https://[username]:[password]@[repourl]
+OR
+https://[token]@[repourl]`)
+      }
+    }
+
     let cauldronRepositories = ernConfig.getValue('cauldronRepositories', {})
     if (cauldronRepositories[alias]) {
       throw new Error(`A Cauldron repository is already associated to ${alias} alias`)


### PR DESCRIPTION
Close https://github.com/electrode-io/electrode-native/issues/389

Initial idea was to redirect stdin to ask the user for credentials, but it complicates things a lot. Also it can lead to issue when people try to do that on CI. So to make things more robust, the simple solution is just to ensure that users provide the credentials as part of the HTTPS url. 

If users don't want their username/password to be used, they can use a token instead, and still if they don't want that, then they can use an SSH url ;)
