### PR TITLE
Add new option addAsTargetDependency to iOS addProject plugin directive

### DIFF
--- a/ern-api-impl-gen/package.json
+++ b/ern-api-impl-gen/package.json
@@ -58,7 +58,7 @@
     "mustache": "^2.3.0",
     "semver": "5.5.0",
     "xcode": "^0.9.1",
-    "xcode-ern": "^1.0.2",
+    "xcode-ern": "^1.0.3",
     "@yarnpkg/lockfile": "^1.0.1"
   },
   "devDependencies": {

--- a/ern-container-gen-ios/package.json
+++ b/ern-container-gen-ios/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "ern-container-gen": "1000.0.0",
     "ern-core": "1000.0.0",
-    "xcode-ern": "^1.0.2",
+    "xcode-ern": "^1.0.3",
     "lodash":"^4.17.10",
     "fs-readdir-recursive": "^1.1.0"
   },

--- a/ern-container-gen/package.json
+++ b/ern-container-gen/package.json
@@ -69,7 +69,7 @@
     "fs-readdir-recursive": "^1.1.0",
     "mustache": "^2.3.0",
     "semver": "^5.5.0",
-    "xcode-ern": "^1.0.2"
+    "xcode-ern": "^1.0.3"
   },
   "devDependencies": {
     "ern-util-dev": "1000.0.0",

--- a/ern-core/package.json
+++ b/ern-core/package.json
@@ -61,7 +61,7 @@
     "semver": "^5.5.0",
     "simple-git": "^1.95.0",
     "tmp": "^0.0.33",
-    "xcode-ern": "^1.0.2",
+    "xcode-ern": "^1.0.3",
     "yarn": "^1.7.0"
   },
   "devDependencies": {

--- a/ern-core/src/Manifest.ts
+++ b/ern-core/src/Manifest.ts
@@ -294,6 +294,12 @@ export interface PluginReplaceInFileDirective {
  */
 export interface IosPluginAddProjectDirective {
   /**
+   * Indicates whether the project should be added to the
+   * Target Dependencies instead of Link Binary With Libraries
+   * section of the target project Build Phases
+   */
+  addAsTargetDependency?: boolean
+  /**
    * Relative path (from plugin root) of the xcodeproj to add
    */
   path: string

--- a/ern-core/src/iosUtil.ts
+++ b/ern-core/src/iosUtil.ts
@@ -194,6 +194,7 @@ export async function fillProjectHull(
               'project.pbxproj'
             )
             const options = {
+              addAsTargetDependency: project.addAsTargetDependency,
               frameworks: project.frameworks,
               projectAbsolutePath,
               staticLibs: project.staticLibs,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5849,9 +5849,9 @@ write-pkg@^3.1.0:
     sort-keys "^2.0.0"
     write-json-file "^2.2.0"
 
-xcode-ern@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/xcode-ern/-/xcode-ern-1.0.2.tgz#1ca93cd336032c1d19aac57d0c52c59c5cf9645b"
+xcode-ern@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/xcode-ern/-/xcode-ern-1.0.3.tgz#fe4535bd6972d177b7f0d7e851f76971b3b10ce0"
   dependencies:
     pegjs "^0.10.0"
     simple-plist "^0.2.1"


### PR DESCRIPTION
- Bump `xcode-ern` dependency version to `1.0.3` which implements the logic for supporting this new option flag.