### PR TITLE
Introduce local Cauldrons

### DIFF
--- a/docs/cli/cauldron/repo/add.md
+++ b/docs/cli/cauldron/repo/add.md
@@ -17,6 +17,7 @@
 `<url>`
 
 * HTTPS or SSH url to the Cauldron git repository
+* Can also use `local` as the url. In that case, a local Cauldron repository will be created. Local Cauldrons are only local to the workstation, and thus cannot be used by other users. A local Cauldron can be of use for using a Cauldron with Electrode Native without having to create a remote git repository. It is also much faster than a remote Cauldron given that it does not have to sync with the remote.
 * For HTTPS urls, the username and password (or token) must be specified in the URL (valid formats are `https://[username]:[password]@[repourl` or `https://[token]@[repourl]`).
 * By default, the `master` branch of the repository will be used. If you need to use a different branch, you can set the branch name you want to use, by appending it at the end of the url using the `#[branch-name]` format (second example below illustrate this).
 

--- a/ern-cauldron-api/src/CauldronApiFactory.ts
+++ b/ern-cauldron-api/src/CauldronApiFactory.ts
@@ -2,29 +2,37 @@ import CauldronApi from './CauldronApi'
 import GitFileStore from './GitFileStore'
 import GitDocumentStore from './GitDocumentStore'
 
-export function defaultCauldron(
-  repository: string,
-  cauldronPath: string,
-  branch: string = 'master'
-) {
-  const sourcemapStore = new GitFileStore(
+export function defaultCauldron({
+  repository,
+  cauldronPath,
+  branch = 'master',
+}: {
+  repository?: string
+  cauldronPath: string
+  branch: string
+}) {
+  const sourcemapStore = new GitFileStore({
+    branch,
+    cauldronPath,
+    prefix: 'sourcemaps',
+    repository,
+  })
+  const yarnlockStore = new GitFileStore({
+    branch,
+    cauldronPath,
+    prefix: 'yarnlocks',
+    repository,
+  })
+  const bundleStore = new GitFileStore({
+    branch,
+    cauldronPath,
+    prefix: 'bundles',
+    repository,
+  })
+  const dbStore = new GitDocumentStore({
+    branch,
     cauldronPath,
     repository,
-    branch,
-    'sourcemaps'
-  )
-  const yarnlockStore = new GitFileStore(
-    cauldronPath,
-    repository,
-    branch,
-    'yarnlocks'
-  )
-  const bundleStore = new GitFileStore(
-    cauldronPath,
-    repository,
-    branch,
-    'bundles'
-  )
-  const dbStore = new GitDocumentStore(cauldronPath, repository, branch)
+  })
   return new CauldronApi(dbStore, sourcemapStore, yarnlockStore, bundleStore)
 }

--- a/ern-cauldron-api/src/GitDocumentStore.ts
+++ b/ern-cauldron-api/src/GitDocumentStore.ts
@@ -11,16 +11,21 @@ export default class GitDocumentStore extends BaseGit
   public readonly jsonPath: string
   private cauldron: Cauldron
 
-  constructor(
-    cauldronPath: string,
-    repository: string,
-    branch: string = 'master',
-    cauldron: Cauldron = {
+  constructor({
+    cauldronPath,
+    repository,
+    branch = 'master',
+    cauldron = {
       nativeApps: [],
       schemaVersion,
-    }
-  ) {
-    super(cauldronPath, repository, branch)
+    },
+  }: {
+    cauldronPath: string
+    repository?: string
+    branch: string
+    cauldron?: Cauldron
+  }) {
+    super({ cauldronPath, repository, branch })
     this.jsonPath = path.resolve(this.fsPath, CAULDRON_FILENAME)
     this.cauldron = cauldron
   }

--- a/ern-cauldron-api/src/GitFileStore.ts
+++ b/ern-cauldron-api/src/GitFileStore.ts
@@ -9,13 +9,18 @@ export default class GitFileStore extends BaseGit
   implements ICauldronFileStore {
   private readonly prefix: string
 
-  constructor(
-    ernPath: string,
-    repository: string,
-    branch: string,
+  constructor({
+    cauldronPath,
+    repository,
+    branch,
+    prefix,
+  }: {
+    cauldronPath: string
+    repository?: string
+    branch: string
     prefix: string
-  ) {
-    super(ernPath, repository, branch)
+  }) {
+    super({ cauldronPath, repository, branch })
     this.prefix = prefix
   }
 

--- a/ern-cauldron-api/src/getActiveCauldron.ts
+++ b/ern-cauldron-api/src/getActiveCauldron.ts
@@ -22,11 +22,17 @@ export default async function getActiveCauldron({
     const cauldronRepoUrl = cauldronRepositories[repoInUse]
     const cauldronRepoBranchReResult = /#(.+)$/.exec(cauldronRepoUrl)
     const cauldronRepoUrlWithoutBranch = cauldronRepoUrl.replace(/#(.+)$/, '')
-    const cauldronCli = defaultCauldron(
-      cauldronRepoUrlWithoutBranch,
-      path.join(Platform.rootDirectory, 'cauldron'),
-      cauldronRepoBranchReResult ? cauldronRepoBranchReResult[1] : 'master'
-    )
+    const cauldronCli = defaultCauldron({
+      branch: cauldronRepoBranchReResult
+        ? cauldronRepoBranchReResult[1]
+        : 'master',
+      cauldronPath: path.isAbsolute(cauldronRepoUrl)
+        ? cauldronRepoUrl
+        : path.join(Platform.rootDirectory, 'cauldron'),
+      repository: path.isAbsolute(cauldronRepoUrl)
+        ? undefined
+        : cauldronRepoUrlWithoutBranch,
+    })
     currentCauldronHelperInstance = new CauldronHelper(cauldronCli)
     const schemaVersionUsedByCauldron = await currentCauldronHelperInstance.getCauldronSchemaVersion()
     const schemaVersionOfCurrentCauldronApi = getCurrentSchemaVersion()

--- a/ern-core/src/Platform.ts
+++ b/ern-core/src/Platform.ts
@@ -20,6 +20,10 @@ export default class Platform {
     return path.join(this.rootDirectory, 'cauldron')
   }
 
+  static get localCauldronsDirectory(): string {
+    return path.join(this.rootDirectory, 'local-cauldrons')
+  }
+
   static get masterManifestDirectory(): string {
     return path.join(this.rootDirectory, 'ern-master-manifest')
   }

--- a/ern-local-cli/src/commands/cauldron/repo/add.ts
+++ b/ern-local-cli/src/commands/cauldron/repo/add.ts
@@ -6,6 +6,7 @@ import {
   log,
 } from 'ern-core'
 import inquirer from 'inquirer'
+import path from 'path'
 import utils from '../../../lib/utils'
 import { Argv } from 'yargs'
 
@@ -34,8 +35,9 @@ export const handler = ({
   current: boolean
 }) => {
   try {
-    if (url.startsWith('https')) {
-      if (!supportedGitHttpsSchemeRe.test(url)) {
+    let cauldronUrl = url
+    if (cauldronUrl.startsWith('https')) {
+      if (!supportedGitHttpsSchemeRe.test(cauldronUrl)) {
         throw new Error(`Cauldron https urls have to be formatted as : 
 https://[username]:[password]@[repourl]
 OR
@@ -49,9 +51,13 @@ https://[token]@[repourl]`)
         `A Cauldron repository is already associated to ${alias} alias`
       )
     }
-    cauldronRepositories[alias] = url
+
+    if (cauldronUrl === 'local') {
+      cauldronUrl = path.join(Platform.localCauldronsDirectory, alias)
+    }
+    cauldronRepositories[alias] = cauldronUrl
     ernConfig.setValue('cauldronRepositories', cauldronRepositories)
-    log.info(`Added Cauldron repository ${url} with alias ${alias}`)
+    log.info(`Added Cauldron repository ${cauldronUrl} with alias ${alias}`)
     if (current) {
       useCauldronRepository(alias)
     } else if (!(current === false)) {


### PR DESCRIPTION
- Add support for local Cauldrons :
  - Local Cauldrons are just local git repositories
  - They are stored in `~/.ern/local-cauldrons`
  - Can be created through `ern cauldron repo add <alias> local`
  - Way faster than remote Cauldrons as there is no need to sync with the remote or perform push
  - Can be used for different use cases, one being to try out Electrode Native with Cauldrons without the need to create a remote git repository (ease training).

If thinking of Cauldrons as being workspaces, an Electrode Native user can choose to have one or more local workspace(s) (local Cauldron(s)) and one or more shared team workspace(s) (remote Cauldron(s)).

- Refactor some function signatures so that we pass an object to them rather than multiple parameters. We should favor passing objects to functions / methods rather than parameters, as it makes it more easier to add new parameters without breaking existing clients.

