### PR TITLE
Store Container JS bundle and assets in Cauldron

### DIFF
--- a/ern-cauldron-api/src/CauldronApi.js
+++ b/ern-cauldron-api/src/CauldronApi.js
@@ -704,6 +704,15 @@ export default class CauldronApi {
     await this.commit(`Set yarn locks for ${descriptor.toString()}`)
   }
 
+  async addBundle (
+    descriptor: NativeApplicationDescriptor,
+    bundle: string | Buffer) {
+    this.throwIfPartialNapDescriptor(descriptor)
+    const filename = `${descriptor.toString()}.zip`
+    await this._bundleStore.storeFile(filename, bundle)
+    return this.commit(`Add bundle for ${descriptor.toString()}`)
+  }
+
   async addPublisher (descriptor: NativeApplicationDescriptor, publisherType: ('maven' | 'github'), url: string) {
     try {
       const platform = await this.getPlatform(descriptor)

--- a/ern-cauldron-api/src/CauldronApi.js
+++ b/ern-cauldron-api/src/CauldronApi.js
@@ -25,14 +25,17 @@ export default class CauldronApi {
   _db: ICauldronDocumentStore
   _sourceMapStore: ICauldronFileStore
   _yarnlockStore: ICauldronFileStore
+  _bundleStore: ICauldronFileStore
 
   constructor (
     db: ICauldronDocumentStore,
     sourcemapStore: ICauldronFileStore,
-    yarnlockStore: ICauldronFileStore) {
+    yarnlockStore: ICauldronFileStore,
+    bundleStore: ICauldronFileStore) {
     this._db = db
     this._sourceMapStore = sourcemapStore
     this._yarnlockStore = yarnlockStore
+    this._bundleStore = bundleStore
   }
 
   async commit (message: string) : Promise<void> {

--- a/ern-cauldron-api/src/CauldronApi.js
+++ b/ern-cauldron-api/src/CauldronApi.js
@@ -708,9 +708,33 @@ export default class CauldronApi {
     descriptor: NativeApplicationDescriptor,
     bundle: string | Buffer) {
     this.throwIfPartialNapDescriptor(descriptor)
-    const filename = `${descriptor.toString()}.zip`
+    const filename = this.getBundleZipFileName(descriptor)
     await this._bundleStore.storeFile(filename, bundle)
     return this.commit(`Add bundle for ${descriptor.toString()}`)
+  }
+
+  async hasBundle (
+    descriptor: NativeApplicationDescriptor) : Promise<boolean> {
+    this.throwIfPartialNapDescriptor(descriptor)
+    const filename = this.getBundleZipFileName(descriptor)
+    return this._bundleStore.hasFile(filename)
+  }
+
+  async getBundle (
+    descriptor: NativeApplicationDescriptor) : Promise<Buffer> {
+    this.throwIfPartialNapDescriptor(descriptor)
+    const filename = this.getBundleZipFileName(descriptor)
+    const zippedBundle = await this._bundleStore.getFile(filename)
+    if (!zippedBundle) {
+      throw new Error(`No zipped bundle stored in Cauldron for ${descriptor.toString()}`)
+    }
+    return zippedBundle
+  }
+
+  getBundleZipFileName (
+    descriptor: NativeApplicationDescriptor) : string {
+    this.throwIfPartialNapDescriptor(descriptor)
+    return `${descriptor.toString()}.zip`
   }
 
   async addPublisher (descriptor: NativeApplicationDescriptor, publisherType: ('maven' | 'github'), url: string) {

--- a/ern-cauldron-api/src/index.js
+++ b/ern-cauldron-api/src/index.js
@@ -12,8 +12,9 @@ export default function factory (
   branch: string = 'master') {
   const sourcemapStore = new GitFileStore(cauldronPath, repository, branch, 'sourcemaps')
   const yarnlockStore = new GitFileStore(cauldronPath, repository, branch, 'yarnlocks')
+  const bundleStore = new GitFileStore(cauldronPath, repository, branch, 'bundles')
   const dbStore = new GitDocumentStore(cauldronPath, repository, branch)
-  return new _CauldronApi(dbStore, sourcemapStore, yarnlockStore)
+  return new _CauldronApi(dbStore, sourcemapStore, yarnlockStore, bundleStore)
 }
 
 export const CauldronApi = _CauldronApi

--- a/ern-cauldron-api/test/CauldronApi-test.js
+++ b/ern-cauldron-api/test/CauldronApi-test.js
@@ -1365,6 +1365,53 @@ describe('CauldronApi.js', () => {
   })
 
   // ==========================================================
+  // hasBundle
+  // ==========================================================
+  describe('hasBundle', () => {
+    it('should throw if the native application descriptor is partial', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.hasBundle, api, NativeApplicationDescriptor.fromString('test:android')))
+    })
+
+    it('should return true if there is a stored bundle for the given native application descriptor', async () => {
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      const api = cauldronApi(tmpFixture)
+      await api.addBundle(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'BUNDLE_CONTENT')
+      assert(await api.hasBundle('test:android:17.7.0'))
+    })
+
+    it('should return false if there is no stored bundle for the given native application descriptor', async () => {
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      const api = cauldronApi(tmpFixture)
+      assert(!await api.hasBundle('test:android:17.7.0'))
+    })
+  })
+
+  // ==========================================================
+  // getBundle
+  // ==========================================================
+  describe('getBundle', () => {
+    it('should throw if the native application descriptor is partial', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.getBundle, api, NativeApplicationDescriptor.fromString('test:android')))
+    })
+
+    it('should throw if there is no stored bundle for the given native application descriptor', async () => {
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      const api = cauldronApi(tmpFixture)
+      assert(await doesThrow(api.getBundle, api, NativeApplicationDescriptor.fromString('test:android:17.7.0')))
+    })
+
+    it('should return the stored bundle for the given native application descriptor', async () => {
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      const api = cauldronApi(tmpFixture)
+      await api.addBundle(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'BUNDLE_CONTENT')
+      const result = await api.getBundle(NativeApplicationDescriptor.fromString('test:android:17.7.0'))
+      expect(result.toString()).eql('BUNDLE_CONTENT')
+    })
+  })
+
+  // ==========================================================
   // throwIfPartialNapDescriptor
   // ==========================================================
   describe('throwIfPartialNapDescriptor', () => {

--- a/ern-cauldron-api/test/CauldronApi-test.js
+++ b/ern-cauldron-api/test/CauldronApi-test.js
@@ -1350,6 +1350,21 @@ describe('CauldronApi.js', () => {
   })
 
   // ==========================================================
+  // addBundle
+  // ==========================================================
+  describe('addBundle', () => {
+    it('should throw if the native application descriptor is partial', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.addBundle, api, NativeApplicationDescriptor.fromString('test:android'), 'BUNDLE_CONTENT'))
+    })
+
+    it('should properly add the bundle', async () => {
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      await cauldronApi(tmpFixture).addBundle(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'BUNDLE_CONTENT')
+    })
+  })
+
+  // ==========================================================
   // throwIfPartialNapDescriptor
   // ==========================================================
   describe('throwIfPartialNapDescriptor', () => {

--- a/ern-cauldron-api/test/CauldronApi-test.js
+++ b/ern-cauldron-api/test/CauldronApi-test.js
@@ -54,7 +54,8 @@ function cauldronApi(cauldronDocument) {
   documentStore = new InMemoryDocumentStore(cauldronDocument)
   const sourceMapStore = new EphemeralFileStore()
   yarnLockStore = new EphemeralFileStore()
-  return new CauldronApi(documentStore, sourceMapStore, yarnLockStore)
+  const bundleStore = new EphemeralFileStore()
+  return new CauldronApi(documentStore, sourceMapStore, yarnLockStore, bundleStore)
 }
 
 function getCauldronFixtureClone() {

--- a/ern-container-gen/src/FlowTypes.js
+++ b/ern-container-gen/src/FlowTypes.js
@@ -4,6 +4,9 @@ import {
   PackagePath,
   MiniApp
 } from 'ern-core'
+import type {
+  BundlingResult
+} from 'ern-core'
 
 export type ContainerGeneratorPaths = {
   // Where we assemble the miniapps together
@@ -33,9 +36,14 @@ export type ContainerGeneratorConfig = {
   pathToYarnLock?: string;
 }
 
+export type ContainerGenResult = {
+  // Metadata resulting from the bundling
+  bundlingResult: BundlingResult
+}
+
 export interface ContainerGenerator {
   // Generate a Container
-  generate(config: ContainerGeneratorConfig) : Promise<void>;
+  generate(config: ContainerGeneratorConfig) : Promise<ContainerGenResult>;
   // Name of the Container Generator
   +name : string;
   // Native platform that this generator targets

--- a/ern-container-gen/src/generators/android/AndroidGenerator.js
+++ b/ern-container-gen/src/generators/android/AndroidGenerator.js
@@ -22,8 +22,12 @@ import readDir from 'fs-readdir-recursive'
 import fs from 'fs'
 import type {
   ContainerGenerator,
-  ContainerGeneratorConfig
+  ContainerGeneratorConfig,
+  ContainerGenResult
 } from '../../FlowTypes'
+import type {
+  BundlingResult
+} from 'ern-core'
 
 const ROOT_DIR = process.cwd()
 const PATH_TO_TEMPLATES_DIR = path.join(__dirname, 'templates')
@@ -58,7 +62,7 @@ export default class AndroidGenerator implements ContainerGenerator {
     }
   }
 
-  async generate (config: ContainerGeneratorConfig) : Promise<void> {
+  async generate (config: ContainerGeneratorConfig) : Promise<ContainerGenResult> {
     try {
       this.prepareDirectories(config)
       config.plugins = sortDependenciesByName(config.plugins)
@@ -69,7 +73,7 @@ export default class AndroidGenerator implements ContainerGenerator {
 
       const jsApiImplDependencies = await coreUtils.extractJsApiImplementations(config.plugins)
 
-      await bundleMiniApps(
+      const bundlingResult: BundlingResult = await bundleMiniApps(
         config.miniApps,
         config.compositeMiniAppDir,
         config.outDir,
@@ -79,6 +83,10 @@ export default class AndroidGenerator implements ContainerGenerator {
 
       if (!config.ignoreRnpmAssets) {
         copyRnpmAssets(config.miniApps, config.compositeMiniAppDir, config.outDir, 'android')
+      }
+
+      return {
+        bundlingResult
       }
     } catch (e) {
       log.error('[generateContainer] Something went wrong. Aborting Container Generation')

--- a/ern-container-gen/src/index.js
+++ b/ern-container-gen/src/index.js
@@ -27,5 +27,6 @@ export type {
   ContainerGenerator,
   ContainerGeneratorConfig,
   ContainerPublisherConfig,
-  ContainerMavenPublisherConfig
+  ContainerMavenPublisherConfig,
+  ContainerGenResult
 } from './FlowTypes'

--- a/ern-container-gen/src/utils.js
+++ b/ern-container-gen/src/utils.js
@@ -16,6 +16,9 @@ import {
   ModuleTypes,
   utils
 } from 'ern-core'
+import type {
+  BundlingResult
+} from 'ern-core'
 
 export async function bundleMiniApps (
   // The miniapps to be bundled
@@ -28,7 +31,7 @@ export async function bundleMiniApps (
     pathToYarnLock?: string
   } = {},
   // JavaScript API implementations
-  jsApiImplDependencies?: Array<PackagePath>) {
+  jsApiImplDependencies?: Array<PackagePath>) : Promise<BundlingResult> {
   try {
     log.debug('[=== Starting mini apps bundling ===]')
 
@@ -41,22 +44,26 @@ export async function bundleMiniApps (
 
     clearReactPackagerCache()
 
+    let result: BundlingResult
+
     if (platform === 'android') {
       log.debug('Bundling miniapp(s) for Android')
-      await reactNativeBundleAndroid(outDir)
-    } else if (platform === 'ios') {
+      result = await reactNativeBundleAndroid(outDir)
+    } else {
       log.debug('Bundling miniapp(s) for iOS')
-      await reactNativeBundleIos(outDir)
+      result = await reactNativeBundleIos(outDir)
     }
 
     log.debug('[=== Completed mini apps bundling ===]')
+
+    return result
   } catch (e) {
     log.error(`[bundleMiniApps] Something went wrong: ${e}`)
     throw e
   }
 }
 
-export async function reactNativeBundleAndroid (outDir: string) {
+export async function reactNativeBundleAndroid (outDir: string) : Promise<BundlingResult> {
   const libSrcMainPath = path.join(outDir, 'lib', 'src', 'main')
   const bundleOutput = path.join(libSrcMainPath, 'assets', 'index.android.bundle')
   const assetsDest = path.join(libSrcMainPath, 'res')
@@ -70,7 +77,7 @@ export async function reactNativeBundleAndroid (outDir: string) {
   })
 }
 
-export async function reactNativeBundleIos (outDir: string) {
+export async function reactNativeBundleIos (outDir: string) : Promise<BundlingResult> {
   const miniAppOutPath = path.join(outDir, 'ElectrodeContainer', 'Libraries', 'MiniApp')
   const bundleOutput = path.join(miniAppOutPath, 'MiniApp.jsbundle')
   const assetsDest = miniAppOutPath

--- a/ern-core/src/CauldronHelper.js
+++ b/ern-core/src/CauldronHelper.js
@@ -234,6 +234,16 @@ export default class CauldronHelper {
     return this.cauldron.addBundle(napDescriptor, bundle)
   }
 
+  async hasBundle (
+    napDescriptor: NativeApplicationDescriptor) : Promise<boolean> {
+    return this.cauldron.hasBundle(napDescriptor)
+  }
+
+  async getBundle (
+    napDescriptor: NativeApplicationDescriptor) : Promise<Buffer> {
+    return this.cauldron.getBundle(napDescriptor)
+  }
+
   async isNativeDependencyInContainer (
     napDescriptor: NativeApplicationDescriptor,
     dependencyName: string) : Promise<boolean> {

--- a/ern-core/src/CauldronHelper.js
+++ b/ern-core/src/CauldronHelper.js
@@ -228,6 +228,12 @@ export default class CauldronHelper {
     return this.cauldron.updateYarnLockId(napDescriptor, key, id)
   }
 
+  async addBundle (
+    napDescriptor: NativeApplicationDescriptor,
+    bundle: string | Buffer) : Promise<void> {
+    return this.cauldron.addBundle(napDescriptor, bundle)
+  }
+
   async isNativeDependencyInContainer (
     napDescriptor: NativeApplicationDescriptor,
     dependencyName: string) : Promise<boolean> {

--- a/ern-core/src/ReactNativeCli.js
+++ b/ern-core/src/ReactNativeCli.js
@@ -12,6 +12,17 @@ import {
 } from './childProcess'
 const fetch = require('node-fetch')
 
+export type BundlingResult = {
+  // The root path to the assets
+  assetsPath: string;
+  // The target platform of the bundle
+  platform: string;
+  // Indicates whether this is a dev bundle or a production one
+  dev: boolean;
+  // Full path to the bundle
+  bundlePath: string;
+}
+
 export default class ReactNativeCli {
   _binaryPath: ?string
 
@@ -45,7 +56,7 @@ export default class ReactNativeCli {
     bundleOutput: string,
     assetsDest: string,
     platform: string
-  }) {
+  }) : Promise<BundlingResult> {
     const bundleCommand =
     `${this.binaryPath} bundle \
 ${entryFile ? `--entry-file=${entryFile}` : ''} \
@@ -54,7 +65,13 @@ ${platform ? `--platform=${platform}` : ''} \
 ${bundleOutput ? `--bundle-output=${bundleOutput}` : ''} \
 ${assetsDest ? `--assets-dest=${assetsDest}` : ''}`
 
-    return execp(bundleCommand)
+    await execp(bundleCommand)
+    return {
+      assetsPath: assetsDest,
+      platform,
+      dev,
+      bundlePath: bundleOutput
+    }
   }
 
   startPackager (cwd: string) {

--- a/ern-core/src/index.js
+++ b/ern-core/src/index.js
@@ -120,3 +120,7 @@ export type {
   CodePushPackage,
   CodePushInitConfig
 } from './CodePushSdk'
+
+export type {
+  BundlingResult
+} from './ReactNativeCli'

--- a/ern-core/test/CauldronHelper-test.js
+++ b/ern-core/test/CauldronHelper-test.js
@@ -85,12 +85,13 @@ const jsApiImplFixtureOne = [ PackagePath.fromString('react-native-test-js-api-i
 
 let cauldronHelper
 let documentStore
+let bundleStore
 
 function createCauldronApi(cauldronDocument) {
   documentStore = new InMemoryDocumentStore(cauldronDocument)
   const sourceMapStore = new EphemeralFileStore()
   const yarnLockStore = new EphemeralFileStore()
-  const bundleStore = new EphemeralFileStore()
+  bundleStore = new EphemeralFileStore()
   return new CauldronApi(documentStore, sourceMapStore, yarnLockStore, bundleStore)
 }
 
@@ -1003,6 +1004,38 @@ describe('CauldronHelper.js', () => {
         '1111111111111171fe5d52e31a2cfabcbb31e33e')
       const nativeAppVersion = jp.query(fixture, testAndroid1770Path)[0]
       expect(nativeAppVersion.yarnLocks).to.have.property('Production').eql('1111111111111171fe5d52e31a2cfabcbb31e33e')
+    })
+  })
+
+  describe('addBundle', () => {
+    it('should throw if the given native application descriptor is partial', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      assert(doesThrow(
+        cauldronHelper.addBundle,
+        cauldronHelper,
+        NativeApplicationDescriptor.fromString('test:android'), 
+        'bundleContent'))
+    })
+
+    it('should throw if the given native application descriptor is not in Cauldron', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      assert(doesThrow(
+        cauldronHelper.addBundle,
+        cauldronHelper,
+        NativeApplicationDescriptor.fromString('test:android:0.0.0'), 
+        'bundleContent'))
+    })
+
+    it('should add the bundle', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      await cauldronHelper.addBundle(
+        NativeApplicationDescriptor.fromString('test:android:17.7.0'),
+        'bundleContent')
+      const bundledAdded = await bundleStore.hasFile('test:android:17.7.0.zip')
+      expect(bundledAdded).true
     })
   })
 

--- a/ern-core/test/CauldronHelper-test.js
+++ b/ern-core/test/CauldronHelper-test.js
@@ -1039,6 +1039,64 @@ describe('CauldronHelper.js', () => {
     })
   })
 
+  describe('hasBundle', () => {
+    it('should throw if the given native application descriptor is partial', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      assert(doesThrow(
+        cauldronHelper.hasBundle,
+        cauldronHelper,
+        NativeApplicationDescriptor.fromString('test:android')))
+    })
+
+    it('should return true if there is a stored bundle for the given native application descriptor', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      await cauldronHelper.addBundle(
+        NativeApplicationDescriptor.fromString('test:android:17.7.0'), 
+        'BUNDLE_CONTENT')
+      const hasBundle = await cauldronHelper.hasBundle('test:android:17.7.0')
+      expect(hasBundle).true
+    })
+
+    it('should return false if there is no stored bundle for the given native application descriptor', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      const hasBundle = await cauldronHelper.hasBundle('test:android:17.7.0')
+      expect(hasBundle).false
+    })
+  })
+
+  describe('getBundle', () => {
+    it('should throw if the given native application descriptor is partial', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      assert(doesThrow(
+        cauldronHelper.getBundle,
+        cauldronHelper,
+        NativeApplicationDescriptor.fromString('test:android')))
+    })
+
+    it('should throw if there is no stored bundle for the given native application descriptor', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      assert(doesThrow(
+        cauldronHelper.getBundle,
+        cauldronHelper,
+        NativeApplicationDescriptor.fromString('test:android:17.7.0')))
+    })
+
+    it('should return the stored bundle for the given native application descriptor', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      await cauldronHelper.addBundle(
+        NativeApplicationDescriptor.fromString('test:android:17.7.0'),
+        'BUNDLE_CONTENT')
+      const bundle = await cauldronHelper.getBundle('test:android:17.7.0')
+      expect(bundle.toString()).eql('BUNDLE_CONTENT')
+    })
+  })
+
   describe ('getNativeDependency', () => {
     it('should throw if the given native application descriptor is partial', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)

--- a/ern-core/test/CauldronHelper-test.js
+++ b/ern-core/test/CauldronHelper-test.js
@@ -90,7 +90,8 @@ function createCauldronApi(cauldronDocument) {
   documentStore = new InMemoryDocumentStore(cauldronDocument)
   const sourceMapStore = new EphemeralFileStore()
   const yarnLockStore = new EphemeralFileStore()
-  return new CauldronApi(documentStore, sourceMapStore, yarnLockStore)
+  const bundleStore = new EphemeralFileStore()
+  return new CauldronApi(documentStore, sourceMapStore, yarnLockStore, bundleStore)
 }
 
 function createCauldronHelper(cauldronDocument) {

--- a/ern-local-cli/package.json
+++ b/ern-local-cli/package.json
@@ -61,6 +61,7 @@
     "ern-container-gen": "1000.0.0",
     "ern-core": "1000.0.0",
     "ern-runner-gen": "1000.0.0",
+    "fs-readdir-recursive": "^1.1.0",
     "inquirer": "^3.0.6",
     "lodash": "^4.17.4",
     "ora": "^1.1.0",

--- a/ern-local-cli/package.json
+++ b/ern-local-cli/package.json
@@ -66,7 +66,8 @@
     "ora": "^1.1.0",
     "semver": "^5.3.0",
     "validate-npm-package-name": "^3.0.0",
-    "yargs": "^7.1.0"
+    "yargs": "^7.1.0",
+    "yazl": "^2.4.3"
   },
   "devDependencies": {
     "ern-util-dev": "1000.0.0"

--- a/ern-local-cli/package.json
+++ b/ern-local-cli/package.json
@@ -55,6 +55,7 @@
     "chalk": "^2.3.0",
     "chokidar": "^1.7.0",
     "cli-table": "^0.3.1",
+    "dir-compare": "^1.4.0",
     "ern-api-gen": "1000.0.0",
     "ern-api-impl-gen": "1000.0.0",
     "ern-cauldron-api": "1000.0.0",

--- a/ern-local-cli/package.json
+++ b/ern-local-cli/package.json
@@ -68,6 +68,7 @@
     "semver": "^5.3.0",
     "validate-npm-package-name": "^3.0.0",
     "yargs": "^7.1.0",
+    "yauzl": "^2.9.1",
     "yazl": "^2.4.3"
   },
   "devDependencies": {

--- a/ern-local-cli/src/lib/publication.js
+++ b/ern-local-cli/src/lib/publication.js
@@ -202,7 +202,7 @@ napDescriptor: NativeApplicationDescriptor, {
 
     const generator = getGeneratorForPlatform(platform)
 
-    await spin(
+    return spin(
       `Creating Container for ${napDescriptor.toString()} from Cauldron`,
       generator.generate({
         miniApps: miniAppsInstances,

--- a/ern-local-cli/yarn.lock
+++ b/ern-local-cli/yarn.lock
@@ -130,11 +130,22 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
+bluebird@3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.1.tgz#b731ddf48e2dd3bedac2e75e1215a11bcb91fa07"
+
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
   dependencies:
     hoek "2.x.x"
+
+brace-expansion@^1.0.0:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
 
 brace-expansion@^1.1.7:
   version "1.1.8"
@@ -154,6 +165,10 @@ braces@^1.8.2:
 buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+
+buffer-equal@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-1.0.0.tgz#59616b498304d556abd466966b22eeda3eca5fbe"
 
 builtin-modules@^1.0.0:
   version "1.1.1"
@@ -260,6 +275,12 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
+  dependencies:
+    graceful-readlink ">= 1.0.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -309,6 +330,16 @@ delayed-stream@~1.0.0:
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
+
+dir-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/dir-compare/-/dir-compare-1.4.0.tgz#afa00ab99c0fb1c412b48dc65e8f4378d257f006"
+  dependencies:
+    bluebird "3.4.1"
+    buffer-equal "1.0.0"
+    colors "1.0.3"
+    commander "2.9.0"
+    minimatch "3.0.2"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -497,6 +528,10 @@ glob@^7.0.5:
 graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+
+"graceful-readlink@>= 1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
 har-schema@^1.0.5:
   version "1.0.5"
@@ -794,6 +829,12 @@ mime-types@^2.1.12, mime-types@~2.1.7:
 mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
+
+minimatch@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.2.tgz#0f398a7300ea441e9c348c83d98ab8c9dbf9c40a"
+  dependencies:
+    brace-expansion "^1.0.0"
 
 minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"

--- a/ern-local-cli/yarn.lock
+++ b/ern-local-cli/yarn.lock
@@ -409,6 +409,10 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
+fs-readdir-recursive@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz#e32fc030a2ccee44a6b5371308da54be0b397d27"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"

--- a/ern-local-cli/yarn.lock
+++ b/ern-local-cli/yarn.lock
@@ -360,6 +360,12 @@ extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
 
+fd-slicer@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
+  dependencies:
+    pend "~1.2.0"
+
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
@@ -961,6 +967,10 @@ path-type@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
@@ -1376,6 +1386,13 @@ yargs@^7.1.0:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^5.0.0"
+
+yauzl@^2.9.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.9.1.tgz#a81981ea70a57946133883f029c5821a89359a7f"
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    fd-slicer "~1.0.1"
 
 yazl@^2.4.3:
   version "2.4.3"

--- a/ern-local-cli/yarn.lock
+++ b/ern-local-cli/yarn.lock
@@ -151,6 +151,10 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
+buffer-crc32@~0.2.3:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+
 builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
@@ -1368,3 +1372,9 @@ yargs@^7.1.0:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^5.0.0"
+
+yazl@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.4.3.tgz#ec26e5cc87d5601b9df8432dbdd3cd2e5173a071"
+  dependencies:
+    buffer-crc32 "~0.2.3"


### PR DESCRIPTION
Whenever a new Container is generated from a Cauldron, the resulting JS bundle and assets are now zipped and added to the Cauldron, using a filename convention based on the native application descriptor.

For example, when generating a new Container for the following native application descriptor `MyApp:android:1.0.0`, the JS bundle and assets will be zipped, resulting in a zip file named `MyApp:android:1.0.0.zip` which is then stored in the Cauldron, at the root, in the `bundles` directory. Any new Container generation for a given descriptor will generate a new zip file that will overwrite the one stored for this native application descriptor (if any).

This feature isn't really useful on its own but allows for future improvements that will make use of this zip files in the context of CodePush (to reduce the size of CodePush updates by diffing bundle and assets).