### PR TITLE
Extract Container Publisher types

### DIFF
--- a/ern-container-publisher/src/publishContainer.ts
+++ b/ern-container-publisher/src/publishContainer.ts
@@ -1,4 +1,4 @@
-import { ContainerPublisherConfig, ContainerPublisher } from './types'
+import { ContainerPublisherConfig } from './types'
 import getPublisher from './getPublisher'
 import {
   createTmpDir,

--- a/ern-container-publisher/src/types/ContainerPublisher.ts
+++ b/ern-container-publisher/src/types/ContainerPublisher.ts
@@ -1,0 +1,18 @@
+import { NativePlatform } from 'ern-core'
+import { ContainerPublisherConfig } from './ContainerPublisherConfig'
+
+export interface ContainerPublisher {
+  /**
+   *  Name of the Container publisher
+   */
+  readonly name: string
+  /**
+   * An array of one or more native platform(s)
+   * that the Container publisher supports
+   */
+  readonly platforms: NativePlatform[]
+  /**
+   *  Publish a Container
+   */
+  publish(config: ContainerPublisherConfig): Promise<void>
+}

--- a/ern-container-publisher/src/types/ContainerPublisherConfig.ts
+++ b/ern-container-publisher/src/types/ContainerPublisherConfig.ts
@@ -1,21 +1,3 @@
-import { NativePlatform } from 'ern-core'
-
-export interface ContainerPublisher {
-  /**
-   *  Name of the Container publisher
-   */
-  readonly name: string
-  /**
-   * An array of one or more native platform(s)
-   * that the Container publisher supports
-   */
-  readonly platforms: NativePlatform[]
-  /**
-   *  Publish a Container
-   */
-  publish(config: ContainerPublisherConfig): Promise<void>
-}
-
 export interface ContainerPublisherConfig {
   /**
    * The publisher to use

--- a/ern-container-publisher/src/types/index.ts
+++ b/ern-container-publisher/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from './ContainerPublisher'
+export * from './ContainerPublisherConfig'


### PR DESCRIPTION
Quick refactoring to extract types from `types.ts` in `ern-container-publisher` and move each type as an independent `.ts` file in a new `types` directory (following similar design as for `ern-container-generator). Should soon follow up with other modules as well.

This is better to hold one type per file (with filename being type name). Leaner and cleaner but also helps when looking for a specific type as it is more convenient to do a file search (one result) vs a file content search (which can yield many results -everywhere type is being used-).