### PR TITLE
Clean ern-container-gen package.json

### DIFF
--- a/ern-container-gen/package.json
+++ b/ern-container-gen/package.json
@@ -61,10 +61,6 @@
     {
       "source": "src/generators/ios/hull",
       "dest": "dist/generators/ios"
-    },
-    {
-      "source": "src/publishers/supplements",
-      "dest": "dist/publishers"
     }
   ],
   "license": "Apache-2.0",


### PR DESCRIPTION
Remove instruction to copy some publishers related files for distribution, given that these files are not present in `ern-container-gen` module anymore (following publishers extraction refactoring).