### PR TITLE
Add .h to determine if a directory is a native module

### DIFF
--- a/ern-core/src/nativeDependenciesLookup.js
+++ b/ern-core/src/nativeDependenciesLookup.js
@@ -8,7 +8,7 @@ import manifest from './Manifest'
 import * as ModuleTypes from './ModuleTypes'
 
 export function findDirectoriesContainingNativeCode (rootDir: string) : Array<string> {
-  return readDir(rootDir).filter(a => /.swift$|.java$/.test(a))
+  return readDir(rootDir).filter(a => /.swift$|.h$|.java$/.test(a))
 }
 
 export function filterDirectories (directories: Array<string>) : Array<string> {


### PR DESCRIPTION
Issue: 
When trying to add `react-native-permissions` as a plugin, the plugin doesn't get passed to ContainerGenerator. After digging into the code, it turns out the following function returned an incorrect result. This function assumes that a folder that has files end with either .swift or .java is a native module. However, this assumption is not correct as many native module third party plugin is written in objective-c whose file extension is either .h or .m. 

Solution:
add `.h` as a filter because for ios native module, if it's just a .framework, it will have only `.h` file extension. As with `.xcproject` module, it will have both .h and .m file extensions. Thus, add `.h` as filter. 