### PR TITLE
Improve Git file store

### DIFF
--- a/ern-cauldron-api/src/CauldronApi.ts
+++ b/ern-cauldron-api/src/CauldronApi.ts
@@ -19,20 +19,23 @@ const yarnLocksStoreDirectory = 'yarnlocks'
 const bundlesStoreDirectory = 'bundles'
 
 export default class CauldronApi {
-  private readonly db: ICauldronDocumentStore
+  private readonly documentStore: ICauldronDocumentStore
   private readonly fileStore: ICauldronFileStore
 
-  constructor(db: ICauldronDocumentStore, fileStore: ICauldronFileStore) {
-    this.db = db
+  constructor(
+    documentStore: ICauldronDocumentStore,
+    fileStore: ICauldronFileStore
+  ) {
+    this.documentStore = documentStore
     this.fileStore = fileStore
   }
 
   public async commit(message: string): Promise<void> {
-    return this.db.commit(message)
+    return this.documentStore.commit(message)
   }
 
   public async getCauldron(): Promise<Cauldron> {
-    return this.db.getCauldron()
+    return this.documentStore.getCauldron()
   }
 
   // =====================================================================================
@@ -63,17 +66,17 @@ export default class CauldronApi {
   // =====================================================================================
 
   public async beginTransaction(): Promise<void> {
-    await this.db.beginTransaction()
+    await this.documentStore.beginTransaction()
     await this.fileStore.beginTransaction()
   }
 
   public async discardTransaction(): Promise<void> {
-    await this.db.discardTransaction()
+    await this.documentStore.discardTransaction()
     await this.fileStore.discardTransaction()
   }
 
   public async commitTransaction(message: string | string[]): Promise<void> {
-    await this.db.commitTransaction(message)
+    await this.documentStore.commitTransaction(message)
     await this.fileStore.commitTransaction(message)
   }
 

--- a/ern-cauldron-api/src/CauldronApi.ts
+++ b/ern-cauldron-api/src/CauldronApi.ts
@@ -16,18 +16,15 @@ import upgradeScripts from './upgrade-scripts/scripts'
 
 export default class CauldronApi {
   private readonly db: ICauldronDocumentStore
-  private readonly sourceMapStore: ICauldronFileStore
   private readonly yarnlockStore: ICauldronFileStore
   private readonly bundleStore: ICauldronFileStore
 
   constructor(
     db: ICauldronDocumentStore,
-    sourcemapStore: ICauldronFileStore,
     yarnlockStore: ICauldronFileStore,
     bundleStore: ICauldronFileStore
   ) {
     this.db = db
-    this.sourceMapStore = sourcemapStore
     this.yarnlockStore = yarnlockStore
     this.bundleStore = bundleStore
   }

--- a/ern-cauldron-api/src/CauldronApiFactory.ts
+++ b/ern-cauldron-api/src/CauldronApiFactory.ts
@@ -16,10 +16,10 @@ export function defaultCauldron({
     cauldronPath,
     repository,
   })
-  const dbStore = new GitDocumentStore({
+  const documentStore = new GitDocumentStore({
     branch,
     cauldronPath,
     repository,
   })
-  return new CauldronApi(dbStore, fileStore)
+  return new CauldronApi(documentStore, fileStore)
 }

--- a/ern-cauldron-api/src/CauldronApiFactory.ts
+++ b/ern-cauldron-api/src/CauldronApiFactory.ts
@@ -11,16 +11,9 @@ export function defaultCauldron({
   cauldronPath: string
   branch: string
 }) {
-  const yarnlockStore = new GitFileStore({
+  const fileStore = new GitFileStore({
     branch,
     cauldronPath,
-    prefix: 'yarnlocks',
-    repository,
-  })
-  const bundleStore = new GitFileStore({
-    branch,
-    cauldronPath,
-    prefix: 'bundles',
     repository,
   })
   const dbStore = new GitDocumentStore({
@@ -28,5 +21,5 @@ export function defaultCauldron({
     cauldronPath,
     repository,
   })
-  return new CauldronApi(dbStore, yarnlockStore, bundleStore)
+  return new CauldronApi(dbStore, fileStore)
 }

--- a/ern-cauldron-api/src/CauldronApiFactory.ts
+++ b/ern-cauldron-api/src/CauldronApiFactory.ts
@@ -11,12 +11,6 @@ export function defaultCauldron({
   cauldronPath: string
   branch: string
 }) {
-  const sourcemapStore = new GitFileStore({
-    branch,
-    cauldronPath,
-    prefix: 'sourcemaps',
-    repository,
-  })
   const yarnlockStore = new GitFileStore({
     branch,
     cauldronPath,
@@ -34,5 +28,5 @@ export function defaultCauldron({
     cauldronPath,
     repository,
   })
-  return new CauldronApi(dbStore, sourcemapStore, yarnlockStore, bundleStore)
+  return new CauldronApi(dbStore, yarnlockStore, bundleStore)
 }

--- a/ern-cauldron-api/src/EphemeralFileStore.ts
+++ b/ern-cauldron-api/src/EphemeralFileStore.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import { ICauldronFileStore } from './types'
 import { createTmpDir } from 'ern-core'
+import shell from 'shelljs'
 
 export default class EphemeralFileStore implements ICauldronFileStore {
   public readonly storePath: string
@@ -23,6 +24,10 @@ export default class EphemeralFileStore implements ICauldronFileStore {
 
   public async storeFile(identifier: string, content: string | Buffer) {
     const pathToFile = path.join(this.storePath, identifier)
+    const pathToDir = path.dirname(pathToFile)
+    if (!fs.existsSync(pathToDir)) {
+      shell.mkdir('-p', pathToDir)
+    }
     fs.writeFileSync(pathToFile, content, 'utf8')
     return Promise.resolve()
   }

--- a/ern-cauldron-api/test/CauldronApi-test.ts
+++ b/ern-cauldron-api/test/CauldronApi-test.ts
@@ -25,20 +25,14 @@ const codePushNewEntryFixture: CauldronCodePushEntry = {
 }
 
 let documentStore
-let yarnLockStore
+let fileStore
 
 function cauldronApi(cauldronDocument?: any) {
   cauldronDocument = cauldronDocument || getCauldronFixtureClone()
   documentStore = new InMemoryDocumentStore(cauldronDocument)
-  const sourceMapStore = new EphemeralFileStore()
-  yarnLockStore = new EphemeralFileStore()
-  const bundleStore = new EphemeralFileStore()
-  return new CauldronApi(
-    documentStore,
-    sourceMapStore,
-    yarnLockStore,
-    bundleStore
-  )
+  fileStore = new EphemeralFileStore()
+
+  return new CauldronApi(documentStore, fileStore)
 }
 
 function getCauldronFixtureClone() {
@@ -113,12 +107,9 @@ describe('CauldronApi.js', () => {
       sinon.assert.calledOnce(beginTransactionStub)
     })
 
-    it('should call beginTransaction on the yarn lock store', async () => {
+    it('should call beginTransaction on the file store', async () => {
       const api = cauldronApi()
-      const beginTransactionStub = sandbox.stub(
-        yarnLockStore,
-        'beginTransaction'
-      )
+      const beginTransactionStub = sandbox.stub(fileStore, 'beginTransaction')
       await api.beginTransaction()
       sinon.assert.calledOnce(beginTransactionStub)
     })
@@ -138,10 +129,10 @@ describe('CauldronApi.js', () => {
       sinon.assert.calledOnce(discardTransactionStub)
     })
 
-    it('should call discardTransaction on the yarn lock store', async () => {
+    it('should call discardTransaction on the file store', async () => {
       const api = cauldronApi()
       const discardTransactionStub = sandbox.stub(
-        yarnLockStore,
+        fileStore,
         'discardTransaction'
       )
       await api.discardTransaction()
@@ -173,22 +164,16 @@ describe('CauldronApi.js', () => {
       sinon.assert.calledWith(commitTransactionStub, 'commit-message')
     })
 
-    it('should call commitTransaction on the yarn lock store ', async () => {
+    it('should call commitTransaction on the file store ', async () => {
       const api = cauldronApi()
-      const commitTransactionStub = sandbox.stub(
-        yarnLockStore,
-        'commitTransaction'
-      )
+      const commitTransactionStub = sandbox.stub(fileStore, 'commitTransaction')
       await api.commitTransaction('commit-message')
       sinon.assert.calledOnce(commitTransactionStub)
     })
 
-    it('should call commitTransaction on the yarn lock store with the right commit message', async () => {
+    it('should call commitTransaction on the file store with the right commit message', async () => {
       const api = cauldronApi()
-      const commitTransactionStub = sandbox.stub(
-        yarnLockStore,
-        'commitTransaction'
-      )
+      const commitTransactionStub = sandbox.stub(fileStore, 'commitTransaction')
       await api.commitTransaction('commit-message')
       sinon.assert.calledWith(commitTransactionStub, 'commit-message')
     })

--- a/ern-cauldron-api/test/CauldronHelper-test.ts
+++ b/ern-cauldron-api/test/CauldronHelper-test.ts
@@ -39,19 +39,12 @@ const miniAppsFixtureOne = [
 ]
 
 let documentStore
-let bundleStore
+let fileStore
 
 function createCauldronApi(cauldronDocument) {
   documentStore = new InMemoryDocumentStore(cauldronDocument)
-  const sourceMapStore = new EphemeralFileStore()
-  const yarnLockStore = new EphemeralFileStore()
-  bundleStore = new EphemeralFileStore()
-  return new CauldronApi(
-    documentStore,
-    sourceMapStore,
-    yarnLockStore,
-    bundleStore
-  )
+  fileStore = new EphemeralFileStore()
+  return new CauldronApi(documentStore, fileStore)
 }
 
 function createCauldronHelper(cauldronDocument) {
@@ -1222,7 +1215,9 @@ describe('CauldronHelper.js', () => {
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         'bundleContent'
       )
-      const bundledAdded = await bundleStore.hasFile('test:android:17.7.0.zip')
+      const bundledAdded = await fileStore.hasFile(
+        'bundles/test:android:17.7.0.zip'
+      )
       expect(bundledAdded).true
     })
   })


### PR DESCRIPTION
Instead of having to work with multiple `GitFileStore` instances, one for each top level directory (`yarnlocks`, `bundles` ..), only keep a single `GitFileStore`, not bound to a specific directory.

This makes things leaner, easier and more flexible as there is no more need to update the `ern-cauldron-api` module to add a new file store directory to Cauldron. 

Before this change, if a new store directory was needed in Cauldron, one would need to instantiate a new `GitFileStore` and update the constructor of `CauldronApi` to pass this file store. Also would need some work in `CauldronApi` class.

For now there is no methods exposed on `CauldronApi` class to create and access arbitrary store directories. This work will be done in a different PR.

This refactoring and subsequent work around Cauldron file store is needed to enable proper implementation of Electrode Native Container Transformers.

Also part of this refactoring is the renaming of `dbStore` to `documentStore` for naming consistency.