### PR TITLE
Update create-container command to disallow non empty out directory

### DIFF
--- a/ern-container-gen/src/generators/android/AndroidGenerator.ts
+++ b/ern-container-gen/src/generators/android/AndroidGenerator.ts
@@ -16,6 +16,7 @@ import {
   sortDependenciesByName,
   populateApiImplMustacheView,
   addElectrodeNativeMetadataFile,
+  prepareDirectories,
 } from '../../utils'
 import _ from 'lodash'
 import path from 'path'
@@ -40,31 +41,11 @@ export default class AndroidGenerator implements ContainerGenerator {
     return 'android'
   }
 
-  public prepareDirectories(config: ContainerGeneratorConfig) {
-    if (!fs.existsSync(config.outDir)) {
-      shell.mkdir('-p', config.outDir)
-    } else {
-      shell.rm('-rf', path.join(config.outDir, '{.*,*}'))
-    }
-
-    if (!fs.existsSync(config.compositeMiniAppDir)) {
-      shell.mkdir('-p', config.compositeMiniAppDir)
-    } else {
-      shell.rm('-rf', path.join(config.compositeMiniAppDir, '{.*,*}'))
-    }
-
-    if (!fs.existsSync(config.pluginsDownloadDir)) {
-      shell.mkdir('-p', config.pluginsDownloadDir)
-    } else {
-      shell.rm('-rf', path.join(config.pluginsDownloadDir, '{.*,*}'))
-    }
-  }
-
   public async generate(
     config: ContainerGeneratorConfig
   ): Promise<ContainerGenResult> {
     try {
-      this.prepareDirectories(config)
+      prepareDirectories(config)
       config.plugins = sortDependenciesByName(config.plugins)
 
       shell.cd(config.outDir)

--- a/ern-container-gen/src/generators/ios/IosGenerator.ts
+++ b/ern-container-gen/src/generators/ios/IosGenerator.ts
@@ -15,6 +15,7 @@ import {
   sortDependenciesByName,
   populateApiImplMustacheView,
   addElectrodeNativeMetadataFile,
+  prepareDirectories,
 } from '../../utils'
 import fs from 'fs'
 import path from 'path'
@@ -39,31 +40,11 @@ export default class IosGenerator implements ContainerGenerator {
     return 'ios'
   }
 
-  public prepareDirectories(config: ContainerGeneratorConfig) {
-    if (!fs.existsSync(config.outDir)) {
-      shell.mkdir('-p', config.outDir)
-    } else {
-      shell.rm('-rf', path.join(config.outDir, '{.*,*}'))
-    }
-
-    if (!fs.existsSync(config.compositeMiniAppDir)) {
-      shell.mkdir('-p', config.compositeMiniAppDir)
-    } else {
-      shell.rm('-rf', path.join(config.compositeMiniAppDir, '{.*,*}'))
-    }
-
-    if (!fs.existsSync(config.pluginsDownloadDir)) {
-      shell.mkdir('-p', config.pluginsDownloadDir)
-    } else {
-      shell.rm('-rf', path.join(config.pluginsDownloadDir, '{.*,*}'))
-    }
-  }
-
   public async generate(
     config: ContainerGeneratorConfig
   ): Promise<ContainerGenResult> {
     try {
-      this.prepareDirectories(config)
+      prepareDirectories(config)
       config.plugins = sortDependenciesByName(config.plugins)
 
       shell.cd(config.outDir)

--- a/ern-container-gen/src/utils.ts
+++ b/ern-container-gen/src/utils.ts
@@ -660,6 +660,26 @@ export function populateApiImplMustacheView(
   }
 }
 
+export function prepareDirectories(conf: ContainerGeneratorConfig) {
+  if (!fs.existsSync(conf.outDir)) {
+    shell.mkdir('-p', conf.outDir)
+  } else {
+    shell.rm('-rf', path.join(conf.outDir, '{.*,*}'))
+  }
+
+  if (!fs.existsSync(conf.compositeMiniAppDir)) {
+    shell.mkdir('-p', conf.compositeMiniAppDir)
+  } else {
+    shell.rm('-rf', path.join(conf.compositeMiniAppDir, '{.*,*}'))
+  }
+
+  if (!fs.existsSync(conf.pluginsDownloadDir)) {
+    shell.mkdir('-p', conf.pluginsDownloadDir)
+  } else {
+    shell.rm('-rf', path.join(conf.pluginsDownloadDir, '{.*,*}'))
+  }
+}
+
 export async function addElectrodeNativeMetadataFile(
   conf: ContainerGeneratorConfig
 ) {

--- a/ern-local-cli/src/commands/create-container.ts
+++ b/ern-local-cli/src/commands/create-container.ts
@@ -17,6 +17,7 @@ import * as constants from '../lib/constants'
 import _ from 'lodash'
 import inquirer from 'inquirer'
 import { Argv } from 'yargs'
+import fs from 'fs'
 
 export const command = 'create-container'
 export const desc = 'Create a container locally'
@@ -90,6 +91,15 @@ export const handler = async ({
   let napDescriptor: NativeApplicationDescriptor | void
 
   try {
+    if (outDir && fs.existsSync(outDir)) {
+      if (fs.readdirSync(outDir).length > 0) {
+        throw new Error(
+          `${outDir} directory exists and is not empty.
+Output directory should either not exist (it will be created) or should be empty.`
+        )
+      }
+    }
+
     await utils.logErrorAndExitIfNotSatisfied({
       noGitOrFilesystemPath: {
         extraErrorMessage:


### PR DESCRIPTION
`create-container` command accept an `--outDir/--out` option to specify the output directory for the generated Container.

Container generator performs cleanup of this directory if it exists (it forces remove all files recursively). This is very dangerous as if a user makes a mistake and set output directory to the user home directory for example, the whole user home directory will be destroyed.

To avoid this, `create-container` command will now ensure that in case an output directory is provided, this directory either does not exist yet (will be created) or is empty. Otherwise the command will fail with the following informative error :

```
An error occurred: /Users/blemair/Code/myContainer directory exists and is not empty.
Output directory should either not exist (it will be created) or should be empty.
```

It also avoid mistakenly overwriting a previously generated container.