### PR TITLE
Improve getActiveCauldron function

### DIFF
--- a/ern-cauldron-api/src/getActiveCauldron.ts
+++ b/ern-cauldron-api/src/getActiveCauldron.ts
@@ -9,54 +9,56 @@ import path from 'path'
 // Returns undefined if no Cauldron is active
 // Throw error if Cauldron is not using the correct schema version
 let currentCauldronHelperInstance
+let currentCauldronRepoInUse
+
 export default async function getActiveCauldron({
   ignoreSchemaVersionMismatch,
 }: {
   ignoreSchemaVersionMismatch?: boolean
 } = {}): Promise<CauldronHelper> {
-  if (!currentCauldronHelperInstance) {
+  const repoInUse = config.getValue('cauldronRepoInUse')
+  if (repoInUse && repoInUse !== currentCauldronRepoInUse) {
     const cauldronRepositories = config.getValue('cauldronRepositories')
-    const cauldronRepoInUse = config.getValue('cauldronRepoInUse')
-    if (cauldronRepoInUse) {
-      const cauldronRepoUrl = cauldronRepositories[cauldronRepoInUse]
-      const cauldronRepoBranchReResult = /#(.+)$/.exec(cauldronRepoUrl)
-      const cauldronRepoUrlWithoutBranch = cauldronRepoUrl.replace(/#(.+)$/, '')
-      const cauldronCli = defaultCauldron(
-        cauldronRepoUrlWithoutBranch,
-        path.join(Platform.rootDirectory, 'cauldron'),
-        cauldronRepoBranchReResult ? cauldronRepoBranchReResult[1] : 'master'
-      )
-      currentCauldronHelperInstance = new CauldronHelper(cauldronCli)
-      const schemaVersionUsedByCauldron = await currentCauldronHelperInstance.getCauldronSchemaVersion()
-      const schemaVersionOfCurrentCauldronApi = getCurrentSchemaVersion()
+    const cauldronRepoUrl = cauldronRepositories[repoInUse]
+    const cauldronRepoBranchReResult = /#(.+)$/.exec(cauldronRepoUrl)
+    const cauldronRepoUrlWithoutBranch = cauldronRepoUrl.replace(/#(.+)$/, '')
+    const cauldronCli = defaultCauldron(
+      cauldronRepoUrlWithoutBranch,
+      path.join(Platform.rootDirectory, 'cauldron'),
+      cauldronRepoBranchReResult ? cauldronRepoBranchReResult[1] : 'master'
+    )
+    currentCauldronHelperInstance = new CauldronHelper(cauldronCli)
+    const schemaVersionUsedByCauldron = await currentCauldronHelperInstance.getCauldronSchemaVersion()
+    const schemaVersionOfCurrentCauldronApi = getCurrentSchemaVersion()
+    if (
+      !ignoreSchemaVersionMismatch &&
+      schemaVersionUsedByCauldron !== schemaVersionOfCurrentCauldronApi
+    ) {
       if (
-        !ignoreSchemaVersionMismatch &&
-        schemaVersionUsedByCauldron !== schemaVersionOfCurrentCauldronApi
+        semver.gt(
+          schemaVersionUsedByCauldron,
+          schemaVersionOfCurrentCauldronApi
+        )
       ) {
-        if (
-          semver.gt(
-            schemaVersionUsedByCauldron,
-            schemaVersionOfCurrentCauldronApi
-          )
-        ) {
-          throw new Error(
-            `Cauldron schema version mismatch (${schemaVersionUsedByCauldron} > ${schemaVersionOfCurrentCauldronApi}).
+        throw new Error(
+          `Cauldron schema version mismatch (${schemaVersionUsedByCauldron} > ${schemaVersionOfCurrentCauldronApi}).
 You should switch to a newer platform version that supports this Cauldron schema.`
-          )
-        } else if (
-          semver.lt(
-            schemaVersionUsedByCauldron,
-            schemaVersionOfCurrentCauldronApi
-          )
-        ) {
-          throw new Error(
-            `Cauldron schema version mismatch (${schemaVersionUsedByCauldron} < ${schemaVersionOfCurrentCauldronApi}.
+        )
+      } else if (
+        semver.lt(
+          schemaVersionUsedByCauldron,
+          schemaVersionOfCurrentCauldronApi
+        )
+      ) {
+        throw new Error(
+          `Cauldron schema version mismatch (${schemaVersionUsedByCauldron} < ${schemaVersionOfCurrentCauldronApi}.
 You should run the following command : 'ern cauldron upgrade' to upgrade your Cauldron to the latest version.
 You can also switch to an older version of the platform which supports this Cauldron schema version.`
-          )
-        }
+        )
       }
     }
+    currentCauldronRepoInUse = repoInUse
   }
+
   return Promise.resolve(currentCauldronHelperInstance)
 }


### PR DESCRIPTION
Before this change, `getActiveCauldron` was assuming that the current Cauldron could not be changed at runtime. It was caching the Cauldron instance once created and returning this cached instance event if the current active Cauldron repo was changed.

This was OK because no commands were changing the current cauldron at runtime, but for more advanced sessions, this is an issue (for example for a desktop app, the session might run for a long time and the user might switch between Cauldrons at runtime). 

This code update still cache the Cauldron instance, but if the user choose a different Cauldron repository at runtime, a new Cauldron instance will be properly created. 