### PR TITLE
Do not store the Container zipped bundle in Cauldron

### DIFF
--- a/ern-local-cli/src/lib/utils.js
+++ b/ern-local-cli/src/lib/utils.js
@@ -25,9 +25,6 @@ import {
   GitHubPublisher,
   JcenterPublisher
 } from 'ern-container-gen'
-import type {
-  ContainerGenResult
-} from 'ern-container-gen'
 import {
   runLocalContainerGen,
   runCauldronContainerGen
@@ -452,7 +449,7 @@ async function performContainerStateUpdateInCauldron (
     const compositeMiniAppDir = createTmpDir()
 
     // Run container generator
-    const containerGenResult: ContainerGenResult = await spin(`Generating new container version ${cauldronContainerVersion} for ${napDescriptor.toString()}`,
+    await spin(`Generating new container version ${cauldronContainerVersion} for ${napDescriptor.toString()}`,
       runCauldronContainerGen(
         napDescriptor, {
           outDir,
@@ -465,15 +462,6 @@ async function performContainerStateUpdateInCauldron (
     // Update yarn lock
     const pathToNewYarnLock = path.join(compositeMiniAppDir, 'yarn.lock')
     await cauldron.addOrUpdateYarnLock(napDescriptor, constants.CONTAINER_YARN_KEY, pathToNewYarnLock)
-
-    // Store bundle in Cauldron
-    if (containerGenResult) {
-      const zippedBundle: Buffer = await createZippedBundle({
-        bundlePath: containerGenResult.bundlingResult.bundlePath,
-        assetsPath: containerGenResult.bundlingResult.assetsPath
-      })
-      await cauldron.addBundle(napDescriptor, zippedBundle)
-    }
 
     // Commit Cauldron transaction
     await spin(`Updating Cauldron`, cauldron.commitTransaction(commitMessage))
@@ -1063,5 +1051,6 @@ export default {
   getDescriptorsMatchingSemVerDescriptor,
   normalizeVersionsToSemver,
   logNativeDependenciesConflicts,
-  unzip
+  unzip,
+  createZippedBundle
 }


### PR DESCRIPTION
We don't want this logic of storing the bundle in Cauldron in `v0.17.0` release as it has no use for now and probably not even for future versions, as we are potentially shifting to a different angle of approach for CodePush bundle delta update. So for now, getting rid of this one as it is useless and will consume Cauldron storage for no reason. 
Just removing a single piece of code, while keeping all the support code for bundle storing, as it might turn out to be useful for other purposes.