### PR TITLE
Reactivate Cauldron after system-tests or regen-fixtures

### DIFF
--- a/system-tests/regen-fixtures.js
+++ b/system-tests/regen-fixtures.js
@@ -2,85 +2,128 @@ const inquirer = require('inquirer')
 const shell = require('shelljs')
 const path = require('path')
 const f = require('./fixtures/constants')
+const cauldronRepoBeforeRun = require('./utils/getCurrentCauldron')()
 
 const regenFunctionByFixtureName = {
-  "android-container": regenAndroidContainerFixture,
-  "ios-container": regenIosContainerFixture,
-  "api-impl-js": regenApiImplJsFixture,
-  "api-impl-native": regenApiImplNativeFixture,
-  "ComplexApi": regenComplexApiFixture,
-  "TestApi": regenTestApiFixture
+  'android-container': regenAndroidContainerFixture,
+  'ios-container': regenIosContainerFixture,
+  'api-impl-js': regenApiImplJsFixture,
+  'api-impl-native': regenApiImplNativeFixture,
+  ComplexApi: regenComplexApiFixture,
+  TestApi: regenTestApiFixture,
 }
 
 const rootFixturesPath = path.join(__dirname, 'fixtures')
 const rootApiFixturesPath = path.join(rootFixturesPath, 'api')
 const pathsToFixtures = {
-  "android-container": path.join(rootFixturesPath, 'android-container'),
-  "ios-container": path.join(rootFixturesPath, 'ios-container'),
-  "api-impl-js": path.join(rootFixturesPath, 'api-impl-js'),
-  "api-impl-native": path.join(rootFixturesPath, 'api-impl-native'),
-  "ComplexApi": path.join(rootApiFixturesPath, 'ComplexApi'),
-  "TestApi": path.join(rootApiFixturesPath, 'TestApi')
+  'android-container': path.join(rootFixturesPath, 'android-container'),
+  'ios-container': path.join(rootFixturesPath, 'ios-container'),
+  'api-impl-js': path.join(rootFixturesPath, 'api-impl-js'),
+  'api-impl-native': path.join(rootFixturesPath, 'api-impl-native'),
+  ComplexApi: path.join(rootApiFixturesPath, 'ComplexApi'),
+  TestApi: path.join(rootApiFixturesPath, 'TestApi'),
 }
 
-inquirer.prompt([{
-  type: 'checkbox',
-  name: 'userSelectedFixturesToRegen',
-  message: 'Choose one or more system test fixture(s) to regenerate',
-  choices: Object.keys(regenFunctionByFixtureName)
-}]).then(answers => {
-  shell.exec(`ern platform config logLevel trace`)
-  shell.exec(`ern cauldron repo clear`)
-  for (const userSelectedFixtureToRegen of answers.userSelectedFixturesToRegen) {
-    regenFunctionByFixtureName[userSelectedFixtureToRegen]()
-  }
-})
+inquirer
+  .prompt([
+    {
+      type: 'checkbox',
+      name: 'userSelectedFixturesToRegen',
+      message: 'Choose one or more system test fixture(s) to regenerate',
+      choices: Object.keys(regenFunctionByFixtureName),
+    },
+  ])
+  .then(answers => {
+    shell.exec(`ern platform config logLevel trace`)
+    shell.exec(`ern cauldron repo clear`)
+    try {
+      for (const userSelectedFixtureToRegen of answers.userSelectedFixturesToRegen) {
+        regenFunctionByFixtureName[userSelectedFixtureToRegen]()
+      }
+    } finally {
+      if (cauldronRepoBeforeRun) {
+        shell.exec(`ern cauldron repo use ${cauldronRepoBeforeRun}`)
+      }
+    }
+  })
 
 const containerMiniapps = [
   `${f.movieListMiniAppPgkName}@${f.movieListMiniAppPkgVersion}`,
-  `${f.movieDetailsMiniAppPkgName}@${f.movieDetailsMiniAppPkgVersion}`
+  `${f.movieDetailsMiniAppPkgName}@${f.movieDetailsMiniAppPkgVersion}`,
 ]
 
 function regenAndroidContainerFixture() {
-  logHeader("Regenerating Android Container Fixture")
+  logHeader('Regenerating Android Container Fixture')
   shell.rm('-rf', pathsToFixtures['android-container'])
-  shell.exec(`ern create-container --miniapps ${containerMiniapps.join(' ')} -p android --dependencies react-native-code-push@5.2.1 --out ${pathsToFixtures['android-container']}`)
+  shell.exec(
+    `ern create-container --miniapps ${containerMiniapps.join(
+      ' '
+    )} -p android --dependencies react-native-code-push@5.2.1 --out ${
+      pathsToFixtures['android-container']
+    }`
+  )
 }
 
 function regenIosContainerFixture() {
-  logHeader("Regenerating iOS Container Fixture")
+  logHeader('Regenerating iOS Container Fixture')
   shell.rm('-rf', pathsToFixtures['ios-container'])
-  shell.exec(`ern create-container --miniapps ${containerMiniapps.join(' ')} -p ios --dependencies react-native-code-push@5.2.1 --out ${pathsToFixtures['ios-container']}`)
+  shell.exec(
+    `ern create-container --miniapps ${containerMiniapps.join(
+      ' '
+    )} -p ios --dependencies react-native-code-push@5.2.1 --out ${
+      pathsToFixtures['ios-container']
+    }`
+  )
 }
 
 function regenApiImplJsFixture() {
-  logHeader("Regenerating JS API Implementation Fixture")
+  logHeader('Regenerating JS API Implementation Fixture')
   shell.rm('-rf', pathsToFixtures['api-impl-js'])
-  shell.exec(`ern create-api-impl ${f.movieApiPkgName} -p ${f.movieApiImplPkgName} --skipNpmCheck --jsOnly --outputDirectory ${pathsToFixtures['api-impl-js']} --force`)
+  shell.exec(
+    `ern create-api-impl ${f.movieApiPkgName} -p ${
+      f.movieApiImplPkgName
+    } --skipNpmCheck --jsOnly --outputDirectory ${
+      pathsToFixtures['api-impl-js']
+    } --force`
+  )
 }
 
 function regenApiImplNativeFixture() {
-  logHeader("Regenerating Native API Implementation Fixture")
+  logHeader('Regenerating Native API Implementation Fixture')
   shell.rm('-rf', pathsToFixtures['api-impl-native'])
-  shell.exec(`ern create-api-impl ${f.movieApiPkgName} -p ${f.movieApiImplPkgName} --skipNpmCheck --nativeOnly --outputDirectory ${pathsToFixtures['api-impl-native']} --force`)
+  shell.exec(
+    `ern create-api-impl ${f.movieApiPkgName} -p ${
+      f.movieApiImplPkgName
+    } --skipNpmCheck --nativeOnly --outputDirectory ${
+      pathsToFixtures['api-impl-native']
+    } --force`
+  )
 }
 
 function regenComplexApiFixture() {
-  logHeader("Regenerating Complex API Fixture")
+  logHeader('Regenerating Complex API Fixture')
   shell.rm('-rf', pathsToFixtures['ComplexApi'])
   shell.cd(rootApiFixturesPath)
-  shell.exec(`ern create-api ${f.complexApiName} -p ${f.testApiPkgName}  --schemaPath ${f.pathToComplexApiSchema} --skipNpmCheck`)
+  shell.exec(
+    `ern create-api ${f.complexApiName} -p ${f.testApiPkgName}  --schemaPath ${
+      f.pathToComplexApiSchema
+    } --skipNpmCheck`
+  )
 }
 
 function regenTestApiFixture() {
-  logHeader("Regenerating Test API Fixture")
+  logHeader('Regenerating Test API Fixture')
   shell.rm('-rf', pathsToFixtures['TestApi'])
   shell.cd(rootApiFixturesPath)
-  shell.exec(`ern create-api ${f.testApiName} -p ${f.testApiPkgName} --schemaPath ${f.pathToTestApiSchema} --skipNpmCheck`)
+  shell.exec(
+    `ern create-api ${f.testApiName} -p ${f.testApiPkgName} --schemaPath ${
+      f.pathToTestApiSchema
+    } --skipNpmCheck`
+  )
 }
 
 function logHeader(message) {
-  console.log("======================================================")
+  console.log('======================================================')
   console.log(message)
-  console.log("======================================================")
+  console.log('======================================================')
 }

--- a/system-tests/system-tests.js
+++ b/system-tests/system-tests.js
@@ -3,29 +3,36 @@ const path = require('path')
 const tmp = require('tmp')
 const inquirer = require('inquirer')
 const run = require('./utils/run')
+const cauldronRepoBeforeRun = require('./utils/getCurrentCauldron')()
 
 const runAll = process.argv.includes('--all')
 
 const pathToSystemTests = path.join(__dirname, 'tests')
 const testsSourceFiles = fs.readdirSync(pathToSystemTests)
 
-if (runAll) {
-  runAllTests()
-} else {
-  inquirer
-    .prompt([
-      {
-        type: 'checkbox',
-        name: 'userSelectedTests',
-        message: 'Choose one or more tests to run',
-        choices: testsSourceFiles,
-      },
-    ])
-    .then(answers => {
-      for (const userSelectedTestSourceFile of answers.userSelectedTests) {
-        runTest(userSelectedTestSourceFile)
-      }
-    })
+try {
+  if (runAll) {
+    runAllTests()
+  } else {
+    inquirer
+      .prompt([
+        {
+          type: 'checkbox',
+          name: 'userSelectedTests',
+          message: 'Choose one or more tests to run',
+          choices: testsSourceFiles,
+        },
+      ])
+      .then(answers => {
+        for (const userSelectedTestSourceFile of answers.userSelectedTests) {
+          runTest(userSelectedTestSourceFile)
+        }
+      })
+  }
+} finally {
+  if (cauldronRepoBeforeRun) {
+    run('ern cauldron repo use ${cauldronRepoBeforeRun}')
+  }
 }
 
 function runAllTests() {

--- a/system-tests/utils/getCurrentCauldron.js
+++ b/system-tests/utils/getCurrentCauldron.js
@@ -1,0 +1,10 @@
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+module.exports = function() {
+  const ERN_PATH = process.env['ERN_HOME'] || path.join(os.homedir(), '.ern')
+  const ERN_RC_PATH = path.join(ERN_PATH, '.ernrc')
+  const ernRc = JSON.parse(fs.readFileSync(ERN_RC_PATH))
+  return ernRc.cauldronRepoInUse
+}


### PR DESCRIPTION
Ensure that the Cauldron that was active (if any) prior to running `regen-fixtures` or `system-tests`, is properly reactivated after run.