### PR TITLE
[code-push][container-gen] add the code push init code to JS side if …

### DIFF
--- a/ern-container-gen/src/resources/CodePushStarterMiniApp.file
+++ b/ern-container-gen/src/resources/CodePushStarterMiniApp.file
@@ -1,0 +1,15 @@
+import { Component } from 'react'
+import codePush from 'react-native-code-push'
+
+export default class App extends Component<Props> {
+  render() {
+    return null
+  }
+}
+
+App = codePush({
+  checkFrequency: codePush.CheckFrequency.ON_APP_RESUME,
+  installMode: codePush.InstallMode.ON_NEXT_RESUME,
+  minimumBackgroundDuration: 60 * 2,
+})(App)
+codePush.sync()

--- a/ern-container-gen/src/utils.ts
+++ b/ern-container-gen/src/utils.ts
@@ -371,14 +371,12 @@ export async function generateMiniAppsComposite(
       fs.readFileSync(pathToReactNativePackageJson, 'utf8')
     )
 
-    //
-    // The following code will need to be uncommented and properly reworked or included
-    // in a different way, once Cart and TYP don't directly depend on code push directly
-    // We will work with Cart team in that direction
-    //
-    // await yarn.add(codePushPlugin.name, codePushPlugin.version)
-    // content += `import codePush from "react-native-code-push"\n`
-    // content += `codePush.sync()`
+    const CodePushStarterFileName = 'CodePushStarterMiniApp'
+    shell.cp(
+      path.join(__dirname, 'resources', `${CodePushStarterFileName}.file`),
+      path.join(outDir, `${CodePushStarterFileName}.js`)
+    )
+    entryIndexJsContent += `import './${CodePushStarterFileName}.js'\n`
 
     // We need to add some info to package.json for CodePush
     // In order to run, code push needs to find the following in package.json


### PR DESCRIPTION
…the generated container has code push plugin inside it. This helps to eliminate the steps to add the starter code to each mini app.

fixes #301