### PR TITLE
Cache packages to boost Container generator speed

### DIFF
--- a/ern-core/package.json
+++ b/ern-core/package.json
@@ -50,6 +50,7 @@
     "console-log-level": "^1.4.0",
     "decompress-zip": "^0.3.1",
     "fs-readdir-recursive": "^1.1.0",
+    "get-folder-size":"^2.0.0",
     "inquirer": "^3.0.6",
     "lodash": "^4.17.10",
     "mustache": "^2.3.0",
@@ -61,6 +62,7 @@
     "semver": "^5.5.0",
     "simple-git": "^1.95.0",
     "tmp": "^0.0.33",
+    "uuid":"^3.2.1",
     "xcode-ern": "^1.0.3",
     "yarn": "^1.7.0"
   },

--- a/ern-core/src/FsCache.ts
+++ b/ern-core/src/FsCache.ts
@@ -1,0 +1,220 @@
+import fs from 'fs'
+import path from 'path'
+import { readJSON, writeJSON, writeJSONSync } from './fileUtil'
+import shell from './shell'
+import uuidv4 from 'uuid/v4'
+import getSize from 'get-folder-size'
+
+/**
+ * Gets the total size (in bytes) of a given directory
+ * @param dirPath path to the directory for which to compute size
+ */
+const getSizeAsync: (dirPath: string) => Promise<number> = dirPath =>
+  new Promise((resolve, reject) => {
+    getSize(dirPath, (err, size) => {
+      err ? reject(err) : resolve(size)
+    })
+  })
+
+export interface CacheManifest {
+  /**
+   * Entries stored in the cache
+   */
+  entries: CacheManifestEntry[]
+  /**
+   * Total size of the cache
+   */
+  size: number
+}
+
+export interface CacheManifestEntry {
+  /**
+   * Id of the entry
+   * ex: my-miniapp@1.0.0
+   */
+  id: string
+  /**
+   * Absolute path to the entry
+   * ex : /Users/blemair/.ern/cache/78c40fda-d5bb-4681-9bd2-a5fba9df1f70
+   */
+  path: string
+  /**
+   * Size in bytes of the entry
+   */
+  size: number
+  /**
+   * Time (epoc) when the entry was last accessed
+   */
+  lastAccessed: number
+}
+
+const cacheManifestFileName = 'cache-manifest.json'
+export const maxDefaultCacheSize = 2 * 1024 * 1024 * 1024 /* 2GB */
+
+type AddObjectToCacheDirectory<T> = (obj: T, dirPath: string) => Promise<void>
+type ObjectToId<T> = (obj: T) => string
+
+/**
+ * Simple generic file system based LRU cache.
+ * This cache stores arbirtrary objects in unique directories.
+ * The root directory for the cache can be configured, as well as
+ * the maximum size allowed for the cache.
+ * Once cache reaches max size, the least recenctly accessed
+ * objects will be removed from the cache, until size of the cache
+ * falls below maximum size.
+ */
+export class FsCache<T> {
+  /**
+   * Root path to the directory holding the cache
+   */
+  public readonly rootCachePath: string
+  /**
+   * Maximum cache size (in bytes)
+   */
+  public readonly maxCacheSize: number
+  /**
+   * Custom function invoked to add an object entry to the cache
+   */
+  private readonly addObjectToCacheDirectory: AddObjectToCacheDirectory<T>
+  /**
+   * Custom function invoked to convert an object entry to a unique id
+   */
+  private readonly objectToId: ObjectToId<T>
+
+  constructor({
+    /**
+     * Custom function invoked to add an object entry to the cache
+     */
+    addObjectToCacheDirectory,
+    /**
+     * Custom function invoked to convert an object entry to a unique id
+     */
+    objectToId,
+    /**
+     * Maximum cache size (in bytes)
+     */
+    maxCacheSize = maxDefaultCacheSize,
+    /**
+     * Root path to the directory holding the cache
+     */
+    rootCachePath,
+  }: {
+    addObjectToCacheDirectory: AddObjectToCacheDirectory<T>
+    objectToId: ObjectToId<T>
+    maxCacheSize?: number
+    rootCachePath: string
+  }) {
+    if (!addObjectToCacheDirectory) {
+      throw new Error('addObjectToDirectory function is required')
+    }
+    if (!objectToId) {
+      throw new Error('objectToId function is required')
+    }
+    if (!rootCachePath) {
+      throw new Error('rootCachePath is required')
+    }
+    this.rootCachePath = rootCachePath
+    this.maxCacheSize = maxCacheSize
+    this.addObjectToCacheDirectory = addObjectToCacheDirectory
+    this.objectToId = objectToId
+    if (!fs.existsSync(rootCachePath)) {
+      shell.mkdir(rootCachePath)
+    }
+    if (!fs.existsSync(this.cacheManifestPath)) {
+      writeJSONSync(this.cacheManifestPath, { entries: [], size: 0 })
+    }
+  }
+
+  /**
+   * Indicates whether a given object is currently stored in the cache
+   * @param obj The object to check for presence in the cache
+   */
+  public async isInCache(obj: T): Promise<boolean> {
+    const manifestObj = await this.getManifestObj()
+    return !!manifestObj.entries.find(e => e.id === this.objectToId(obj))
+  }
+
+  /**
+   * Adds an object entry to the cache
+   * @param obj The object to add to the cache
+   */
+  public async addToCache(obj: T): Promise<string> {
+    if (await this.isInCache(obj)) {
+      throw new Error(
+        `Object with id ${this.objectToId(obj)} is already in the cache`
+      )
+    }
+    // Create unique directory to store the object
+    const pathToObjectCacheDir = this.createUniqueCacheDirectory()
+    // Invoke client provided function to write object in cache directory
+    await this.addObjectToCacheDirectory(obj, pathToObjectCacheDir)
+    // Compute cached object directory size
+    const cachedObjectDirSize = await getSizeAsync(pathToObjectCacheDir)
+    // Create manifest entry for new cached object
+    const entry: CacheManifestEntry = {
+      id: this.objectToId(obj),
+      lastAccessed: Date.now(),
+      path: pathToObjectCacheDir,
+      size: cachedObjectDirSize,
+    }
+    // Update manifest total cache size
+    const manifestObj = await this.getManifestObj()
+    manifestObj.size += cachedObjectDirSize
+    manifestObj.entries.push(entry)
+    // Clean cache if newly added object caused total cache
+    // size to exceed the defined max cache size
+    // Remove all entries that were least recently accessed
+    // until the total cache size falls below the max cache size
+    const entriesSortedByLat = manifestObj.entries.sort(
+      (a, b) => b.lastAccessed - a.lastAccessed
+    )
+    while (manifestObj.size >= this.maxCacheSize) {
+      const entryToRemove = entriesSortedByLat.pop()
+      manifestObj.size -= entryToRemove!.size
+      shell.rm('-rf', entryToRemove!.id)
+    }
+    manifestObj.entries = entriesSortedByLat
+    // Save updated manifest
+    await writeJSON(this.cacheManifestPath, manifestObj)
+    return pathToObjectCacheDir
+  }
+
+  /**
+   * Gets path to the directory containing a cached object
+   * @param obj The object for which to retrieve cached directory path
+   */
+  public async getObjectCachePath(obj: T): Promise<string | void> {
+    const manifestObj = await this.getManifestObj()
+    const cacheEntry = manifestObj.entries.find(
+      e => e.id === this.objectToId(obj)
+    )
+    if (cacheEntry) {
+      cacheEntry.lastAccessed = Date.now()
+      await writeJSON(this.cacheManifestPath, manifestObj)
+      return cacheEntry.path
+    }
+  }
+
+  /**
+   * Gets the cache manifest object
+   */
+  private async getManifestObj(): Promise<CacheManifest> {
+    return readJSON(this.cacheManifestPath)
+  }
+
+  /**
+   * Creates a uniquely named cache directory
+   */
+  private createUniqueCacheDirectory(): string {
+    const pathToCacheDirectory = path.join(this.rootCachePath, uuidv4())
+    shell.mkdir(pathToCacheDirectory)
+    return pathToCacheDirectory
+  }
+
+  /**
+   * Gets the path to the cache manifest file
+   */
+  private get cacheManifestPath() {
+    return path.join(this.rootCachePath, cacheManifestFileName)
+  }
+}

--- a/ern-core/src/Platform.ts
+++ b/ern-core/src/Platform.ts
@@ -17,6 +17,10 @@ export default class Platform {
     return path.join(HOME_DIRECTORY, '.ern')
   }
 
+  static get packagesCacheDirectory(): string {
+    return path.join(this.rootDirectory, 'packages-cache')
+  }
+
   static get cauldronDirectory(): string {
     return path.join(this.rootDirectory, 'cauldron')
   }

--- a/ern-core/src/index.ts
+++ b/ern-core/src/index.ts
@@ -77,3 +77,4 @@ export { ManifestOverrideConfig } from './Manifest'
 
 export { NativePlatform } from './NativePlatform'
 export { FsCache } from './FsCache'
+export { packageCache } from './packageCache'

--- a/ern-core/src/index.ts
+++ b/ern-core/src/index.ts
@@ -76,3 +76,4 @@ export { BundlingResult } from './ReactNativeCli'
 export { ManifestOverrideConfig } from './Manifest'
 
 export { NativePlatform } from './NativePlatform'
+export { FsCache } from './FsCache'

--- a/ern-core/src/packageCache.ts
+++ b/ern-core/src/packageCache.ts
@@ -1,0 +1,32 @@
+import { FsCache } from './FsCache'
+import { PackagePath } from './PackagePath'
+import { yarn } from './clients'
+import config from './config'
+import Platform from './Platform'
+import shell from './shell'
+import path from 'path'
+import { readPackageJson } from './packageJsonFileUtils'
+
+/**
+ * Singleton instance of a file system based cache dealing
+ * with caching Packages
+ */
+export const packageCache = new FsCache<PackagePath>({
+  addObjectToCacheDirectory: async (obj: PackagePath, dirPath: string) => {
+    try {
+      shell.pushd(dirPath)
+      await yarn.init()
+      await yarn.add(obj)
+      const packageJson = await readPackageJson('.')
+      const packageName = Object.keys(packageJson.dependencies)[0]
+      shell.rm('package.json')
+      shell.mv(path.join('node_modules', packageName, '*'), '.')
+      shell.rm('-rf', path.join('node_modules', packageName, '*'))
+    } finally {
+      shell.popd()
+    }
+  },
+  maxCacheSize: config.getValue('max-package-cache-size'),
+  objectToId: (obj: PackagePath) => obj.fullPath,
+  rootCachePath: Platform.packagesCacheDirectory,
+})

--- a/ern-core/test/FsCache-test.ts
+++ b/ern-core/test/FsCache-test.ts
@@ -118,26 +118,6 @@ describe('FsCache', () => {
       await sut.addToCache('AString')
       assert(await sut.isInCache('AString'))
     })
-
-    it('should remove least recently accessed object from cache once hitting max cache size', async () => {
-      const sut = new FsCache<string>({
-        addObjectToDirectory: async (obj: string, dirPath: string) => {
-          await writeFile(
-            path.join(dirPath, 'filename'),
-            _.fill(Array(500), 0).join('')
-          )
-        },
-        maxCacheSize: 1100,
-        objectToId: (obj: string) => obj,
-        rootCachePath: testRootCachePath,
-      })
-      await sut.addToCache('AString')
-      await sut.addToCache('AnotherString')
-      await sut.addToCache('YetAnoterString')
-      assert(await sut.isInCache('YetAnoterString'))
-      assert(!(await sut.isInCache('AnotherString')))
-      assert(!(await sut.isInCache('AString')))
-    })
   })
 
   describe('getObjectCachePath', () => {

--- a/ern-core/test/FsCache-test.ts
+++ b/ern-core/test/FsCache-test.ts
@@ -1,0 +1,167 @@
+import { assert, expect } from 'chai'
+import { FsCache, maxDefaultCacheSize } from '../src/FsCache'
+import { writeFile } from '../src/fileUtil'
+import { doesThrow, doesNotThrow } from 'ern-util-dev'
+import shell from '../src/shell'
+import path from 'path'
+import fs from 'fs'
+import _ from 'lodash'
+
+const testRootCachePath = path.join(__dirname, 'tmp')
+
+/**
+ * These tests are using string as the cached object type, for simplicity.
+ * objectToId will return the string itself
+ */
+describe('FsCache', () => {
+  afterEach(() => {
+    shell.rm('-rf', testRootCachePath)
+  })
+
+  describe('constructor', () => {
+    it('should succesfully create a new instance given valid parameters', () => {
+      const sut = new FsCache<string>({
+        addObjectToCacheDirectory: async (obj: string, dirPath: string) =>
+          Promise.resolve(),
+        objectToId: (obj: string) => obj,
+        rootCachePath: testRootCachePath,
+      })
+      expect(sut).not.undefined
+    })
+
+    it('should create the root cache directory if it does not exist', () => {
+      const sut = new FsCache<string>({
+        addObjectToCacheDirectory: async (obj: string, dirPath: string) =>
+          Promise.resolve(),
+        objectToId: (obj: string) => '1',
+        rootCachePath: testRootCachePath,
+      })
+      expect(fs.existsSync(testRootCachePath)).true
+    })
+
+    it('should property set the rootCachePath', () => {
+      const sut = new FsCache<string>({
+        addObjectToCacheDirectory: async (obj: string, dirPath: string) =>
+          Promise.resolve(),
+        objectToId: (obj: string) => '1',
+        rootCachePath: testRootCachePath,
+      })
+      expect(sut.rootCachePath).eql(testRootCachePath)
+    })
+
+    it('should use default cache size if not provided', () => {
+      const sut = new FsCache<string>({
+        addObjectToCacheDirectory: async (obj: string, dirPath: string) =>
+          Promise.resolve(),
+        objectToId: (obj: string) => '1',
+        rootCachePath: testRootCachePath,
+      })
+      expect(sut.maxCacheSize).eql(maxDefaultCacheSize)
+    })
+
+    it('should use provided cache size', () => {
+      const sut = new FsCache<string>({
+        addObjectToCacheDirectory: async (obj: string, dirPath: string) =>
+          Promise.resolve(),
+        maxCacheSize: 1000,
+        objectToId: (obj: string) => '1',
+        rootCachePath: testRootCachePath,
+      })
+      expect(sut.maxCacheSize).eql(1000)
+    })
+  })
+
+  describe('isInCache', () => {
+    it('should return false if object is not in cache', async () => {
+      const sut = new FsCache<string>({
+        addObjectToCacheDirectory: async (obj: string, dirPath: string) =>
+          Promise.resolve(),
+        objectToId: (obj: string) => obj,
+        rootCachePath: testRootCachePath,
+      })
+      const isAStringInCache = await sut.isInCache('AString')
+      expect(isAStringInCache).false
+    })
+
+    it('should return true if object is in cache', async () => {
+      const sut = new FsCache<string>({
+        addObjectToCacheDirectory: async (obj: string, dirPath: string) =>
+          Promise.resolve(),
+        objectToId: (obj: string) => obj,
+        rootCachePath: testRootCachePath,
+      })
+      await sut.addToCache('AString')
+      const isAStringInCache = await sut.isInCache('AString')
+      expect(isAStringInCache).true
+    })
+  })
+
+  describe('addToCache', () => {
+    it('should throw if object is already in cache', async () => {
+      const sut = new FsCache<string>({
+        addObjectToCacheDirectory: async (obj: string, dirPath: string) =>
+          Promise.resolve(),
+        objectToId: (obj: string) => obj,
+        rootCachePath: testRootCachePath,
+      })
+      await sut.addToCache('AString')
+      assert(await doesThrow(sut.addToCache, sut, 'AString'))
+    })
+
+    it('should add the object to the cache', async () => {
+      const sut = new FsCache<string>({
+        addObjectToCacheDirectory: async (obj: string, dirPath: string) =>
+          Promise.resolve(),
+        objectToId: (obj: string) => obj,
+        rootCachePath: testRootCachePath,
+      })
+      await sut.addToCache('AString')
+      assert(await sut.isInCache('AString'))
+    })
+
+    it('should remove least recently accessed object from cache once hitting max cache size', async () => {
+      const sut = new FsCache<string>({
+        addObjectToDirectory: async (obj: string, dirPath: string) => {
+          await writeFile(
+            path.join(dirPath, 'filename'),
+            _.fill(Array(500), 0).join('')
+          )
+        },
+        maxCacheSize: 1100,
+        objectToId: (obj: string) => obj,
+        rootCachePath: testRootCachePath,
+      })
+      await sut.addToCache('AString')
+      await sut.addToCache('AnotherString')
+      await sut.addToCache('YetAnoterString')
+      assert(await sut.isInCache('YetAnoterString'))
+      assert(!(await sut.isInCache('AnotherString')))
+      assert(!(await sut.isInCache('AString')))
+    })
+  })
+
+  describe('getObjectCachePath', () => {
+    it('should return path to cache directory containing object', async () => {
+      const sut = new FsCache<string>({
+        addObjectToCacheDirectory: async (obj: string, dirPath: string) =>
+          Promise.resolve(),
+        objectToId: (obj: string) => obj,
+        rootCachePath: testRootCachePath,
+      })
+      await sut.addToCache('AString')
+      const pathToObjectDirectoryCache = await sut.getObjectCachePath('AString')
+      expect(pathToObjectDirectoryCache).not.undefined
+    })
+
+    it('should return undefined if object is not in cache', async () => {
+      const sut = new FsCache<string>({
+        addObjectToCacheDirectory: async (obj: string, dirPath: string) =>
+          Promise.resolve(),
+        objectToId: (obj: string) => obj,
+        rootCachePath: testRootCachePath,
+      })
+      const pathToObjectDirectoryCache = await sut.getObjectCachePath('AString')
+      expect(pathToObjectDirectoryCache).undefined
+    })
+  })
+})

--- a/ern-local-cli/src/commands/platform/config.ts
+++ b/ern-local-cli/src/commands/platform/config.ts
@@ -31,6 +31,16 @@ const availableUserConfigKeys = [
     name: 'retain-tmp-dir',
     values: [true, false],
   },
+  {
+    desc: 'Enable package cache [EXPERIMENTAL]',
+    name: 'package-cache-enabled',
+    values: [true, false],
+  },
+  {
+    desc: 'Max package cache size in bytes',
+    name: 'max-package-cache-size',
+    values: ['number'],
+  },
 ]
 
 const userConfigSchemaString = () =>
@@ -61,8 +71,12 @@ export const handler = ({ key, value }: { key: string; value?: string }) => {
       )
     }
     if (value) {
-      const valueToset =
-        value === 'true' ? true : value === 'false' ? false : value
+      let valueToset: any = value
+      if (!isNaN(+value)) {
+        valueToset = +value
+      } else {
+        valueToset = value === 'true' ? true : value === 'false' ? false : value
+      }
 
       ernConfig.setValue(key, valueToset)
       log.info(`${key} set to ${ernConfig.getValue(key)}`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1964,6 +1964,10 @@ ftp@~0.3.10:
     readable-stream "1.1.x"
     xregexp "2.0.0"
 
+gar@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/gar/-/gar-1.0.3.tgz#cd6e954dff11821697a9ed5852c7ac5f18df02ce"
+
 gauge@~2.7.1, gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -1980,6 +1984,13 @@ gauge@~2.7.1, gauge@~2.7.3:
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
+
+get-folder-size@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-folder-size/-/get-folder-size-2.0.0.tgz#f0ecb4aa30ea855e051366714eaabcc41cf9d43f"
+  dependencies:
+    gar "^1.0.2"
+    tiny-each-async "2.0.3"
 
 get-func-name@^2.0.0:
   version "2.0.0"
@@ -5399,6 +5410,10 @@ timed-out@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
 
+tiny-each-async@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-each-async/-/tiny-each-async-2.0.3.tgz#8ebbbfd6d6295f1370003fbb37162afe5a0a51d1"
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -5701,7 +5716,7 @@ uuid@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
-uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
+uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0, uuid@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 


### PR DESCRIPTION
This PR introduces a simple caching mechanism to cache packages used during Container generation (MiniApps, APIs & APIs implementations, native modules).

As a baseline, for a big sample production Container, if not changing anything in the Container but just calling `cauldron regen-container`, time to generate a Container goes from ~10min to ~6min (~40% decrease). This is the ideal scenario, with all packages versions being cached. 

Speed gains decrease linearly with the number of non-cached packages versions.

The cache has a default size of 2GB (for this big sample production Container, all packages at a specific version represent ~1GB, so this leaves us room to cache a few different versions). The package cache max size is configurable through `platform config max-package-cache-size`. Once max cache size is exceeded, the least recently accessed package(s) will be removed from the cache until total cache size gets below max cache size.

The package cache is disabled by default, and still experimental, so not yet documented. It will be shipped in Electrode Native 0.21.0, battle tested internally and will be moved out of experimental phase and documented in Electrode Native 0.22.0 most probably.

Enabling the package cache can be done through `platform config package-cache-enabled true`.

The packages cache directory is located inside the `.ern` folder in `packages-cache`.

Most of Container Generation time is now spent for composite MiniApp generation and bundling. This is a little bit trickier to cache but possible. That being said, we won't really be able to decrease bundling speed (if we stick to Metro) as it is out of our control. But caching composite prior to bundling could add a few minutes gain, probably making our reference container generation from ~10min down to ~3-4min.