### PR TITLE
Update GitManifest

### DIFF
--- a/ern-core/src/GitManifest.ts
+++ b/ern-core/src/GitManifest.ts
@@ -84,11 +84,14 @@ export default class GitManifest {
     )
   }
 
-  // We only sync once during a whole "session" (in our context : "an ern command exection")
-  // This is done to speed up things as during a single command execution, multiple manifest
-  // access can be performed.
-  // If you need to access a `Manifest` in a different context, a long session, you might
-  // want to improve the code to act a bit smarter.
+  /**
+   * We only sync once during a whole "session"
+   * (in our context : "an ern command exection")
+   * This is done to speed up things as during a single command execution,
+   * multiple manifest access can be performed.
+   * If you need to access a `Manifest` in a different context, a long session,
+   *  you might want to improve the code to act a bit smarter.
+   */
   public async syncIfNeeded() {
     if (!this.cachedManifest) {
       await this.sync()
@@ -106,19 +109,29 @@ export default class GitManifest {
     )
   }
 
-  //
-  // Return an array containing all top level plugin configuration directories that
-  // are matching an Electrode Native version lower or equal than the specified maxVersion
-  // For example, given the following directories :
-  //   /Users/blemair/.ern/ern-override-manifest/plugins/ern_v0.5.0+
-  //   /Users/blemair/.ern/ern-override-manifest/plugins/ern_v0.10.0+
-  //   /Users/blemair/.ern/ern-override-manifest/plugins/ern_v0.13.0+
-  // And maxVersion = '0.10.0'
-  // The function would return :
-  // [
-  //   '/Users/blemair/.ern/ern-override-manifest/plugins/ern_v0.5.0+',
-  //   '/Users/blemair/.ern/ern-override-manifest/plugins/ern_v0.10.0+'
-  // ]
+  /**
+   * Return an array containing all top level plugin configuration directories
+   * are matching an Electrode Native version lower or equal than the specified
+   * maxVersion.
+   *
+   * For example, given the following directories :
+   *
+   *  /Users/blemair/.ern/ern-override-manifest/plugins/ern_v0.5.0+
+   *  /Users/blemair/.ern/ern-override-manifest/plugins/ern_v0.10.0+
+   *  /Users/blemair/.ern/ern-override-manifest/plugins/ern_v0.13.0+
+   *
+   * And maxVersion='0.10.0'
+   *
+   * The function would return :
+   *
+   *  [
+   *   '/Users/blemair/.ern/ern-override-manifest/plugins/ern_v0.5.0+',
+   *   '/Users/blemair/.ern/ern-override-manifest/plugins/ern_v0.10.0+'
+   *  ]
+   * @param maxVersion The upper bound Electrode Native version.
+   *                   Only plugin configuration directories lower than this
+   *                   version will be returned.
+   */
   public getPluginsConfigurationDirectories(
     maxVersion: string = Platform.currentVersion
   ): string[] {
@@ -132,6 +145,15 @@ export default class GitManifest {
       .value()
   }
 
+  /**
+   * Given a fixed versioned plugin, return the local file system path
+   * to the directory containing the plugin configuration files, or
+   * undefined if no configuration matching this plugin version exists
+   * in the Manifest.
+   * @param plugin Fixed versioned plugin for which to retrieve configuration
+   * @param platformVersion Platform version that is querying for
+   *                        the plugin configuration.
+   */
   public async getPluginConfigurationPath(
     plugin: PackagePath,
     platformVersion: string = Platform.currentVersion
@@ -222,9 +244,10 @@ export default class GitManifest {
     }
   }
 
-  //
-  // Old way of getting plugin configuration path
-  // -- To be deprecated --
+  /**
+   * Old way of getting plugin configuration path
+   *  -- To be deprecated --
+   */
   private async getPluginConfigurationPathLegacy(
     plugin: PackagePath,
     platformVersion: string = Platform.currentVersion

--- a/ern-core/src/GitManifest.ts
+++ b/ern-core/src/GitManifest.ts
@@ -158,6 +158,13 @@ export default class GitManifest {
     plugin: PackagePath,
     platformVersion: string = Platform.currentVersion
   ): Promise<string | void> {
+    if (!plugin.version) {
+      throw new Error('Plugin version is required to retrieve configuration')
+    } else if (!semver.valid(plugin.version)) {
+      throw new Error(
+        'Plugin version is required to be fixed and not ranged to retrieve configuration'
+      )
+    }
     let result = await this.getPluginConfigurationPathNew(
       plugin,
       platformVersion

--- a/ern-core/src/GitManifest.ts
+++ b/ern-core/src/GitManifest.ts
@@ -172,11 +172,9 @@ export default class GitManifest {
     // ]
     const orderedPluginsConfigurationDirectories = this.getPluginsConfigurationDirectories(
       platformVersion
+    ).sort((a, b) =>
+      semver.rcompare(versionRe.exec(a)![1], versionRe.exec(b)![1])
     )
-      .sort((a, b) =>
-        semver.compare(versionRe.exec(a)![1], versionRe.exec(b)![1])
-      )
-      .reverse()
 
     for (const pluginsConfigurationDirectory of orderedPluginsConfigurationDirectories) {
       let pluginScope
@@ -204,9 +202,8 @@ export default class GitManifest {
         s => versionRe.exec(s)![1]
       )
 
-      const matchingVersion = _.find(
-        pluginVersions.sort(semver.compare).reverse(),
-        d => semver.gte(plugin.version!, d)
+      const matchingVersion = _.find(pluginVersions.sort(semver.rcompare), d =>
+        semver.gte(plugin.version!, d)
       )
       if (matchingVersion) {
         let pluginConfigurationPath = ''
@@ -242,11 +239,9 @@ export default class GitManifest {
     const versionRe = /_v(.+)\+/
     const orderedPluginsConfigurationDirectories = this.getPluginsConfigurationDirectories(
       platformVersion
+    ).sort((a, b) =>
+      semver.rcompare(versionRe.exec(a)![1], versionRe.exec(b)![1])
     )
-      .sort((a, b) =>
-        semver.compare(versionRe.exec(a)![1], versionRe.exec(b)![1])
-      )
-      .reverse()
 
     for (const pluginsConfigurationDirectory of orderedPluginsConfigurationDirectories) {
       // Directory names cannot contain '/', so, replaced by ':'
@@ -259,9 +254,8 @@ export default class GitManifest {
         s => versionRe.exec(s)![1]
       )
 
-      const matchingVersion = _.find(
-        pluginVersions.sort(semver.compare).reverse(),
-        d => semver.gte(plugin.version!, d)
+      const matchingVersion = _.find(pluginVersions.sort(semver.rcompare), d =>
+        semver.gte(plugin.version!, d)
       )
       if (matchingVersion) {
         const pluginConfigurationPath = path.join(


### PR DESCRIPTION
- Use `semver.rcompare` (reversed order compare) rather than `semver.compare`. This way we get rid of an extra statement (no more need  to call `reverse` on the sorted Array).
- Update function documentation headers to comply with JSDoc formatting (better this way as it is properly parsed by IDE to display proper function documentation on hover).
- Document `getPluginConfigurationPath` function.
- Add guard clauses to `getPluginConfigurationPath` to ensure that the plugin is properly versioned (have a version AND version is not a range but a fixed one)