### PR TITLE
 pre check if the code push command options are well formed

### DIFF
--- a/docs/cli/code-push/promote.md
+++ b/docs/cli/code-push/promote.md
@@ -43,6 +43,8 @@ If no `targetDescriptors` nor a `targetSemVerDescriptor` is specified, the comma
 * Semver expression that specifies the binary app version this release is targeting
 * If omitted, the release will target the exact version of the descriptor
 * If versionModifier is specified in the codePush config , exact version of the descriptor is appended to versionModifier
+* For using `targetBinaryVersion` option users must target only 1 descriptor
+* For using `targetBinaryVersion` option users cannot use semVerDescriptor
 
 `--mandatory/-m`
 

--- a/docs/cli/code-push/release.md
+++ b/docs/cli/code-push/release.md
@@ -52,6 +52,8 @@ If no `descriptors` nor a `semVerDescriptor` is specified, the command will list
 * Semver expression that specifies the binary app version this release is targeting
 * If omitted, the release will target the exact version of the descriptor
 * If versionModifier is specified in the codePush config , exact version of the descriptor is appended to versionModifier
+* For using `targetBinaryVersion` option users must target only 1 descriptor
+* For using `targetBinaryVersion` option users cannot use semVerDescriptor
 
 `--mandatory/-m`
 

--- a/ern-local-cli/src/commands/code-push/promote.js
+++ b/ern-local-cli/src/commands/code-push/promote.js
@@ -101,6 +101,14 @@ exports.handler = async function ({
   try {
     let targetNapDescriptors
 
+    await utils.logErrorAndExitIfNotSatisfied({
+      checkIfCodePushOptionsAreValid: {
+        descriptors: targetDescriptors,
+        targetBinaryVersion,
+        semVerDescriptor: targetSemVerDescriptor
+      }
+    })
+
     if (!sourceDescriptor) {
       sourceDescriptor = await utils.askUserToChooseANapDescriptorFromCauldron({
         onlyReleasedVersions: true,

--- a/ern-local-cli/src/commands/code-push/release.js
+++ b/ern-local-cli/src/commands/code-push/release.js
@@ -106,6 +106,14 @@ exports.handler = async function ({
       throw new Error('You need to provide at least one MiniApp or one JS API implementation version to CodePush')
     }
 
+    await utils.logErrorAndExitIfNotSatisfied({
+      checkIfCodePushOptionsAreValid: {
+        descriptors,
+        targetBinaryVersion,
+        semVerDescriptor
+      }
+    })
+
     if (descriptors.length > 0) {
       // User provided one or more descriptor(s)
       await utils.logErrorAndExitIfNotSatisfied({

--- a/ern-local-cli/src/lib/Ensure.js
+++ b/ern-local-cli/src/lib/Ensure.js
@@ -263,7 +263,7 @@ export default class Ensure {
     }
   }
 
-  static async checkIfCodePushOptionsAreValid (
+  static checkIfCodePushOptionsAreValid (
     descriptors?: Array<string>,
     targetBinaryVersion?: string,
     semVerDescriptor?: string,

--- a/ern-local-cli/src/lib/Ensure.js
+++ b/ern-local-cli/src/lib/Ensure.js
@@ -262,4 +262,18 @@ export default class Ensure {
       throw new Error(`There is no active Cauldron\n${extraErrorMessage}`)
     }
   }
+
+  static async checkIfCodePushOptionsAreValid (
+    descriptors?: Array<string>,
+    targetBinaryVersion?: string,
+    semVerDescriptor?: string,
+    extraErrorMessage?: string = ''
+  ) {
+    if (targetBinaryVersion && semVerDescriptor) {
+      throw new Error('Specify either targetBinaryVersion or semVerDescriptor not both')
+    }
+    if (targetBinaryVersion && descriptors && descriptors.length > 1) {
+      throw new Error('targetBinaryVersion must specify only 1 target native application version for the push')
+    }
+  }
 }

--- a/ern-local-cli/src/lib/utils.js
+++ b/ern-local-cli/src/lib/utils.js
@@ -318,7 +318,7 @@ async function logErrorAndExitIfNotSatisfied ({
     }
     if (checkIfCodePushOptionsAreValid) {
       spinner.text = 'Ensuring that preconditions for code-push command are valid'
-      await Ensure.checkIfCodePushOptionsAreValid(
+      Ensure.checkIfCodePushOptionsAreValid(
         checkIfCodePushOptionsAreValid.descriptors,
         checkIfCodePushOptionsAreValid.targetBinaryVersion,
         checkIfCodePushOptionsAreValid.semVerDescriptor,

--- a/ern-local-cli/src/lib/utils.js
+++ b/ern-local-cli/src/lib/utils.js
@@ -98,7 +98,8 @@ async function logErrorAndExitIfNotSatisfied ({
   dependencyNotInUseByAMiniApp,
   cauldronIsActive,
   isValidNpmPackageName,
-  isValidElectrodeNativeModuleName
+  isValidElectrodeNativeModuleName,
+  checkIfCodePushOptionsAreValid
 } : {
   noGitOrFilesystemPath?: {
     obj: string | Array<string>,
@@ -181,6 +182,12 @@ async function logErrorAndExitIfNotSatisfied ({
   },
   isValidElectrodeNativeModuleName?: {
     name: string,
+    extraErrorMessage?: string
+  },
+  checkIfCodePushOptionsAreValid? : {
+    descriptors?: Array<string>,
+    targetBinaryVersion?: string,
+    semVerDescriptor?: string,
     extraErrorMessage?: string
   }
 } = {}) {
@@ -307,6 +314,15 @@ async function logErrorAndExitIfNotSatisfied ({
       await Ensure.isValidElectrodeNativeModuleName(
         isValidElectrodeNativeModuleName.name,
         isValidElectrodeNativeModuleName.extraErrorMessage
+      )
+    }
+    if (checkIfCodePushOptionsAreValid) {
+      spinner.text = 'Ensuring that preconditions for code-push command are valid'
+      await Ensure.checkIfCodePushOptionsAreValid(
+        checkIfCodePushOptionsAreValid.descriptors,
+        checkIfCodePushOptionsAreValid.targetBinaryVersion,
+        checkIfCodePushOptionsAreValid.semVerDescriptor,
+        checkIfCodePushOptionsAreValid.extraErrorMessage
       )
     }
     spinner.succeed('Validity checks have passed')

--- a/ern-local-cli/test/Ensure-test.js
+++ b/ern-local-cli/test/Ensure-test.js
@@ -184,8 +184,43 @@ describe('Ensure.js', () => {
       expect(() => Ensure.sameNativeApplicationAndPlatform(fixtures.sameNativeApplicationPlatformDescriptors)).to.not.throw()
     })
     
-    it('should throw if descriptors are not matching the same native application and platforn', () => {
+    it('should throw if descriptors are not matching the same native application and platform', () => {
       expect(() => Ensure.sameNativeApplicationAndPlatform(fixtures.differentNativeApplicationPlatformDescriptors)).to.throw()
+    })
+  })
+
+  // ==========================================================
+  // checkIfCodePushOptionsAreValid
+  // ==========================================================
+  describe('checkIfCodePushOptionsAreValid', () => {
+    it('should not throw if descriptors and semVerDescriptor are specified', () => {
+      expect(() => Ensure.checkIfCodePushOptionsAreValid(
+        fixtures.differentNativeApplicationPlatformDescriptors,
+        '',
+        '1.0.0'
+      )).to.not.throw()
+    })
+
+    it('should not throw if 1 descriptor and targetBinaryVersion are specified', () => {
+      expect(() => Ensure.checkIfCodePushOptionsAreValid(
+        ['testapp:android:1.0.0'],
+        '1.0.0'
+      )).to.not.throw()
+    })
+
+    it('should throw if more than 1 descriptor and targetBinaryVersion are specified', () => {
+      expect(() => Ensure.checkIfCodePushOptionsAreValid(
+        fixtures.differentNativeApplicationPlatformDescriptors,
+        '1.0.0'
+      )).to.throw()
+    })
+
+    it('should throw if 1 descriptor ,targetBinaryVersion and semVerDescriptor are specified', () => {
+      expect(() => Ensure.checkIfCodePushOptionsAreValid(
+        ['testapp:android:1.0.0'],
+        '1.0.0',
+        '~1.0.0'
+      )).to.throw()
     })
   })
 })

--- a/ern-local-cli/test/utils-test.js
+++ b/ern-local-cli/test/utils-test.js
@@ -293,16 +293,57 @@ describe('utils.js', () => {
       })
     })
 
-    it('[sameNativeApplicationAndPlatform] Shoud log error and exit process if descriptors do not all match same native application platform', async () => {
+    it('[sameNativeApplicationAndPlatform] Should log error and exit process if descriptors do not all match same native application platform', async () => {
       await utils.logErrorAndExitIfNotSatisfied({
         sameNativeApplicationAndPlatform: {descriptors: fixtures.differentNativeApplicationPlatformDescriptors}
       })
       assertLoggedErrorAndExitedProcess()
     })
 
-    it('[sameNativeApplicationAndPlatform] Shoud not log error anornd exit process if descriptors do not all match same native application platform', async () => {
+    it('[sameNativeApplicationAndPlatform] Should not log error anornd exit process if descriptors do not all match same native application platform', async () => {
       await utils.logErrorAndExitIfNotSatisfied({
         sameNativeApplicationAndPlatform: {descriptors: fixtures.sameNativeApplicationPlatformDescriptors}
+      })
+      assertNoErrorLoggedAndNoProcessExit()
+    })
+
+    it('[checkIfCodePushOptionsAreValid] Should log error and exit process if targetBinaryVersion is specified with more than 1 descriptor ', async () => {
+      await utils.logErrorAndExitIfNotSatisfied({
+        checkIfCodePushOptionsAreValid: {
+          descriptors: fixtures.differentNativeApplicationPlatformDescriptors,
+          targetBinaryVersion: '1.1.0'
+        }
+      })
+      assertLoggedErrorAndExitedProcess()
+    })
+
+    it('[checkIfCodePushOptionsAreValid] Should not log error and exit process if targetBinaryVersion is specified with more than 1 descriptor ', async () => {
+      await utils.logErrorAndExitIfNotSatisfied({
+        checkIfCodePushOptionsAreValid: {
+          descriptors: ['testapp:android:1.0.0'],
+          targetBinaryVersion: '1.1.0'
+        }
+      })
+      assertNoErrorLoggedAndNoProcessExit()
+    })
+
+    it('[checkIfCodePushOptionsAreValid] Should log error and exit process if targetBinaryVersion & semVerDescriptor are specified ', async () => {
+      await utils.logErrorAndExitIfNotSatisfied({
+        checkIfCodePushOptionsAreValid: {
+          descriptors: ['testapp:android:1.0.0'],
+          targetBinaryVersion: '1.1.0',
+          semVerDescriptor : '~1.1.0'
+        }
+      })
+      assertLoggedErrorAndExitedProcess()
+    })
+
+    it('[checkIfCodePushOptionsAreValid] Should not log error and exit process if more than 1 descriptor and semVerDescriptor are specified', async () => {
+      await utils.logErrorAndExitIfNotSatisfied({
+        checkIfCodePushOptionsAreValid: {
+          descriptors: fixtures.differentNativeApplicationPlatformDescriptors,
+          semVerDescriptor : '~1.1.0'
+        }
       })
       assertNoErrorLoggedAndNoProcessExit()
     })


### PR DESCRIPTION
- For using `targetBinaryVersion` option users must target only 1 descriptor
- For using `targetBinaryVersion` option users cannot use semVerDescriptor

- [x] Update command to pre check if the code push command options are well formed
- [x] Add Unit test
- [x] Update documentation