### PR TITLE
force cleaning of package directory in node_modules after moving the …

### DIFF
--- a/ern-core/src/MiniApp.js
+++ b/ern-core/src/MiniApp.js
@@ -88,6 +88,7 @@ Are you sure this is a MiniApp ?`)
     const packageName = Object.keys(packageJson.dependencies)[0]
     shell.rm(path.join(tmpMiniAppPath, 'package.json'))
     shell.mv(path.join(tmpMiniAppPath, 'node_modules', packageName, '*'), tmpMiniAppPath)
+    shell.rm('-rf', path.join(tmpMiniAppPath, 'node_modules', packageName, '*'))
     return new MiniApp(tmpMiniAppPath, false /* isLocal */, packagePath)
   }
 


### PR DESCRIPTION
…contents to root directory

**Issue**: When miniapp is looking for it's native dependencies the miniapp name is also returned in the list. 


**Root cause**: This was caused because of the `electrode-native-bridge` directory was still remaining inside `node_modules/<miniappname>` directory even after the [move](https://github.com/electrode-io/electrode-native/compare/master...deepueg:fix-create-container-issue?expand=1#diff-45142d217dea7e95458dcef2b4c18fb2R90) command execution. 


**Solution**: Ensure the `node_modules/<miniappname>` directory is emptied after the move. 