### PR TITLE
Clean package.json scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,14 @@ script:
 - 'set -ev;
 if [ ${TRAVIS_EVENT_TYPE} != "cron" ]; then
   npm run rebuild;
-  npm run lint-check;
-  npm run test;
+  npm run check:lint;
+  npm run test:unit;
 else
   npm install -g electrode-native;
   ern;
   node setup-dev;
   ern platform use 1000.0.0;
-  npm run system-tests -- --all; 
+  npm run test:system -- --all; 
 fi'
 notifications:
   slack:

--- a/package.json
+++ b/package.json
@@ -6,31 +6,28 @@
   "keywords": [],
   "license": "Apache-2.0",
   "scripts": {
-    "setup-dev": "node setup-dev.js",
-    "rebuild": "lerna clean --yes && lerna bootstrap && lerna run build",
-    "test": "yarn test:unit && yarn test:system",
-    "test:unit": "lerna run test",
-    "test:system": "node system-tests/system-tests",
+    "check": "yarn check:lint && yarn check:yarnlock",
+    "check:lint": "tslint -c tslint.json '**/src/**/*.ts' '**/test/**/*.ts' -e 'node_modules/**'",
+    "check:yarnlock": "node yarn-lock-check",
     "coverage": "yarn coverage:unit && yarn coverage:system",
-    "coverage:unit":
-      "rimraf ern-*/.nyc_output && lerna run coverage && yarn istanbul report --include=ern-*/.coverage/coverage-final.json html",
-    "coverage:system":
-      "rimraf .nyc_output && node system-tests/system-tests-coverage",
-    "coverage:ci":
-      "yarn coverage:unit && yarn coverage:system && yarn istanbul report --include=**/.coverage/coverage-final.json text-lcov | coveralls",
+    "coverage:ci": "yarn coverage:unit && yarn coverage:system && yarn istanbul report --include=**/.coverage/coverage-final.json text-lcov | coveralls",
+    "coverage:system": "rimraf .nyc_output && node system-tests/system-tests-coverage",
+    "coverage:unit": "rimraf ern-*/.nyc_output && lerna run coverage && yarn istanbul report --include=ern-*/.coverage/coverage-final.json html",
+    "ern-debug": "node --nolazy --inspect-brk=5858 ern-local-cli/src/index.dev.js",
     "istanbul": "istanbul",
+    "postmerge": "node auto-rebuild.js",
     "precommit": "yarn check:yarnlock && yarn check:lint && yarn prettier",
     "prettier": "pretty-quick --staged",
-    "postmerge": "node auto-rebuild.js",
+    "rebuild": "lerna clean --yes && lerna bootstrap && lerna run build",
     "regen-fixtures": "node system-tests/regen-fixtures",
-    "ern-debug":
-      "node --nolazy --inspect-brk=5858 ern-local-cli/src/index.dev.js",
-    "check": "yarn check:lint && yarn check:yarnlock",
-    "check:lint":
-      "tslint -c tslint.json '**/src/**/*.ts' '**/test/**/*.ts' -e 'node_modules/**'",
-    "check:yarnlock": "node yarn-lock-check"
+    "setup-dev": "node setup-dev.js",
+    "test": "yarn test:unit && yarn test:system",
+    "test:system": "node system-tests/system-tests",
+    "test:unit": "lerna run test"
   },
-  "workspaces": ["./ern-*"],
+  "workspaces": [
+    "./ern-*"
+  ],
   "dependencies": {
     "@types/node": "^9.6.7",
     "chalk": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -8,24 +8,27 @@
   "scripts": {
     "setup-dev": "node setup-dev.js",
     "rebuild": "lerna clean --yes && lerna bootstrap && lerna run build",
-    "test": "lerna run test",
-    "system-tests": "node system-tests/system-tests",
-    "coverage-unit":
+    "test": "yarn test:unit && yarn test:system",
+    "test:unit": "lerna run test",
+    "test:system": "node system-tests/system-tests",
+    "coverage": "yarn coverage:unit && yarn coverage:system",
+    "coverage:unit":
       "rimraf ern-*/.nyc_output && lerna run coverage && yarn istanbul report --include=ern-*/.coverage/coverage-final.json html",
-    "coverage-system-tests":
+    "coverage:system":
       "rimraf .nyc_output && node system-tests/system-tests-coverage",
-    "coverage-ci":
-      "yarn coverage-unit && yarn coverage-system-tests && yarn istanbul report --include=**/.coverage/coverage-final.json text-lcov | coveralls",
+    "coverage:ci":
+      "yarn coverage:unit && yarn coverage:system && yarn istanbul report --include=**/.coverage/coverage-final.json text-lcov | coveralls",
     "istanbul": "istanbul",
-    "precommit":
-      "yarn yarn-lock-check && yarn lint-check && pretty-quick --staged",
+    "precommit": "yarn check:yarnlock && yarn check:lint && yarn prettier",
+    "prettier": "pretty-quick --staged",
     "postmerge": "node auto-rebuild.js",
     "regen-fixtures": "node system-tests/regen-fixtures",
     "ern-debug":
       "node --nolazy --inspect-brk=5858 ern-local-cli/src/index.dev.js",
-    "lint-check":
+    "check": "yarn check:lint && yarn check:yarnlock",
+    "check:lint":
       "tslint -c tslint.json '**/src/**/*.ts' '**/test/**/*.ts' -e 'node_modules/**'",
-    "yarn-lock-check": "node yarn-lock-check"
+    "check:yarnlock": "node yarn-lock-check"
   },
   "workspaces": ["./ern-*"],
   "dependencies": {


### PR DESCRIPTION
- Use npm groups to group related scripts together (following best practices).
- Sort package.json scripts alphabetically for better coherence (grouping) and readability.
- Make all scripts as one liners for better readability (thanks to be prettier being now disabled for json files)