### PR TITLE
Update publish-container command

### DIFF
--- a/docs/cli/publish-container.md
+++ b/docs/cli/publish-container.md
@@ -16,6 +16,16 @@
 
 **Options**  
 
+`--containerPath`
+
+* The local file system path to the directory containing the Container to publish.
+* **Default**  If this option is not provided, the command will look for a Container in the default platform directory `~/.ern/containergen/out/[platform]`.
+
+`--platform/-p <android|ios>`
+
+* Specify the native platform of the target Container to publish.
+* This option is required, there is no default.
+
 `--version/-v <version>`
 
 * Specify the Container version to use for publication.


### PR DESCRIPTION
This PR update the `publish-container` command to make it more consistent with its alter ego `create-container`

- Remove mandatory `containerPath`. It is now an option. If not specified, the default path will be Electrode Native default container path (`~/.ern/containergen/out/[platform]`). This makes the command consistent with `create-container` which takes an option `outDir`, being the path where to generate the Container and if not specified will fallback to default Electrode Native container generation directory.

- Add `platform` option. This is needed because of `containerPath` being now optional. If no `containerPath` is specified, then the command needs to know which container path to use (basically `../out/android` or `../out/ios`). Good thing is that the `create-container` also takes a `platform` option so it reinforces consistency.

*For Release Notes:*  This is a **Breaking Change** for `publish-container` command
