### PR TITLE
Move common package.json access code to dedicated functions

### DIFF
--- a/ern-api-impl-gen/src/ApiImpl.ts
+++ b/ern-api-impl-gen/src/ApiImpl.ts
@@ -9,6 +9,8 @@ import {
   yarn,
   Platform,
   log,
+  readPackageJsonSync,
+  writePackageJsonSync,
 } from 'ern-core'
 import ApiImplGen from './generators/ApiImplGen'
 
@@ -172,8 +174,7 @@ function ernifyPackageJson(
   hasConfig: boolean,
   scope?: string
 ) {
-  const packageJsonPath = path.join(outputDirectoryPath, 'package.json')
-  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
+  const packageJson = readPackageJsonSync(outputDirectoryPath)
   const moduleType = nativeOnly
     ? ModuleTypes.NATIVE_API_IMPL
     : ModuleTypes.JS_API_IMPL
@@ -189,5 +190,5 @@ function ernifyPackageJson(
   packageJson.keywords
     ? packageJson.keywords.push(moduleType)
     : (packageJson.keywords = [moduleType])
-  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2))
+  writePackageJsonSync(outputDirectoryPath, packageJson)
 }

--- a/ern-api-impl-gen/src/generators/ApiImplGen.ts
+++ b/ern-api-impl-gen/src/generators/ApiImplGen.ts
@@ -1,4 +1,12 @@
-import { spin, PackagePath, shell, yarn, log } from 'ern-core'
+import {
+  spin,
+  PackagePath,
+  shell,
+  yarn,
+  log,
+  readPackageJsonSync,
+  writePackageJsonSync,
+} from 'ern-core'
 import { ApiGenUtils } from 'ern-api-gen'
 import _ from 'lodash'
 import chalk from 'chalk'
@@ -206,9 +214,8 @@ export default class ApiImplGen {
     outputDirectoryPath: string,
     apis: any[]
   ) {
-    const packageJsonPath = path.join(outputDirectoryPath, 'package.json')
-    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
+    const packageJson = readPackageJsonSync(outputDirectoryPath)
     packageJson.ern.containerGen.apiNames = _.map(apis, api => api.apiName)
-    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2))
+    writePackageJsonSync(outputDirectoryPath, packageJson)
   }
 }

--- a/ern-container-gen/src/copyAndroidRnpmAssetsFromMiniAppPath.ts
+++ b/ern-container-gen/src/copyAndroidRnpmAssetsFromMiniAppPath.ts
@@ -1,4 +1,4 @@
-import { handleCopyDirective } from 'ern-core'
+import { handleCopyDirective, readPackageJsonSync } from 'ern-core'
 import fs from 'fs'
 import path from 'path'
 
@@ -6,9 +6,7 @@ export function copyAndroidRnpmAssetsFromMiniAppPath(
   miniAppPath: string,
   outputPath: string
 ) {
-  const packageJson = JSON.parse(
-    fs.readFileSync(path.join(miniAppPath, 'package.json'), 'utf-8')
-  )
+  const packageJson = readPackageJsonSync(miniAppPath)
   if (packageJson.rnpm && packageJson.rnpm.assets) {
     for (const assetDirectoryName of packageJson.rnpm.assets) {
       const source = path.join(assetDirectoryName, '*')

--- a/ern-container-gen/src/copyIosRnpmAssetsFromMiniAppPath.ts
+++ b/ern-container-gen/src/copyIosRnpmAssetsFromMiniAppPath.ts
@@ -1,4 +1,4 @@
-import { handleCopyDirective } from 'ern-core'
+import { handleCopyDirective, readPackageJsonSync } from 'ern-core'
 import fs from 'fs'
 import path from 'path'
 
@@ -6,9 +6,7 @@ export function copyIosRnpmAssetsFromMiniAppPath(
   miniAppPath: string,
   outputPath: string
 ) {
-  const packageJson = JSON.parse(
-    fs.readFileSync(path.join(miniAppPath, 'package.json'), 'utf-8')
-  )
+  const packageJson = readPackageJsonSync(miniAppPath)
   if (packageJson.rnpm && packageJson.rnpm.assets) {
     for (const assetDirectoryName of packageJson.rnpm.assets) {
       const source = path.join(assetDirectoryName, '*')

--- a/ern-container-gen/src/populateApiImplMustacheView.ts
+++ b/ern-container-gen/src/populateApiImplMustacheView.ts
@@ -1,4 +1,4 @@
-import { log, ModuleTypes, utils } from 'ern-core'
+import { log, ModuleTypes, utils, readPackageJsonSync } from 'ern-core'
 import fs from 'fs'
 import path from 'path'
 
@@ -15,9 +15,7 @@ export function populateApiImplMustacheView(
   excludeJsImpl?: boolean,
   excludeNativeImpl?: boolean
 ) {
-  const packageJson = JSON.parse(
-    fs.readFileSync(path.join(apiImplPluginPath, 'package.json'), 'utf-8')
-  )
+  const packageJson = readPackageJsonSync(apiImplPluginPath)
   const containerGenConfig = packageJson.ern.containerGen
   if (containerGenConfig && containerGenConfig.apiNames) {
     mustacheView.apiImplementations = mustacheView.apiImplementations

--- a/ern-core/src/fileUtil.ts
+++ b/ern-core/src/fileUtil.ts
@@ -1,17 +1,18 @@
 import fs from 'fs'
+import path from 'path'
 import shell from './shell'
 
 /**
- * ==============================================================================
- * Async wrappers around node fs
- * ==============================================================================
+ * Asynchronously reads a file and return its content
+ * @param filePath Path to the file
+ * @param encoding The encoding of the file (default : 'utf8')
  */
 export async function readFile(
-  filename: string,
+  filePath: string,
   encoding: string = 'utf8'
 ): Promise<string> {
   return new Promise<string>((resolve, reject) => {
-    fs.readFile(filename, encoding, (err, res) => {
+    fs.readFile(filePath, encoding, (err, res) => {
       if (err) {
         reject(err)
       } else {
@@ -20,15 +21,18 @@ export async function readFile(
     })
   })
 }
-export async function readJSON(filename: string) {
-  return readFile(filename).then(JSON.parse)
-}
-export async function writeJSON(filename: string, json: string) {
-  return writeFile(filename, JSON.stringify(json, null, 2))
-}
-export async function writeFile(filename: string, data: string) {
-  return new Promise((resolve, reject) => {
-    fs.writeFile(filename, data, err => {
+
+/**
+ * Asynchronously writes a file with a given content
+ * @param filePath Path to the file
+ * @param content Content of the file
+ */
+export async function writeFile(
+  filePath: string,
+  content: string
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    fs.writeFile(filePath, content, err => {
       if (err) {
         reject(err)
       } else {
@@ -39,10 +43,49 @@ export async function writeFile(filename: string, data: string) {
 }
 
 /**
+ * Asynchronously reads a JSON file and returns it as a JavaScript Object
+ * @param filePath Path to the JSON file
+ */
+export async function readJSON(filePath: string): Promise<any> {
+  return readFile(filePath).then(JSON.parse)
+}
+
+/**
+ * Synchronously reads a JSON file and returns it as a JavaScript Object
+ * @param filePath Path to the JSON file
+ */
+export function readJSONSync(filePath: string): any {
+  const fileContent: string = fs.readFileSync(filePath).toString()
+  return JSON.parse(fileContent)
+}
+
+/**
+ * Asynchronously writes a given JavaScript Object to a JSON file
+ * and returns the path to the JSON file
+ * @param filePath Path to the JSON file
+ * @param obj The object to store as JSON
+ */
+export async function writeJSON(filePath: string, obj: any): Promise<string> {
+  await writeFile(filePath, JSON.stringify(obj, null, 2))
+  return filePath
+}
+
+/**
+ * Synchronously writes a given JavaScript Object to a JSON file
+ * and returns the path to the JSON file
+ * @param filePath Path to the JSON file
+ * @param obj The object to store as JSON
+ */
+export function writeJSONSync(filePath: string, obj: any): string {
+  fs.writeFileSync(filePath, JSON.stringify(obj, null, 2))
+  return filePath
+}
+
+/**
  * Recursively apply file mode for a given path
  * @param fileMode
  * @param path
  */
-export function chmodr(fileMode: string, path: string) {
-  shell.chmod('-R', fileMode, path)
+export function chmodr(fileMode: string, filePath: string) {
+  shell.chmod('-R', fileMode, filePath)
 }

--- a/ern-core/src/index.ts
+++ b/ern-core/src/index.ts
@@ -33,6 +33,12 @@ export {
 } from './nativeDependenciesLookup'
 export { tagOneLine } from './tagoneline'
 export { YarnCli } from './YarnCli'
+export {
+  readPackageJson,
+  readPackageJsonSync,
+  writePackageJson,
+  writePackageJsonSync,
+} from './packageJsonFileUtils'
 
 export const config = _config
 export const Platform = _Platform

--- a/ern-core/src/packageJsonFileUtils.ts
+++ b/ern-core/src/packageJsonFileUtils.ts
@@ -1,0 +1,51 @@
+import * as fileUtils from './fileUtil'
+import fs from 'fs'
+import path from 'path'
+
+const PACKAGE_JSON_FILENAME = 'package.json'
+
+/**
+ * Asynchronously reads a package.json file from a given directory
+ * and returns the parsed object
+ * @param p Path to the directory containing the package.json file
+ */
+export const readPackageJson = async (p: string): Promise<any> =>
+  fileUtils.readJSON(getPathToPackageJson(p))
+
+/**
+ * Synchronously reads a package.json file from a given directory
+ * and returns the parsed object
+ * @param p Path to the directory containing the package.json file
+ */
+export const readPackageJsonSync = (p: string): any =>
+  fileUtils.readJSONSync(getPathToPackageJson(p))
+
+/**
+ * Asynchronously writes a package.json file to a given directory and
+ * returns the full path to the file
+ * @param p Path to the directory where to store the package.json file
+ * @param content Content of package.json as an object
+ */
+export const writePackageJson = (p: string, content: any): Promise<string> =>
+  fileUtils.writeJSON(getPathToPackageJson(p), content)
+
+/**
+ * Synchronously writes a package.json file to a given directory and
+ * returns the full path to the file
+ * @param p Path to the directory where to store the package.json file
+ * @param content Content of package.json as an object
+ */
+export const writePackageJsonSync = (p: string, content: any): string =>
+  fileUtils.writeJSONSync(getPathToPackageJson(p), content)
+
+/**
+ * Given a directory holding a package.json file, return the full path
+ * to the package.json file
+ * @param p Path to the directory containing the package.json
+ */
+export function getPathToPackageJson(p: string) {
+  if (!fs.statSync(p).isDirectory) {
+    throw new Error(`${p} is not a directory`)
+  }
+  return path.join(p, PACKAGE_JSON_FILENAME)
+}


### PR DESCRIPTION
Introduce `packageJsonFileUtils.ts` in `ern-core` module, exporting the following helper functions :
- `readPackageJson`
- `readPackageJsonSync`
- `writePackageJson`
- `writePackageJsonSync`

Replace code that was reading/writing to package.json file with these functions, removing some duplication.

Lightly refactor `fileUtil.ts` by the same occasion.