### PR TITLE
Get rid of circular dependency between core and cauldron-api

### DIFF
--- a/ern-cauldron-api/src/CauldronApiFactory.js
+++ b/ern-cauldron-api/src/CauldronApiFactory.js
@@ -1,0 +1,13 @@
+// @flow
+
+import CauldronApi from './CauldronApi'
+import GitFileStore from './GitFileStore'
+import GitDocumentStore from './GitDocumentStore'
+
+export function defaultCauldron (repository: string, cauldronPath: string, branch: string = 'master') {
+  const sourcemapStore = new GitFileStore(cauldronPath, repository, branch, 'sourcemaps')
+  const yarnlockStore = new GitFileStore(cauldronPath, repository, branch, 'yarnlocks')
+  const bundleStore = new GitFileStore(cauldronPath, repository, branch, 'bundles')
+  const dbStore = new GitDocumentStore(cauldronPath, repository, branch)
+  return new CauldronApi(dbStore, sourcemapStore, yarnlockStore, bundleStore)
+}

--- a/ern-cauldron-api/src/CauldronHelper.js
+++ b/ern-cauldron-api/src/CauldronHelper.js
@@ -1,15 +1,17 @@
 // @flow
 
-import PackagePath from './PackagePath'
-import NativeApplicationDescriptor from './NativeApplicationDescriptor'
-import * as fileUtils from './fileUtil'
-import * as promptUtils from './promptUtils'
 import _ from 'lodash'
+import {
+  PackagePath,
+  NativeApplicationDescriptor,
+  fileUtils,
+  promptUtils
+} from 'ern-core'
 import type {
-  CauldronApi,
   CauldronCodePushMetadata,
   CauldronCodePushEntry
-} from 'ern-cauldron-api'
+} from './FlowTypes'
+import CauldronApi from './CauldronApi'
 
 //
 // Helper class to access the cauldron

--- a/ern-cauldron-api/src/getActiveCauldron.js
+++ b/ern-cauldron-api/src/getActiveCauldron.js
@@ -1,0 +1,54 @@
+// @flow
+
+import CauldronHelper from './CauldronHelper'
+import {
+  config,
+  Platform
+} from 'ern-core'
+import {
+  getCurrentSchemaVersion
+} from './util'
+import semver from 'semver'
+import { defaultCauldron } from './CauldronApiFactory'
+import path from 'path'
+
+// Singleton CauldronHelper
+// Returns undefined if no Cauldron is active
+// Throw error if Cauldron is not using the correct schema version
+let currentCauldronHelperInstance
+export default async function getActiveCauldron ({
+    ignoreSchemaVersionMismatch
+  } : {
+    ignoreSchemaVersionMismatch?: boolean
+  } = {}) : Promise<CauldronHelper> {
+  if (!currentCauldronHelperInstance) {
+    const cauldronRepositories = config.getValue('cauldronRepositories')
+    const cauldronRepoInUse = config.getValue('cauldronRepoInUse')
+    if (cauldronRepoInUse) {
+      const cauldronRepoUrl = cauldronRepositories[cauldronRepoInUse]
+      const cauldronRepoBranchReResult = /#(.+)$/.exec(cauldronRepoUrl)
+      const cauldronRepoUrlWithoutBranch = cauldronRepoUrl.replace(/#(.+)$/, '')
+      const cauldronCli = defaultCauldron(
+        cauldronRepoUrlWithoutBranch,
+        path.join(Platform.rootDirectory, 'cauldron'),
+        cauldronRepoBranchReResult ? cauldronRepoBranchReResult[1] : 'master')
+      currentCauldronHelperInstance = new CauldronHelper(cauldronCli)
+      const schemaVersionUsedByCauldron = await currentCauldronHelperInstance.getCauldronSchemaVersion()
+      const schemaVersionOfCurrentCauldronApi = getCurrentSchemaVersion()
+      if (!ignoreSchemaVersionMismatch && (schemaVersionUsedByCauldron !== schemaVersionOfCurrentCauldronApi)) {
+        if (semver.gt(schemaVersionUsedByCauldron, schemaVersionOfCurrentCauldronApi)) {
+          throw new Error(
+`Cauldron schema version mismatch (${schemaVersionUsedByCauldron} > ${schemaVersionOfCurrentCauldronApi}).
+You should switch to a newer platform version that supports this Cauldron schema.`
+          )
+        } else if (semver.lt(schemaVersionUsedByCauldron, schemaVersionOfCurrentCauldronApi)) {
+          throw new Error(
+`Cauldron schema version mismatch (${schemaVersionUsedByCauldron} < ${schemaVersionOfCurrentCauldronApi}.
+You should run the following command : 'ern cauldron upgrade' to upgrade your Cauldron to the latest version.
+You can also switch to an older version of the platform which supports this Cauldron schema version.`)
+        }
+      }
+    }
+  }
+  return Promise.resolve(currentCauldronHelperInstance)
+}

--- a/ern-cauldron-api/src/index.js
+++ b/ern-cauldron-api/src/index.js
@@ -3,23 +3,28 @@
 import _CauldronApi from './CauldronApi'
 import _EphemeralFileStore from './EphemeralFileStore'
 import _InMemoryDocumentStore from './InMemoryDocumentStore'
-import GitFileStore from './GitFileStore'
-import GitDocumentStore from './GitDocumentStore'
-
-export default function factory (
-  repository: string,
-  cauldronPath: string,
-  branch: string = 'master') {
-  const sourcemapStore = new GitFileStore(cauldronPath, repository, branch, 'sourcemaps')
-  const yarnlockStore = new GitFileStore(cauldronPath, repository, branch, 'yarnlocks')
-  const bundleStore = new GitFileStore(cauldronPath, repository, branch, 'bundles')
-  const dbStore = new GitDocumentStore(cauldronPath, repository, branch)
-  return new _CauldronApi(dbStore, sourcemapStore, yarnlockStore, bundleStore)
-}
+import _GitFileStore from './GitFileStore'
+import _GitDocumentStore from './GitDocumentStore'
+import _CauldronHelper from './CauldronHelper'
+import _getActiveCauldron from './getActiveCauldron'
 
 export const CauldronApi = _CauldronApi
 export const EphemeralFileStore = _EphemeralFileStore
 export const InMemoryDocumentStore = _InMemoryDocumentStore
+export const GitFileStore = _GitFileStore
+export const GitDocumentStore = _GitDocumentStore
+export const getActiveCauldron = _getActiveCauldron
+export const CauldronHelper = _CauldronHelper
+
+export default ({
+  CauldronApi: _CauldronApi,
+  EphemeralFileStore: _EphemeralFileStore,
+  InMemoryDocumentStore: _InMemoryDocumentStore,
+  GitFileStore: _GitFileStore,
+  GitDocumentStore: _GitDocumentStore,
+  getActiveCauldron: _getActiveCauldron,
+  CauldronHelper: _CauldronHelper
+})
 
 export type {
   CauldronCodePushMetadata,

--- a/ern-cauldron-api/test/CauldronApi-test.js
+++ b/ern-cauldron-api/test/CauldronApi-test.js
@@ -449,27 +449,27 @@ describe('CauldronApi.js', () => {
 
     it('should throw if incorrect version is provided', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.getNativeDependency, api, NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'react-native-electrode-bridge@0.1.0'))
+      assert(await doesThrow(api.getContainerNativeDependency, api, NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'react-native-electrode-bridge@0.1.0'))
     })
 
     it('should throw if dependency does not exist', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.getNativeDependency, api, NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'unexisting'))
+      assert(await doesThrow(api.getContainerNativeDependency, api, NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'unexisting'))
     })
 
     it('should throw if native application version does not exist', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.getNativeDependency, api, NativeApplicationDescriptor.fromString('test:android:0.1.0'), 'react-native-electrode-bridge'))
+      assert(await doesThrow(api.getContainerNativeDependency, api, NativeApplicationDescriptor.fromString('test:android:0.1.0'), 'react-native-electrode-bridge'))
     })
 
     it('should throw if native application platform does not exist', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.getNativeDependency, api, NativeApplicationDescriptor.fromString('test:unexisting:17.7.0'), 'react-native-electrode-bridge'))
+      assert(await doesThrow(api.getContainerNativeDependency, api, NativeApplicationDescriptor.fromString('test:unexisting:17.7.0'), 'react-native-electrode-bridge'))
     })
 
     it('should throw if native application name does not exist', async () => {
       const api = cauldronApi()
-      assert(await doesThrow(api.getNativeDependency, api, NativeApplicationDescriptor.fromString('unexisting:android:17.7.0'), 'react-native-electrode-bridge'))
+      assert(await doesThrow(api.getContainerNativeDependency, api, NativeApplicationDescriptor.fromString('unexisting:android:17.7.0'), 'react-native-electrode-bridge'))
     })
   })
 
@@ -1377,13 +1377,13 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       await api.addBundle(NativeApplicationDescriptor.fromString('test:android:17.7.0'), 'BUNDLE_CONTENT')
-      assert(await api.hasBundle('test:android:17.7.0'))
+      assert(await api.hasBundle(NativeApplicationDescriptor.fromString('test:android:17.7.0')))
     })
 
     it('should return false if there is no stored bundle for the given native application descriptor', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
-      assert(!await api.hasBundle('test:android:17.7.0'))
+      assert(!await api.hasBundle(NativeApplicationDescriptor.fromString('test:android:17.7.0')))
     })
   })
 

--- a/ern-cauldron-api/test/CauldronHelper-test.js
+++ b/ern-cauldron-api/test/CauldronHelper-test.js
@@ -4,8 +4,10 @@ import {
 } from 'chai'
 import CauldronHelper from '../src/CauldronHelper'
 import sinon from 'sinon'
-import PackagePath from '../src/PackagePath'
-import NativeApplicationDescriptor from '../src/NativeApplicationDescriptor'
+import { 
+  PackagePath,
+  NativeApplicationDescriptor
+} from 'ern-core'
 import {
   doesThrow,
   doesNotThrow,

--- a/ern-core/package.json
+++ b/ern-core/package.json
@@ -56,7 +56,6 @@
     "code-push": "^2.0.4",
     "console-log-level": "^1.4.0",
     "decompress-zip": "^0.3.0",
-    "ern-cauldron-api": "1000.0.0",
     "fs-readdir-recursive": "^1.0.0",
     "inquirer": "^3.0.6",
     "lodash": "^4.17.4",

--- a/ern-core/src/index.js
+++ b/ern-core/src/index.js
@@ -2,7 +2,7 @@
 
 import _handleCopyDirective from './handleCopyDirective'
 import _Platform from './Platform'
-import _manifest from './Manifest'
+import _manifest, { Manifest as _Manifest } from './Manifest'
 import _MavenUtils from './MavenUtils'
 import * as _compatibility from './compatibility'
 import _MiniApp from './MiniApp'
@@ -42,6 +42,7 @@ import * as _nativeDepenciesVersionResolution from './resolveNativeDependenciesV
 export const handleCopyDirective = _handleCopyDirective
 export const Platform = _Platform
 export const manifest = _manifest
+export const Manifest = _Manifest
 export const compatibility = _compatibility
 export const MiniApp = _MiniApp
 export const ModuleTypes = _ModuleTypes
@@ -80,6 +81,7 @@ export default ({
   handleCopyDirective: _handleCopyDirective,
   Platform: _Platform,
   manifest: _manifest,
+  Manifest: _Manifest,
   compatibility: _compatibility,
   MiniApp: _MiniApp,
   ModuleTypes: _ModuleTypes,
@@ -124,3 +126,7 @@ export type {
 export type {
   BundlingResult
 } from './ReactNativeCli'
+
+export type {
+  ManifestOverrideConfig
+} from './Manifest'

--- a/ern-core/src/index.js
+++ b/ern-core/src/index.js
@@ -4,7 +4,6 @@ import _handleCopyDirective from './handleCopyDirective'
 import _Platform from './Platform'
 import _manifest, { Manifest as _Manifest } from './Manifest'
 import _MavenUtils from './MavenUtils'
-import * as _compatibility from './compatibility'
 import _MiniApp from './MiniApp'
 import * as _ModuleTypes from './ModuleTypes'
 import * as _utils from './utils'
@@ -15,7 +14,6 @@ import {
 import * as _dependencyLookup from './dependencyLookup'
 import _ErnBinaryStore from './ErnBinaryStore'
 import * as _iosUtil from './iosUtil'
-import _CauldronHelper from './CauldronHelper'
 import * as _nativeDependenciesLookup from './nativeDependenciesLookup'
 import * as _android from './android'
 import _shell from './shell'
@@ -43,7 +41,6 @@ export const handleCopyDirective = _handleCopyDirective
 export const Platform = _Platform
 export const manifest = _manifest
 export const Manifest = _Manifest
-export const compatibility = _compatibility
 export const MiniApp = _MiniApp
 export const ModuleTypes = _ModuleTypes
 export const yarn = _yarn
@@ -53,7 +50,6 @@ export const utils = _utils
 export const MavenUtils = _MavenUtils
 export const ErnBinaryStore = _ErnBinaryStore
 export const IosUtil = _iosUtil
-export const CauldronHelper = _CauldronHelper
 export const nativeDependenciesLookup = _nativeDependenciesLookup
 export const android = _android
 export const shell = _shell
@@ -82,7 +78,6 @@ export default ({
   Platform: _Platform,
   manifest: _manifest,
   Manifest: _Manifest,
-  compatibility: _compatibility,
   MiniApp: _MiniApp,
   ModuleTypes: _ModuleTypes,
   yarn: _yarn,
@@ -92,7 +87,6 @@ export default ({
   MavenUtils: _MavenUtils,
   ErnBinaryStore: _ErnBinaryStore,
   IosUtil: _iosUtil,
-  CauldronHelper: _CauldronHelper,
   nativeDependenciesLookup: _nativeDependenciesLookup,
   android: _android,
   shell: _shell,

--- a/ern-local-cli/src/commands/binarystore/add.js
+++ b/ern-local-cli/src/commands/binarystore/add.js
@@ -2,9 +2,11 @@
 
 import {
   NativeApplicationDescriptor,
-  ErnBinaryStore,
-  utils as coreUtils
+  ErnBinaryStore
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import utils from '../../lib/utils'
 import path from 'path'
 
@@ -38,7 +40,7 @@ exports.handler = async function ({
 
   const napDescriptor = NativeApplicationDescriptor.fromString(descriptor)
 
-  const cauldron = await coreUtils.getCauldronInstance()
+  const cauldron = await getActiveCauldron()
   const binaryStoreConfig = await cauldron.getBinaryStoreConfig()
   if (!binaryStoreConfig) {
     return log.error('No binaryStore configuration was found in Cauldron')

--- a/ern-local-cli/src/commands/binarystore/get.js
+++ b/ern-local-cli/src/commands/binarystore/get.js
@@ -3,9 +3,11 @@
 import {
   NativeApplicationDescriptor,
   shell,
-  utils as coreUtils,
   ErnBinaryStore
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import utils from '../../lib/utils'
 import fs from 'fs'
 import path from 'path'
@@ -40,7 +42,7 @@ exports.handler = async function ({
 
   const napDescriptor = NativeApplicationDescriptor.fromString(descriptor)
 
-  const cauldron = await coreUtils.getCauldronInstance()
+  const cauldron = await getActiveCauldron()
   const binaryStoreConfig = await cauldron.getBinaryStoreConfig()
   if (!binaryStoreConfig) {
     return log.error('No binaryStore configuration was found in Cauldron')

--- a/ern-local-cli/src/commands/binarystore/remove.js
+++ b/ern-local-cli/src/commands/binarystore/remove.js
@@ -2,9 +2,11 @@
 
 import {
   NativeApplicationDescriptor,
-  utils as coreUtils,
   ErnBinaryStore
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import utils from '../../lib/utils'
 
 exports.command = 'remove <descriptor>'
@@ -37,7 +39,7 @@ exports.handler = async function ({
 
   const napDescriptor = NativeApplicationDescriptor.fromString(descriptor)
 
-  const cauldron = await coreUtils.getCauldronInstance()
+  const cauldron = await getActiveCauldron()
   const binaryStoreConfig = await cauldron.getBinaryStoreConfig()
   if (!binaryStoreConfig) {
     return log.error('No binaryStore configuration was found in Cauldron')

--- a/ern-local-cli/src/commands/cauldron/add/dependencies.js
+++ b/ern-local-cli/src/commands/cauldron/add/dependencies.js
@@ -5,6 +5,9 @@ import {
   NativeApplicationDescriptor,
   utils as coreUtils
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import utils from '../../../lib/utils'
 import _ from 'lodash'
 
@@ -81,7 +84,7 @@ exports.handler = async function ({
       : `Add multiple native dependencies to ${napDescriptor.toString()}`}`
     ]
 
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     await utils.performContainerStateUpdateInCauldron(
       async () => {
         for (const dependencyObj of dependenciesObjs) {

--- a/ern-local-cli/src/commands/cauldron/add/jsapiimpls.js
+++ b/ern-local-cli/src/commands/cauldron/add/jsapiimpls.js
@@ -5,6 +5,9 @@ import {
   NativeApplicationDescriptor,
   utils as coreUtils
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import utils from '../../../lib/utils'
 
 exports.command = 'jsapiimpls <jsapiimpls..>'
@@ -72,7 +75,7 @@ exports.handler = async function ({
       : `Add multiple JS API implementations to ${napDescriptor.toString()}`}`
     ]
 
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     await utils.performContainerStateUpdateInCauldron(
       async () => {
         for (const jsApiImpl of jsapiimpls) {

--- a/ern-local-cli/src/commands/cauldron/add/miniapps.js
+++ b/ern-local-cli/src/commands/cauldron/add/miniapps.js
@@ -8,6 +8,9 @@ import {
   utils as coreUtils,
   nativeDepenciesVersionResolution as resolver
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import utils from '../../../lib/utils'
 import _ from 'lodash'
 
@@ -83,7 +86,7 @@ exports.handler = async function ({
       miniAppsObjs.push(m)
     }
 
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     const miniAppsInCauldron = await cauldron.getContainerMiniApps(napDescriptor)
     let miniAppsInCauldronObjs = []
     for (const miniAppInCauldron of miniAppsInCauldron) {

--- a/ern-local-cli/src/commands/cauldron/add/nativeapp.js
+++ b/ern-local-cli/src/commands/cauldron/add/nativeapp.js
@@ -1,12 +1,15 @@
 // @flow
 
 import {
-  CauldronHelper,
   PackagePath,
   NativeApplicationDescriptor,
   spin,
   utils as coreUtils
 } from 'ern-core'
+import {
+  CauldronHelper,
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import inquirer from 'inquirer'
 import _ from 'lodash'
 import utils from '../../../lib/utils'
@@ -51,7 +54,7 @@ exports.handler = async function ({
   const napDescriptor = NativeApplicationDescriptor.fromString(descriptor)
 
   try {
-    var cauldron = await coreUtils.getCauldronInstance()
+    var cauldron = await getActiveCauldron()
     await cauldron.beginTransaction()
 
     const desc = new NativeApplicationDescriptor(napDescriptor.name, napDescriptor.platform)

--- a/ern-local-cli/src/commands/cauldron/add/publisher.js
+++ b/ern-local-cli/src/commands/cauldron/add/publisher.js
@@ -4,6 +4,9 @@ import {
   NativeApplicationDescriptor,
   utils as coreUtils
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import utils from '../../../lib/utils'
 
 exports.command = 'publisher'
@@ -62,7 +65,7 @@ exports.handler = async function ({
       throw new Error('Maven publisher is only supported for android, you selected ios.')
     }
     const publisherType = mavenUrl ? 'maven' : 'github'
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     await cauldron.addPublisher(publisherType, url, napDescriptor)
     log.info(`${publisherType} publisher was successfully added!`)
   } catch (e) {

--- a/ern-local-cli/src/commands/cauldron/batch.js
+++ b/ern-local-cli/src/commands/cauldron/batch.js
@@ -7,6 +7,9 @@ import {
   MiniApp,
   nativeDepenciesVersionResolution as resolver
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import utils from '../../lib/utils'
 import _ from 'lodash'
 
@@ -165,7 +168,7 @@ exports.handler = async function ({
 
     const cauldronCommitMessage = [ `Batch operation on ${napDescriptor.toString()} native application` ]
 
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     await utils.performContainerStateUpdateInCauldron(async () => {
       // Del Dependencies
       for (const delDependencyObj of delDependenciesObjs) {

--- a/ern-local-cli/src/commands/cauldron/del/dependencies.js
+++ b/ern-local-cli/src/commands/cauldron/del/dependencies.js
@@ -5,6 +5,9 @@ import {
   NativeApplicationDescriptor,
   utils as coreUtils
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import utils from '../../../lib/utils'
 import _ from 'lodash'
 
@@ -88,7 +91,7 @@ exports.handler = async function ({
       : `Remove multiple native dependencies from ${napDescriptor.toString()}`}`
     ]
 
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     await utils.performContainerStateUpdateInCauldron(
       async () => {
         for (const dependencyObj: PackagePath of dependenciesObjs) {

--- a/ern-local-cli/src/commands/cauldron/del/jsapiimpls.js
+++ b/ern-local-cli/src/commands/cauldron/del/jsapiimpls.js
@@ -5,6 +5,9 @@ import {
   NativeApplicationDescriptor,
   utils as coreUtils
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import utils from '../../../lib/utils'
 
 exports.command = 'jsapiimpls <jsapiimpls..>'
@@ -66,7 +69,7 @@ exports.handler = async function ({
       : `Remove multiple JS API implementations from ${napDescriptor.toString()}`}`
     ]
 
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     await utils.performContainerStateUpdateInCauldron(
       async () => {
         for (const jsApiImpl of jsapiimpls) {

--- a/ern-local-cli/src/commands/cauldron/del/miniapps.js
+++ b/ern-local-cli/src/commands/cauldron/del/miniapps.js
@@ -5,6 +5,9 @@ import {
   PackagePath,
   utils as coreUtils
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import utils from '../../../lib/utils'
 import _ from 'lodash'
 
@@ -80,7 +83,7 @@ exports.handler = async function ({
       : `Remove multiple MiniApps from ${napDescriptor.toString()}`}`
     ]
 
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     await utils.performContainerStateUpdateInCauldron(
       async () => {
         for (const miniAppAsDep of miniAppsAsDeps) {

--- a/ern-local-cli/src/commands/cauldron/del/nativeapp.js
+++ b/ern-local-cli/src/commands/cauldron/del/nativeapp.js
@@ -4,6 +4,9 @@ import {
   NativeApplicationDescriptor,
   utils as coreUtils
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import utils from '../../../lib/utils'
 
 exports.command = 'nativeapp <descriptor>'
@@ -29,7 +32,7 @@ exports.handler = async function ({
   })
 
   try {
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     await cauldron.removeDescriptor(NativeApplicationDescriptor.fromString(descriptor))
   } catch (e) {
     coreUtils.logErrorAndExitProcess(e)

--- a/ern-local-cli/src/commands/cauldron/get/config.js
+++ b/ern-local-cli/src/commands/cauldron/get/config.js
@@ -4,6 +4,9 @@ import {
   NativeApplicationDescriptor,
   utils as coreUtils
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import utils from '../../../lib/utils'
 
 exports.command = 'config <descriptor>'
@@ -25,7 +28,7 @@ exports.handler = async function ({
   })
 
   try {
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     const config = await cauldron.getConfig(NativeApplicationDescriptor.fromString(descriptor))
     log.info(JSON.stringify(config, null, 2))
   } catch (e) {

--- a/ern-local-cli/src/commands/cauldron/get/dependency.js
+++ b/ern-local-cli/src/commands/cauldron/get/dependency.js
@@ -4,6 +4,9 @@ import {
   NativeApplicationDescriptor,
   utils as coreUtils
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import utils from '../../../lib/utils'
 
 exports.command = 'dependency <descriptor>'
@@ -31,7 +34,7 @@ exports.handler = async function ({
 
   try {
     const napDescriptor = NativeApplicationDescriptor.fromString(descriptor)
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     const dependencies = await cauldron.getNativeDependencies(napDescriptor)
     for (const dependency of dependencies) {
       log.info(dependency.toString())

--- a/ern-local-cli/src/commands/cauldron/get/nativeapp.js
+++ b/ern-local-cli/src/commands/cauldron/get/nativeapp.js
@@ -4,6 +4,9 @@ import {
   NativeApplicationDescriptor,
   utils as coreUtils
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import utils from '../../../lib/utils'
 
 exports.command = 'nativeapp [descriptor]'
@@ -25,7 +28,7 @@ exports.handler = async function ({
   })
 
   try {
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     if (!descriptor) {
       const napDescriptors = await utils.getNapDescriptorStringsFromCauldron()
       napDescriptors.forEach(n => log.info(n))

--- a/ern-local-cli/src/commands/cauldron/regen-container.js
+++ b/ern-local-cli/src/commands/cauldron/regen-container.js
@@ -7,6 +7,9 @@ import {
   utils as coreUtils,
   nativeDepenciesVersionResolution as resolver
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import utils from '../../lib/utils'
 import _ from 'lodash'
 
@@ -65,7 +68,7 @@ exports.handler = async function ({
       }
     })
 
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     const miniAppsInCauldron = await cauldron.getContainerMiniApps(napDescriptor)
     const gitMiniAppsInCauldron = _.filter(miniAppsInCauldron, m => m.isGitPath === true)
 

--- a/ern-local-cli/src/commands/cauldron/update/dependencies.js
+++ b/ern-local-cli/src/commands/cauldron/update/dependencies.js
@@ -5,6 +5,9 @@ import {
   NativeApplicationDescriptor,
   utils as coreUtils
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import utils from '../../../lib/utils'
 import _ from 'lodash'
 
@@ -82,7 +85,7 @@ exports.handler = async function ({
       : `Update multiple native dependencies versions in ${napDescriptor.toString()}`}`
     ]
 
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     await utils.performContainerStateUpdateInCauldron(
       async () => {
         for (const dependencyObj of dependenciesObjs) {

--- a/ern-local-cli/src/commands/cauldron/update/jsapiimpls.js
+++ b/ern-local-cli/src/commands/cauldron/update/jsapiimpls.js
@@ -5,6 +5,9 @@ import {
   NativeApplicationDescriptor,
   utils as coreUtils
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import utils from '../../../lib/utils'
 import _ from 'lodash'
 
@@ -69,7 +72,7 @@ exports.handler = async function ({
 
     const jsApiImplPackagePaths = _.map(jsapiimpls, j => PackagePath.fromString(j))
 
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     await utils.performContainerStateUpdateInCauldron(
       async () => {
         for (const jsApiImplPackagePath of jsApiImplPackagePaths) {

--- a/ern-local-cli/src/commands/cauldron/update/miniapps.js
+++ b/ern-local-cli/src/commands/cauldron/update/miniapps.js
@@ -8,6 +8,9 @@ import {
   utils as coreUtils,
   nativeDepenciesVersionResolution as resolver
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import utils from '../../../lib/utils'
 import _ from 'lodash'
 
@@ -90,7 +93,7 @@ exports.handler = async function ({
       miniAppsObjs.push(m)
     }
 
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     const miniAppsInCauldron = await cauldron.getContainerMiniApps(napDescriptor)
     const nonUpdatedMiniAppsInCauldron = _.xorBy(miniAppsDependencyPaths, miniAppsInCauldron, 'basePath')
     let nonUpdatedMiniAppsInCauldronObjs = []

--- a/ern-local-cli/src/commands/cauldron/update/nativeapp.js
+++ b/ern-local-cli/src/commands/cauldron/update/nativeapp.js
@@ -4,6 +4,9 @@ import {
   NativeApplicationDescriptor,
   utils as coreUtils
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import utils from '../../../lib/utils'
 
 exports.command = 'nativeapp <descriptor> [isReleased]'
@@ -40,7 +43,7 @@ exports.handler = async function ({
     })
 
     const napDescriptor = NativeApplicationDescriptor.fromString(descriptor)
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     cauldron.updateNativeAppIsReleased(napDescriptor, isReleased)
   } catch (e) {
     coreUtils.logErrorAndExitProcess(e)

--- a/ern-local-cli/src/commands/cauldron/upgrade.js
+++ b/ern-local-cli/src/commands/cauldron/upgrade.js
@@ -3,13 +3,16 @@
 import {
   utils as coreUtils
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 
 exports.command = 'upgrade'
 exports.desc = 'Upgrade the Cauldron schema'
 exports.builder = function (yargs: any) {}
 exports.handler = async function () {
   try {
-    const cauldron = await coreUtils.getCauldronInstance({ignoreSchemaVersionMismatch: true})
+    const cauldron = await getActiveCauldron({ignoreSchemaVersionMismatch: true})
     if (!cauldron) {
       throw new Error('A Cauldron must be active in order to use this command')
     }

--- a/ern-local-cli/src/commands/code-push/release.js
+++ b/ern-local-cli/src/commands/code-push/release.js
@@ -6,6 +6,9 @@ import {
   utils as coreUtils
 } from 'ern-core'
 import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
+import {
   performCodePushOtaUpdate,
   askUserForCodePushDeploymentName
 } from '../../lib/publication'
@@ -195,7 +198,7 @@ exports.handler = async function ({
 async function getPathToYarnLock (
   napDescriptor: NativeApplicationDescriptor,
   deploymentName: string) {
-  const cauldron = await coreUtils.getCauldronInstance()
+  const cauldron = await getActiveCauldron()
   if (!cauldron) {
     throw new Error('[getPathToYarnLock] No active Cauldron')
   }

--- a/ern-local-cli/src/commands/compat-check.js
+++ b/ern-local-cli/src/commands/compat-check.js
@@ -1,13 +1,13 @@
 // @flow
 
 import {
-  compatibility,
   PackagePath,
   MiniApp,
   NativeApplicationDescriptor,
   utils as coreUtils
 } from 'ern-core'
 import utils from '../lib/utils'
+import * as compatibility from '../lib/compatibility'
 
 exports.command = 'compat-check [miniapp]'
 exports.desc = 'Run compatibility checks for one or more MiniApp(s) against a target native application version'

--- a/ern-local-cli/src/commands/create-container.js
+++ b/ern-local-cli/src/commands/create-container.js
@@ -11,6 +11,9 @@ import {
   Platform
 } from 'ern-core'
 import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
+import {
   runLocalContainerGen,
   runCauldronContainerGen
 } from '../lib/publication'
@@ -101,7 +104,7 @@ exports.handler = async function ({
       throw new Error(`You can only provide extra native dependencies, when generating a non-JS-only / non-Cauldron based container`)
     }
 
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     if (!cauldron && !miniapps) {
       throw new Error('A Cauldron must be active, if you don\'t explicitly provide miniapps')
     }

--- a/ern-local-cli/src/commands/why.js
+++ b/ern-local-cli/src/commands/why.js
@@ -6,6 +6,9 @@ import {
   PackagePath,
   NativeApplicationDescriptor
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import utils from '../lib/utils'
 
 exports.command = 'why <dependency> <completeNapDescriptor>'
@@ -30,7 +33,7 @@ exports.handler = async function ({
     })
 
     const napDescriptor = NativeApplicationDescriptor.fromString(completeNapDescriptor)
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     const miniApps = await cauldron.getContainerMiniApps(napDescriptor)
     log.info(`This might take a while. The more MiniApps, the longer.`)
     const result = await dependencyLookup.getMiniAppsUsingNativeDependency(miniApps, PackagePath.fromString(dependency))

--- a/ern-local-cli/src/index.js
+++ b/ern-local-cli/src/index.js
@@ -5,7 +5,12 @@ import {
   Platform,
   ColoredLog,
   config as ernConfig,
-  shell
+  shell,
+  Manifest,
+  utils as coreUtils
+} from 'ern-core'
+import type {
+  ManifestOverrideConfig
 } from 'ern-core'
 import chalk from 'chalk'
 import yargs from 'yargs'
@@ -37,6 +42,17 @@ function showVersion () {
   const packageInfo = JSON.parse(execSync(`npm ls -g electrode-native --json`).toString())
   if (packageInfo && packageInfo.dependencies) {
     log.info(`electrode-native : ${packageInfo.dependencies['electrode-native'].version}`)
+  }
+}
+
+Manifest.getOverrideManifestConfig = async () : Promise<?ManifestOverrideConfig> => {
+  const cauldronInstance = await coreUtils.getCauldronInstance()
+  const manifestConfig = cauldronInstance && await cauldronInstance.getManifestConfig()
+  if (manifestConfig && manifestConfig.override && manifestConfig.override.url) {
+    return {
+      url: manifestConfig.override.url,
+      type: manifestConfig.override.type || 'partial'
+    }
   }
 }
 

--- a/ern-local-cli/src/index.js
+++ b/ern-local-cli/src/index.js
@@ -6,12 +6,14 @@ import {
   ColoredLog,
   config as ernConfig,
   shell,
-  Manifest,
-  utils as coreUtils
+  Manifest
 } from 'ern-core'
 import type {
   ManifestOverrideConfig
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import chalk from 'chalk'
 import yargs from 'yargs'
 import { execSync } from 'child_process'
@@ -46,7 +48,7 @@ function showVersion () {
 }
 
 Manifest.getOverrideManifestConfig = async () : Promise<?ManifestOverrideConfig> => {
-  const cauldronInstance = await coreUtils.getCauldronInstance()
+  const cauldronInstance = await getActiveCauldron()
   const manifestConfig = cauldronInstance && await cauldronInstance.getManifestConfig()
   if (manifestConfig && manifestConfig.override && manifestConfig.override.url) {
     return {

--- a/ern-local-cli/src/lib/Ensure.js
+++ b/ern-local-cli/src/lib/Ensure.js
@@ -6,6 +6,9 @@ import {
   utils as coreUtils,
   dependencyLookup
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import _ from 'lodash'
 import semver from 'semver'
 import validateNpmPackageName from 'validate-npm-package-name'
@@ -45,7 +48,7 @@ export default class Ensure {
     napDescriptor: string,
     containerVersion: string,
     extraErrorMessage: string = '') {
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     const cauldronContainerVersion = await cauldron.getTopLevelContainerVersion(NativeApplicationDescriptor.fromString(napDescriptor))
     if (cauldronContainerVersion && !semver.gt(containerVersion, cauldronContainerVersion)) {
       throw new Error(`Container version ${containerVersion} is older than ${cauldronContainerVersion}\n${extraErrorMessage}`)
@@ -88,7 +91,7 @@ export default class Ensure {
   static async napDescritorExistsInCauldron (
     napDescriptor: string | Array<string>,
     extraErrorMessage: string = '') {
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     const descriptors = napDescriptor instanceof Array
       ? _.map(napDescriptor, d => NativeApplicationDescriptor.fromString(d))
       : [ NativeApplicationDescriptor.fromString(napDescriptor) ]
@@ -112,7 +115,7 @@ export default class Ensure {
   static async napDescritorDoesNotExistsInCauldron (
     napDescriptor: string,
     extraErrorMessage: string = '') {
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     const descriptor = NativeApplicationDescriptor.fromString(napDescriptor)
     if (await cauldron.isDescriptorInCauldron(descriptor)) {
       throw new Error(`${descriptor.toString()} descriptor exist in Cauldron.\n${extraErrorMessage}`)
@@ -135,7 +138,7 @@ export default class Ensure {
     napDescriptor: NativeApplicationDescriptor,
     extraErrorMessage: string = '') {
     if (!obj) return
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     const miniAppsStrings = obj instanceof Array ? obj : [ obj ]
     for (const miniAppString of miniAppsStrings) {
       const basePathMiniAppString = PackagePath.fromString(miniAppString).basePath
@@ -150,7 +153,7 @@ export default class Ensure {
     napDescriptor: NativeApplicationDescriptor,
     extraErrorMessage: string = '') {
     if (!obj) return
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     const dependenciesStrings = obj instanceof Array ? obj : [ obj ]
     for (const dependencyString of dependenciesStrings) {
       const unversionedDependencyString = PackagePath.fromString(dependencyString).basePath
@@ -165,7 +168,7 @@ export default class Ensure {
     napDescriptor: NativeApplicationDescriptor,
     extraErrorMessage: string = '') {
     if (!obj) return
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     const miniAppsStrings = obj instanceof Array ? obj : [ obj ]
     for (const miniAppString of miniAppsStrings) {
       const basePathMiniAppString = PackagePath.fromString(miniAppString).basePath
@@ -180,7 +183,7 @@ export default class Ensure {
     napDescriptor: NativeApplicationDescriptor,
     extraErrorMessage: string = '') {
     if (!obj) return
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     const dependenciesStrings = obj instanceof Array ? obj : [ obj ]
     for (const dependencyString of dependenciesStrings) {
       const unversionedDependencyString = PackagePath.fromString(dependencyString).basePath
@@ -195,7 +198,7 @@ export default class Ensure {
     napDescriptor: NativeApplicationDescriptor,
     extraErrorMessage: string = '') {
     if (!obj) return
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     const miniAppsStrings = obj instanceof Array ? obj : [ obj ]
     const basePathMiniAppsStrings = _.map(miniAppsStrings, m => PackagePath.fromString(m).basePath)
     await this.miniAppIsInNativeApplicationVersionContainer(basePathMiniAppsStrings, napDescriptor)
@@ -214,7 +217,7 @@ export default class Ensure {
     napDescriptor: NativeApplicationDescriptor,
     extraErrorMessage: string = '') {
     if (!obj) return
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     await this.dependencyIsInNativeApplicationVersionContainer(obj, napDescriptor)
     const dependenciesStrings = obj instanceof Array ? obj : [ obj ]
     for (const dependencyString of dependenciesStrings) {
@@ -231,7 +234,7 @@ export default class Ensure {
     napDescriptor: NativeApplicationDescriptor,
     extraErrorMessage: string = '') {
     if (!obj) return
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     const dependencies = obj instanceof Array ? obj : [ obj ]
     const dependenciesObjs = _.map(dependencies, d => PackagePath.fromString(d))
 
@@ -258,7 +261,7 @@ export default class Ensure {
   }
 
   static async cauldronIsActive (extraErrorMessage: string = '') {
-    if (!await coreUtils.getCauldronInstance()) {
+    if (!await getActiveCauldron()) {
       throw new Error(`There is no active Cauldron\n${extraErrorMessage}`)
     }
   }

--- a/ern-local-cli/src/lib/compatibility.js
+++ b/ern-local-cli/src/lib/compatibility.js
@@ -1,11 +1,15 @@
 // @flow
 
-import PackagePath from './PackagePath'
-import NativeApplicationDescriptor from './NativeApplicationDescriptor'
-import spin from './spin'
-import * as utils from './utils.js'
-import manifest from './Manifest.js'
-import MiniApp from './MiniApp.js'
+import {
+  NativeApplicationDescriptor,
+  PackagePath,
+  manifest,
+  spin,
+  MiniApp
+} from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import _ from 'lodash'
 import chalk from 'chalk'
 import Table from 'cli-table'
@@ -98,7 +102,7 @@ export async function getNativeAppCompatibilityReport (miniApp: MiniApp, {
   versionName: ?string
 }= {}) {
   let result = []
-  const cauldronInstance = await utils.getCauldronInstance()
+  const cauldronInstance = await getActiveCauldron()
   if (!cauldronInstance) {
     throw new Error('[getNativeAppCompatibilityReport] No Cauldron is active')
   }

--- a/ern-local-cli/src/lib/publication.js
+++ b/ern-local-cli/src/lib/publication.js
@@ -8,8 +8,6 @@ import {
 } from 'ern-container-gen'
 import {
   createTmpDir,
-  utils as coreUtils,
-  compatibility,
   CodePushSdk,
   PackagePath,
   config,
@@ -23,7 +21,10 @@ import type {
   CodePushPackage,
   CodePushInitConfig
 } from 'ern-core'
-
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
+import * as compatibility from './compatibility'
 import inquirer from 'inquirer'
 import _ from 'lodash'
 import path from 'path'
@@ -178,7 +179,7 @@ napDescriptor: NativeApplicationDescriptor, {
   compositeMiniAppDir?: string
 } = {}) {
   try {
-    const cauldron = await coreUtils.getCauldronInstance()
+    const cauldron = await getActiveCauldron()
     const plugins = await cauldron.getNativeDependencies(napDescriptor)
     const miniapps = await cauldron.getContainerMiniApps(napDescriptor)
     const jsApiImpls = await cauldron.getContainerJsApiImpls(napDescriptor)
@@ -233,7 +234,7 @@ export async function performCodePushPatch (
     rollout?: number
   }) {
   try {
-    var cauldron = await coreUtils.getCauldronInstance()
+    var cauldron = await getActiveCauldron()
     const codePushSdk = getCodePushSdk()
     await cauldron.beginTransaction()
     const appName = await getCodePushAppName(napDescriptor)
@@ -282,7 +283,7 @@ export async function performCodePushPromote (
   } = {}) {
   try {
     const codePushSdk = getCodePushSdk()
-    var cauldron = await coreUtils.getCauldronInstance()
+    var cauldron = await getActiveCauldron()
     await cauldron.beginTransaction()
     const cauldronCommitMessage = [
       `CodePush release promotion of ${sourceNapDescriptor.toString()} ${sourceDeploymentName} to ${targetDeploymentName} of`
@@ -382,7 +383,7 @@ jsApiImpls: Array<PackagePath>, {
 } = {}) {
   try {
     const codePushSdk = getCodePushSdk()
-    var cauldron = await coreUtils.getCauldronInstance()
+    var cauldron = await getActiveCauldron()
     const plugins = await cauldron.getNativeDependencies(napDescriptor)
     await cauldron.beginTransaction()
     const codePushPlugin = _.find(plugins, p => p.basePath === 'react-native-code-push')
@@ -530,7 +531,7 @@ export async function getCodePushTargetVersionName (
     throw new Error(`Native application descriptor ${napDescriptor.toString()} does not contain a version !`)
   }
   let result = napDescriptor.version
-  const cauldron = await coreUtils.getCauldronInstance()
+  const cauldron = await getActiveCauldron()
   const codePushConfig = await cauldron.getCodePushConfig(napDescriptor.withoutVersion())
   if (codePushConfig && codePushConfig.versionModifiers) {
     const versionModifier = _.find(codePushConfig.versionModifiers, m => m.deploymentName === deploymentName)
@@ -544,7 +545,7 @@ export async function getCodePushTargetVersionName (
 async function getCodePushAppName (
   napDescriptor: NativeApplicationDescriptor) : Promise<string> {
   let result = napDescriptor.name
-  const cauldron = await coreUtils.getCauldronInstance()
+  const cauldron = await getActiveCauldron()
   const codePushConfig = await cauldron.getCodePushConfig(napDescriptor.withoutVersion())
   if (codePushConfig && codePushConfig.appName) {
     result = codePushConfig.appName
@@ -610,7 +611,7 @@ async function askUserToForceCodePushPublication () : Promise<boolean> {
 }
 
 export async function askUserForCodePushDeploymentName (napDescriptor: NativeApplicationDescriptor, message?: string) : Promise<string> {
-  const cauldron = await coreUtils.getCauldronInstance()
+  const cauldron = await getActiveCauldron()
   const config = await cauldron.getConfig(napDescriptor)
   const hasCodePushDeploymentsConfig = config && config.codePush && config.codePush.deployments
   const choices = hasCodePushDeploymentsConfig ? config && config.codePush.deployments : undefined

--- a/ern-local-cli/src/lib/start.js
+++ b/ern-local-cli/src/lib/start.js
@@ -9,10 +9,12 @@ import {
   NativeApplicationDescriptor,
   spin,
   shell,
-  utils as coreUtils,
   reactnative,
   ErnBinaryStore
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import {
   generateMiniAppsComposite
 } from 'ern-container-gen'
@@ -51,7 +53,7 @@ export default async function start ({
   let napDescriptor
   let pathToYarnLock
 
-  const cauldron = await coreUtils.getCauldronInstance()
+  const cauldron = await getActiveCauldron()
   if (!cauldron && descriptor) {
     throw new Error('To use a native application descriptor, a Cauldron must be active')
   }

--- a/ern-local-cli/src/lib/utils.js
+++ b/ern-local-cli/src/lib/utils.js
@@ -2,7 +2,6 @@
 
 import {
   createTmpDir,
-  utils as coreUtils,
   MiniApp,
   Platform,
   reactnative,
@@ -16,6 +15,9 @@ import {
   shell,
   MavenUtils
 } from 'ern-core'
+import {
+  getActiveCauldron
+} from 'ern-cauldron-api'
 import {
   generateRunnerProject,
   regenerateRunnerConfig
@@ -63,7 +65,7 @@ async function getNapDescriptorStringsFromCauldron ({
   onlyReleasedVersions?: boolean,
   onlyNonReleasedVersions?: boolean
 } = {}) {
-  const cauldron = await coreUtils.getCauldronInstance()
+  const cauldron = await getActiveCauldron()
   const nativeApps = await cauldron.getAllNativeApps()
   return _.filter(
             _.flattenDeep(
@@ -426,7 +428,7 @@ async function performContainerStateUpdateInCauldron (
   let cauldron
 
   try {
-    cauldron = await coreUtils.getCauldronInstance()
+    cauldron = await getActiveCauldron()
 
     if (containerVersion) {
       cauldronContainerVersion = containerVersion
@@ -611,7 +613,7 @@ async function runMiniApp (platform: 'android' | 'ios', {
 
   let cauldron
   if (descriptor) {
-    cauldron = await coreUtils.getCauldronInstance()
+    cauldron = await getActiveCauldron()
     if (cauldron == null) {
       throw new Error('[runMiniApp] No cauldron instance found')
     }
@@ -948,7 +950,7 @@ async function getDescriptorsMatchingSemVerDescriptor (semVerDescriptor: NativeA
     throw new Error(`${semVerDescriptor.toString()} descriptor is missing platform and/or version`)
   }
   const result = []
-  const cauldron = await coreUtils.getCauldronInstance()
+  const cauldron = await getActiveCauldron()
   const versionsNames = await cauldron.getVersionsNames(semVerDescriptor)
   const semVerVersionNames = normalizeVersionsToSemver(versionsNames)
   const zippedVersions = _.zipWith(versionsNames, semVerVersionNames, (nonSemVer, semVer) => ({nonSemVer, semVer}))

--- a/ern-local-cli/test/Ensure-test.js
+++ b/ern-local-cli/test/Ensure-test.js
@@ -4,8 +4,8 @@ import {
   assert,
   expect
 } from 'chai'
+import * as cauldron from 'ern-cauldron-api'
 import {
-  CauldronHelper,
   utils
 } from 'ern-core'
 import {
@@ -21,8 +21,8 @@ let cauldronHelperStub
 
 describe('Ensure.js', () => {
   beforeEach(() => {
-    cauldronHelperStub = sandbox.createStubInstance(CauldronHelper)
-    sandbox.stub(utils, 'getCauldronInstance').resolves(cauldronHelperStub)
+    cauldronHelperStub = sandbox.createStubInstance(cauldron.CauldronHelper)
+    sandbox.stub(cauldron, 'getActiveCauldron').resolves(cauldronHelperStub)
   })
   
   afterEach(() => {

--- a/ern-local-cli/test/utils-test.js
+++ b/ern-local-cli/test/utils-test.js
@@ -5,12 +5,12 @@ import {
   expect
 } from 'chai'
 import {
-  CauldronHelper,
   ModuleTypes,
   NativeApplicationDescriptor,
   yarn,
   utils as coreUtils
 } from 'ern-core'
+import * as cauldron from 'ern-cauldron-api'
 import {
   doesThrow,
   doesNotThrow,
@@ -43,7 +43,7 @@ describe('utils.js', () => {
   // Before each test
   beforeEach(() => {
     beforeTest()
-    cauldronHelperStub = sandbox.createStubInstance(CauldronHelper)
+    cauldronHelperStub = sandbox.createStubInstance(cauldron.CauldronHelper)
     cauldronHelperStub.getContainerVersion.resolves('1.0.0')
     cauldronHelperStub.getTopLevelContainerVersion.resolves(topLevelContainerVersion)
     cauldronHelperStub.getVersionsNames.resolves(['1.2.3', '1.2.4', '2.0.0', '3.0'])
@@ -63,7 +63,7 @@ describe('utils.js', () => {
     processExitStub = sandbox.stub(process, 'exit')
     inquirerPromptStub = sandbox.stub(inquirer, 'prompt')
 
-    sandbox.stub(coreUtils, 'getCauldronInstance').resolves(cauldronHelperStub)
+    sandbox.stub(cauldron, 'getActiveCauldron').resolves(cauldronHelperStub)
   })
 
   afterEach(() => {


### PR DESCRIPTION
We have a circular dependency between`ern-cauldron-api` and `ern-core` (i.e they both depend on each other).

This has not caused any issue yet (apart from causing a warning when running lerna), but it could in the future if left unfixed. Anyway, this is a design smell.

This PR gets rids of this dependency (ern-core should not depend on any other ern modules) through some refactoring :

- **Decouples Manifest class from Cauldron**
Instead of retrieving the override Manifest config from Cauldron on its own, it delegates this responsibility to an externally implemented function. This function is implemented in the entry point of `ern-local-cli` for now (which have a legit dependency on `ern-cauldron-api`).

- **Moves CauldronHelper class from ern-core to ern-cauldron-api**

- **Removes getCauldronInstance from ern-core utils**
Rather, a new function `getActiveCauldron` is now exported from `ern-cauldron-api`.

- **Moves compatibility functions from ern-core to ern-local-cli**
These functions were relying in part on Cauldron access and were only used by `ern-local-cli`.

- **Update all tests accordingly**

✅ Unit tests
✅ System tests