### PR TITLE
yarn.lock support for MiniApps retrieved from git

### DIFF
--- a/ern-container-gen/test/temp-test.ts
+++ b/ern-container-gen/test/temp-test.ts
@@ -116,8 +116,8 @@ describe('ern-container-gen utils.js', () => {
     it('should yarn add new MiniApps', async () => {
       const miniAppsDeltas = {
         new: [
-          { name: 'MiniAppFour', version: '7.0.0' },
-          { name: 'MiniAppFive', version: '4.0.0' },
+          PackagePath.fromString('MiniAppFour@7.0.0'),
+          PackagePath.fromString('MiniAppFive@4.0.0'),
         ],
       }
       await runYarnUsingMiniAppDeltas(miniAppsDeltas)
@@ -127,8 +127,8 @@ describe('ern-container-gen utils.js', () => {
     it('should yarn upgrade upgraded MiniApps', async () => {
       const miniAppsDeltas = {
         upgraded: [
-          { name: 'MiniAppOne', version: '7.0.0' },
-          { name: 'MiniAppTwo', version: '4.0.0' },
+          PackagePath.fromString('MiniAppOne@7.0.0'),
+          PackagePath.fromString('MiniAppTwo@4.0.0'),
         ],
       }
       await runYarnUsingMiniAppDeltas(miniAppsDeltas)
@@ -138,8 +138,8 @@ describe('ern-container-gen utils.js', () => {
     it('should not yarn upgrade nor yarn add same MiniApps versions', async () => {
       const miniAppsDeltas = {
         same: [
-          { name: 'MiniAppOne', version: '6.0.0' },
-          { name: 'MiniAppTwo', version: '3.0.0' },
+          PackagePath.fromString('MiniAppOne@6.0.0'),
+          PackagePath.fromString('MiniAppTwo@3.0.0'),
         ],
       }
       await runYarnUsingMiniAppDeltas(miniAppsDeltas)
@@ -149,31 +149,14 @@ describe('ern-container-gen utils.js', () => {
 
     it('should work correctly with mixed deltas', async () => {
       const miniAppsDeltas = {
-        new: [
-          {
-            basePath: 'MiniAppFour',
-            version: '7.0.0',
-          },
-        ],
+        new: [PackagePath.fromString('MiniAppFour@7.0.0')],
         same: [
-          {
-            basePath: 'MiniAppOne',
-            version: '6.0.0',
-          },
-          {
-            basePath: 'MiniAppTwo',
-            version: '3.0.0',
-          },
+          PackagePath.fromString('MiniAppOne@6.0.0'),
+          PackagePath.fromString('MiniAppTwo@3.0.0'),
         ],
         upgraded: [
-          {
-            nabasePathme: 'MiniAppOne',
-            version: '7.0.0',
-          },
-          {
-            basePath: 'MiniAppTwo',
-            version: '4.0.0',
-          },
+          PackagePath.fromString('MiniAppOne@7.0.0'),
+          PackagePath.fromString('MiniAppTwo@4.0.0'),
         ],
       }
       await runYarnUsingMiniAppDeltas(miniAppsDeltas)
@@ -189,8 +172,8 @@ describe('ern-container-gen utils.js', () => {
     it('should inject MiniApps that have same version as previous', () => {
       const miniAppsDeltas = {
         same: [
-          { basePath: 'MiniAppOne', version: '6.0.0' },
-          { basePath: 'MiniAppTwo', version: '3.0.0' },
+          PackagePath.fromString('MiniAppOne@6.0.0'),
+          PackagePath.fromString('MiniAppTwo@3.0.0'),
         ],
       }
       const result = getPackageJsonDependenciesUsingMiniAppDeltas(
@@ -204,8 +187,8 @@ describe('ern-container-gen utils.js', () => {
     it('should inject MiniApps that have upgraded versions', () => {
       const miniAppsDeltas = {
         upgraded: [
-          { basePath: 'MiniAppOne', version: '7.0.0' },
-          { basePath: 'MiniAppTwo', version: '4.0.0' },
+          PackagePath.fromString('MiniAppOne@7.0.0'),
+          PackagePath.fromString('MiniAppTwo@4.0.0'),
         ],
       }
       const result = getPackageJsonDependenciesUsingMiniAppDeltas(
@@ -219,8 +202,8 @@ describe('ern-container-gen utils.js', () => {
     it('should not inject MiniApps that are new', () => {
       const miniAppsDeltas = {
         new: [
-          { basePath: 'MiniAppFour', version: '7.0.0' },
-          { basePath: 'MiniAppFive', version: '4.0.0' },
+          PackagePath.fromString('MiniAppFour@7.0.0'),
+          PackagePath.fromString('MiniAppFive@4.0.0'),
         ],
       }
       const result = getPackageJsonDependenciesUsingMiniAppDeltas(
@@ -232,24 +215,9 @@ describe('ern-container-gen utils.js', () => {
 
     it('should inject proper MiniApps', () => {
       const miniAppsDeltas = {
-        new: [
-          {
-            basePath: 'MiniAppFour',
-            version: '7.0.0',
-          },
-        ],
-        same: [
-          {
-            basePath: 'MiniAppOne',
-            version: '6.0.0',
-          },
-        ],
-        upgraded: [
-          {
-            basePath: 'MiniAppTwo',
-            version: '4.0.0',
-          },
-        ],
+        new: [PackagePath.fromString('MiniAppFour@7.0.0')],
+        same: [PackagePath.fromString('MiniAppOne@6.0.0')],
+        upgraded: [PackagePath.fromString('MiniAppTwo@4.0.0')],
       }
       const result = getPackageJsonDependenciesUsingMiniAppDeltas(
         miniAppsDeltas,

--- a/ern-core/src/PackagePath.ts
+++ b/ern-core/src/PackagePath.ts
@@ -34,7 +34,7 @@ export class PackagePath {
   /**
    * Package path without version
    * - File path        : path without scheme prefix
-   * - Git path         : path without scheme prefix nor branch/tag/commit
+   * - Git path         : path without branch/tag/commit
    * - Registry path    : package name (unscoped)
    */
   public readonly basePath: string

--- a/ern-local-cli/src/commands/create-miniapp.ts
+++ b/ern-local-cli/src/commands/create-miniapp.ts
@@ -92,7 +92,6 @@ export const handler = async ({
 
     logSuccessFooter(appName)
   } catch (e) {
-    console.log('BOUM')
     coreUtils.logErrorAndExitProcess(e)
   }
 }


### PR DESCRIPTION
This PR adds proper `yarn.lock` support for MiniApps that are retrieved from git.
Prior to these changes, as soon as one of the MiniApps was retrieved from git instead of npm, the `yarn.lock` functionality was disabled.

This guarantees consistency and ensure that solely the dependency tree(s) of updated or new MiniApps are refreshed, and not in any way the dependency tree of non updated MiniApps.

Important given that we might start pushing for using a development flow based on git MiniApps in Cauldron rather than registry published versions, as it eases dev lifecycle.