### PR TITLE
Rename git publisher to github

### DIFF
--- a/docs/cli/publish-container.md
+++ b/docs/cli/publish-container.md
@@ -25,14 +25,14 @@
 
 `--publisher/-p <publisher>`
 
-* Specify the publisher to use. Can either be `maven` or `git`.
+* Specify the publisher to use. Can either be `maven` or `github`.
 * This option is required, there is no default.
 
 `--url/-u <url>`
 
 * The publication url to publish the Container to.
 * Can either be the url of a Git repository or a Maven repository (local or remote), depending on the publisher being used.
-* This option is required for the `git` publisher. For `maven` publisher, it will default to the standard Maven local path (`~/.m2/repository`) if not specified.
+* This option is required for the `github` publisher. For `maven` publisher, it will default to the standard Maven local path (`~/.m2/repository`) if not specified.
 
 `--config/-c <config>`
 

--- a/ern-container-publisher/src/publishContainer.ts
+++ b/ern-container-publisher/src/publishContainer.ts
@@ -27,7 +27,7 @@ export default async function publishContainer(conf: ContainerPublisherConfig) {
   // Instantiates a Container publisher based on it's name and call
   // publish fumction to trigger Container publication
   switch (conf.publisherName) {
-    case 'git':
+    case 'github':
       return new GithubPublisher().publish(conf)
     case 'maven':
       return new MavenPublisher().publish(conf)

--- a/ern-local-cli/src/commands/publish-container.ts
+++ b/ern-local-cli/src/commands/publish-container.ts
@@ -19,7 +19,7 @@ export const builder = (argv: Argv) => {
     })
     .option('publisher', {
       alias: 'p',
-      choices: ['git', 'maven', 'jcenter'],
+      choices: ['github', 'maven', 'jcenter'],
       demandOption: true,
       describe: 'The publisher type',
       type: 'string',


### PR DESCRIPTION
For some reason, Cauldron was using `github` as the name of the publisher whereas the `publish-container` command was expecting `git`. Thanks to a recent refactoring, container publication got centralized and is not all over the place so let's use same naming for the `GitHubPublisher` as `github` (makes more sense than `git` given the naming of the class).