### PR TITLE
Whitelist codePushAccessKey as a valid config key

### DIFF
--- a/ern-local-cli/src/commands/platform/config.ts
+++ b/ern-local-cli/src/commands/platform/config.ts
@@ -41,6 +41,11 @@ const availableUserConfigKeys = [
     name: 'max-package-cache-size',
     values: ['number'],
   },
+  {
+    desc: 'Code push access key associated with your account',
+    name: 'codePushAccessKey',
+    values: ['string'],
+  },
 ]
 
 const userConfigSchemaString = () =>


### PR DESCRIPTION
whitelist codePushAccessKey as a valid config

`ern platform config codePushAccessKey YOUR_CODE_PUSH_ACCESS_KEY` results in 
```An error occurred: Configuration key codePushAccessKey does not exists. Did you mean logLevel ?```