### PR TITLE
Cauldron file system

### DIFF
--- a/ern-cauldron-api/src/CauldronApi.ts
+++ b/ern-cauldron-api/src/CauldronApi.ts
@@ -804,6 +804,70 @@ export default class CauldronApi {
   // =====================================================================================
 
   // -------------------------------------------------------------------------------------
+  // ARBITRARY FILE ACCESS
+  // -------------------------------------------------------------------------------------
+
+  public async addFile({
+    cauldronFilePath,
+    fileContent,
+    fileMode,
+  }: {
+    cauldronFilePath: string
+    fileContent: string | Buffer
+    fileMode?: string
+  }) {
+    if (!cauldronFilePath) {
+      throw new Error('[addFile] cauldronFilePath is required')
+    }
+    if (!fileContent) {
+      throw new Error('[addFile] fileContent is required')
+    }
+    if (await this.hasFile({ cauldronFilePath })) {
+      throw new Error(
+        `[addFile] ${cauldronFilePath} already exists. Use updateFile instead.`
+      )
+    }
+    return this.fileStore.storeFile(cauldronFilePath, fileContent, fileMode)
+  }
+
+  public async updateFile({
+    cauldronFilePath,
+    fileContent,
+    fileMode,
+  }: {
+    cauldronFilePath: string
+    fileContent: string | Buffer
+    fileMode?: string
+  }) {
+    if (!cauldronFilePath) {
+      throw new Error('[updateFile] cauldronFilePath is required')
+    }
+    if (!fileContent) {
+      throw new Error('[updateFile] fileContent is required')
+    }
+    if (!(await this.hasFile({ cauldronFilePath }))) {
+      throw new Error(
+        `[updateFile] ${cauldronFilePath} does not exist. Use addFile first.`
+      )
+    }
+    return this.fileStore.storeFile(cauldronFilePath, fileContent, fileMode)
+  }
+
+  public async removeFile({ cauldronFilePath }: { cauldronFilePath: string }) {
+    if (!cauldronFilePath) {
+      throw new Error('[removeFile] cauldronFilePath is required')
+    }
+    if (!(await this.hasFile({ cauldronFilePath }))) {
+      throw new Error(`[removeFile] ${cauldronFilePath} does not exist`)
+    }
+    return this.fileStore.removeFile(cauldronFilePath)
+  }
+
+  public async hasFile({ cauldronFilePath }: { cauldronFilePath: string }) {
+    return this.fileStore.hasFile(cauldronFilePath)
+  }
+
+  // -------------------------------------------------------------------------------------
   // YARN LOCKS STORE ACCESS
   // -------------------------------------------------------------------------------------
 

--- a/ern-cauldron-api/src/CauldronHelper.ts
+++ b/ern-cauldron-api/src/CauldronHelper.ts
@@ -206,6 +206,46 @@ export class CauldronHelper {
     return _.map(dependencies, PackagePath.fromString)
   }
 
+  public async addFile({
+    localFilePath,
+    cauldronFilePath,
+  }: {
+    localFilePath: string
+    cauldronFilePath: string
+  }) {
+    const fileContent = await fileUtils.readFile(localFilePath)
+    const isExecutable = await fileUtils.isExecutable(localFilePath)
+    return this.cauldron.addFile({
+      cauldronFilePath,
+      fileContent,
+      fileMode: isExecutable ? '+x' : undefined,
+    })
+  }
+
+  public async updateFile({
+    localFilePath,
+    cauldronFilePath,
+  }: {
+    localFilePath: string
+    cauldronFilePath: string
+  }) {
+    const fileContent = await fileUtils.readFile(localFilePath)
+    const isExecutable = await fileUtils.isExecutable(localFilePath)
+    return this.cauldron.updateFile({
+      cauldronFilePath,
+      fileContent,
+      fileMode: isExecutable ? '+x' : undefined,
+    })
+  }
+
+  public async removeFile({ cauldronFilePath }: { cauldronFilePath: string }) {
+    return this.cauldron.removeFile({ cauldronFilePath })
+  }
+
+  public async hasFile({ cauldronFilePath }: { cauldronFilePath: string }) {
+    return this.cauldron.hasFile({ cauldronFilePath })
+  }
+
   public async hasYarnLock(
     napDescriptor: NativeApplicationDescriptor,
     key: string

--- a/ern-cauldron-api/src/EphemeralFileStore.ts
+++ b/ern-cauldron-api/src/EphemeralFileStore.ts
@@ -22,13 +22,20 @@ export default class EphemeralFileStore implements ICauldronFileStore {
   // ICauldronFileAccess implementation
   // ===========================================================
 
-  public async storeFile(identifier: string, content: string | Buffer) {
+  public async storeFile(
+    identifier: string,
+    content: string | Buffer,
+    fileMode?: string
+  ) {
     const pathToFile = path.join(this.storePath, identifier)
     const pathToDir = path.dirname(pathToFile)
     if (!fs.existsSync(pathToDir)) {
       shell.mkdir('-p', pathToDir)
     }
     fs.writeFileSync(pathToFile, content, 'utf8')
+    if (fileMode) {
+      shell.chmod(fileMode, pathToFile)
+    }
     return Promise.resolve()
   }
 

--- a/ern-cauldron-api/src/GitFileStore.ts
+++ b/ern-cauldron-api/src/GitFileStore.ts
@@ -25,7 +25,11 @@ export default class GitFileStore extends BaseGit
   // ICauldronFileAccess implementation
   // ===========================================================
 
-  public async storeFile(filePath: string, content: string | Buffer) {
+  public async storeFile(
+    filePath: string,
+    content: string | Buffer,
+    fileMode?: string
+  ) {
     await this.sync()
     const storeDirectoryPath = path.resolve(this.fsPath, path.dirname(filePath))
     if (!fs.existsSync(storeDirectoryPath)) {
@@ -34,6 +38,9 @@ export default class GitFileStore extends BaseGit
     }
     const pathToFile = path.resolve(storeDirectoryPath, path.basename(filePath))
     await writeFile(pathToFile, content, { flag: 'w' })
+    if (fileMode) {
+      shell.chmod(fileMode, pathToFile)
+    }
     await this.git.addAsync(pathToFile)
     if (!this.pendingTransaction) {
       await this.git.commitAsync(`Add file ${filePath}`)

--- a/ern-cauldron-api/src/types/ICauldronFileAccess.ts
+++ b/ern-cauldron-api/src/types/ICauldronFileAccess.ts
@@ -1,5 +1,9 @@
 export interface ICauldronFileAccess {
-  storeFile(filename: string, payload: string | Buffer): Promise<void>
+  storeFile(
+    filename: string,
+    payload: string | Buffer,
+    fileMode?: string
+  ): Promise<void>
   hasFile(filename: string): Promise<boolean>
   getPathToFile(filename: string): Promise<string | void>
   getFile(filename: string): Promise<Buffer | void>

--- a/ern-cauldron-api/test/CauldronApi-test.ts
+++ b/ern-cauldron-api/test/CauldronApi-test.ts
@@ -1,7 +1,7 @@
 import { assert, expect } from 'chai'
 import sinon from 'sinon'
-import { NativeApplicationDescriptor, PackagePath } from 'ern-core'
-import { doesThrow, fixtures } from 'ern-util-dev'
+import { NativeApplicationDescriptor, PackagePath, fileUtils } from 'ern-core'
+import { doesThrow, doesNotThrow, fixtures } from 'ern-util-dev'
 import { CauldronCodePushEntry } from '../src/types'
 import CauldronApi from '../src/CauldronApi'
 import EphemeralFileStore from '../src/EphemeralFileStore'
@@ -1841,6 +1841,120 @@ describe('CauldronApi.js', () => {
           NativeApplicationDescriptor.fromString('test:android:17.20.0'),
           codePushNewEntryFixture
         )
+      )
+    })
+  })
+
+  // ==========================================================
+  // addFile
+  // ==========================================================
+  describe('addFile', () => {
+    it('should throw if cauldronFilePath is undefined', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.addFile, api, { fileContent: 'content' }))
+    })
+
+    it('should throw if fileContent is undefined', async () => {
+      const api = cauldronApi()
+      assert(
+        await doesThrow(api.addFile, api, { cauldronFilePath: 'dir/file' })
+      )
+    })
+
+    it('should throw if file already exist', async () => {
+      const api = cauldronApi()
+      await api.addFile({
+        cauldronFilePath: 'dir/file',
+        fileContent: 'content',
+      })
+      assert(
+        await doesThrow(api.addFile, api, {
+          cauldronFilePath: 'dir/file',
+          fileContent: 'newcontent',
+        })
+      )
+    })
+
+    it('should not throw in nominal proper use case', async () => {
+      const api = cauldronApi()
+      assert(
+        await doesNotThrow(api.addFile, api, {
+          cauldronFilePath: 'dir/file',
+          fileContent: 'content',
+        })
+      )
+    })
+  })
+
+  // ==========================================================
+  // updateFile
+  // ==========================================================
+  describe('updateFile', () => {
+    it('should throw if cauldronFilePath is undefined', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.updateFile, api, { fileContent: 'content' }))
+    })
+
+    it('should throw if fileContent is undefined', async () => {
+      const api = cauldronApi()
+      assert(
+        await doesThrow(api.updateFile, api, { cauldronFilePath: 'dir/file' })
+      )
+    })
+
+    it('should throw if file does not already exist', async () => {
+      const api = cauldronApi()
+      assert(
+        await doesThrow(api.updateFile, api, {
+          cauldronFilePath: 'dir/file',
+          fileContent: 'newcontent',
+        })
+      )
+    })
+
+    it('should not throw in nominal proper use case', async () => {
+      const api = cauldronApi()
+      await api.addFile({
+        cauldronFilePath: 'dir/file',
+        fileContent: 'content',
+      })
+      assert(
+        await doesNotThrow(api.updateFile, api, {
+          cauldronFilePath: 'dir/file',
+          fileContent: 'content',
+        })
+      )
+    })
+  })
+
+  // ==========================================================
+  // removeFile
+  // ==========================================================
+  describe('removeFile', () => {
+    it('should throw if cauldronFilePath is undefined', async () => {
+      const api = cauldronApi()
+      assert(await doesThrow(api.removeFile, api, {}))
+    })
+
+    it('should throw if file does not exist', async () => {
+      const api = cauldronApi()
+      assert(
+        await doesThrow(api.removeFile, api, {
+          cauldronFilePath: 'dir/file',
+        })
+      )
+    })
+
+    it('should not throw in nominal proper use case', async () => {
+      const api = cauldronApi()
+      await api.addFile({
+        cauldronFilePath: 'dir/file',
+        fileContent: 'content',
+      })
+      assert(
+        await doesNotThrow(api.removeFile, api, {
+          cauldronFilePath: 'dir/file',
+        })
       )
     })
   })

--- a/ern-core/src/fileUtil.ts
+++ b/ern-core/src/fileUtil.ts
@@ -89,3 +89,15 @@ export function writeJSONSync(filePath: string, obj: any): string {
 export function chmodr(fileMode: string, filePath: string) {
   shell.chmod('-R', fileMode, filePath)
 }
+
+/**
+ * Check if a given file is executable
+ * @param filePath Path to the file to check
+ */
+export async function isExecutable(filePath: string): Promise<boolean> {
+  return new Promise<boolean>(resolve => {
+    fs.access(filePath, fs.constants.X_OK, err => {
+      err ? resolve(false) : resolve(true)
+    })
+  })
+}

--- a/ern-local-cli/src/commands/cauldron/add/file.ts
+++ b/ern-local-cli/src/commands/cauldron/add/file.ts
@@ -1,0 +1,40 @@
+import { utils as coreUtils, log } from 'ern-core'
+import { getActiveCauldron } from 'ern-cauldron-api'
+import utils from '../../../lib/utils'
+import { Argv } from 'yargs'
+import fs from 'fs'
+
+export const command = 'file <localFilePath> <cauldronFilePath>'
+export const desc = 'Add a file in the Cauldron'
+
+export const builder = (argv: Argv) => argv
+
+export const handler = async ({
+  localFilePath,
+  cauldronFilePath,
+}: {
+  localFilePath: string
+  cauldronFilePath: string
+}) => {
+  try {
+    await utils.logErrorAndExitIfNotSatisfied({
+      cauldronIsActive: {
+        extraErrorMessage:
+          'A Cauldron must be active in order to use this command',
+      },
+    })
+
+    if (!fs.existsSync(localFilePath)) {
+      throw new Error(`File ${localFilePath} does not exist`)
+    }
+
+    const cauldron = await getActiveCauldron()
+    await cauldron.addFile({
+      cauldronFilePath,
+      localFilePath,
+    })
+    log.info(`${localFilePath} file was successfully added !`)
+  } catch (e) {
+    coreUtils.logErrorAndExitProcess(e)
+  }
+}

--- a/ern-local-cli/src/commands/cauldron/del/file.ts
+++ b/ern-local-cli/src/commands/cauldron/del/file.ts
@@ -1,0 +1,33 @@
+import { utils as coreUtils, log } from 'ern-core'
+import { getActiveCauldron } from 'ern-cauldron-api'
+import utils from '../../../lib/utils'
+import { Argv } from 'yargs'
+import fs from 'fs'
+
+export const command = 'file <cauldronFilePath>'
+export const desc = 'Remove a file from the Cauldron'
+
+export const builder = (argv: Argv) => argv
+
+export const handler = async ({
+  cauldronFilePath,
+}: {
+  cauldronFilePath: string
+}) => {
+  try {
+    await utils.logErrorAndExitIfNotSatisfied({
+      cauldronIsActive: {
+        extraErrorMessage:
+          'A Cauldron must be active in order to use this command',
+      },
+    })
+
+    const cauldron = await getActiveCauldron()
+    await cauldron.removeFile({
+      cauldronFilePath,
+    })
+    log.info(`${cauldronFilePath} file was successfully removed !`)
+  } catch (e) {
+    coreUtils.logErrorAndExitProcess(e)
+  }
+}

--- a/ern-local-cli/src/commands/cauldron/update/file.ts
+++ b/ern-local-cli/src/commands/cauldron/update/file.ts
@@ -1,0 +1,40 @@
+import { utils as coreUtils, log } from 'ern-core'
+import { getActiveCauldron } from 'ern-cauldron-api'
+import utils from '../../../lib/utils'
+import { Argv } from 'yargs'
+import fs from 'fs'
+
+export const command = 'file <localFilePath> <cauldronFilePath>'
+export const desc = 'Update a file in the Cauldron'
+
+export const builder = (argv: Argv) => argv
+
+export const handler = async ({
+  localFilePath,
+  cauldronFilePath,
+}: {
+  localFilePath: string
+  cauldronFilePath: string
+}) => {
+  try {
+    await utils.logErrorAndExitIfNotSatisfied({
+      cauldronIsActive: {
+        extraErrorMessage:
+          'A Cauldron must be active in order to use this command',
+      },
+    })
+
+    if (!fs.existsSync(localFilePath)) {
+      throw new Error(`File ${localFilePath} does not exist`)
+    }
+
+    const cauldron = await getActiveCauldron()
+    await cauldron.updateFile({
+      cauldronFilePath,
+      localFilePath,
+    })
+    log.info(`${localFilePath} file was successfully updated !`)
+  } catch (e) {
+    coreUtils.logErrorAndExitProcess(e)
+  }
+}


### PR DESCRIPTION
Add support to store arbitrary files in Cauldron. 
This PR introduces three new cauldron subcommands :
- `ern cauldron add file`
- `ern cauldron update file`
- `ern cauldron delete file`

For example, running `ern cauldron add file /Users/username/test.json data/json/test.json` will add the `test.json` in the Cauldron in the `data/json` directory from the root of the Cauldron (creating the directori(es) if needed).

First use case for this will probably be to store publishers and/or transformers configurations (as transformers configurations can grow quite big and bloat main cauldron document, also better to keep them separate for easier management). Also for example the planned `script` transformer will allow the execution of arbitrary scripts which can get quite big (fat-binary for iOS being one). It will be a pain to store it directly embedded in the Cauldron document, and a pain also to keep such scripts in sync across different dev or build machines if not stored in a central repository such as the Cauldron.

Since a recent PR, `publish-container` / `transform-container` commands are allowing for the `publisher`/`transformer` configuration to be passed as a local file path to a file containing the configuration. This is a nice improvement but doesn't solve the sharing aspect. Idea is therefore to also allow to pass a reference to a file stored in Cauldron, using a scheme that we will introduce (most probably `cauldron://`). This way config (complex or simple) or supporting files could be kept separate from the Cauldron document (thus not bloating it) while being shared across users of a Cauldron and allow easy maintenance.

This PR contains some tests, but no documentation for new commands yet. A specific PR for documentation regarding Cauldron file storage will be done prior to 0.22 release, including transformers documentation as well as updated publishers documentation, as they will be closely related.