### PR TITLE
New NativePlatform type and Container metadata enhancement

### DIFF
--- a/ern-container-gen/src/FlowTypes.ts
+++ b/ern-container-gen/src/FlowTypes.ts
@@ -1,4 +1,4 @@
-import { PackagePath, MiniApp, BundlingResult } from 'ern-core'
+import { PackagePath, MiniApp, BundlingResult, NativePlatform } from 'ern-core'
 
 export interface ContainerGeneratorPaths {
   /**
@@ -40,6 +40,10 @@ export interface ContainerGeneratorConfig {
    * Directory where the MiniApps will be composed together during generation
    */
   compositeMiniAppDir: string
+  /**
+   * Target native platform
+   */
+  targetPlatform: NativePlatform
   /**
    * Indicates whether rmpm assets should be included in the Container
    */

--- a/ern-container-gen/src/FlowTypes.ts
+++ b/ern-container-gen/src/FlowTypes.ts
@@ -1,43 +1,73 @@
 import { PackagePath, MiniApp, BundlingResult } from 'ern-core'
 
 export interface ContainerGeneratorPaths {
-  // Where we assemble the miniapps together
+  /**
+   * Where we assemble the miniapps together
+   */
   compositeMiniApp: string
-  // Where we download plugins
+  /**
+   * Where we download plugins
+   */
   pluginsDownloadDirectory: string
-  // Where we output final generated container
+  /**
+   * Where we output final generated container
+   */
   outDirectory: string
 }
 
 export interface ContainerGeneratorConfig {
-  // The MiniApps that should be included in the generated Container
+  /**
+   * The MiniApps that should be included in the generated Container
+   */
   miniApps: MiniApp[]
-  // The plugins that should be included in the generated Container
+  /**
+   * The plugins that should be included in the generated Container
+   */
   plugins: PackagePath[]
-  // The JS API implementations that should be included in the generated Container
+  /**
+   * The JS API implementations that should be included in the generated Container
+   */
   jsApiImpls: PackagePath[]
-  // The output directory where to generate the Container
+  /**
+   * The output directory where to generate the Container
+   */
   outDir: string
-  // Directory where the plugins should be downloaded to during generation
+  /**
+   * Directory where the plugins should be downloaded to during generation
+   */
   pluginsDownloadDir: string
-  // Directory where the MiniApps will be composed together during generation
+  /**
+   * Directory where the MiniApps will be composed together during generation
+   */
   compositeMiniAppDir: string
-  // Indicates whether rmpm assets should be included in the Container
+  /**
+   * Indicates whether rmpm assets should be included in the Container
+   */
   ignoreRnpmAssets?: boolean
-  // Path to the current yarn lock
+  /**
+   * Path to the current yarn lock
+   */
   pathToYarnLock?: string
 }
 
 export interface ContainerGenResult {
-  // Metadata resulting from the bundling
+  /**
+   *  Metadata resulting from the bundling
+   */
   bundlingResult: BundlingResult
 }
 
 export interface ContainerGenerator {
-  // Name of the Container Generator
+  /**
+   *  Name of the Container Generator
+   */
   readonly name: string
-  // Native platform that this generator targets
+  /**
+   * Native platform that this generator targets
+   */
   readonly platform: string
-  // Generate a Container
+  /**
+   *  Generate a Container
+   */
   generate(config: ContainerGeneratorConfig): Promise<ContainerGenResult>
 }

--- a/ern-container-gen/src/utils.ts
+++ b/ern-container-gen/src/utils.ts
@@ -15,6 +15,7 @@ import {
   ModuleTypes,
   utils,
   log,
+  NativePlatform,
 } from 'ern-core'
 import { ContainerGeneratorConfig } from './FlowTypes'
 
@@ -46,7 +47,7 @@ export async function bundleMiniApps(
   miniapps: MiniApp[],
   compositeMiniAppDir: string,
   outDir: string,
-  platform: 'android' | 'ios',
+  platform: NativePlatform,
   {
     pathToYarnLock,
   }: {
@@ -663,7 +664,7 @@ export function copyRnpmAssets(
   miniApps: MiniApp[],
   compositeMiniAppDir: string,
   outDir: string,
-  platform: 'android' | 'ios'
+  platform: NativePlatform
 ) {
   // Case of local container for runner
   if (miniApps.length === 1 && miniApps[0].path) {

--- a/ern-container-gen/src/utils.ts
+++ b/ern-container-gen/src/utils.ts
@@ -16,6 +16,7 @@ import {
   utils,
   log,
   NativePlatform,
+  Platform,
 } from 'ern-core'
 import { ContainerGeneratorConfig } from './FlowTypes'
 
@@ -820,9 +821,11 @@ export async function addElectrodeNativeMetadataFile(
   conf: ContainerGeneratorConfig
 ) {
   const metadata = {
+    ernVersion: Platform.currentVersion,
     jsApiImpls: conf.jsApiImpls.map(j => j.toString()),
     miniApps: conf.miniApps.map(m => m.packagePath.toString()),
     nativeDeps: conf.plugins.map(p => p.toString()),
+    platform: conf.targetPlatform,
   }
   const pathToMetadataFile = path.join(conf.outDir, 'container-metadata.json')
   return writeFile(pathToMetadataFile, JSON.stringify(metadata, null, 2))

--- a/ern-core/src/NativeApplicationDescriptor.ts
+++ b/ern-core/src/NativeApplicationDescriptor.ts
@@ -1,17 +1,23 @@
+import { NativePlatform } from './NativePlatform'
+
 export class NativeApplicationDescriptor {
   public static fromString(
     napDescriptorLiteral: string
   ): NativeApplicationDescriptor {
     const arr: string[] = napDescriptorLiteral.split(':')
-    return new NativeApplicationDescriptor(arr[0], arr[1], arr[2])
+    return new NativeApplicationDescriptor(
+      arr[0],
+      arr[1] as NativePlatform,
+      arr[2]
+    )
   }
 
   public readonly name: string
-  public readonly platform?: string
+  public readonly platform?: NativePlatform
   public readonly version?: string
   public readonly toto: string = 'toto'
 
-  constructor(name: string, platform?: string, version?: string) {
+  constructor(name: string, platform?: NativePlatform, version?: string) {
     if (!name) {
       throw new Error('[NativeApplicationDescriptor] name is required')
     }

--- a/ern-core/src/NativePlatform.ts
+++ b/ern-core/src/NativePlatform.ts
@@ -1,0 +1,1 @@
+export type NativePlatform = 'android' | 'ios'

--- a/ern-core/src/index.ts
+++ b/ern-core/src/index.ts
@@ -68,3 +68,5 @@ export {
 export { BundlingResult } from './ReactNativeCli'
 
 export { ManifestOverrideConfig } from './Manifest'
+
+export { NativePlatform } from './NativePlatform'

--- a/ern-local-cli/src/commands/code-push/promote.ts
+++ b/ern-local-cli/src/commands/code-push/promote.ts
@@ -1,4 +1,9 @@
-import { NativeApplicationDescriptor, utils as coreUtils, log } from 'ern-core'
+import {
+  NativeApplicationDescriptor,
+  utils as coreUtils,
+  log,
+  NativePlatform,
+} from 'ern-core'
 import {
   performCodePushPromote,
   askUserForCodePushDeploymentName,
@@ -96,7 +101,7 @@ export const handler = async ({
   sourceDeploymentName?: string
   targetDeploymentName?: string
   targetBinaryVersion?: string
-  platform: 'android' | 'ios'
+  platform: NativePlatform
   mandatory?: boolean
   rollout?: number
   skipConfirmation?: boolean

--- a/ern-local-cli/src/commands/code-push/release.ts
+++ b/ern-local-cli/src/commands/code-push/release.ts
@@ -3,6 +3,7 @@ import {
   NativeApplicationDescriptor,
   utils as coreUtils,
   log,
+  NativePlatform,
 } from 'ern-core'
 import { getActiveCauldron } from 'ern-cauldron-api'
 import {
@@ -102,7 +103,7 @@ export const handler = async ({
   appName: string
   deploymentName: string
   targetBinaryVersion?: string
-  platform: 'android' | 'ios'
+  platform: NativePlatform
   mandatory?: boolean
   rollout?: number
   skipConfirmation?: boolean

--- a/ern-local-cli/src/commands/create-container.ts
+++ b/ern-local-cli/src/commands/create-container.ts
@@ -6,6 +6,7 @@ import {
   utils as coreUtils,
   Platform,
   log,
+  NativePlatform,
 } from 'ern-core'
 import { getActiveCauldron } from 'ern-cauldron-api'
 import {
@@ -84,7 +85,7 @@ export const handler = async ({
   miniapps?: string[]
   jsApiImpls: string[]
   dependencies: string[]
-  platform?: 'android' | 'ios'
+  platform?: NativePlatform
   publicationUrl?: string
   ignoreRnpmAssets?: boolean
 }) => {
@@ -219,7 +220,7 @@ Output directory should either not exist (it will be created) or should be empty
             },
           ])
 
-          platform = <'android' | 'ios'>userSelectedPlatform
+          platform = userSelectedPlatform as NativePlatform
         }
 
         await spin(

--- a/ern-local-cli/src/lib/publication.ts
+++ b/ern-local-cli/src/lib/publication.ts
@@ -194,6 +194,7 @@ export async function runLocalContainerGen(
           ...extraNativeDependencies,
         ],
         pluginsDownloadDir: createTmpDir(),
+        targetPlatform: platform,
       })
     )
   } catch (e) {
@@ -270,6 +271,7 @@ export async function runCauldronContainerGen(
         pathToYarnLock: pathToYarnLock || undefined,
         plugins,
         pluginsDownloadDir: createTmpDir(),
+        targetPlatform: platform,
       })
     )
   } catch (e) {

--- a/ern-local-cli/src/lib/publication.ts
+++ b/ern-local-cli/src/lib/publication.ts
@@ -23,6 +23,7 @@ import {
   CodePushPackage,
   CodePushInitConfig,
   log,
+  NativePlatform,
 } from 'ern-core'
 import { getActiveCauldron } from 'ern-cauldron-api'
 import * as compatibility from './compatibility'
@@ -104,7 +105,7 @@ export function resolvePluginsVersions(
 export async function runLocalContainerGen(
   miniappPackagesPaths: PackagePath[],
   jsApiImplsPackagePaths: PackagePath[],
-  platform: 'android' | 'ios',
+  platform: NativePlatform,
   {
     outDir = path.join(Platform.rootDirectory, 'containergen'),
     extraNativeDependencies = [],

--- a/ern-local-cli/src/lib/utils.ts
+++ b/ern-local-cli/src/lib/utils.ts
@@ -14,6 +14,7 @@ import {
   shell,
   MavenUtils,
   utils as coreUtils,
+  NativePlatform,
 } from 'ern-core'
 import { publishContainer } from 'ern-container-publisher'
 import { getActiveCauldron } from 'ern-cauldron-api'
@@ -43,7 +44,7 @@ async function getNapDescriptorStringsFromCauldron({
   onlyReleasedVersions,
   onlyNonReleasedVersions,
 }: {
-  platform?: 'ios' | 'android'
+  platform?: NativePlatform
   onlyReleasedVersions?: boolean
   onlyNonReleasedVersions?: boolean
 } = {}): Promise<string[]> {
@@ -362,7 +363,7 @@ async function askUserToChooseANapDescriptorFromCauldron({
   onlyNonReleasedVersions,
   message,
 }: {
-  platform?: 'ios' | 'android'
+  platform?: NativePlatform
   onlyReleasedVersions?: boolean
   onlyNonReleasedVersions?: boolean
   message?: string
@@ -400,7 +401,7 @@ async function askUserToChooseOneOrMoreNapDescriptorFromCauldron({
   onlyNonReleasedVersions,
   message,
 }: {
-  platform?: 'ios' | 'android'
+  platform?: NativePlatform
   onlyReleasedVersions?: boolean
   onlyNonReleasedVersions?: boolean
   message?: string
@@ -617,7 +618,7 @@ function epilog({ command }: { command: string }) {
 }
 
 async function runMiniApp(
-  platform: 'android' | 'ios',
+  platform: NativePlatform,
   {
     mainMiniAppName,
     miniapps,
@@ -824,7 +825,7 @@ async function runMiniApp(
 }
 
 async function generateContainerForRunner(
-  platform: 'android' | 'ios',
+  platform: NativePlatform,
   {
     napDescriptor,
     dependenciesObjs = [],


### PR DESCRIPTION
**Add NativePlatform type**

We were using type `'android' | 'ios'` in multiple locations in the code to type variables representing a platform.

Multiple problems with this approach :
- Duplication
- Prone to error (mistyping)
- Painful if ever a new native platform is supported

Therefore, moving this one as a dedicated type `NativePlatform` in `ern-core`.

Let's make sure that everywhere we see a variable holding a native platform name in the code, we use this type rather than plain old `string` type (primitive type obsession anti-pattern). In this PR I just replaced all locations where `'android' | 'ios'` (or reverse) were used. I did not took care of the one variables that are using `string` (harder to locate).

**Add more properties to Container metadata**

Add the following properties to the `container-metadata.json` document generated with the Container :

- `platform` (either `ios` or `android`) 
Identifies the target platform of this Container (can be useful for publishers to easily identify the target platform of any given Container).
- `ernVersion` 
The `ern` version that was used to generated this Container (can be useful for troubleshooting but also for some platform logic).
