### PR TITLE
Introduce ern-container-transformer package

### DIFF
--- a/ern-container-transformer/.npmignore
+++ b/ern-container-transformer/.npmignore
@@ -1,0 +1,6 @@
+src
+.coverage
+.nyc_output
+test
+tsconfig.release.json
+yarn.lock

--- a/ern-container-transformer/README.md
+++ b/ern-container-transformer/README.md
@@ -1,0 +1,3 @@
+# Electrode Native Container Transformer
+
+This package can be used to transform Electrode Native Containers using a specific transformer.

--- a/ern-container-transformer/package.json
+++ b/ern-container-transformer/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "ern-container-transformer",
+  "version": "1000.0.0",
+  "description": "Electrode Native Container Transformer",
+  "main": "./dist/index.js",
+  "homepage": "http://www.electrode.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/electrode-io/electrode-native.git"
+  },
+  "bugs": {
+    "url": "https://github.com/electrode-io/electrode-native/issues"
+  },
+  "keywords": [
+    "electrode",
+    "ern",
+    "react-native",
+    "trasnformer",
+    "container",
+    "node",
+    "android",
+    "ios"
+  ],
+  "contributors": [
+    {
+      "name": "Benoit Lemaire",
+      "email": "blemaire@walmartlabs.com"
+    },
+    {
+      "name": "Bharath Marulasiddappa",
+      "email": "BMarulasiddappa@walmartlabs.com"
+    },
+    {
+      "name": "Deepu Ganapathiyadan",
+      "email": "DGanapathiyadan@walmartlabs.com"
+    },
+    {
+      "name": "Krunal Shah",
+      "email": "KShah1@walmartlabs.com"
+    }
+  ],
+  "scripts": {
+    "build": "ern-typescript",
+    "test": "ern-mocha",
+    "coverage": "ern-nyc",
+    "prepublish": "yarn run build"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "ern-core": "1000.0.0"
+  },
+  "devDependencies": {
+    "ern-util-dev": "1000.0.0"
+  },
+  "engines": {
+    "node": ">=6"
+  }
+}

--- a/ern-container-transformer/src/getTransformer.ts
+++ b/ern-container-transformer/src/getTransformer.ts
@@ -1,0 +1,43 @@
+import { PackagePath, Platform, shell, yarn } from 'ern-core'
+import { ContainerTransformer } from './types'
+import fs from 'fs'
+import path from 'path'
+
+const ERN_TRANSFORMER_PACKAGE_PREFIX = 'ern-container-transformer-'
+const REGISTRY_PATH_VERSION_RE = new RegExp(/^(.+)@(.+)$/)
+
+export default async function getTransformer(
+  transformer: string
+): Promise<ContainerTransformer> {
+  let pathToTransformerEntry
+  if (fs.existsSync(transformer)) {
+    const pathWithSrc = path.join(transformer, 'src')
+    pathToTransformerEntry = fs.existsSync(pathWithSrc)
+      ? pathWithSrc
+      : transformer
+  } else {
+    try {
+      shell.pushd(Platform.containerTransformersCacheDirectory)
+      if (
+        !transformer.startsWith('@') &&
+        !transformer.startsWith(ERN_TRANSFORMER_PACKAGE_PREFIX)
+      ) {
+        transformer = `${ERN_TRANSFORMER_PACKAGE_PREFIX}${transformer}`
+      }
+      await yarn.add(PackagePath.fromString(transformer))
+      const pkgName = REGISTRY_PATH_VERSION_RE.test(transformer)
+        ? REGISTRY_PATH_VERSION_RE.exec(transformer)![1]
+        : transformer
+      pathToTransformerEntry = path.join(
+        Platform.containerTransformersCacheDirectory,
+        'node_modules',
+        pkgName
+      )
+    } finally {
+      shell.popd()
+    }
+  }
+
+  const Transformer = require(pathToTransformerEntry).default
+  return new Transformer()
+}

--- a/ern-container-transformer/src/index.ts
+++ b/ern-container-transformer/src/index.ts
@@ -1,0 +1,6 @@
+import _transformContainer from './transformContainer'
+import _getTransformer from './getTransformer'
+
+export const transformContainer = _transformContainer
+export const getTransformer = _getTransformer
+export { ContainerTransformer, ContainerTransformerConfig } from './types'

--- a/ern-container-transformer/src/transformContainer.ts
+++ b/ern-container-transformer/src/transformContainer.ts
@@ -1,0 +1,32 @@
+import { ContainerTransformerConfig } from './types'
+import getTransformer from './getTransformer'
+import { createTmpDir, shell, Platform, yarn } from 'ern-core'
+import fs from 'fs'
+import path from 'path'
+
+export default async function transformContainer(
+  conf: ContainerTransformerConfig
+) {
+  conf.ernVersion = Platform.currentVersion
+
+  if (!fs.existsSync(Platform.containerTransformersCacheDirectory)) {
+    shell.mkdir('-p', Platform.containerTransformersCacheDirectory)
+    try {
+      shell.pushd(Platform.containerTransformersCacheDirectory)
+      await yarn.init()
+    } finally {
+      shell.popd()
+    }
+  }
+
+  const transformer = await getTransformer(conf.transformer)
+
+  if (!transformer.platforms.includes(conf.platform)) {
+    throw new Error(
+      `The ${transformer.name} transformer does not support transformation of ${
+        conf.platform
+      } Containers`
+    )
+  }
+  return transformer.transform(conf)
+}

--- a/ern-container-transformer/src/types/ContainerTransformer.ts
+++ b/ern-container-transformer/src/types/ContainerTransformer.ts
@@ -1,0 +1,18 @@
+import { NativePlatform } from 'ern-core'
+import { ContainerTransformerConfig } from './ContainerTransformerConfig'
+
+export interface ContainerTransformer {
+  /**
+   * Name of the Container publisher
+   */
+  readonly name: string
+  /**
+   * An array of one or more native platform(s)
+   * that the Container transformer supports
+   */
+  readonly platforms: NativePlatform[]
+  /**
+   * Transform a Container
+   */
+  transform(config: ContainerTransformerConfig): Promise<void>
+}

--- a/ern-container-transformer/src/types/ContainerTransformerConfig.ts
+++ b/ern-container-transformer/src/types/ContainerTransformerConfig.ts
@@ -1,0 +1,30 @@
+export interface ContainerTransformerConfig {
+  /**
+   * The transformer to use
+   * Can either be
+   * - An absolute path to the directory containing the transformer
+   * package (mostly to be used for transformer development and testing)
+   * - The transformer package to be retrieved from npm registry.
+   * In case of a package from a registry  :
+   * - If version is omitted, the latest version will be used
+   * - If version is specified, the exact version will be used
+   */
+  transformer: string
+  /**
+   * Local file system path to the generated Container to transform
+   */
+  containerPath: string
+  /**
+   * The platform of the Container to transform
+   */
+  platform: 'android' | 'ios'
+  /**
+   * Version of Electrode Native used
+   */
+  ernVersion?: string
+  /**
+   * Optional extra configuration.
+   * Specific to the transformer
+   */
+  extra?: any
+}

--- a/ern-container-transformer/src/types/index.ts
+++ b/ern-container-transformer/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from './ContainerTransformer'
+export * from './ContainerTransformerConfig'

--- a/ern-container-transformer/tsconfig.release.json
+++ b/ern-container-transformer/tsconfig.release.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.release.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "dist"
+  },
+  "include": ["**/*"],
+  "exclude": ["node_modules", "**/*.spec.ts", "test", "dist"]
+}

--- a/ern-core/src/Platform.ts
+++ b/ern-core/src/Platform.ts
@@ -45,6 +45,10 @@ export default class Platform {
     return path.join(this.rootDirectory, 'container-publishers-cache')
   }
 
+  static get containerTransformersCacheDirectory(): string {
+    return path.join(this.rootDirectory, 'container-transformers-cache')
+  }
+
   static get containerGenDirectory(): string {
     return path.join(this.rootDirectory, 'containergen')
   }


### PR DESCRIPTION
Very similar approach and code as for `ern-container-publisher`.

Will generalize most of the code of these two packages through refactoring at some point.

There is only one transformer currently available (in dev only, not published to npm yet) : the [iOS Build Config Transformer](https://github.com/electrode-io/ern-container-transformer-build-config)

Potential transformers to follow : Script / iOS Project.
Also might have some transformers for Android Containers at some point (to patch dependencies versions, or other utilities).

`transform-container` command will be introduced in a different PR.
Same goes for Cauldron support.