### PR TITLE
Introduce latest version for platform use and install commands

### DIFF
--- a/docs/cli/platform/install.md
+++ b/docs/cli/platform/install.md
@@ -13,6 +13,8 @@
 `<version>`
 
 * The version of Electrode Native platform to install. 
+* Sample values : `v0.18.0` / `0.18.0` / `latest`
+* Using `latest` will install the latest version of Electrode Native
 
 #### Related commands
 

--- a/docs/cli/platform/use.md
+++ b/docs/cli/platform/use.md
@@ -13,6 +13,8 @@
 `<version>`
 
 * The Electrode Native platform version to activate.
+* Sample values : `v0.18.0` / `0.18.0` / `latest`
+* Using `latest` will switch to the latest version of Electrode Native
 
 #### Remarks
 

--- a/ern-local-cli/src/commands/platform/install.ts
+++ b/ern-local-cli/src/commands/platform/install.ts
@@ -11,7 +11,7 @@ export const builder = (argv: Argv) => {
 
 export const handler = ({ version }: { version: string }) => {
   try {
-    Platform.installPlatform(version.toString().replace('v', ''))
+    Platform.installPlatform(version.toString())
   } catch (e) {
     coreUtils.logErrorAndExitProcess(e)
   }

--- a/ern-local-cli/src/commands/platform/use.ts
+++ b/ern-local-cli/src/commands/platform/use.ts
@@ -11,7 +11,7 @@ export const builder = (argv: Argv) => {
 
 export const handler = ({ version }: { version: string }) => {
   try {
-    Platform.switchToVersion(version.toString().replace('v', ''))
+    Platform.switchToVersion(version.toString())
   } catch (e) {
     coreUtils.logErrorAndExitProcess(e)
   }


### PR DESCRIPTION
- `latest` can now be used as the `version` provided to the `platform use` and `platform install` commands.  It will pick the latest available version of Electrode Native (convenient for users who don't want to check the available versions before using these commands, but just want to update to the most recent version of Electrode Native).

- These commands will now gracefully fail with a proper error message in case the `version` used is not a valid version.

- If a version is valid but not available, the `platform use` command now properly logs the `non available version` only (prior to this PR, the `ern v${version} is not installed yet. Installing now.` was logged before failing with `non available version`, which was confusing.

- **Internal** : Remove the need to do a string replacement on the version to cleanup potential `v` prefix. Using `semver.valid` instead which exactly does that and also performs validation

- Update the two commands doc.