### PR TITLE
Cleanup dist directory from ern-typescript script

### DIFF
--- a/ern-util-dev/bin/ern-typescript.js
+++ b/ern-util-dev/bin/ern-typescript.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
-const ernModulePath = process.cwd()
 const path = require('path')
+const ernModulePath = process.cwd()
+require('rimraf').sync(path.resolve(ernModulePath, 'dist'))
 process.argv.push('--project')
 process.argv.push(path.resolve(ernModulePath, 'tsconfig.release.json'))
 console.log('running tsc with', process.argv.slice(2))

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "setup-dev": "node setup-dev.js",
-    "rebuild":
-      "rimraf ern-*/**/dist && lerna clean --yes && lerna bootstrap && lerna run build",
+    "rebuild": "lerna clean --yes && lerna bootstrap && lerna run build",
     "test": "lerna run test",
     "system-tests": "node system-tests/system-tests",
     "coverage-unit":


### PR DESCRIPTION
Transfer responsibility of removing Electrode Native module `dist`directory to the `ern-typescript` script. It makes more sense as it is this script that is producing the `dist` directory in the first place.