### PR TITLE
Add initial custom scripting support for Container generator

### DIFF
--- a/ern-container-gen/src/utils.js
+++ b/ern-container-gen/src/utils.js
@@ -5,6 +5,7 @@ import _ from 'lodash'
 import path from 'path'
 import semver from 'semver'
 import {
+  config,
   reactnative,
   yarn,
   MiniApp,
@@ -271,6 +272,18 @@ export async function generateMiniAppsComposite (
   await writeFile('index.android.js', entryIndexJsContent)
   log.debug('Creating index.ios.js')
   await writeFile('index.ios.js', entryIndexJsContent)
+
+  await runAfterJsCompositeGenerationScript(outDir)
+}
+
+async function runAfterJsCompositeGenerationScript (outDir: string) {
+  const customScript = config.getValue('custom-script')
+  if (customScript) {
+    if (!fs.existsSync(customScript)) {
+      throw new Error(`custom-script was not found in ${customScript}`)
+    }
+    await require(customScript).afterJsCompositeGeneration({ outDir, yarn })
+  }
 }
 
 // TODO : [WINDOWS SUPPORT]


### PR DESCRIPTION
Initial commit to allow user written JS scripts to be executed during container generation, at certain steps of the container generation lifecycle. For now, this commit just allow for running a custom script function after the JS Composite MiniApp is generated.

Electrode Native provide the output directory path of the composite as a parameter to the script function, as well as the yarn object.

This is currently tailored for a specific use case that we need to deal with internally, and not the final implementation. Final implementation will include more hooks such as `beforeNativeContainerGeneration`, `afterNativeContainerGeneration`,`beforeJsCompositeGeneration`, `afterJsCompositeGeneration`, `beforeJsBundling`, `afterJsBundling` ... and will also provide more arguments than just the `yarn` object. Also custom script should be ultimately stored in Cauldron to be shared by all users of all the Cauldron. Keeping it local (as it is done is this PR) is just for experimentation and testing of the script, but is not the proper sharable way.