### PR TITLE
Fix native dependencies lookup

### DIFF
--- a/ern-core/src/nativeDependenciesLookup.js
+++ b/ern-core/src/nativeDependenciesLookup.js
@@ -8,7 +8,7 @@ import manifest from './Manifest'
 import * as ModuleTypes from './ModuleTypes'
 
 export function findDirectoriesContainingNativeCode (rootDir: string) : Array<string> {
-  return readDir(rootDir).filter(a => /.swift$|.h$|.java$/.test(a))
+  return readDir(rootDir).filter(a => /.swift$|.pbxproj$|.java$/.test(a))
 }
 
 export function filterDirectories (directories: Array<string>) : Array<string> {


### PR DESCRIPTION
This PR fix https://github.com/electrode-io/electrode-native/pull/692 (sorry that I missed this one :()
While the intent was proper, the problem of looking for `.h` files is that it is an extension that can be present in a lot of non iOS specific modules (C/C++ is used for quite some JavaScript node modules). We then end up with a lot of false negative in term of native dependencies. 
For example, running `ern list dependencies` on the composite Walmart JS app, ends up listing a lot of `Third party not declared in manifest` native dependencies (false positive as they are not native dependencies -see below output of command-). Solution is just to look for `.pbxproj` instead of `.h` which is a stronger indication that this is an iOS native module. With this modification, `react-native-permissions` is properly handled while not listing (greatly reducing the risk) any false positive 

```
➜ ern list dependencies
=== APIs ===
@walmart/react-native-ccm-api@1.0.6
@walmart/react-native-easyreturns-api@1.5.2
@walmart/react-native-metaheader-api@0.1.0
@walmart/react-native-payment-api@0.0.6
@walmart/react-native-walmart-location-api@0.0.2
@walmart/react-native-walmartanalytics-api@0.19.1
@walmart/react-native-walmartcart-api@1.2.0
@walmart/react-native-walmartcheckout-api@0.0.3
@walmart/react-native-walmartcookie-api@0.18.2
@walmart/react-native-walmartheader-api@0.0.10
@walmart/react-native-walmartnavigation-api@0.18.4
@walmart/react-native-walmartscanner-api@1.0.1
@walmart/react-native-walmartstate-api@0.32.1
@walmart/react-native-walmartuserauth-api@0.18.4
=== Third party declared in Manifest ===
react-native@0.42.0
react-native-android-settings-library@1.0.3
react-native-code-push@1.17.1-beta
react-native-electrode-bridge@1.5.9
react-native-fbsdk@0.5.0
react-native-keep-awake@2.0.4
react-native-linear-gradient@2.1.0
react-native-llimageview@0.0.7
react-native-llphotoassets@0.0.2
react-native-lluploader@0.1.3
react-native-location@0.27.0
react-native-maps@0.13.1
react-native-permissions@1.1.1
=== Third party not declared in Manifest ===
@walmart/electrode-fetch@6.7.1
@walmart/electrode-npm-singleton@1.2.0
@walmart/s2s-auth-signature@1.0.0
@walmart/wmreact-icons@1.22.1
babel-cli@6.26.0
babel-polyfill@6.26.0
code-push@1.8.0-beta
core-util-is@1.0.2
cssstyle@0.2.37
duplexer2@0.0.2
fsevents@1.1.3
jest-haste-map@21.2.0
multiparty@3.3.2
nan@2.10.0
node-uuid@1.4.7
object.assign@4.1.0
stream-counter@0.2.0
temp@0.8.3
tmp@0.0.29
which@1.3.0
```
