### PR TITLE
Store ern version along with Container in Cauldron

### DIFF
--- a/ern-cauldron-api/src/CauldronApi.ts
+++ b/ern-cauldron-api/src/CauldronApi.ts
@@ -612,6 +612,26 @@ export default class CauldronApi {
     return version.containerVersion
   }
 
+  public async updateContainerErnVersion(
+    descriptor: NativeApplicationDescriptor,
+    ernVersion: string
+  ) {
+    this.throwIfPartialNapDescriptor(descriptor)
+    const version = await this.getVersion(descriptor)
+    version.container.ernVersion = ernVersion
+    return this.commit(
+      `Update version of ern used to generate Container of ${descriptor.toString()}`
+    )
+  }
+
+  public async getContainerErnVersion(
+    descriptor: NativeApplicationDescriptor
+  ): Promise<string | void> {
+    this.throwIfPartialNapDescriptor(descriptor)
+    const version = await this.getVersion(descriptor)
+    return version.container.ernVersion
+  }
+
   public async removeContainerMiniApp(
     descriptor: NativeApplicationDescriptor,
     miniAppName: string

--- a/ern-cauldron-api/src/CauldronHelper.ts
+++ b/ern-cauldron-api/src/CauldronHelper.ts
@@ -755,6 +755,19 @@ export class CauldronHelper {
     return this.cauldron.getTopLevelContainerVersion(napDescriptor)
   }
 
+  public async updateContainerErnVersion(
+    napDescriptor: NativeApplicationDescriptor,
+    ernVersion: string
+  ): Promise<void> {
+    return this.cauldron.updateContainerErnVersion(napDescriptor, ernVersion)
+  }
+
+  public async getContainerErnVersion(
+    napDescriptor: NativeApplicationDescriptor
+  ): Promise<string | void> {
+    return this.cauldron.getContainerErnVersion(napDescriptor)
+  }
+
   public async updateContainerMiniAppVersion(
     napDescriptor: NativeApplicationDescriptor,
     miniApp: PackagePath

--- a/ern-cauldron-api/src/schemas.ts
+++ b/ern-cauldron-api/src/schemas.ts
@@ -1,6 +1,7 @@
 import Joi from 'joi'
 
 export const container = Joi.object({
+  ernVersion: Joi.string().default(undefined),
   jsApiImpls: Joi.array().default([]),
   miniApps: Joi.array().default([]),
   nativeDeps: Joi.array().default([]),

--- a/ern-cauldron-api/src/types.ts
+++ b/ern-cauldron-api/src/types.ts
@@ -21,6 +21,12 @@ export interface CauldronContainer {
   miniApps: string[]
   nativeDeps: string[]
   jsApiImpls: string[]
+  /**
+   * The ern version used to generate this Container.
+   * Introduced in 0.19.0. Required from this version onward.
+   * Kept optional for backward compatibility.
+   */
+  ernVersion?: string
 }
 
 export interface CauldronNativeAppVersion {

--- a/ern-local-cli/src/lib/utils.ts
+++ b/ern-local-cli/src/lib/utils.ts
@@ -501,6 +501,12 @@ async function performContainerStateUpdateInCauldron(
       cauldronContainerVersion
     )
 
+    // Update version of ern used to generate this Container
+    await cauldron.updateContainerErnVersion(
+      napDescriptor,
+      Platform.currentVersion
+    )
+
     // Update yarn lock
     const pathToNewYarnLock = path.join(compositeMiniAppDir, 'yarn.lock')
     await cauldron.addOrUpdateYarnLock(


### PR DESCRIPTION
Store the ern version that was used to generate a Cauldron Container as `ernVersion`.

No usage in Electrode Native -yet-, just to document in Cauldron the version used to generate a Container, to help troubleshoting.