### PR TITLE
Fix Getting Started guide for Android

### DIFF
--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -388,7 +388,7 @@ public class MainActivity extends AppCompatActivity {
                         responseListener.onFailure(BridgeFailureMessage.create("ERROR_NAVIGATION_FAILED", "Something went wrong.", new Exception("Data received is null. No MiniApp name provided to navigate.")));
                     }
                 } else {
-                    Log.w(TAG, "Activity is finishing or null, cannot get a valid activity context to navigate");
+                    Log.w("NAVIGATION", "Activity is finishing or null, cannot get a valid activity context to navigate");
                     responseListener.onFailure(BridgeFailureMessage.create("ERROR_NAVIGATION_FAILED", "Something went wrong.", new Exception("No valid activity context found. Current activity is either null or finishing.")));
                 }
             }


### PR DESCRIPTION
Fix `MainActivity.java` from Getting Started guide.
`TAG` is not properly declared in the source file, leading to compilation issue. 
Using harcoded `"NAVIGATION"` String instead of `TAG` (similar to how the other log statement is done a few lines above), to fix issue.