### PR TITLE
Add host and port options to run-ios and run-android

### DIFF
--- a/docs/cli/run-android.md
+++ b/docs/cli/run-android.md
@@ -28,6 +28,12 @@
 `--usePreviousDevice/-u`
 * Use the previously selected device to avoid prompt
 
+`--host`
+* Host or ip to launch the local packager on *(default: localhost)*
+
+`--port`
+* Port on which the local packager should listen on *(default: 8081)*
+
 #### Remarks
 
 * You can launch the MiniApp located in the current working directory or on a connected Android device or running emulator if available. If a connected Android device is not available, the command prompts you to select an emulator to launch from the list of installed emulator images.  

--- a/docs/cli/run-ios.md
+++ b/docs/cli/run-ios.md
@@ -28,6 +28,12 @@
  `--usePreviousDevice/-u`
  * Use the previously selected device to avoid prompt
 
+`--host`
+* Host or ip to launch the local packager on *(default: localhost)*
+
+`--port`
+* Port on which the local packager should listen on *(default: 8081)*
+
 #### Remarks
 
 * You can launch the MiniApp located in the current working directory or on a connected iOS device or running emulator if available. If a connected iOS device is not available, the command prompts you to select an emulator to launch from the list of installed emulator images.  

--- a/ern-local-cli/src/commands/run-android.js
+++ b/ern-local-cli/src/commands/run-android.js
@@ -39,6 +39,16 @@ exports.builder = function (yargs: any) {
       alias: 'u',
       describe: 'Use the previously selected device to avoid prompt'
     })
+    .option('host', {
+      type: 'string',
+      describe: 'Host/IP to use for the local packager',
+      default: 'localhost'
+    })
+    .option('port', {
+      type: 'string',
+      describe: 'Port to use for the local package',
+      default: '8081'
+    })
     .epilog(utils.epilog(exports))
 }
 
@@ -48,14 +58,18 @@ exports.handler = async function ({
   descriptor,
   mainMiniAppName,
   dev,
-  usePreviousDevice
+  usePreviousDevice,
+  host,
+  port
 } : {
   miniapps?: Array<string>,
   dependencies: Array<string>,
   descriptor?: string,
   mainMiniAppName?: string,
   dev?: boolean,
-  usePreviousDevice?: boolean
+  usePreviousDevice?: boolean,
+  host?: string,
+  port?: string
 }) {
   try {
     deviceConfig.updateDeviceConfig('android', usePreviousDevice)
@@ -65,7 +79,9 @@ exports.handler = async function ({
       miniapps,
       dependencies,
       descriptor,
-      dev
+      dev,
+      host,
+      port
     })
     process.exit(0)
   } catch (e) {

--- a/ern-local-cli/src/commands/run-ios.js
+++ b/ern-local-cli/src/commands/run-ios.js
@@ -39,6 +39,16 @@ exports.builder = function (yargs: any) {
       alias: 'u',
       describe: 'Use the previously selected device to avoid prompt'
     })
+    .option('host', {
+      type: 'string',
+      describe: 'Host/IP to use for the local packager',
+      default: 'localhost'
+    })
+    .option('port', {
+      type: 'string',
+      describe: 'Port to use for the local package',
+      default: '8081'
+    })
     .epilog(utils.epilog(exports))
 }
 
@@ -48,14 +58,18 @@ exports.handler = async function ({
   descriptor,
   mainMiniAppName,
   dev,
-  usePreviousDevice
+  usePreviousDevice,
+  host,
+  port
 } : {
   miniapps?: Array<string>,
   dependencies: Array<string>,
   descriptor?: string,
   mainMiniAppName?: string,
   dev?: boolean,
-  usePreviousDevice?: boolean
+  usePreviousDevice?: boolean,
+  host?: string,
+  port?: string
 }) {
   try {
     if (process.platform !== 'darwin') {
@@ -68,7 +82,9 @@ exports.handler = async function ({
       miniapps,
       dependencies,
       descriptor,
-      dev
+      dev,
+      host,
+      port
     })
   } catch (e) {
     coreUtils.logErrorAndExitProcess(e)

--- a/ern-runner-gen/runner-hull/android/app/src/main/java/com/walmartlabs/ern/RunnerConfig.java
+++ b/ern-runner-gen/runner-hull/android/app/src/main/java/com/walmartlabs/ern/RunnerConfig.java
@@ -11,4 +11,6 @@ import com.walmartlabs.ern.container.miniapps.{{{pascalCaseMiniAppName}}}Activit
 final class RunnerConfig {
   static final Class MAIN_MINIAPP_ACTIVITY_CLASS =  {{{pascalCaseMiniAppName}}}Activity.class;
   static final boolean RN_DEV_SUPPORT_ENABLED = {{{isReactNativeDevSupportEnabled}}};
+  static final String PACKAGER_HOST = "{{{packagerHost}}}";
+  static final String PACKAGER_PORT = "{{{packagerPort}}}";
 }

--- a/ern-runner-gen/runner-hull/ios/ErnRunner/RunnerConfig.m
+++ b/ern-runner-gen/runner-hull/ios/ErnRunner/RunnerConfig.m
@@ -24,3 +24,5 @@
 
 NSString *const MainMiniAppName = @"{{{miniAppName}}}";
 BOOL const RnDevSupportEnabled = {{{isReactNativeDevSupportEnabled}}};
+NSString *const PackagerHost = @"{{{packagerHost}}}";
+NSString *const PackagerPort = @"{{{packagerPort}}}";

--- a/ern-runner-gen/src/index.js
+++ b/ern-runner-gen/src/index.js
@@ -49,14 +49,20 @@ export async function generateAndroidRunnerProject (
   outDir: string,
   containerGenWorkingDir: string,
   mainMiniAppName: string, {
-    reactNativeDevSupportEnabled
+    reactNativeDevSupportEnabled,
+    host = 'localhost',
+    port = '8081'
   } : {
-    reactNativeDevSupportEnabled?: boolean
+    reactNativeDevSupportEnabled?: boolean,
+    host?: string,
+    port?: string
   } = {}) {
   const mustacheView = {
     miniAppName: mainMiniAppName,
     pascalCaseMiniAppName: pascalCase(mainMiniAppName),
-    isReactNativeDevSupportEnabled: reactNativeDevSupportEnabled === true ? 'true' : 'false'
+    isReactNativeDevSupportEnabled: reactNativeDevSupportEnabled === true ? 'true' : 'false',
+    packagerHost: host,
+    packagerPort: port
   }
   shell.cp('-R', path.join(runnerHullPath, 'android', '*'), outDir)
   const files = readDir(path.join(runnerHullPath, 'android'),
@@ -71,16 +77,22 @@ export async function generateIosRunnerProject (
   outDir: string,
   containerGenWorkingDir: string,
   mainMiniAppName: string, {
-    reactNativeDevSupportEnabled
+    reactNativeDevSupportEnabled,
+    host = 'localhost',
+    port = '8081'
   } : {
-    reactNativeDevSupportEnabled?: boolean
+    reactNativeDevSupportEnabled?: boolean,
+    host?: string,
+    port?: string
   } = {}) {
   const pathToElectrodeContainerXcodeProj = replaceHomePathWithTidle(path.join(containerGenWorkingDir, 'out', 'ios'))
   const mustacheView = {
     miniAppName: mainMiniAppName,
     pascalCaseMiniAppName: pascalCase(mainMiniAppName),
     isReactNativeDevSupportEnabled: reactNativeDevSupportEnabled === true ? 'YES' : 'NO',
-    pathToElectrodeContainerXcodeProj
+    pathToElectrodeContainerXcodeProj,
+    packagerHost: host,
+    packagerPort: port
   }
 
   shell.cp('-R', path.join(runnerHullPath, 'ios', '*'), outDir)
@@ -99,17 +111,29 @@ export async function regenerateRunnerConfig (
   outDir: string,
   containerGenWorkingDir: string,
   mainMiniAppName: string, {
-    reactNativeDevSupportEnabled
+    reactNativeDevSupportEnabled,
+    host,
+    port
   } : {
-    reactNativeDevSupportEnabled?: boolean
+    reactNativeDevSupportEnabled?: boolean,
+    host?: string,
+    port?: string
   } = {}) {
   try {
     if (platform === 'android') {
       await regenerateAndroidRunnerConfig(
-        outDir, containerGenWorkingDir, mainMiniAppName, { reactNativeDevSupportEnabled })
+        outDir, containerGenWorkingDir, mainMiniAppName, {
+          reactNativeDevSupportEnabled,
+          host,
+          port
+        })
     } else if (platform === 'ios') {
       await regenerateIosRunnerConfig(
-        outDir, containerGenWorkingDir, mainMiniAppName, { reactNativeDevSupportEnabled })
+        outDir, containerGenWorkingDir, mainMiniAppName, {
+          reactNativeDevSupportEnabled,
+          host,
+          port
+        })
     }
   } catch (e) {
     log.error('Something went wrong: ' + e)
@@ -121,14 +145,20 @@ export async function regenerateAndroidRunnerConfig (
   pathToRunnerProject: string,
   containerGenWorkingDir: string,
   mainMiniAppName: string, {
-    reactNativeDevSupportEnabled
+    reactNativeDevSupportEnabled,
+    host = 'localhost',
+    port = '8081'
   } : {
-    reactNativeDevSupportEnabled?: boolean
+    reactNativeDevSupportEnabled?: boolean,
+    host?: string,
+    port?: string
   } = {}) {
   const mustacheView = {
     miniAppName: mainMiniAppName,
     pascalCaseMiniAppName: pascalCase(mainMiniAppName),
-    isReactNativeDevSupportEnabled: reactNativeDevSupportEnabled === true ? 'true' : 'false'
+    isReactNativeDevSupportEnabled: reactNativeDevSupportEnabled === true ? 'true' : 'false',
+    packagerHost: host,
+    packagerPort: port
   }
   const subPathToRunnerConfig = path.join('app', 'src', 'main', 'java', 'com', 'walmartlabs', 'ern', 'RunnerConfig.java')
   const pathToRunnerConfigHull = path.join(runnerHullPath, 'android', subPathToRunnerConfig)
@@ -141,18 +171,23 @@ export async function regenerateAndroidRunnerConfig (
 export async function regenerateIosRunnerConfig (
   pathToRunnerProject: string,
   containerGenWorkingDir: string,
-  mainMiniAppName: string,
-  {
-    reactNativeDevSupportEnabled
+  mainMiniAppName: string, {
+    reactNativeDevSupportEnabled,
+    host = 'localhost',
+    port = '8081'
   } : {
-    reactNativeDevSupportEnabled?: boolean
+    reactNativeDevSupportEnabled?: boolean,
+    host?: string,
+    port?: string
   } = {}) {
   const pathToElectrodeContainerXcodeProj = replaceHomePathWithTidle(path.join(containerGenWorkingDir, 'out', 'ios'))
   const mustacheView = {
     miniAppName: mainMiniAppName,
     pascalCaseMiniAppName: pascalCase(mainMiniAppName),
     isReactNativeDevSupportEnabled: reactNativeDevSupportEnabled === true ? 'YES' : 'NO',
-    pathToElectrodeContainerXcodeProj
+    pathToElectrodeContainerXcodeProj,
+    packagerHost: host,
+    packagerPort: port
   }
   const pathToRunnerConfig = path.join(pathToRunnerProject, 'ErnRunner/RunnerConfig.m')
   shell.cp(path.join(runnerHullPath, 'ios', 'ErnRunner', 'RunnerConfig.m'), pathToRunnerConfig)


### PR DESCRIPTION
Add `host` and `port` options to `run-ios` and `run-android`.
All that this does for now is to add the `host` and `port` to the generation config source file (`RunnerConfig.java` and `RunnerConfig.m`).
Next step is to update Container code to properly use the specified host and port instead of always using the default (localhost/8081).
Related to https://github.com/electrode-io/electrode-native/issues/688