### PR TITLE
Update yarn-lock-check script

### DIFF
--- a/yarn-lock-check.js
+++ b/yarn-lock-check.js
@@ -6,61 +6,42 @@ const path = require('path')
 const yarnLock = 'yarn.lock'
 const yarnRegistryRe = /https:\/\/registry.yarnpkg.com|http:\/\/registry.npmjs.org/
 
-let ernDirs = fs.readdirSync(process.cwd()).filter(x => x.startsWith('ern'))
-ernDirs.push(yarnLock) // Root yarn.lock
+const yarnLockContent = fs.readFileSync(yarnLock, 'utf8')
+const yarnLockParsed = lockfile.parse(yarnLockContent)
 
-ernDirs.forEach(current => {
-  let yarnLockPath =
-    current === yarnLock ? yarnLock : path.join(current, yarnLock)
-
-  try {
-    let yarnLockContent = fs.readFileSync(yarnLockPath, 'utf8')
-    let yarnLockParsed = lockfile.parse(yarnLockContent)
-
-    /*
-     {
-     type: 'success',
-     object: {
-     '@yarnpkg/lockfile@^1.0.0': {
-     version: '1.0.0',
-     resolved: 'http://npme.walmart.com/@yarnpkg/lockfile/-/lockfile-1.0.0.tgz#33d1dbb659a23b81f87f048762b35a446172add3'
-     },
-     'JSONSelect@0.4.0': {
-     version: '0.4.0',
-     resolved: 'https://registry.yarnpkg.com/JSONSelect/-/JSONSelect-0.4.0.tgz#a08edcc67eb3fcbe99ed630855344a0cf282bb8d'
-     }
-     }
-     */
-    if (yarnLockParsed && yarnLockParsed.object) {
-      let incorrectRegistries = []
-      for (let key of Object.keys(yarnLockParsed.object)) {
-        if (yarnLockParsed.object[key]) {
-          let resolved = yarnLockParsed.object[key].resolved
-          if (resolved && !yarnRegistryRe.exec(resolved)) {
-            incorrectRegistries.push(resolved)
-          }
-        }
-      }
-
-      /*
-       yarn.lock contains registry other than https://registry.yarnpkg.com
-       http://npme.walmart.com/@yarnpkg/lockfile/-/lockfile-1.0.0.tgz#33d1dbb659a23b81f87f048762b35a446172add3
-       http://npme.walmart.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63
-       http://npme.walmart.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c
-       */
-      if (incorrectRegistries.length > 0) {
-        console.log(
-          chalk.bold.red(
-            `${yarnLockPath} contains registry other than https://registry.yarnpkg.com`
-          )
-        )
-        incorrectRegistries.forEach(item => {
-          console.log(chalk.bold.red(item))
-        })
-        process.exit(1)
+/*
+  {
+  type: 'success',
+  object: {
+  'JSONSelect@0.4.0': {
+  version: '0.4.0',
+  resolved: 'https://registry.yarnpkg.com/JSONSelect/-/JSONSelect-0.4.0.tgz#a08edcc67eb3fcbe99ed630855344a0cf282bb8d'
+  }
+  }
+  */
+if (yarnLockParsed && yarnLockParsed.object) {
+  let incorrectRegistries = []
+  for (let key of Object.keys(yarnLockParsed.object)) {
+    if (yarnLockParsed.object[key]) {
+      let resolved = yarnLockParsed.object[key].resolved
+      if (resolved && !yarnRegistryRe.exec(resolved)) {
+        incorrectRegistries.push(resolved)
       }
     }
-  } catch (e) {
-    console.log(chalk.yellow(`Skip yarn-lock registry check for ${current}`))
   }
-})
+
+  /*
+    yarn.lock contains registry other than https://registry.yarnpkg.com
+    */
+  if (incorrectRegistries.length > 0) {
+    console.log(
+      chalk.bold.red(
+        `yarn.lock contains registry other than https://registry.yarnpkg.com`
+      )
+    )
+    incorrectRegistries.forEach(item => {
+      console.log(chalk.bold.red(item))
+    })
+    process.exit(1)
+  }
+}


### PR DESCRIPTION
Given that we are now using [Yarn Workspaces](https://yarnpkg.com/lang/en/docs/workspaces/) there is no longer a need to check for validity of modules lock files because due to the nature of yarn workspaces, there is just one top level lock file and no module lock files. 

From Yarn Workspaces documentation :
> Yarn will use a single lockfile rather than a different one for each project, which means less conflicts and easier reviews.

This PR updates yarn-lock-check script so that it doesn't look for lock files in modules directories and just check the validity of the top level project lock file.