### PR TITLE
Remove ern-container-gen dependency from ern-runner-gen

### DIFF
--- a/ern-runner-gen/package.json
+++ b/ern-runner-gen/package.json
@@ -50,7 +50,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "ern-container-gen": "1000.0.0",
     "ern-core": "1000.0.0",
     "fs-readdir-recursive": "^1.1.0",
     "mustache": "^2.3.0"


### PR DESCRIPTION
This dependency is no longer needed