### PR TITLE
Add npmignore to Electrode Native packages

### DIFF
--- a/ern-api-gen/.npmignore
+++ b/ern-api-gen/.npmignore
@@ -1,0 +1,7 @@
+src
+.coverage
+.nyc_output
+test
+tsconfig.release.json
+yarn.lock
+tmp

--- a/ern-api-impl-gen/.npmignore
+++ b/ern-api-impl-gen/.npmignore
@@ -1,0 +1,6 @@
+src
+.coverage
+.nyc_output
+test
+tsconfig.release.json
+yarn.lock

--- a/ern-cauldron-api/.npmignore
+++ b/ern-cauldron-api/.npmignore
@@ -1,0 +1,6 @@
+src
+.coverage
+.nyc_output
+test
+tsconfig.release.json
+yarn.lock

--- a/ern-container-gen-android/.npmignore
+++ b/ern-container-gen-android/.npmignore
@@ -1,0 +1,6 @@
+src
+.coverage
+.nyc_output
+test
+tsconfig.release.json
+yarn.lock

--- a/ern-container-gen-ios/.npmignore
+++ b/ern-container-gen-ios/.npmignore
@@ -1,0 +1,6 @@
+src
+.coverage
+.nyc_output
+test
+tsconfig.release.json
+yarn.lock

--- a/ern-container-gen/.npmignore
+++ b/ern-container-gen/.npmignore
@@ -1,0 +1,6 @@
+src
+.coverage
+.nyc_output
+test
+tsconfig.release.json
+yarn.lock

--- a/ern-container-publisher-jcenter/.npmignore
+++ b/ern-container-publisher-jcenter/.npmignore
@@ -1,0 +1,6 @@
+src
+.coverage
+.nyc_output
+test
+tsconfig.release.json
+yarn.lock

--- a/ern-container-publisher-maven/.npmignore
+++ b/ern-container-publisher-maven/.npmignore
@@ -1,0 +1,6 @@
+src
+.coverage
+.nyc_output
+test
+tsconfig.release.json
+yarn.lock

--- a/ern-container-publisher/.npmignore
+++ b/ern-container-publisher/.npmignore
@@ -1,0 +1,6 @@
+src
+.coverage
+.nyc_output
+test
+tsconfig.release.json
+yarn.lock

--- a/ern-core/.npmignore
+++ b/ern-core/.npmignore
@@ -1,0 +1,6 @@
+src
+.coverage
+.nyc_output
+test
+tsconfig.release.json
+yarn.lock

--- a/ern-local-cli/.npmignore
+++ b/ern-local-cli/.npmignore
@@ -1,0 +1,5 @@
+.coverage
+.nyc_output
+test
+tsconfig.release.json
+yarn.lock

--- a/ern-runner-gen/.npmignore
+++ b/ern-runner-gen/.npmignore
@@ -1,0 +1,6 @@
+src
+.coverage
+.nyc_output
+test
+tsconfig.release.json
+yarn.lock


### PR DESCRIPTION
Noticed that all of our Electrode Native packages published to NPM contain a lot of things that are not needed (such as `src` directory or `test` directory or even test coverage directories). 

This PR adds a `.npmignore` file to each Electrode Native package, so that all the non necessary things are not included in the npm package. This reduces the size of of Electrode Native packages, thus reducing overall size of Electrode Native installed versions and also potentially speeding up install (might not really be noticeable though, given that Electrode Native packages contribute maybe to 1% of overall packages size when accounting for node modules dependencies).

Please note that the `src` directory is excluded (`dist` -transpiled code- is the one that is included and needed at runtime), except for `ern-local-cli` that still need it because of bad design decision in our [global-cli](https://github.com/electrode-io/electrode-native/blob/master/global-cli/src/index.js#L154-L155). Quite hard to change as we can't really force users to update the global cli. That's the way it is, not too much of an issue.