### PR TITLE
Update tslint excludes

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "check": "yarn check:lint && yarn check:yarnlock",
-    "check:lint": "tslint -c tslint.json '**/src/**/*.ts' '**/test/**/*.ts' -e 'node_modules/**'",
+    "check:lint": "tslint -c tslint.json '**/src/**/*.ts' '**/test/**/*.ts' -e '**/node_modules/**'",
     "check:yarnlock": "node yarn-lock-check",
     "coverage": "yarn coverage:unit && yarn coverage:system",
     "coverage:ci": "yarn coverage:unit && yarn coverage:system && yarn istanbul report --include=**/.coverage/coverage-final.json text-lcov | coveralls",


### PR DESCRIPTION
Update glob pattern for tslint exclude from `node_modules/**`  to `**/node_modules/**`, ensuring that we properly exclude all node_modules directories and not just the top level one.