### PR TITLE
Allow config from file for publish-container command

### DIFF
--- a/docs/cli/publish-container.md
+++ b/docs/cli/publish-container.md
@@ -47,6 +47,8 @@
 
 * Extra configuration specific to the publisher used.
 * Some publishers might not need an extra configuration. Check the Container publisher documentation for reference.
+* The configuration is a json document.
+* Configuration can either be a json string or the path to a file holding the configuration.
 
 #### Related commands
 

--- a/ern-local-cli/src/commands/publish-container.ts
+++ b/ern-local-cli/src/commands/publish-container.ts
@@ -1,4 +1,9 @@
-import { utils as coreUtils, Platform, NativePlatform } from 'ern-core'
+import {
+  utils as coreUtils,
+  Platform,
+  NativePlatform,
+  fileUtils,
+} from 'ern-core'
 import { publishContainer } from 'ern-container-publisher'
 import utils from '../lib/utils'
 import fs from 'fs'
@@ -40,7 +45,8 @@ export const builder = (argv: Argv) => {
     })
     .option('config', {
       alias: 'c',
-      describe: 'Optional publisher configuration (as a JSON string)',
+      describe:
+        'Optional publisher configuration (json string or path to config file)',
       type: 'string',
     })
     .epilog(utils.epilog(exports))
@@ -75,15 +81,18 @@ export const handler = async ({
       )
     }
 
-    // Container path validation
     if (!fs.existsSync(containerPath)) {
       throw new Error('containerPath path does not exist')
     }
 
-    // JSON config validation
+    let configObj
     if (config) {
       try {
-        JSON.parse(config)
+        if (fs.existsSync(config)) {
+          configObj = await fileUtils.readJSON(config)
+        } else {
+          configObj = JSON.parse(config)
+        }
       } catch (e) {
         throw new Error('config should be valid JSON')
       }
@@ -92,7 +101,7 @@ export const handler = async ({
     await publishContainer({
       containerPath,
       containerVersion: version,
-      extra: config ? JSON.parse(config) : undefined,
+      extra: configObj,
       platform,
       publisher,
       url,


### PR DESCRIPTION
Allow `--config/-c` value to be the path to a json file holding the publisher configuration.
Given that publishers configuration are relatively light -as of current publishers-, this is not really needed. 

That being said, the `transform-container` upcoming command will be very similar in term of options to the `publish-container` command, and transformers config can be quite large, making it more convenient to be stored in a file rather than provided on the command line. If the config of `transform-container` can be provided as a file, so should the config of `publish-container`, for command options consistency.
