### PR TITLE
Add ernVersion to Container Publisher config

### DIFF
--- a/ern-container-publisher-git/src/index.ts
+++ b/ern-container-publisher-git/src/index.ts
@@ -1,7 +1,4 @@
-import {
-  ContainerPublisher,
-  ContainerPublisherConfig,
-} from 'ern-container-publisher'
+import { ContainerPublisher } from 'ern-container-publisher'
 import { createTmpDir, gitCli, shell, log, NativePlatform } from 'ern-core'
 import path from 'path'
 

--- a/ern-container-publisher-jcenter/src/index.ts
+++ b/ern-container-publisher-jcenter/src/index.ts
@@ -1,7 +1,4 @@
-import {
-  ContainerPublisher,
-  ContainerPublisherConfig,
-} from 'ern-container-publisher'
+import { ContainerPublisher } from 'ern-container-publisher'
 import {
   createTmpDir,
   shell,

--- a/ern-container-publisher-maven/src/index.ts
+++ b/ern-container-publisher-maven/src/index.ts
@@ -1,7 +1,4 @@
-import {
-  ContainerPublisher,
-  ContainerPublisherConfig,
-} from 'ern-container-publisher'
+import { ContainerPublisher } from 'ern-container-publisher'
 import { MavenUtils, shell, childProcess, log, NativePlatform } from 'ern-core'
 import fs from 'fs'
 import path from 'path'

--- a/ern-container-publisher/src/publishContainer.ts
+++ b/ern-container-publisher/src/publishContainer.ts
@@ -30,6 +30,7 @@ export default async function publishContainer(conf: ContainerPublisherConfig) {
     publicationWorkingDir
   )
   conf.containerPath = publicationWorkingDir
+  conf.ernVersion = Platform.currentVersion
 
   if (!fs.existsSync(Platform.containerPublishersCacheDirectory)) {
     shell.mkdir('-p', Platform.containerPublishersCacheDirectory)

--- a/ern-container-publisher/src/types/ContainerPublisherConfig.ts
+++ b/ern-container-publisher/src/types/ContainerPublisherConfig.ts
@@ -23,6 +23,10 @@ export interface ContainerPublisherConfig {
    */
   containerVersion: string
   /**
+   * Version of Electrode Native used
+   */
+  ernVersion?: string
+  /**
    * Option url to publish the container to.
    * Specific to the publisher type
    */


### PR DESCRIPTION
Add `ernVersion` to `ContainerPublisherConfig` type.
This way, publishers modules can know the version of Electrode Native in use and react accordingly if they don't support the version, or need to handle things differently based on the version of Electrode Native.

Also cleanup some unused imports.
