### PR TITLE
Fix ern-container-gen-android .npmignore

### DIFF
--- a/ern-container-gen-android/.npmignore
+++ b/ern-container-gen-android/.npmignore
@@ -1,4 +1,4 @@
-src
+src/
 .coverage
 .nyc_output
 test


### PR DESCRIPTION
`.npmignore` was configured to ignore all `src` directories instead of top level `src` directory only.
This caused a big issue for Android Container Generator, as the Java hull code is kept in a directory named ... `src`. 

This hull src directory was therefore not packaged, leading to failure during Android Container Generation.