### PR TITLE
Allow arbitrary directory for ern root

### DIFF
--- a/ern-core/src/Platform.ts
+++ b/ern-core/src/Platform.ts
@@ -8,13 +8,13 @@ import path from 'path'
 import os from 'os'
 import semver from 'semver'
 
-const HOME_DIRECTORY = os.homedir()
+const ROOT_DIRECTORY = process.env.ERN_HOME || path.join(os.homedir(), '.ern')
 // Name of ern local client NPM package
 const ERN_LOCAL_CLI_PACKAGE = 'ern-local-cli'
 
 export default class Platform {
   static get rootDirectory(): string {
-    return path.join(HOME_DIRECTORY, '.ern')
+    return ROOT_DIRECTORY
   }
 
   static get cauldronDirectory(): string {

--- a/ern-core/src/config.ts
+++ b/ern-core/src/config.ts
@@ -2,7 +2,8 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 
-const ERN_RC_GLOBAL_FILE_PATH = path.join(os.homedir(), '.ern', '.ernrc')
+const ERN_ROOT_PATH = process.env.ERN_HOME || path.join(os.homedir(), '.ern')
+const ERN_RC_GLOBAL_FILE_PATH = path.join(ERN_ROOT_PATH, '.ernrc')
 const ERN_RC_LOCAL_FILE_PATH = path.join(process.cwd(), '.ernrc')
 
 export class ErnConfig {

--- a/global-cli/package.json
+++ b/global-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrode-native",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Electrode Native Global CLI",
   "main": "./dist/index.js",
   "bin": {

--- a/global-cli/src/index.js
+++ b/global-cli/src/index.js
@@ -26,7 +26,7 @@ updateNotifier({ pkg }).notify()
 // Initial process cwd
 const INITIAL_PROCESS_CWD = process.cwd()
 // Path to ern platform root directory
-const ERN_PATH = path.join(os.homedir(), '.ern')
+const ERN_PATH = process.env['ERN_HOME'] || path.join(os.homedir(), '.ern')
 // Path to ern platform versions directory (containing all installed versions of the platform)
 const ERN_VERSIONS_CACHE_PATH = path.join(ERN_PATH, 'versions')
 // Path to ern global configuration file
@@ -34,7 +34,9 @@ const ERN_RC_GLOBAL_FILE_PATH = path.join(ERN_PATH, '.ernrc')
 // Path to potential ern local configuration file (local to the directory where ern command is run)
 const ERN_RC_LOCAL_FILE_PATH = path.join(INITIAL_PROCESS_CWD, '.ernrc')
 // Resolved path to ern configuration file
-const ENR_RC_RESOLVED_PATH = fs.existsSync(ERN_RC_LOCAL_FILE_PATH) ? ERN_RC_LOCAL_FILE_PATH : ERN_RC_GLOBAL_FILE_PATH
+const ENR_RC_RESOLVED_PATH = fs.existsSync(ERN_RC_LOCAL_FILE_PATH)
+  ? ERN_RC_LOCAL_FILE_PATH
+  : ERN_RC_GLOBAL_FILE_PATH
 // Name of ern local client NPM package
 const ERN_LOCAL_CLI_PACKAGE = 'ern-local-cli'
 
@@ -49,11 +51,13 @@ if (!fs.existsSync(ERN_PATH)) {
 
 // First run ever of ern (no versions installed at all yet)
 // Create all directories and install/activate current platform version
-function firstTimeInstall () {
+function firstTimeInstall() {
   try {
     const isDebug = process.argv.indexOf('--debug') !== -1
 
-    const spinner = ora('Performing first time install of Electrode Native').start()
+    const spinner = ora(
+      'Performing first time install of Electrode Native'
+    ).start()
 
     // Create path platform root directory
     fs.mkdirSync(ERN_PATH)
@@ -72,7 +76,10 @@ function firstTimeInstall () {
     }
 
     // Create the version directory
-    const pathToVersionDirectory = path.join(ERN_VERSIONS_CACHE_PATH, initialVersion)
+    const pathToVersionDirectory = path.join(
+      ERN_VERSIONS_CACHE_PATH,
+      initialVersion
+    )
     fs.mkdirSync(pathToVersionDirectory)
     fs.mkdirSync(path.join(pathToVersionDirectory, 'node_modules'))
     process.chdir(pathToVersionDirectory)
@@ -82,50 +89,85 @@ function firstTimeInstall () {
       // Favor yarn if it is installed as it will greatly speed up install
       spinner.text = `Installing Electrode Native v${initialVersion} using yarn. This might take a while`
       if (IS_WINDOWS_PLATFORM) {
-        installProc = spawn('cmd',
-          ['/s', '/c', 'yarn', 'add', `${ERN_LOCAL_CLI_PACKAGE}@${initialVersion}`, '--exact', '--ignore-engines'],
-          { cwd: pathToVersionDirectory })
+        installProc = spawn(
+          'cmd',
+          [
+            '/s',
+            '/c',
+            'yarn',
+            'add',
+            `${ERN_LOCAL_CLI_PACKAGE}@${initialVersion}`,
+            '--exact',
+            '--ignore-engines',
+          ],
+          { cwd: pathToVersionDirectory }
+        )
       } else {
-        installProc = spawn('yarn',
-          ['add', `${ERN_LOCAL_CLI_PACKAGE}@${initialVersion}`, '--exact', '--ignore-engines'],
-          { cwd: pathToVersionDirectory })
+        installProc = spawn(
+          'yarn',
+          [
+            'add',
+            `${ERN_LOCAL_CLI_PACKAGE}@${initialVersion}`,
+            '--exact',
+            '--ignore-engines',
+          ],
+          { cwd: pathToVersionDirectory }
+        )
       }
     } else {
       spinner.text = `Installing Electrode Native v${initialVersion} using npm. This might take a while`
       if (IS_WINDOWS_PLATFORM) {
-        installProc = spawn('cmd',
-          ['/s', '/c', 'npm', 'install', `${ERN_LOCAL_CLI_PACKAGE}@${initialVersion}`],
-          { cwd: pathToVersionDirectory })
+        installProc = spawn(
+          'cmd',
+          [
+            '/s',
+            '/c',
+            'npm',
+            'install',
+            `${ERN_LOCAL_CLI_PACKAGE}@${initialVersion}`,
+          ],
+          { cwd: pathToVersionDirectory }
+        )
       } else {
-        installProc = spawn('npm',
+        installProc = spawn(
+          'npm',
           ['install', `${ERN_LOCAL_CLI_PACKAGE}@${initialVersion}`],
-          { cwd: pathToVersionDirectory })
+          { cwd: pathToVersionDirectory }
+        )
       }
     }
 
-    installProc.stdout.on('data', function (data) {
+    installProc.stdout.on('data', function(data) {
       isDebug && console.log(data.toString())
     })
 
-    installProc.stderr.on('data', function (data) {
+    installProc.stderr.on('data', function(data) {
       isDebug && console.log(data.toString())
     })
 
-    installProc.on('error', function (err) {
-      console.log(`Something went wrong ${err} :( Run the command again with --debug flag for more info.`)
+    installProc.on('error', function(err) {
+      console.log(
+        `Something went wrong ${err} :( Run the command again with --debug flag for more info.`
+      )
       removeErnDirectory()
     })
 
-    installProc.on('close', function (code) {
+    installProc.on('close', function(code) {
       if (code === 0) {
-        spinner.succeed(`Hurray ! Electrode Native v${initialVersion} was successfully installed.`)
+        spinner.succeed(
+          `Hurray ! Electrode Native v${initialVersion} was successfully installed.`
+        )
       } else {
-        spinner.fail(`Something went wrong :( Run the command again with --debug flag for more info.`)
+        spinner.fail(
+          `Something went wrong :( Run the command again with --debug flag for more info.`
+        )
         removeErnDirectory()
       }
     })
   } catch (e) {
-    console.log(`Something went wrong :( Run the command again with --debug flag for more info.`)
+    console.log(
+      `Something went wrong :( Run the command again with --debug flag for more info.`
+    )
     removeErnDirectory()
   }
 }
@@ -133,7 +175,7 @@ function firstTimeInstall () {
 // Remove .ern global directory.
 // Done if something' gone wrong during install.
 // Don't want to leave the .ern global directory hanging around in a bad state
-function removeErnDirectory () {
+function removeErnDirectory() {
   console.log(`Performing cleanup. Please wait for the process to exit.`)
   process.chdir(INITIAL_PROCESS_CWD)
   if (IS_WINDOWS_PLATFORM) {
@@ -148,11 +190,25 @@ function removeErnDirectory () {
 // and call the default exported method
 // Basically, it just proxy the ern command to the ern-local-cli (local client)
 // of the version currently in use
-function runLocalCli () {
+function runLocalCli() {
   const ernRc = JSON.parse(fs.readFileSync(ENR_RC_RESOLVED_PATH, 'utf-8'))
-  const pathToErnVersionEntryPoint = ((ernRc.platformVersion === '1000') || (ernRc.platformVersion === '1000.0.0'))
-    ? path.join(ERN_VERSIONS_CACHE_PATH, '1000.0.0', 'ern-local-cli', 'src', 'index.dev.js')
-    : path.join(ERN_VERSIONS_CACHE_PATH, ernRc.platformVersion, 'node_modules', 'ern-local-cli', 'src', 'index.prod.js')
+  const pathToErnVersionEntryPoint =
+    ernRc.platformVersion === '1000' || ernRc.platformVersion === '1000.0.0'
+      ? path.join(
+          ERN_VERSIONS_CACHE_PATH,
+          '1000.0.0',
+          'ern-local-cli',
+          'src',
+          'index.dev.js'
+        )
+      : path.join(
+          ERN_VERSIONS_CACHE_PATH,
+          ernRc.platformVersion,
+          'node_modules',
+          'ern-local-cli',
+          'src',
+          'index.prod.js'
+        )
 
   if (!fs.existsSync(pathToErnVersionEntryPoint)) {
     console.error(`Path not found : ${pathToErnVersionEntryPoint}`)
@@ -163,13 +219,17 @@ function runLocalCli () {
   require(pathToErnVersionEntryPoint)
 }
 
-function getLatestErnLocalCliVersion () {
+function getLatestErnLocalCliVersion() {
   try {
     let versions
     if (isYarnInstalled()) {
-      versions = JSON.parse(execSync(`yarn info ${ERN_LOCAL_CLI_PACKAGE} versions --json`)).data
+      versions = JSON.parse(
+        execSync(`yarn info ${ERN_LOCAL_CLI_PACKAGE} versions --json`)
+      ).data
     } else {
-      versions = JSON.parse(execSync(`npm info ${ERN_LOCAL_CLI_PACKAGE} versions --json`))
+      versions = JSON.parse(
+        execSync(`npm info ${ERN_LOCAL_CLI_PACKAGE} versions --json`)
+      )
     }
     return versions.pop()
   } catch (e) {
@@ -177,7 +237,7 @@ function getLatestErnLocalCliVersion () {
   }
 }
 
-function isYarnInstalled () {
+function isYarnInstalled() {
   try {
     execSync('yarn --version')
     return true

--- a/global-cli/yarn.lock
+++ b/global-cli/yarn.lock
@@ -16,6 +16,12 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  dependencies:
+    color-convert "^1.9.0"
+
 boxen@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-0.6.0.tgz#8364d4248ac34ff0ef1b2f2bf49a6c60ce0d81b6"
@@ -38,7 +44,7 @@ capture-stack-trace@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz#4a6fa07399c26bba47f0b2496b4d0fb408c5550d"
 
-chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
+chalk@^1.0.0, chalk@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -47,6 +53,14 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
 
 cli-boxes@^1.0.0:
   version "1.0.0"
@@ -58,13 +72,23 @@ cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
-cli-spinners@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-1.0.1.tgz#2675321c100f195b02877ac499e9911fa34b9783"
+cli-spinners@^1.0.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-1.3.1.tgz#002c1990912d0d59580c93bd36c056de99e4259a"
 
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+
+color-convert@^1.9.0:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.2.tgz#49881b8fba67df12a96bdf3f56c0aab9e7913147"
+  dependencies:
+    color-name "1.1.1"
+
+color-name@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.1.tgz#4b1415304cf50028ea81643643bd82ea05803689"
 
 configstore@^2.0.0:
   version "2.1.0"
@@ -90,9 +114,9 @@ create-error-class@^3.0.1:
   dependencies:
     capture-stack-trace "^1.0.0"
 
-deep-extend@~0.4.0:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
 
 dot-prop@^3.0.0:
   version "3.0.0"
@@ -107,12 +131,12 @@ duplexer2@^0.1.4:
     readable-stream "^2.0.2"
 
 error-ex@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
   dependencies:
     is-arrayish "^0.2.1"
 
-escape-string-regexp@^1.0.2:
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -150,6 +174,10 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
@@ -159,8 +187,8 @@ inherits@~2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
 ini@~1.3.0:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -212,19 +240,19 @@ lazy-req@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/lazy-req/-/lazy-req-1.1.0.tgz#bdaebead30f8d824039ce0ce149d4daa07ba1fac"
 
-log-symbols@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+log-symbols@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
   dependencies:
-    chalk "^1.0.0"
+    chalk "^2.0.1"
 
 lowercase-keys@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
 
 mimic-fn@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
 
 minimist@0.0.8:
   version "0.0.8"
@@ -259,13 +287,13 @@ onetime@^2.0.0:
     mimic-fn "^1.0.0"
 
 ora@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/ora/-/ora-1.3.0.tgz#80078dd2b92a934af66a3ad72a5b910694ede51a"
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-1.4.0.tgz#884458215b3a5d4097592285f93321bb7a79e2e5"
   dependencies:
-    chalk "^1.1.1"
+    chalk "^2.1.0"
     cli-cursor "^2.1.0"
-    cli-spinners "^1.0.0"
-    log-symbols "^1.0.2"
+    cli-spinners "^1.0.1"
+    log-symbols "^2.1.0"
 
 os-homedir@^1.0.0:
   version "1.0.2"
@@ -276,8 +304,8 @@ os-tmpdir@^1.0.0:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
 osenv@^0.1.0:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.4.tgz#42fe6d5953df06c8064be6f176c3d05aaaa34644"
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
@@ -311,15 +339,15 @@ prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
 
-process-nextick-args@~1.0.6:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
+process-nextick-args@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
 
 rc@^1.0.1, rc@^1.1.6:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.1.tgz#2e03e8e42ee450b8cb3dce65be1bf8974e1dfd95"
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   dependencies:
-    deep-extend "~0.4.0"
+    deep-extend "^0.6.0"
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
@@ -332,20 +360,20 @@ read-all-stream@^3.0.0:
     readable-stream "^2.0.0"
 
 readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
     isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
+    process-nextick-args "~2.0.0"
     safe-buffer "~5.1.1"
-    string_decoder "~1.0.3"
+    string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
 registry-auth-token@^3.0.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.3.1.tgz#fb0d3289ee0d9ada2cbb52af5dfe66cb070d3006"
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.3.2.tgz#851fd49038eecb586911115af845260eec983f20"
   dependencies:
     rc "^1.1.6"
     safe-buffer "^5.0.1"
@@ -370,8 +398,8 @@ restore-cursor@^2.0.0:
     signal-exit "^3.0.2"
 
 safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
 
 semver-diff@^2.0.0:
   version "2.1.0"
@@ -380,8 +408,8 @@ semver-diff@^2.0.0:
     semver "^5.0.3"
 
 semver@^5.0.3, semver@^5.1.0:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
 signal-exit@^3.0.2:
   version "3.0.2"
@@ -399,9 +427,9 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string_decoder@~1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
   dependencies:
     safe-buffer "~5.1.0"
 
@@ -418,6 +446,12 @@ strip-json-comments@~2.0.1:
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+
+supports-color@^5.3.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
+  dependencies:
+    has-flag "^3.0.0"
 
 timed-out@^3.0.0:
   version "3.1.3"


### PR DESCRIPTION
Through `ERN_HOME` environment variable.

This is useful in a few contexts but mostly for CI env, as it allows to keep the whole `.ern` directory under the job workspace.