### PR TITLE
Fix default config values for Cauldron publishers

### DIFF
--- a/ern-local-cli/src/lib/utils.ts
+++ b/ern-local-cli/src/lib/utils.ts
@@ -558,21 +558,24 @@ async function performContainerStateUpdateInCauldron(
       for (const publisherFromCauldron of publishersFromCauldron) {
         let extra = publisherFromCauldron.extra
         if (!extra) {
-          switch (publisherFromCauldron.name) {
-            case 'maven':
-              extra = {
-                artifactId: `${napDescriptor.name}-ern-container`,
-                groupId: 'com.walmartlabs.ern',
-                mavenPassword: publisherFromCauldron.mavenPassword,
-                mavenUser: publisherFromCauldron.mavenUser,
-              }
-              break
-            case 'jcenter':
-              extra = {
-                artifactId: `${napDescriptor.name}-ern-container`,
-                groupId: 'com.walmartlabs.ern',
-              }
-              break
+          if (
+            publisherFromCauldron.name === 'maven' ||
+            publisherFromCauldron.name.startsWith('maven@')
+          ) {
+            extra = {
+              artifactId: `${napDescriptor.name}-ern-container`,
+              groupId: 'com.walmartlabs.ern',
+              mavenPassword: publisherFromCauldron.mavenPassword,
+              mavenUser: publisherFromCauldron.mavenUser,
+            }
+          } else if (
+            publisherFromCauldron.name === 'jcenter' ||
+            publisherFromCauldron.name.startsWith('jcenter@')
+          ) {
+            extra = {
+              artifactId: `${napDescriptor.name}-ern-container`,
+              groupId: 'com.walmartlabs.ern',
+            }
           }
         }
 


### PR DESCRIPTION
Because Container publisher name can include a specific version of the publisher, fix a bug that was not setting the default config in the later case, as it was just checking for the exact publisher name and not a publisher name with a specific version set.

i.e if the publisher name is set to `maven` in Cauldron, default maven publisher config is properly set. However if publisher name is set to `maven@1.0.0` then default maven publisher config was not applied.