### PR TITLE
Add a few new guard functions

### DIFF
--- a/ern-local-cli/src/lib/Ensure.ts
+++ b/ern-local-cli/src/lib/Ensure.ts
@@ -8,7 +8,7 @@ import { getActiveCauldron } from 'ern-cauldron-api'
 import _ from 'lodash'
 import semver from 'semver'
 import validateNpmPackageName from 'validate-npm-package-name'
-
+import fs from 'fs'
 export default class Ensure {
   public static isValidElectrodeNativeModuleName(
     name: string,
@@ -387,6 +387,59 @@ export default class Ensure {
     if (!(await getActiveCauldron())) {
       throw new Error(`There is no active Cauldron\n${extraErrorMessage}`)
     }
+  }
+
+  public static async pathExist(
+    p: fs.PathLike,
+    extraErrorMessage: string = ''
+  ) {
+    return new Promise((resolve, reject) => {
+      fs.exists(
+        p,
+        exists =>
+          exists
+            ? resolve()
+            : reject(`${p} path does not exist.\n${extraErrorMessage}`)
+      )
+    })
+  }
+
+  public static async isFilePath(
+    p: fs.PathLike,
+    extraErrorMessage: string = ''
+  ) {
+    return new Promise((resolve, reject) => {
+      fs.stat(p, (err, stats) => {
+        if (err) {
+          reject(`${p} path does not exist.\n${extraErrorMessage}`)
+        } else {
+          if (stats.isFile()) {
+            resolve()
+          } else {
+            reject(`${p} is not a file.\n${extraErrorMessage}`)
+          }
+        }
+      })
+    })
+  }
+
+  public static async isDirectoryPath(
+    p: fs.PathLike,
+    extraErrorMessage: string = ''
+  ) {
+    return new Promise((resolve, reject) => {
+      fs.stat(p, (err, stats) => {
+        if (err) {
+          reject(`${p} path does not exist.\n${extraErrorMessage}`)
+        } else {
+          if (stats.isDirectory()) {
+            resolve()
+          } else {
+            reject(`${p} is not a directory.\n${extraErrorMessage}`)
+          }
+        }
+      })
+    })
   }
 
   public static checkIfCodePushOptionsAreValid(

--- a/ern-local-cli/src/lib/utils.ts
+++ b/ern-local-cli/src/lib/utils.ts
@@ -99,6 +99,9 @@ async function logErrorAndExitIfNotSatisfied({
   isValidNpmPackageName,
   isValidElectrodeNativeModuleName,
   checkIfCodePushOptionsAreValid,
+  isFilePath,
+  isDirectoryPath,
+  pathExist,
 }: {
   noGitOrFilesystemPath?: {
     obj: string | string[]
@@ -187,6 +190,18 @@ async function logErrorAndExitIfNotSatisfied({
     descriptors?: string[]
     targetBinaryVersion?: string
     semVerDescriptor?: string
+    extraErrorMessage?: string
+  }
+  isFilePath?: {
+    p: fs.PathLike
+    extraErrorMessage?: string
+  }
+  isDirectoryPath?: {
+    p: fs.PathLike
+    extraErrorMessage?: string
+  }
+  pathExist?: {
+    p: fs.PathLike
     extraErrorMessage?: string
   }
 } = {}) {
@@ -350,6 +365,18 @@ async function logErrorAndExitIfNotSatisfied({
         checkIfCodePushOptionsAreValid.semVerDescriptor,
         checkIfCodePushOptionsAreValid.extraErrorMessage
       )
+    }
+    if (pathExist) {
+      spinner.text = 'Ensuring that path exist'
+      await Ensure.pathExist(pathExist.p)
+    }
+    if (isFilePath) {
+      spinner.text = 'Ensuring that path is a file path'
+      await Ensure.isFilePath(isFilePath.p)
+    }
+    if (isDirectoryPath) {
+      spinner.text = 'Ensuring that path is a directory path'
+      await Ensure.isDirectoryPath(isDirectoryPath.p)
     }
     spinner.succeed('Validity checks have passed')
   } catch (e) {

--- a/ern-local-cli/test/Ensure-test.js
+++ b/ern-local-cli/test/Ensure-test.js
@@ -1,21 +1,15 @@
-// @flow 
+// @flow
 
-import {
-  assert,
-  expect
-} from 'chai'
+import { assert, expect } from 'chai'
 import * as cauldron from 'ern-cauldron-api'
-import {
-  utils
-} from 'ern-core'
-import {
-  doesThrow,
-  doesNotThrow
-} from 'ern-util-dev'
+import { utils, createTmpDir } from 'ern-core'
+import { doesThrow, doesNotThrow } from 'ern-util-dev'
 import sinon from 'sinon'
 import Ensure from '../src/lib/Ensure'
 import * as fixtures from './fixtures/common'
 const sandbox = sinon.createSandbox()
+import fs from 'fs'
+import path from 'path'
 
 let cauldronHelperStub
 
@@ -24,7 +18,7 @@ describe('Ensure.js', () => {
     cauldronHelperStub = sandbox.createStubInstance(cauldron.CauldronHelper)
     sandbox.stub(cauldron, 'getActiveCauldron').resolves(cauldronHelperStub)
   })
-  
+
   afterEach(() => {
     sandbox.restore()
   })
@@ -35,13 +29,19 @@ describe('Ensure.js', () => {
   describe('isValidContainerVersion', () => {
     fixtures.validContainerVersions.forEach(version => {
       it('shoud not throw if version is valid', () => {
-        expect(() => Ensure.isValidContainerVersion(version), `throw for ${version}`).to.not.throw()
+        expect(
+          () => Ensure.isValidContainerVersion(version),
+          `throw for ${version}`
+        ).to.not.throw()
       })
     })
 
     fixtures.invalidContainerVersions.forEach(version => {
       it('should throw if version is invalid', () => {
-        expect(() => Ensure.isValidContainerVersion(version), `does not throw for ${version}`).to.throw()
+        expect(
+          () => Ensure.isValidContainerVersion(version),
+          `does not throw for ${version}`
+        ).to.throw()
       })
     })
   })
@@ -52,13 +52,19 @@ describe('Ensure.js', () => {
   describe('isCompleteNapDescriptorString', () => {
     fixtures.completeNapDescriptors.forEach(napDescriptor => {
       it('shoud not throw if given a complete napDescriptor string', () => {
-        expect(() => Ensure.isCompleteNapDescriptorString(napDescriptor), `throw for ${napDescriptor}`).to.not.throw()
+        expect(
+          () => Ensure.isCompleteNapDescriptorString(napDescriptor),
+          `throw for ${napDescriptor}`
+        ).to.not.throw()
       })
     })
 
     fixtures.incompleteNapDescriptors.forEach(napDescriptor => {
       it('should throw if given a partial napDescriptor string', () => {
-        expect(() => Ensure.isCompleteNapDescriptorString(napDescriptor), `does not throw for ${napDescriptor}`).to.throw()
+        expect(
+          () => Ensure.isCompleteNapDescriptorString(napDescriptor),
+          `does not throw for ${napDescriptor}`
+        ).to.throw()
       })
     })
   })
@@ -69,13 +75,19 @@ describe('Ensure.js', () => {
   describe('noGitOrFilesystemPath', () => {
     fixtures.withoutGitOrFileSystemPath.forEach(obj => {
       it('shoud not throw if no git or file system path', () => {
-        expect(() => Ensure.noGitOrFilesystemPath(obj), `throw for ${obj}`).to.not.throw()
+        expect(
+          () => Ensure.noGitOrFilesystemPath(obj),
+          `throw for ${obj}`
+        ).to.not.throw()
       })
     })
 
     fixtures.withGitOrFileSystemPath.forEach(obj => {
       it('should throw if git or file system path', () => {
-        expect(() => Ensure.noGitOrFilesystemPath(obj), `does not throw for ${obj}`).to.throw()
+        expect(
+          () => Ensure.noGitOrFilesystemPath(obj),
+          `does not throw for ${obj}`
+        ).to.throw()
       })
     })
   })
@@ -86,13 +98,19 @@ describe('Ensure.js', () => {
   describe('noFileSystemPath', () => {
     fixtures.withoutFileSystemPath.forEach(obj => {
       it('shoud not throw if no file system path', () => {
-        expect(() => Ensure.noFileSystemPath(obj), `throw for ${obj}`).to.not.throw()
+        expect(
+          () => Ensure.noFileSystemPath(obj),
+          `throw for ${obj}`
+        ).to.not.throw()
       })
     })
 
     fixtures.withFileSystemPath.forEach(obj => {
       it('should throw if file system path', () => {
-        expect(() => Ensure.noFileSystemPath(obj), `does not throw for ${obj}`).to.throw()
+        expect(
+          () => Ensure.noFileSystemPath(obj),
+          `does not throw for ${obj}`
+        ).to.throw()
       })
     })
   })
@@ -103,12 +121,24 @@ describe('Ensure.js', () => {
   describe('napDescritorExistsInCauldron', () => {
     it('should not throw if nap descriptor exists in Cauldron', async () => {
       cauldronHelperStub.isDescriptorInCauldron.resolves(true)
-      assert(await doesNotThrow(Ensure.napDescritorExistsInCauldron, null, 'testapp:android:1.0.0'))
+      assert(
+        await doesNotThrow(
+          Ensure.napDescritorExistsInCauldron,
+          null,
+          'testapp:android:1.0.0'
+        )
+      )
     })
 
     it('should throw if nap descriptor does not exist in Cauldron', async () => {
       cauldronHelperStub.isDescriptorInCauldron.resolves(false)
-      assert(await doesThrow(Ensure.napDescritorExistsInCauldron, null, 'testapp:android:1.0.0'))
+      assert(
+        await doesThrow(
+          Ensure.napDescritorExistsInCauldron,
+          null,
+          'testapp:android:1.0.0'
+        )
+      )
     })
   })
 
@@ -118,7 +148,9 @@ describe('Ensure.js', () => {
   describe('publishedToNpm', () => {
     it('should not throw if dependency is published to npm', async () => {
       sandbox.stub(utils, 'isPublishedToNpm').resolves(true)
-      assert(await doesNotThrow(Ensure.publishedToNpm, null, 'nonpublished@1.0.0'))
+      assert(
+        await doesNotThrow(Ensure.publishedToNpm, null, 'nonpublished@1.0.0')
+      )
     })
 
     it('should throw if dependency is not published to npm', async () => {
@@ -148,13 +180,19 @@ describe('Ensure.js', () => {
   describe('isValidNpmPackageName', () => {
     fixtures.validNpmPackageNames.forEach(name => {
       it('shoud not throw if name is valid', () => {
-        expect(() => Ensure.isValidNpmPackageName(name), `throw for ${name}`).to.not.throw()
+        expect(
+          () => Ensure.isValidNpmPackageName(name),
+          `throw for ${name}`
+        ).to.not.throw()
       })
     })
 
     fixtures.invalidNpmPackageNames.forEach(name => {
       it('should throw if name is invalid', () => {
-        expect(() => Ensure.isValidNpmPackageName(name), `does not throw for ${name}`).to.throw()
+        expect(
+          () => Ensure.isValidNpmPackageName(name),
+          `does not throw for ${name}`
+        ).to.throw()
       })
     })
   })
@@ -165,13 +203,19 @@ describe('Ensure.js', () => {
   describe('isValidElectrodeNativeModuleName', () => {
     fixtures.validElectrodeNativeModuleNames.forEach(name => {
       it('should not throw if name is valid', () => {
-        expect(() => Ensure.isValidElectrodeNativeModuleName(name), `throw for ${name}`).to.not.throw()
+        expect(
+          () => Ensure.isValidElectrodeNativeModuleName(name),
+          `throw for ${name}`
+        ).to.not.throw()
       })
     })
 
     fixtures.invalidElectrodeNativeModuleNames.forEach(name => {
       it('should throw if name is invalid', () => {
-        expect(() => Ensure.isValidElectrodeNativeModuleName(name), `does not throw for ${name}`).to.throw()
+        expect(
+          () => Ensure.isValidElectrodeNativeModuleName(name),
+          `does not throw for ${name}`
+        ).to.throw()
       })
     })
   })
@@ -181,11 +225,19 @@ describe('Ensure.js', () => {
   // ==========================================================
   describe('sameNativeAplicationAndPlatform', () => {
     it('should not throw if descriptors are matching the same native application and platform', () => {
-      expect(() => Ensure.sameNativeApplicationAndPlatform(fixtures.sameNativeApplicationPlatformDescriptors)).to.not.throw()
+      expect(() =>
+        Ensure.sameNativeApplicationAndPlatform(
+          fixtures.sameNativeApplicationPlatformDescriptors
+        )
+      ).to.not.throw()
     })
-    
+
     it('should throw if descriptors are not matching the same native application and platform', () => {
-      expect(() => Ensure.sameNativeApplicationAndPlatform(fixtures.differentNativeApplicationPlatformDescriptors)).to.throw()
+      expect(() =>
+        Ensure.sameNativeApplicationAndPlatform(
+          fixtures.differentNativeApplicationPlatformDescriptors
+        )
+      ).to.throw()
     })
   })
 
@@ -194,33 +246,102 @@ describe('Ensure.js', () => {
   // ==========================================================
   describe('checkIfCodePushOptionsAreValid', () => {
     it('should not throw if descriptors and semVerDescriptor are specified', () => {
-      expect(() => Ensure.checkIfCodePushOptionsAreValid(
-        fixtures.differentNativeApplicationPlatformDescriptors,
-        '',
-        '1.0.0'
-      )).to.not.throw()
+      expect(() =>
+        Ensure.checkIfCodePushOptionsAreValid(
+          fixtures.differentNativeApplicationPlatformDescriptors,
+          '',
+          '1.0.0'
+        )
+      ).to.not.throw()
     })
 
     it('should not throw if 1 descriptor and targetBinaryVersion are specified', () => {
-      expect(() => Ensure.checkIfCodePushOptionsAreValid(
-        ['testapp:android:1.0.0'],
-        '1.0.0'
-      )).to.not.throw()
+      expect(() =>
+        Ensure.checkIfCodePushOptionsAreValid(
+          ['testapp:android:1.0.0'],
+          '1.0.0'
+        )
+      ).to.not.throw()
     })
 
     it('should throw if more than 1 descriptor and targetBinaryVersion are specified', () => {
-      expect(() => Ensure.checkIfCodePushOptionsAreValid(
-        fixtures.differentNativeApplicationPlatformDescriptors,
-        '1.0.0'
-      )).to.throw()
+      expect(() =>
+        Ensure.checkIfCodePushOptionsAreValid(
+          fixtures.differentNativeApplicationPlatformDescriptors,
+          '1.0.0'
+        )
+      ).to.throw()
     })
 
     it('should throw if 1 descriptor ,targetBinaryVersion and semVerDescriptor are specified', () => {
-      expect(() => Ensure.checkIfCodePushOptionsAreValid(
-        ['testapp:android:1.0.0'],
-        '1.0.0',
-        '~1.0.0'
-      )).to.throw()
+      expect(() =>
+        Ensure.checkIfCodePushOptionsAreValid(
+          ['testapp:android:1.0.0'],
+          '1.0.0',
+          '~1.0.0'
+        )
+      ).to.throw()
+    })
+  })
+
+  // ==========================================================
+  // pathExist
+  // ==========================================================
+  describe('pathExist', () => {
+    it('should not throw if path exist', async () => {
+      const tmpDirPath = createTmpDir()
+      assert(await doesNotThrow(Ensure.pathExist, Ensure, tmpDirPath))
+    })
+
+    it('should throw if path does not exist', async () => {
+      const tmpDirPath = createTmpDir()
+      assert(await doesThrow(Ensure.pathExist, Ensure, '/non/existing/path'))
+    })
+  })
+
+  // ==========================================================
+  // isFilePath
+  // ==========================================================
+  describe('isFilePath', () => {
+    it('should not throw if path is a file', async () => {
+      const tmpDirPath = createTmpDir()
+      const tmpFilePath = path.join(tmpDirPath, 'file.test')
+      const tmpFile = fs.writeFileSync(tmpFilePath, 'CONTENT')
+      assert(await doesNotThrow(Ensure.isFilePath, Ensure, tmpFilePath))
+    })
+
+    it('should throw if path is not a file', async () => {
+      const tmpDirPath = createTmpDir()
+      assert(await doesThrow(Ensure.isFilePath, Ensure, tmpDirPath))
+    })
+
+    it('should throw if path does not exist', async () => {
+      const tmpDirPath = createTmpDir()
+      assert(await doesThrow(Ensure.isFilePath, Ensure, '/non/existing/path'))
+    })
+  })
+
+  // ==========================================================
+  // isDirectoryPath
+  // ==========================================================
+  describe('isDirectoryPath', () => {
+    it('should not throw if path is a  directory', async () => {
+      const tmpDirPath = createTmpDir()
+      assert(await doesNotThrow(Ensure.isDirectoryPath, Ensure, tmpDirPath))
+    })
+
+    it('should throw if path is not a directory', async () => {
+      const tmpDirPath = createTmpDir()
+      const tmpFilePath = path.join(tmpDirPath, 'file.test')
+      const tmpFile = fs.writeFileSync(tmpFilePath, 'CONTENT')
+      assert(await doesThrow(Ensure.isDirectoryPath, Ensure, tmpFilePath))
+    })
+
+    it('should throw if path does not exist', async () => {
+      const tmpDirPath = createTmpDir()
+      assert(
+        await doesThrow(Ensure.isDirectoryPath, Ensure, '/non/existing/path')
+      )
     })
   })
 })

--- a/ern-local-cli/test/utils-test.js
+++ b/ern-local-cli/test/utils-test.js
@@ -6,6 +6,7 @@ import {
   NativeApplicationDescriptor,
   yarn,
   utils as coreUtils,
+  createTmpDir,
 } from 'ern-core'
 import * as cauldron from 'ern-cauldron-api'
 import {
@@ -21,6 +22,8 @@ import utils from '../src/lib/utils'
 import * as fixtures from './fixtures/common'
 import ora from 'ora'
 import inquirer from 'inquirer'
+import fs from 'fs'
+import path from 'path'
 
 // Fixtures
 const basicCauldronFixture = utilFixtures.defaultCauldron
@@ -396,6 +399,87 @@ describe('utils.js', () => {
         },
       })
       assertNoErrorLoggedAndNoProcessExit()
+    })
+
+    it('[pathExist] Should not log error nor exist if path exist', async () => {
+      const tmpDirPath = createTmpDir()
+      await utils.logErrorAndExitIfNotSatisfied({
+        pathExist: {
+          p: tmpDirPath,
+        },
+      })
+      assertNoErrorLoggedAndNoProcessExit()
+    })
+
+    it('[pathExist] Should log error and exist if path does not exist', async () => {
+      await utils.logErrorAndExitIfNotSatisfied({
+        pathExist: {
+          p: '/non/existing/path',
+        },
+      })
+      assertLoggedErrorAndExitedProcess()
+    })
+
+    it('[isFilePath] Should not log error nor exist if path is a file path', async () => {
+      const tmpDirPath = createTmpDir()
+      const tmpFilePath = path.join(tmpDirPath, 'file.test')
+      const tmpFile = fs.writeFileSync(tmpFilePath, 'CONTENT')
+      await utils.logErrorAndExitIfNotSatisfied({
+        isFilePath: {
+          p: tmpFilePath,
+        },
+      })
+      assertNoErrorLoggedAndNoProcessExit()
+    })
+
+    it('[isFilePath] Should log error and exist if path is not a file path', async () => {
+      const tmpDirPath = createTmpDir()
+      await utils.logErrorAndExitIfNotSatisfied({
+        isFilePath: {
+          p: tmpDirPath,
+        },
+      })
+      assertLoggedErrorAndExitedProcess()
+    })
+
+    it('[isFilePath] Should log error and exist if path does not exist', async () => {
+      await utils.logErrorAndExitIfNotSatisfied({
+        isFilePath: {
+          p: '/non/existing/path',
+        },
+      })
+      assertLoggedErrorAndExitedProcess()
+    })
+
+    it('[isDirectoryPath] Should not log error nor exist if path is a directory path', async () => {
+      const tmpDirPath = createTmpDir()
+      await utils.logErrorAndExitIfNotSatisfied({
+        isDirectoryPath: {
+          p: tmpDirPath,
+        },
+      })
+      assertNoErrorLoggedAndNoProcessExit()
+    })
+
+    it('[isDirectoryPath] Should log error and exist if path is not a directory path', async () => {
+      const tmpDirPath = createTmpDir()
+      const tmpFilePath = path.join(tmpDirPath, 'file.test')
+      const tmpFile = fs.writeFileSync(tmpFilePath, 'CONTENT')
+      await utils.logErrorAndExitIfNotSatisfied({
+        isDirectoryPath: {
+          p: tmpFilePath,
+        },
+      })
+      assertLoggedErrorAndExitedProcess()
+    })
+
+    it('[isDirectoryPath] Should log error and exist if path does not exist', async () => {
+      await utils.logErrorAndExitIfNotSatisfied({
+        isDirectoryPath: {
+          p: '/non/existing/path',
+        },
+      })
+      assertLoggedErrorAndExitedProcess()
     })
   })
 


### PR DESCRIPTION
Add the following new guard functions to `Ensure` / `logErrorAndExitIfNotSatisfied` :
- `pathExist` (check if a given path exists)
- `isFilePath` (check if a given path is a path to a file)
- `isDirectoryPath` (check if a given path is a path to a directory)

Can be used in a few places but will be use to improve recent new commands `cauldron add file` / `cauldron update file`, in a separate PR.