### PR TITLE
Fail code-push commands if there is no active cauldron

### DIFF
--- a/ern-local-cli/src/commands/code-push/patch.ts
+++ b/ern-local-cli/src/commands/code-push/patch.ts
@@ -63,6 +63,13 @@ export const handler = async ({
   rollout?: number
 }) => {
   try {
+    await utils.logErrorAndExitIfNotSatisfied({
+      cauldronIsActive: {
+        extraErrorMessage:
+          'A Cauldron must be active in order to use this command',
+      },
+    })
+
     if (!descriptor) {
       descriptor = await utils.askUserToChooseANapDescriptorFromCauldron({
         onlyReleasedVersions: true,

--- a/ern-local-cli/src/commands/code-push/promote.ts
+++ b/ern-local-cli/src/commands/code-push/promote.ts
@@ -112,6 +112,10 @@ export const handler = async ({
     let targetNapDescriptors
 
     await utils.logErrorAndExitIfNotSatisfied({
+      cauldronIsActive: {
+        extraErrorMessage:
+          'A Cauldron must be active in order to use this command',
+      },
       checkIfCodePushOptionsAreValid: {
         descriptors: targetDescriptors,
         semVerDescriptor: targetSemVerDescriptor,

--- a/ern-local-cli/src/commands/code-push/release.ts
+++ b/ern-local-cli/src/commands/code-push/release.ts
@@ -118,6 +118,10 @@ export const handler = async ({
     }
 
     await utils.logErrorAndExitIfNotSatisfied({
+      cauldronIsActive: {
+        extraErrorMessage:
+          'A Cauldron must be active in order to use this command',
+      },
       checkIfCodePushOptionsAreValid: {
         descriptors,
         semVerDescriptor,


### PR DESCRIPTION
To avoid this kind of cryptic error messages :

```
$ ern code-push patch -l v2 --deploymentName Production -r 10

[v0.20.0] [Cauldron: -NONE-]
An error occurred: Cannot read property 'getAllNativeApps' of undefined
```

```
$ ern code-push patch -l v2 --deploymentName Production -r 10 --descriptor test:android:3.7.0

[v0.20.0] [Cauldron: -NONE-]
✖ Cannot read property 'isDescriptorInCauldron' of undefined
An error occurred: Cannot read property 'isDescriptorInCauldron' of undefined
```