### PR TITLE
Update publisher and transformer extra config option name

### DIFF
--- a/ern-local-cli/src/commands/cauldron/add/publisher.ts
+++ b/ern-local-cli/src/commands/cauldron/add/publisher.ts
@@ -1,14 +1,8 @@
-import {
-  NativeApplicationDescriptor,
-  utils as coreUtils,
-  log,
-  fileUtils,
-} from 'ern-core'
+import { NativeApplicationDescriptor, utils as coreUtils, log } from 'ern-core'
 import { getActiveCauldron } from 'ern-cauldron-api'
 import { getPublisher, ContainerPublisher } from 'ern-container-publisher'
 import utils from '../../../lib/utils'
 import { Argv } from 'yargs'
-import fs from 'fs'
 
 export const command = 'publisher'
 export const desc = 'Add a Container publisher for a native application'
@@ -49,7 +43,7 @@ export const handler = async ({
   publisher: string
   descriptor: string
   url?: string
-  extra?: any
+  extra?: string
 }) => {
   try {
     await utils.logErrorAndExitIfNotSatisfied({
@@ -59,18 +53,7 @@ export const handler = async ({
       },
     })
 
-    let extraObj
-    if (extra) {
-      try {
-        if (fs.existsSync(extra)) {
-          extraObj = await fileUtils.readJSON(extra)
-        } else {
-          extraObj = JSON.parse(extra)
-        }
-      } catch (e) {
-        throw new Error('config should be valid JSON')
-      }
-    }
+    const extraObj = extra && (await utils.parseJsonFromStringOrFile(extra))
 
     const p: ContainerPublisher = await getPublisher(publisher)
 

--- a/ern-local-cli/src/commands/publish-container.ts
+++ b/ern-local-cli/src/commands/publish-container.ts
@@ -8,7 +8,6 @@ import { publishContainer } from 'ern-container-publisher'
 import utils from '../lib/utils'
 import fs from 'fs'
 import path from 'path'
-import os from 'os'
 import { Argv } from 'yargs'
 
 export const command = 'publish-container'
@@ -43,10 +42,10 @@ export const builder = (argv: Argv) => {
       describe: 'The publication url',
       type: 'string',
     })
-    .option('config', {
-      alias: 'c',
+    .option('extra', {
+      alias: 'e',
       describe:
-        'Optional publisher configuration (json string or path to config file)',
+        'Optional extra publisher configuration (json string or path to config file)',
       type: 'string',
     })
     .epilog(utils.epilog(exports))
@@ -57,14 +56,14 @@ export const handler = async ({
   version,
   publisher,
   url,
-  config,
+  extra,
   platform,
 }: {
   containerPath?: string
   version: string
   publisher: string
   url: string
-  config?: string
+  extra?: string
   platform: NativePlatform
 }) => {
   try {
@@ -85,13 +84,13 @@ export const handler = async ({
       throw new Error('containerPath path does not exist')
     }
 
-    let configObj
-    if (config) {
+    let extraObj
+    if (extra) {
       try {
-        if (fs.existsSync(config)) {
-          configObj = await fileUtils.readJSON(config)
+        if (fs.existsSync(extra)) {
+          extraObj = await fileUtils.readJSON(extra)
         } else {
-          configObj = JSON.parse(config)
+          extraObj = JSON.parse(extra)
         }
       } catch (e) {
         throw new Error('config should be valid JSON')
@@ -101,7 +100,7 @@ export const handler = async ({
     await publishContainer({
       containerPath,
       containerVersion: version,
-      extra: configObj,
+      extra: extraObj,
       platform,
       publisher,
       url,

--- a/ern-local-cli/src/commands/publish-container.ts
+++ b/ern-local-cli/src/commands/publish-container.ts
@@ -1,9 +1,4 @@
-import {
-  utils as coreUtils,
-  Platform,
-  NativePlatform,
-  fileUtils,
-} from 'ern-core'
+import { utils as coreUtils, Platform, NativePlatform } from 'ern-core'
 import { publishContainer } from 'ern-container-publisher'
 import utils from '../lib/utils'
 import fs from 'fs'
@@ -84,18 +79,7 @@ export const handler = async ({
       throw new Error('containerPath path does not exist')
     }
 
-    let extraObj
-    if (extra) {
-      try {
-        if (fs.existsSync(extra)) {
-          extraObj = await fileUtils.readJSON(extra)
-        } else {
-          extraObj = JSON.parse(extra)
-        }
-      } catch (e) {
-        throw new Error('config should be valid JSON')
-      }
-    }
+    const extraObj = extra && (await utils.parseJsonFromStringOrFile(extra))
 
     await publishContainer({
       containerPath,

--- a/ern-local-cli/src/commands/transform-container.ts
+++ b/ern-local-cli/src/commands/transform-container.ts
@@ -1,9 +1,4 @@
-import {
-  utils as coreUtils,
-  Platform,
-  NativePlatform,
-  fileUtils,
-} from 'ern-core'
+import { utils as coreUtils, Platform, NativePlatform } from 'ern-core'
 import { transformContainer } from 'ern-container-transformer'
 import utils from '../lib/utils'
 import fs from 'fs'
@@ -66,18 +61,7 @@ export const handler = async ({
       throw new Error('containerPath path does not exist')
     }
 
-    let extraObj
-    if (extra) {
-      try {
-        if (fs.existsSync(extra)) {
-          extraObj = await fileUtils.readJSON(extra)
-        } else {
-          extraObj = JSON.parse(extra)
-        }
-      } catch (e) {
-        throw new Error('config should be valid JSON')
-      }
-    }
+    const extraObj = extra && (await utils.parseJsonFromStringOrFile(extra))
 
     await transformContainer({
       containerPath,

--- a/ern-local-cli/src/commands/transform-container.ts
+++ b/ern-local-cli/src/commands/transform-container.ts
@@ -19,10 +19,10 @@ export const builder = (argv: Argv) => {
       describe: 'Local path to the Container to transform',
       type: 'string',
     })
-    .option('config', {
-      alias: 'c',
+    .option('extra', {
+      alias: 'e',
       describe:
-        'Optional transformer configuration (json string or path to config file)',
+        'Optional extra transformer configuration (json string or path to config file)',
       type: 'string',
     })
     .option('platform', {
@@ -43,12 +43,12 @@ export const builder = (argv: Argv) => {
 
 export const handler = async ({
   containerPath,
-  config,
+  extra,
   platform,
   transformer,
 }: {
   containerPath?: string
-  config?: string
+  extra?: string
   platform: NativePlatform
   transformer: string
 }) => {
@@ -66,13 +66,13 @@ export const handler = async ({
       throw new Error('containerPath path does not exist')
     }
 
-    let configObj
-    if (config) {
+    let extraObj
+    if (extra) {
       try {
-        if (fs.existsSync(config)) {
-          configObj = await fileUtils.readJSON(config)
+        if (fs.existsSync(extra)) {
+          extraObj = await fileUtils.readJSON(extra)
         } else {
-          configObj = JSON.parse(config)
+          extraObj = JSON.parse(extra)
         }
       } catch (e) {
         throw new Error('config should be valid JSON')
@@ -81,7 +81,7 @@ export const handler = async ({
 
     await transformContainer({
       containerPath,
-      extra: configObj,
+      extra: extraObj,
       platform,
       transformer,
     })

--- a/ern-local-cli/src/lib/utils.ts
+++ b/ern-local-cli/src/lib/utils.ts
@@ -15,6 +15,7 @@ import {
   MavenUtils,
   utils as coreUtils,
   NativePlatform,
+  fileUtils,
 } from 'ern-core'
 import { publishContainer } from 'ern-container-publisher'
 import { transformContainer } from 'ern-container-transformer'
@@ -1239,6 +1240,25 @@ async function unzip(zippedData: Buffer, destPath: string) {
   })
 }
 
+/**
+ * Parse json from a string or a file and return the
+ * resulting JavaScript object
+ * @param s A json string or a path to a json file
+ */
+async function parseJsonFromStringOrFile(s: string): Promise<any> {
+  let result
+  try {
+    if (fs.existsSync(s)) {
+      result = await fileUtils.readJSON(s)
+    } else {
+      result = JSON.parse(s)
+    }
+  } catch (e) {
+    throw new Error('[parseJsonFromStringOrFile] Invalid JSON')
+  }
+  return result
+}
+
 export default {
   askUserToChooseANapDescriptorFromCauldron,
   askUserToChooseOneOrMoreNapDescriptorFromCauldron,
@@ -1251,6 +1271,7 @@ export default {
   logErrorAndExitIfNotSatisfied,
   logNativeDependenciesConflicts,
   normalizeVersionsToSemver,
+  parseJsonFromStringOrFile,
   performContainerStateUpdateInCauldron,
   performPkgNameConflictCheck,
   promptUserToUseSuffixModuleName,


### PR DESCRIPTION
Rename `--config/-c` option of `publish-container`/`transform-container` and `cauldron add publisher` commands, to `--extra/-e` for consistency with the name of the object (`extra`) stored in Cauldron or passed programmatically to `publish` / `transform` methods.

Also, for consistency as well, allow `--extra/-e` to be a path to a file containing the extra configuration, for the `cauldron add publisher` command (to be on par with `publish-container` and `transform-container` commands).

**For release notes : This is a breaking change to the following commands**
- publish-container
- transform-container
- cauldron add publisher

**After release task**
- Update the README of the publishers and transformers accordingly.