### PR TITLE
Refactor Container publishers

### DIFF
--- a/ern-container-gen/src/FlowTypes.ts
+++ b/ern-container-gen/src/FlowTypes.ts
@@ -43,6 +43,8 @@ export interface ContainerGenerator {
 }
 
 export interface ContainerPublisherConfig {
+  // Publisher name
+  publisherName: string
   // Path to the generate Container to publish
   containerPath: string
   // Version of the Container to publish

--- a/ern-container-gen/src/publishers/GithubPublisher.ts
+++ b/ern-container-gen/src/publishers/GithubPublisher.ts
@@ -8,15 +8,15 @@ export default class GithubPublisher implements ContainerPublisher {
   }
 
   public async publish(config: ContainerPublisherConfig) {
-    const workingDir = createTmpDir()
+    const workingGitDir = createTmpDir()
 
     try {
-      shell.pushd(workingDir)
+      shell.pushd(workingGitDir)
       const git = gitCli()
-      log.debug(`Cloning git repository(${config.url}) to ${workingDir}`)
+      log.debug(`Cloning git repository(${config.url}) to ${workingGitDir}`)
       await gitCli().cloneAsync(config.url, '.')
-      shell.rm('-rf', `${workingDir}/*`)
-      shell.cp('-Rf', path.join(config.containerPath, '{.*,*}'), workingDir)
+      shell.rm('-rf', `${workingGitDir}/*`)
+      shell.cp('-Rf', path.join(config.containerPath, '{.*,*}'), workingGitDir)
       await git.addAsync('./*')
       await git.commitAsync(`Container v${config.containerVersion}`)
       await git.tagAsync([`v${config.containerVersion}`])

--- a/ern-container-gen/src/publishers/JcenterPublisher.ts
+++ b/ern-container-gen/src/publishers/JcenterPublisher.ts
@@ -28,11 +28,8 @@ export default class JcenterPublisher implements ContainerPublisher {
     mustacheConfig.groupId = config.extra.groupId
     mustacheConfig.containerVersion = config.containerVersion
 
-    const workingDir = createTmpDir()
-    shell.cp('-Rf', path.join(config.containerPath, '{.*,*}'), workingDir)
-
     fs.appendFileSync(
-      path.join(workingDir, 'lib', 'build.gradle'),
+      path.join(config.containerPath, 'lib', 'build.gradle'),
       `
     task androidSourcesJar(type: Jar) {
       classifier = 'sources'
@@ -48,7 +45,7 @@ export default class JcenterPublisher implements ContainerPublisher {
     )
 
     fs.appendFileSync(
-      path.join(workingDir, 'build.gradle'),
+      path.join(config.containerPath, 'build.gradle'),
       `buildscript {
       dependencies {
           classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
@@ -58,17 +55,17 @@ export default class JcenterPublisher implements ContainerPublisher {
 
     shell.cp(
       path.join(__dirname, 'supplements', 'jcenter-publish.gradle'),
-      path.join(workingDir, 'lib')
+      path.join(config.containerPath, 'lib')
     )
     mustacheUtils.mustacheRenderToOutputFileUsingTemplateFile(
-      path.join(workingDir, 'lib', 'jcenter-publish.gradle'),
+      path.join(config.containerPath, 'lib', 'jcenter-publish.gradle'),
       mustacheConfig,
-      path.join(workingDir, 'lib', 'jcenter-publish.gradle')
+      path.join(config.containerPath, 'lib', 'jcenter-publish.gradle')
     )
 
     try {
       log.debug('[=== Starting build and jcenter publication ===]')
-      shell.pushd(workingDir)
+      shell.pushd(config.containerPath)
       await this.buildAndUploadArchive()
       log.debug('[=== Completed build and publication of the module ===]')
     } finally {

--- a/ern-container-gen/src/publishers/MavenPublisher.ts
+++ b/ern-container-gen/src/publishers/MavenPublisher.ts
@@ -1,5 +1,5 @@
 import { ContainerPublisher, ContainerPublisherConfig } from '../FlowTypes'
-import { createTmpDir, MavenUtils, shell, childProcess, log } from 'ern-core'
+import { MavenUtils, shell, childProcess, log } from 'ern-core'
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
@@ -26,9 +26,6 @@ export default class MavenPublisher implements ContainerPublisher {
     const artifactId = config.extra.artifactId
     const groupId = config.extra.groupId
 
-    const workingDir = createTmpDir()
-    shell.cp('-Rf', path.join(config.containerPath, '{.*,*}'), workingDir)
-
     if (MavenUtils.isLocalMavenRepo(config.url)) {
       MavenUtils.createLocalMavenDirectoryIfDoesNotExist()
     }
@@ -36,7 +33,7 @@ export default class MavenPublisher implements ContainerPublisher {
     config.url = config.url.replace('file:~', `file:${os.homedir() || ''}`)
 
     fs.appendFileSync(
-      path.join(workingDir, 'lib', 'build.gradle'),
+      path.join(config.containerPath, 'lib', 'build.gradle'),
       `
   apply plugin: 'maven'
   
@@ -68,7 +65,7 @@ export default class MavenPublisher implements ContainerPublisher {
 
     try {
       log.debug('[=== Starting build and publication ===]')
-      shell.pushd(workingDir)
+      shell.pushd(config.containerPath)
       await this.buildAndUploadArchive()
       log.debug('[=== Completed build and publication of the module ===]')
     } finally {

--- a/ern-local-cli/src/commands/publish-container.ts
+++ b/ern-local-cli/src/commands/publish-container.ts
@@ -5,6 +5,7 @@ import {
   JcenterPublisher,
 } from 'ern-container-gen'
 import utils from '../lib/utils'
+import * as publication from '../lib/publication'
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
@@ -80,31 +81,13 @@ export const handler = async ({
       }
     }
 
-    switch (publisher) {
-      case 'git':
-        await new GitHubPublisher().publish({
-          containerPath,
-          containerVersion: version,
-          url,
-        })
-        break
-      case 'maven':
-        await new MavenPublisher().publish({
-          containerPath,
-          containerVersion: version,
-          extra: config ? JSON.parse(config) : undefined,
-          url,
-        })
-        break
-      case 'jcenter':
-        await new JcenterPublisher().publish({
-          containerPath,
-          containerVersion: version,
-          extra: config ? JSON.parse(config) : undefined,
-          url: '', // jcenter does not require a url
-        })
-        break
-    }
+    await publication.publishContainer({
+      containerPath,
+      containerVersion: version,
+      extra: config ? JSON.parse(config) : undefined,
+      publisherName: publisher,
+      url,
+    })
   } catch (e) {
     coreUtils.logErrorAndExitProcess(e)
   }

--- a/ern-local-cli/src/lib/publication.ts
+++ b/ern-local-cli/src/lib/publication.ts
@@ -3,6 +3,10 @@ import {
   IosGenerator,
   AndroidGenerator,
   ContainerGenerator,
+  ContainerPublisherConfig,
+  GitHubPublisher,
+  MavenPublisher,
+  JcenterPublisher,
 } from 'ern-container-gen'
 import {
   createTmpDir,
@@ -835,4 +839,17 @@ export async function askUserForCodePushDeploymentName(
   )
 
   return userSelectedDeploymentName
+}
+
+export async function publishContainer(conf: ContainerPublisherConfig) {
+  switch (conf.publisherName) {
+    case 'git':
+      return new GitHubPublisher().publish(conf)
+    case 'maven':
+      return new MavenPublisher().publish(conf)
+    case 'jcenter':
+      return new JcenterPublisher().publish(conf)
+    default:
+      throw new Error(`Unsupported Container publisher : ${conf.publisherName}`)
+  }
 }

--- a/ern-local-cli/src/lib/publication.ts
+++ b/ern-local-cli/src/lib/publication.ts
@@ -842,6 +842,26 @@ export async function askUserForCodePushDeploymentName(
 }
 
 export async function publishContainer(conf: ContainerPublisherConfig) {
+  // Duplicate the directory containing generated Container to a temporary
+  // directory, and pass this temporary directory to the publisher.
+  // This is done because Container generation and publication are
+  // clearly distinct (separation of concerns), we don't want the publisher
+  // to update the Container generated code for its publication needs.
+  // It also ensures that this function can be called multiple times
+  // with different publishers for the same Container (idempotent).
+  // Otherwise, if publication changes were made to the original Container
+  // path, it would be much harder to use a different publisher for the
+  // same Container.
+  const publicationWorkingDir = createTmpDir()
+  shell.cp(
+    '-Rf',
+    path.join(conf.containerPath, '{.*,*}'),
+    publicationWorkingDir
+  )
+  conf.containerPath = publicationWorkingDir
+
+  // Instantiates a Container publisher based on it's name and call
+  // publish fumction to trigger Container publication
   switch (conf.publisherName) {
     case 'git':
       return new GitHubPublisher().publish(conf)

--- a/ern-local-cli/src/lib/utils.ts
+++ b/ern-local-cli/src/lib/utils.ts
@@ -24,7 +24,6 @@ import {
 } from 'ern-container-gen'
 import { runLocalContainerGen, runCauldronContainerGen } from './publication'
 import { spawn, spawnSync } from 'child_process'
-import utils from './utils'
 import _ from 'lodash'
 import inquirer from 'inquirer'
 import semver from 'semver'
@@ -687,7 +686,7 @@ async function runMiniApp(
     if (cauldron == null) {
       throw new Error('[runMiniApp] No cauldron instance found')
     }
-    await utils.logErrorAndExitIfNotSatisfied({
+    await logErrorAndExitIfNotSatisfied({
       isCompleteNapDescriptorString: { descriptor },
       napDescriptorExistInCauldron: {
         descriptor,


### PR DESCRIPTION
Light refactoring around Container publishers :

- Remove duplication of publisher factory code (quite similar code in two different source files). Centralize this code in a new function `publishContainer` (in ern-local-cli/publication.js).

- Move logic to copy Container to temporary directory, out of the publishers. It removes some duplicated code in the publishers, and also by doing this upstream, we can guarantee that new publishers (or third party publishers that could be supported soon) will be provided with a duplicated container path instead of the original container path (not to be tampered with).