### PR TITLE
Fix issue in api-impl-gen related to bridge version range

### DIFF
--- a/ern-api-impl-gen/package.json
+++ b/ern-api-impl-gen/package.json
@@ -56,8 +56,10 @@
     "ern-core": "1000.0.0",
     "lodash": "^4.17.4",
     "mustache": "^2.3.0",
+    "semver": "5.5.0",
     "xcode": "^0.9.1",
-    "xcode-ern": "1.0.1"
+    "xcode-ern": "1.0.1",
+    "@yarnpkg/lockfile": "^1.0.1"
   },
   "devDependencies": {
     "ern-util-dev": "1000.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,6 +24,10 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.0.0.tgz#33d1dbb659a23b81f87f048762b35a446172add3"
 
+"@yarnpkg/lockfile@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.0.1.tgz#294155ffbf78cec882a23bc61800b8e629b6b384"
+
 JSONSelect@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/JSONSelect/-/JSONSelect-0.4.0.tgz#a08edcc67eb3fcbe99ed630855344a0cf282bb8d"
@@ -4780,7 +4784,7 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 >=2.2.1 || 3.x || 4 || 5", "semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", "semver@^2.3.0 || 3.x || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
+"semver@2 >=2.2.1 || 3.x || 4 || 5", "semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@5.5.0, "semver@^2.3.0 || 3.x || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 


### PR DESCRIPTION
This PR fix a bug that was reported by daily job system tests failure.

A bug was recently discovered and fixed in GitManifest (comparing versions as strings instead of using semver lib) : https://github.com/electrode-io/electrode-native/commit/2e7d23272db2c0783654b921850ce68c6c0f3300#diff-2fde8a8f6c7fa832045033cb61368189L203

Fixing this bug actually uncovered another issue/bug in api-impl-gen.
The problem is that api-impl-gen is installing the api dependency along with its dependencies. APIs have a dependency on bridge, but not on a fixed version of bridge, rather a range (`1.5.x`). `yarn add` call goes fine with such a range dependency but at some point in GitManifest, when asking for the plugin configuration, the manifest resolver fails on the call to `semver.gte` as this function is used to compare two versions (fixed), and a range well, it's not a version ...

Quick fix is that instead of providing the dependencies as such, with ranged versions, we just install all of them, and then, for all dependencies versions that were using a range, have a peek in the resulting yarn.lock to figure out the fixed versions that were actually installed. We then rebuild a dependency array (PackagePath array) matching the original one, at the difference that all dependencies with ranged versions now have a real fixed version (the one that was truly installed), making such an array ready to be fed to semver comparators.

GitManifest should have some guard clauses to ensure that all dependencies it is fed with are containing fixed versions and not range, should throw exception if not, in order to fail early. Will beef up Manifest with guards soon.

This is fixing the current bug as well as the impacted system test. That being said, system tests are still failing due to a recent new bridge version publication (1.5.13) and system test fixtures not having been regenerated. https://github.com/electrode-io/electrode-native/pull/753 is containing the regenerated fixtures.