### PR TITLE
Improve Container publishers

### DIFF
--- a/ern-container-gen/src/FlowTypes.ts
+++ b/ern-container-gen/src/FlowTypes.ts
@@ -51,7 +51,7 @@ export interface ContainerPublisherConfig {
   containerVersion: string
   // Url to publish the container to
   // The url scheme is specific to the publisher type
-  url: string
+  url?: string
   // Extra optional configuration specific to the publisher
   extra?: any
 }

--- a/ern-container-gen/src/publishers/GithubPublisher.ts
+++ b/ern-container-gen/src/publishers/GithubPublisher.ts
@@ -10,6 +10,10 @@ export default class GithubPublisher implements ContainerPublisher {
   public async publish(config: ContainerPublisherConfig) {
     const workingGitDir = createTmpDir()
 
+    if (!config.url) {
+      throw new Error('url is required for GitHub publisher')
+    }
+
     try {
       shell.pushd(workingGitDir)
       const git = gitCli()
@@ -22,6 +26,10 @@ export default class GithubPublisher implements ContainerPublisher {
       await git.tagAsync([`v${config.containerVersion}`])
       await git.pushAsync('origin', 'master')
       await git.pushTagsAsync('origin')
+      log.info('[=== Completed publication of the Container ===]')
+      log.info(`[Publication url : ${config.url}]`)
+      log.info('[Git Branch: master]')
+      log.info(`[Git Tag: v${config.containerVersion}]`)
     } finally {
       shell.popd()
     }

--- a/ern-container-gen/src/publishers/JcenterPublisher.ts
+++ b/ern-container-gen/src/publishers/JcenterPublisher.ts
@@ -5,6 +5,9 @@ import path from 'path'
 const { execp } = childProcess
 
 export default class JcenterPublisher implements ContainerPublisher {
+  public static readonly DEFAULT_ARTIFACT_ID: string = 'local-container'
+  public static readonly DEFAULT_GROUP_ID: string = 'com.walmartlabs.ern'
+
   get name(): string {
     return 'jcenter'
   }
@@ -15,11 +18,15 @@ export default class JcenterPublisher implements ContainerPublisher {
     }
 
     if (!config.extra.artifactId) {
-      config.extra.artifactId = 'local-container'
+      log.debug(
+        `Using default artifactId: ${JcenterPublisher.DEFAULT_ARTIFACT_ID}`
+      )
+      config.extra.artifactId = JcenterPublisher.DEFAULT_ARTIFACT_ID
     }
 
     if (!config.extra.groupId) {
-      config.extra.groupId = 'com.walmartlabs.ern'
+      log.debug(`Using default groupId: ${JcenterPublisher.DEFAULT_GROUP_ID}`)
+      config.extra.groupId = JcenterPublisher.DEFAULT_GROUP_ID
     }
 
     const mustacheConfig: any = {}
@@ -64,10 +71,15 @@ export default class JcenterPublisher implements ContainerPublisher {
     )
 
     try {
-      log.debug('[=== Starting build and jcenter publication ===]')
+      log.info('[=== Starting build and jcenter publication ===]')
       shell.pushd(config.containerPath)
       await this.buildAndUploadArchive()
-      log.debug('[=== Completed build and publication of the module ===]')
+      log.info('[=== Completed build and publication of the Container ===]')
+      log.info(
+        `[Artifact: ${config.extra.groupId}:${config.extra.artifactId}:${
+          config.containerVersion
+        } ]`
+      )
     } finally {
       shell.popd()
     }

--- a/ern-local-cli/src/commands/publish-container.ts
+++ b/ern-local-cli/src/commands/publish-container.ts
@@ -60,13 +60,6 @@ export const handler = async ({
       isValidContainerVersion: { containerVersion: version },
     })
 
-    // url validation
-    if (!url && publisher === 'git') {
-      throw new Error('url is required when using a git publisher')
-    } else if (!url && publisher === 'maven') {
-      url = `file:${path.join(os.homedir() || '', '.m2', 'repository')}`
-    }
-
     // Container path validation
     if (!fs.existsSync(containerPath)) {
       throw new Error('containerPath path does not exist')


### PR DESCRIPTION
- Makes `url` property optional in `ContainerPublisherConfig`. Some publishers might not need an url (for example current JCenter publisher). 
- Add some logging to the publishers.
- Remove validation and default value set in `publish-container` command. It's not the responsibility of the command to do this, but rather the publishers themselves should perform validation and setting default values for config.