### PR TITLE
Disable Prettier for json files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 **/*.md
+*.json
 **/coverage
 **/docs
 **/.coverage


### PR DESCRIPTION
Don't want Prettier to mess with json files formatting, especially package.json, so disabling it for json files.