### PR TITLE
Add Visual Studio Code workspace settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,9 +21,6 @@ node_modules/
 npm-debug.log
 */node_modules
 
-# VSCode
-.vscode
-
 # distrib
 distrib
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "javascript.validate.enable": false,
+  "typescript.check.npmIsInstalled": false,
+  "flow.pathToFlow": "${workspaceRoot}/node_modules/.bin/flow"
+}


### PR DESCRIPTION
This way, developers using Visual Studio Code for electrode-native development, will have proper workspace settings applied.