### PR TITLE
Update MiniApp versions for system tests and getting started

### DIFF
--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -461,12 +461,12 @@ We've developed and published this MiniApp to reuse it in this tutorial. You may
 
 {% sample lang="android" %}  
 ```bash
-$ ern run-android --miniapps moviedetailsminiapp@0.0.19 --mainMiniAppName MovieListMiniApp
+$ ern run-android --miniapps moviedetailsminiapp@0.0.20 --mainMiniAppName MovieListMiniApp
 ```  
 {% sample lang="ios" %}  
 ```bash
 $ cd MovieListMiniApp //make sure you are in root dir of MovieListMiniApp
-$ ern run-ios --miniapps moviedetailsminiapp@0.0.19 --mainMiniAppName MovieListMiniApp
+$ ern run-ios --miniapps moviedetailsminiapp@0.0.20 --mainMiniAppName MovieListMiniApp
 ```  
 
 {% common %}

--- a/system-tests/fixtures/constants.js
+++ b/system-tests/fixtures/constants.js
@@ -19,9 +19,9 @@ const baseConstants = {
   systemTestNativeApplicationVersion1: '1.0.0',
   systemTestNativeApplicationVersion2: '2.0.0',
   movieListMiniAppPgkName: 'movielistminiapp',
-  movieListMiniAppPkgVersion: '0.0.19',
+  movieListMiniAppPkgVersion: '0.0.20',
   movieDetailsMiniAppPkgName: 'moviedetailsminiapp',
-  movieDetailsMiniAppPkgVersion: '0.0.19',
+  movieDetailsMiniAppPkgVersion: '0.0.20',
   movieApiImplJsPkgName: 'react-native-ernmovie-api-impl-js',
   movieApiImplJsPkgVersion: '0.0.2'
 }


### PR DESCRIPTION
In preparation of Electrode Native v0.19.0 release, published new versions of the following MiniApps (bumping React Native from `0.55.3` to `0.55.4`.

`moviedetailsminiapp` from `0.0.19` to `0.0.20`
`movielistminiapp` from `0.0.19` to `0.0.20`

Updated system tests and getting started guide to use these new versions.

