### PR TITLE
Improve platform config command

### DIFF
--- a/ern-local-cli/package.json
+++ b/ern-local-cli/package.json
@@ -66,6 +66,7 @@
     "ern-runner-gen": "1000.0.0",
     "ern-runner-gen-android": "1000.0.0",
     "ern-runner-gen-ios": "1000.0.0",
+    "fast-levenshtein": "^2.0.6",
     "fs-readdir-recursive": "^1.1.0",
     "inquirer": "^3.0.6",
     "lodash": "^4.17.10",

--- a/ern-local-cli/src/commands/platform/config.ts
+++ b/ern-local-cli/src/commands/platform/config.ts
@@ -1,16 +1,65 @@
 import { config as ernConfig, utils as coreUtils, log } from 'ern-core'
 import utils from '../../lib/utils'
 import { Argv } from 'yargs'
+import levenshtein from 'fast-levenshtein'
 
 export const command = 'config <key> [value]'
 export const desc = 'Get or set a configuration key'
 
 export const builder = (argv: Argv) => {
-  return argv.epilog(utils.epilog(exports))
+  return argv.epilog(userConfigSchemaString() + utils.epilog(exports))
 }
+
+const availableUserConfigKeys = [
+  {
+    desc: 'Set the log level to use for all commands',
+    name: 'logLevel',
+    values: ['trace', 'debug', 'info', 'error', 'fatal'],
+  },
+  {
+    desc: 'Show the Electrode Native banner when running commands',
+    name: 'showBanner',
+    values: [true, false],
+  },
+  {
+    desc: 'Temporary directory to use during commands execution',
+    name: 'tmp-dir',
+    values: ['string'],
+  },
+  {
+    desc: 'Do not remove temporary directories after command execution',
+    name: 'retain-tmp-dir',
+    values: [true, false],
+  },
+]
+
+const userConfigSchemaString = () =>
+  'The following configuration keys are available :\n' +
+  availableUserConfigKeys
+    .map(
+      e =>
+        `${e.name.padEnd(15)} : ${e.desc.padEnd(60)}  [${e.values.join('|')}]`
+    )
+    .join('\n') +
+  '\n\n'
+
+const availableKeys = () => availableUserConfigKeys.map(e => e.name)
+
+const closestKeyName = key =>
+  availableKeys().reduce(
+    (acc, cur) =>
+      levenshtein.get(acc, key) > levenshtein.get(cur, key) ? cur : acc
+  )
 
 export const handler = ({ key, value }: { key: string; value?: string }) => {
   try {
+    if (!availableKeys().includes(key)) {
+      throw new Error(
+        `Configuration key ${key} does not exists. Did you mean ${closestKeyName(
+          key
+        )} ?`
+      )
+    }
     if (value) {
       const valueToset =
         value === 'true' ? true : value === 'false' ? false : value

--- a/yarn.lock
+++ b/yarn.lock
@@ -1745,7 +1745,7 @@ fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
 
-fast-levenshtein@~2.0.4:
+fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 


### PR DESCRIPTION
- The command now logs the available configuration keys in the command help :

```
➜ ern platform config
[v1000.0.0] [Cauldron: -NONE-]

ern platform config <key> [value]

Options:
  --help  Show help                                                                                                                                                                                                       [boolean]

The following configuration keys are available :
logLevel        : Set the log level to use for all commands                     [trace|debug|info|error|fatal]
showBanner      : Show the Electrode Native banner when running commands        [true|false]
tmp-dir         : Temporary directory to use during commands execution          [string]
retain-tmp-dir  : Do not remove temporary directories after command execution   [true|false]

More info about this command @ https://electrode.gitbooks.io/electrode-native/content/cli/platform/config.html
```

- The command now performs key validation. In case the user enters a non available key, the command will fail. It will also offer a hint to the user, by returning the closest key name (using levenshtein distance), which is helpful in case of simple typo.

```
➜ ern platform config log-level
[v1000.0.0] [Cauldron: -NONE-]

An error occurred: Config key log-level does not exists. Did you mean logLevel ?
```