### PR TITLE
Add cauldron file uri scheme support

### DIFF
--- a/ern-cauldron-api/src/CauldronApi.ts
+++ b/ern-cauldron-api/src/CauldronApi.ts
@@ -1,6 +1,6 @@
 import * as schemas from './schemas'
 import { NativeApplicationDescriptor, PackagePath } from 'ern-core'
-import { exists, joiValidate, shasum } from './util'
+import { exists, joiValidate, shasum, normalizeCauldronFilePath } from './util'
 import _ from 'lodash'
 import {
   Cauldron,
@@ -822,6 +822,7 @@ export default class CauldronApi {
     if (!fileContent) {
       throw new Error('[addFile] fileContent is required')
     }
+    cauldronFilePath = normalizeCauldronFilePath(cauldronFilePath)
     if (await this.hasFile({ cauldronFilePath })) {
       throw new Error(
         `[addFile] ${cauldronFilePath} already exists. Use updateFile instead.`
@@ -845,6 +846,7 @@ export default class CauldronApi {
     if (!fileContent) {
       throw new Error('[updateFile] fileContent is required')
     }
+    cauldronFilePath = normalizeCauldronFilePath(cauldronFilePath)
     if (!(await this.hasFile({ cauldronFilePath }))) {
       throw new Error(
         `[updateFile] ${cauldronFilePath} does not exist. Use addFile first.`
@@ -857,6 +859,7 @@ export default class CauldronApi {
     if (!cauldronFilePath) {
       throw new Error('[removeFile] cauldronFilePath is required')
     }
+    cauldronFilePath = normalizeCauldronFilePath(cauldronFilePath)
     if (!(await this.hasFile({ cauldronFilePath }))) {
       throw new Error(`[removeFile] ${cauldronFilePath} does not exist`)
     }
@@ -864,6 +867,7 @@ export default class CauldronApi {
   }
 
   public async hasFile({ cauldronFilePath }: { cauldronFilePath: string }) {
+    cauldronFilePath = normalizeCauldronFilePath(cauldronFilePath)
     return this.fileStore.hasFile(cauldronFilePath)
   }
 
@@ -875,6 +879,7 @@ export default class CauldronApi {
     if (!cauldronFilePath) {
       throw new Error('[removeFile] cauldronFilePath is required')
     }
+    cauldronFilePath = normalizeCauldronFilePath(cauldronFilePath)
     if (!(await this.hasFile({ cauldronFilePath }))) {
       throw new Error(`[getFile] ${cauldronFilePath} does not exist.`)
     }

--- a/ern-cauldron-api/src/index.ts
+++ b/ern-cauldron-api/src/index.ts
@@ -22,4 +22,5 @@ export {
 export {
   getSchemaVersionMatchingCauldronApiVersion,
   getCurrentSchemaVersion,
+  cauldronFileUriScheme,
 } from './util'

--- a/ern-cauldron-api/src/util.ts
+++ b/ern-cauldron-api/src/util.ts
@@ -65,3 +65,9 @@ export function getSchemaVersionMatchingCauldronApiVersion(
 export function getCurrentSchemaVersion() {
   return schemaVersion
 }
+
+export const cauldronFileUriScheme = 'cauldron://'
+
+export function normalizeCauldronFilePath(cauldronFilePath: string): string {
+  return cauldronFilePath && cauldronFilePath.replace(cauldronFileUriScheme, '')
+}

--- a/ern-cauldron-api/test/CauldronApi-test.ts
+++ b/ern-cauldron-api/test/CauldronApi-test.ts
@@ -1884,6 +1884,24 @@ describe('CauldronApi.js', () => {
         })
       )
     })
+
+    it('should add the file [non cauldron scheme]', async () => {
+      const api = cauldronApi()
+      await api.addFile({
+        cauldronFilePath: 'dir/file',
+        fileContent: 'content',
+      })
+      assert(await api.hasFile({ cauldronFilePath: 'dir/file' }))
+    })
+
+    it('should add the file [cauldron scheme]', async () => {
+      const api = cauldronApi()
+      await api.addFile({
+        cauldronFilePath: 'cauldron://dir/file',
+        fileContent: 'content',
+      })
+      assert(await api.hasFile({ cauldronFilePath: 'dir/file' }))
+    })
   })
 
   // ==========================================================
@@ -1925,6 +1943,34 @@ describe('CauldronApi.js', () => {
         })
       )
     })
+
+    it('should update the file [non cauldron scheme]', async () => {
+      const api = cauldronApi()
+      await api.addFile({
+        cauldronFilePath: 'dir/file',
+        fileContent: 'content',
+      })
+      assert(
+        await doesNotThrow(api.updateFile, api, {
+          cauldronFilePath: 'dir/file',
+          fileContent: 'content',
+        })
+      )
+    })
+
+    it('should update the file [cauldron scheme]', async () => {
+      const api = cauldronApi()
+      await api.addFile({
+        cauldronFilePath: 'dir/file',
+        fileContent: 'content',
+      })
+      assert(
+        await doesNotThrow(api.updateFile, api, {
+          cauldronFilePath: 'cauldron://dir/file',
+          fileContent: 'content',
+        })
+      )
+    })
   })
 
   // ==========================================================
@@ -1957,6 +2003,30 @@ describe('CauldronApi.js', () => {
         })
       )
     })
+
+    it('should remove the file [non cauldron scheme]', async () => {
+      const api = cauldronApi()
+      await api.addFile({
+        cauldronFilePath: 'dir/file',
+        fileContent: 'content',
+      })
+      await api.removeFile({
+        cauldronFilePath: 'dir/file',
+      })
+      assert(!(await api.hasFile({ cauldronFilePath: 'dir/file' })))
+    })
+
+    it('should remove the file [cauldron scheme]', async () => {
+      const api = cauldronApi()
+      await api.addFile({
+        cauldronFilePath: 'dir/file',
+        fileContent: 'content',
+      })
+      await api.removeFile({
+        cauldronFilePath: 'cauldron://dir/file',
+      })
+      assert(!(await api.hasFile({ cauldronFilePath: 'dir/file' })))
+    })
   })
 
   // ==========================================================
@@ -1988,6 +2058,28 @@ describe('CauldronApi.js', () => {
           cauldronFilePath: 'dir/file',
         })
       )
+    })
+
+    it('should get the file [non cauldron scheme]', async () => {
+      const api = cauldronApi()
+      await api.addFile({
+        cauldronFilePath: 'dir/file',
+        fileContent: 'content',
+      })
+      const file = await api.getFile({ cauldronFilePath: 'dir/file' })
+      expect(file.toString()).eql('content')
+    })
+
+    it('should get the file [cauldron scheme]', async () => {
+      const api = cauldronApi()
+      await api.addFile({
+        cauldronFilePath: 'dir/file',
+        fileContent: 'content',
+      })
+      const file = await api.getFile({
+        cauldronFilePath: 'cauldron://dir/file',
+      })
+      expect(file.toString()).eql('content')
     })
   })
 

--- a/ern-cauldron-api/test/util-test.ts
+++ b/ern-cauldron-api/test/util-test.ts
@@ -1,6 +1,5 @@
-import { assert, expect } from 'chai'
+import { expect } from 'chai'
 import * as util from '../src/util'
-import sinon from 'sinon'
 
 describe('util.js', () => {
   describe('exists', () => {
@@ -64,6 +63,18 @@ describe('util.js', () => {
     it('should return the correct file name extension for iOS', () => {
       const result = util.getNativeBinaryFileExt('ios')
       expect(result).eql('app')
+    })
+  })
+
+  describe('normalizeCauldronFilePath', () => {
+    it('should return the path as such for a non cauldron scheme path', () => {
+      const result = util.normalizeCauldronFilePath('dir/file')
+      expect(result).eql('dir/file')
+    })
+
+    it('should remove the cauldron scheme for a cauldron scheme path', () => {
+      const result = util.normalizeCauldronFilePath('cauldron://dir/file')
+      expect(result).eql('dir/file')
     })
   })
 })


### PR DESCRIPTION
Update Cauldron file access functions to support Cauldron file paths prefixed by new `cauldron://` file uri scheme.

This allows to build new features that can reference files stored in Cauldron using the `cauldron://` scheme, to properly distinguish a path to a file stored in Cauldron v.s a local file path. 
i.e `cauldron://dir/file.json` is the path to a file named `file.json` located in the `dir` directory in Cauldron, whereas `dir/file.json` indicate a local path to a file name `file.json` in the `dir` directory relative to the current pwd.

