### PR TITLE
Update auto-rebuild script for yarn workspace

### DIFF
--- a/auto-rebuild.js
+++ b/auto-rebuild.js
@@ -1,21 +1,16 @@
 #!/usr/bin/env node
 var execSync = require('child_process').execSync
 
-var stdout = execSync('git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD')
+var stdout = execSync(
+  'git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD'
+)
 
 if (stdout) {
   if (/\nyarn\.lock/.test(stdout)) {
     console.log('========================================================')
-    console.log('Dependency changes detected in Electrode Native root')
+    console.log('Dependency changes detected')
     console.log('Running yarn install')
     console.log('========================================================')
     execSync('yarn install', { stdio: [0, 1, 2] })
-  }
-  if (/ern-.+(\/|\\)yarn\.lock/.test(stdout)) {
-    console.log('========================================================')
-    console.log('Dependency changes detected in one or more ern module(s)')
-    console.log('Rebuilding Electrode Native platform')
-    console.log('========================================================')
-    execSync('npm run rebuild', { stdio: [0, 1, 2] })
   }
 }


### PR DESCRIPTION
Due to the recent move to [Yarn workspaces](https://yarnpkg.com/lang/en/docs/workspaces/), there is no longer a `yarn.lock` lock file in each `ern-` module directory. Instead, Yarn workspace is keeping only a single top level `yarn.lock` file encapsulating all dependencies of all `ern-` modules.

This PR update the `auto-rebuild` script to account for this change. If we detect a change in the top level `yarn.lock` we just simply run `yarn install`.