### PR TITLE
Iterate babel resolver plugin config correctly for multiple miniapps

### DIFF
--- a/ern-container-gen/src/generateMiniAppsComposite.ts
+++ b/ern-container-gen/src/generateMiniAppsComposite.ts
@@ -178,8 +178,7 @@ export async function generateMiniAppsComposite(
                 // Another MiniApp  has already declared module-resolver
                 // plugin & config. If we have conflicts for aliases, we'll just abort
                 // bundling as of now to avoid generating a potentially unstable bundle
-                let item: any
-                for (item in babelPlugin) {
+                for (const item of babelPlugin) {
                   if (item instanceof Object && item.alias) {
                     for (const aliasKey of Object.keys(item.alias)) {
                       if (


### PR DESCRIPTION
If multiple miniapps have a `package.json` babel config, only the first miniapp's config gets used. This is happening because of `for ... in` instead of `for ... of` on the `babelPlugin` array.