### PR TITLE
Extra config from cauldron file

### DIFF
--- a/docs/cli/cauldron/add/publisher.md
+++ b/docs/cli/cauldron/add/publisher.md
@@ -3,35 +3,79 @@
 ### Description
 
 * Add a Container publisher for a given native application to automatically publish generated Containers to a remote location.
-* A native application can have more than one Container publisher.
+* A native application can have more than one Container publisher (for example you might want to publish you Containers to a Git repository, as well as a Maven repository)
 * If a native application has no publishers, Containers of this application will not be published anywhere (will just be generated locally).
 * Check the specific Container publisher documentation as it contains reference on how to use this command with it.
+* You can create/distribute your own custom custom Container publisher if needed.
 
-#### Syntax
+### Currently Available Official Publishers
+
+- [git](https://github.com/electrode-io/ern-container-publisher-maven)  
+To publish Android and iOS Electrode Native Containers to a remote git repository. The git repository provider does not matter (GitHub, BitBucket, TFS ...).
+
+- [maven](https://github.com/electrode-io/ern-container-publisher-maven)  
+To publish Android Electrode Native Containers to a local or remote Maven repository.
+
+- [jcenter](https://github.com/electrode-io/ern-container-publisher-jcenter)  
+To publish Android Electrode Native Containers to a remote JCenter repository.
+
+- [dummy](https://github.com/electrode-io/ern-container-publisher-dummy)  
+This publisher is mostly used for testing and as starter simple publisher reference to create your own. It does not actually publish the Containers anywhere.
+
+### Syntax
 
 **Options**
 
 `--publisher/-p`
 
-* The Container publisher to add
+* The name of the Container publisher to add (for ex `git`)
+* Can also include a specific version or a version range (for ex `git@1.0.0` or `git@^1.0.0`)
+* If no version is specified, the latest available version of the publisher will be used at the time of publication (this is a bit risky given that new major publisher versions will contain breaking changes. We **recommend** that you use a specific version or version range allowing minor and patch updates only)
+* This option is required, there is no default.
 
 `--url/-u`
 
-* The url to publish the Container to 
+* The url to publish the Container to
 * Some publishers might not need an url. Check the specific Container publisher documentation for reference
 
 `--descriptor/-d`
 
-* Partial native application descriptor (without version)
-* If ommitted, the command will prompt interactively
+* Partial native application descriptor (without version) corresponding to a specific native application / platform couple (for example `MyNativeApp:android`) for which to add the publisher to.
+* If ommitted, the command will prompt interactively to select a native application and platform couple from the Cauldron
 
-`--config/c`
+`--extra/-e`
 
-* Extra configuration specific to the publisher used.
-* Some publishers might not need an extra configuration. Check the Container publisher documentation for reference.
+* Extra configuration specific to the publisher (as json)
+* Some publishers might not need any extra configuration. Check the specific Container publisher documentation for reference.
+* There is three different ways to provide the json extra configuration :
+  - **As a json string**  
+  For example `--extra '{"configKey": "configValue"}'`  
+  In that case, the configuration will be added to the Cauldron main document.  
+  - **As a file path**  
+  For example `--extra /Users/username/my-publisher-config.json`  
+  In that case, the configuration will be read from the file and will be added to the Cauldron main document.
+  - **As a Cauldron file path**  
+  For example `--extra cauldron://config/publishers/my-publisher-config.json`  
+  In that case, the configuration will not be added to the Cauldron main document, but only the reference to the file stored in Cauldron that is containing the configuration.  
+  For this way to work, the file must exist in Cauldron (you can add a file to the cauldron by using the [ern cauldron add file] command).  
+  This is the recommend approach, especially for large configurations, as the configuration is kept separate from the main Cauldron document (not bloating it) and all configurations can be grouped in a specific location in Cauldron, making it easier to refer to and manage.
 
-#### Remarks
 
-* The `ern cauldron add publisher` command is mostly used during the initial setup of cauldron.
-* You can create your own Container publisher if you need to !
+### Examples
 
+- `ern cauldron add publisher -p git -u git@github.com:user/walmart-ios-container.git -d walmart:ios`  
+Add a git publisher for the walmart iOS native application.  
+All Containers generated from Cauldron for the walmart iOS application, will be published to the user/walmart-ios-container git repository on GitHub.
+
+- `ern cauldron add publisher -p maven -u https://url/to/maven/repository -d walmart:android -e '{"artifactId": "walmart-android-container", "groupId": "com.walmart.container"}'`  
+Add a maven publisher for the walmart Android native application.  
+All Containers generated from Cauldron for the walmart Android application, will be published to the maven repository located at https://url/to/maven/repository. The artifactId/groupId used for the maven artifact will be walmart-android-container/com.walmart.container.
+
+- `ern cauldron add publisher -p maven -u https://url/to/maven/repository -d walmart:android -e /path/to/walmart-maven-publisher-config.json`  
+Same as previous example, but the json configuration (artifactId/groupId) is retrieved from a local file.
+
+- `ern cauldron add publisher -p maven -u https://url/to/maven/repository -d walmart:android -e cauldron://config/walmart/publishers/maven-publisher-config.json`  
+Same as previous example, but the maven publisher configuration is stored in the maven-publisher-config.json file in the config/walmart/publishers directory of the Cauldron.
+
+_________
+[ern cauldron add file]: ../add/file.md

--- a/docs/cli/publish-container.md
+++ b/docs/cli/publish-container.md
@@ -4,15 +4,23 @@
 
 * This command can be used to publish a local Container to a remote repository using a given publisher.
 
+### Currently Available Official Publishers
+
+- [git](https://github.com/electrode-io/ern-container-publisher-maven)  
+To publish Android and iOS Electrode Native Containers to a remote git repository. The git repository provider does not matter (GitHub, BitBucket, TFS ...).
+
+- [maven](https://github.com/electrode-io/ern-container-publisher-maven)  
+To publish Android Electrode Native Containers to a local or remote Maven repository.
+
+- [jcenter](https://github.com/electrode-io/ern-container-publisher-jcenter)  
+To publish Android Electrode Native Containers to a remote JCenter repository.
+
+- [dummy](https://github.com/electrode-io/ern-container-publisher-dummy)  
+This publisher is mostly used for testing and as starter simple publisher reference to create your own. It does not actually publish the Containers anywhere.
+
 #### Syntax
 
-`ern publish-container <containerPath>`  
-
-**Arguments**
-
-`<containerPath>`
-
-* The local file system path to the directory containing the Container to publish.
+`ern publish-container`  
 
 **Options**  
 
@@ -21,37 +29,47 @@
 * The local file system path to the directory containing the Container to publish.
 * **Default**  If this option is not provided, the command will look for a Container in the default platform directory `~/.ern/containergen/out/[platform]`.
 
-`--platform <android|ios>`
+`--platform`
 
-* Specify the native platform of the target Container to publish.
+* Specify the native platform of the target Container to publish (`android` or `ios`)
 * This option is required, there is no default.
 
-`--version/-v <version>`
+`--version/-v`
 
 * Specify the Container version to use for publication.
 * The version must be in the format: `x.y.z` where x, y and z are integers. For example `version=1.2.30`.
 * Defaults to `1.0.0`.
 
-`--publisher/-p <publisher>`
+`--publisher/-p`
 
 * Specify the Container publisher to use.
 * This option is required, there is no default.
 * You can also use a local file system path to a Container publisher package (only used for developing custom publishers)
 
-`--url/-u <url>`
+`--url/-u`
 
 * The url to publish the Container to 
 * Some publishers might not need an url. Check the specific Container publisher documentation for reference
 
-`--config/-c <config>`
+`--extra/-e`
 
 * Extra configuration specific to the publisher used.
 * Some publishers might not need an extra configuration. Check the Container publisher documentation for reference.
-* The configuration is a json document.
-* Configuration can either be a json string or the path to a file holding the configuration.
+* There is three different ways to provide the json extra configuration :
+  - **As a json string**  
+  For example `--extra '{"configKey": "configValue"}'`    
+  - **As a file path**  
+  For example `--extra /Users/username/my-publisher-config.json`  
+  In that case, the configuration will be read from the file.  
+  - **As a Cauldron file path**  
+  For example `--extra cauldron://config/publishers/my-publisher-config.json`  
+  In that case, the configuration will be read from the file stored in Cauldron.   
+  For this way to work, the file must exist in Cauldron (you can add a file to the cauldron by using the [ern cauldron add file] command). 
+
 
 #### Related commands
 
 [ern create-container] | Create a new container (native or JavaScript only) locally to the workstation.
 
 [ern create-container]: ./create-container.md
+[ern cauldron add file]: ./add/file.md

--- a/docs/cli/transform-container.md
+++ b/docs/cli/transform-container.md
@@ -1,8 +1,16 @@
 ## `ern transform-container`
 
-#### Description
+### Description
 
 * This command can be used to transform a local Container using a given Container transformer.
+
+### Currently Available Official Transformers
+
+- [pbxproj](https://github.com/electrode-io/ern-container-transformer-pbxproj)  
+Can be used to patch one or more pbxproj (iOS project file) included in the Container, in specific ways.
+
+- [build-config](https://github.com/electrode-io/ern-container-transformer-build-config)  
+ can be used to update Build Configuration(s) -build settings- of a generated iOS Container.
 
 #### Syntax
 
@@ -15,29 +23,40 @@
 * The local file system path to the directory containing the Container to transform.
 * **Default**  If this option is not provided, the command will look for a Container in the default platform directory `~/.ern/containergen/out/[platform]`.
 
-`--platform/-p <android|ios>`
+`--platform/-p`
 
 * Specify the native platform of the target Container to transform.
 * This option is required, there is no default.
 
-`--transformer/-t <transformer>`
+`--transformer/-t`
 
 * Specify the Container transformer to use (for ex `build-config`).
-* A semantic version for the transformer can be specified (for ex `build-config@1.0.0` or `build-config@^1.0.0`).
+* Can also include a specific version or a version range (for ex `build-config@1.0.0` or `build-config@^1.0.0`)
+* If no version is specified, the latest available version of the publisher will be used at the time of publication (this is a bit risky given that new major publisher versions will contain breaking changes. We **recommend** that you use a specific version or version range allowing minor and patch updates only)
 * It is also possible to pass a local file system path to a Container transformer package (only used for transformers development).
 * This option is required, there is no default.
 
-`--config/-c <config>`
+`--extra/-e`
 
-* Extra configuration specific to the transformer used.
-* Some transformers might not need an extra configuration. Check the specific Container transformer documentation for reference.
-* The configuration is a json document.
-* Configuration can either be a json string or the path to a file holding the configuration.
+* Extra configuration specific to the transformer (as json)
+* Some transformers might not need any extra configuration. Check the specific Container transformer documentation for reference.
+* There is three different ways to provide the json extra configuration :
+  - **As a json string**  
+  For example `--extra '{"configKey": "configValue"}'`  
+  - **As a file path**  
+  For example `--extra /Users/username/my-transformer-config.json`  
+  In that case, the configuration will be read from the file
+  - **As a Cauldron file path**  
+  For example `--extra cauldron://config/publishers/my-transformer-config.json`  
+  In that case, the configuration will be read from the file stored in Cauldron.   
+  For this way to work, the file must exist in Cauldron (you can add a file to the cauldron by using the [ern cauldron add file] command).  
 
 #### Related commands
 
-[ern create-container] | Create a new Container (native or JavaScript only) locally to the workstation.
+[ern create-container] | Create a new Container (native or JavaScript only) locally to the workstation.  
 [ern publish-container] | Publish a Container.
 
+_________
 [ern create-container]: ./create-container.md
 [ern publish-container]: ./publish-container.md
+[ern cauldron add file]: ./add/file.md

--- a/ern-local-cli/src/commands/cauldron/add/publisher.ts
+++ b/ern-local-cli/src/commands/cauldron/add/publisher.ts
@@ -1,5 +1,5 @@
 import { NativeApplicationDescriptor, utils as coreUtils, log } from 'ern-core'
-import { getActiveCauldron } from 'ern-cauldron-api'
+import { getActiveCauldron, cauldronFileUriScheme } from 'ern-cauldron-api'
 import { getPublisher, ContainerPublisher } from 'ern-container-publisher'
 import utils from '../../../lib/utils'
 import { Argv } from 'yargs'
@@ -29,7 +29,7 @@ export const builder = (argv: Argv) => {
     .option('extra', {
       alias: 'e',
       describe:
-        'Optional extra publisher configuration (json string or path to config file)',
+        'Optional extra publisher configuration (json string or local/cauldron path to config file)',
       type: 'string',
     })
 }
@@ -53,7 +53,41 @@ export const handler = async ({
       },
     })
 
-    const extraObj = extra && (await utils.parseJsonFromStringOrFile(extra))
+    const cauldron = await getActiveCauldron()
+
+    let extraObj
+    if (extra) {
+      if (extra.startsWith(cauldronFileUriScheme)) {
+        //
+        // Cauldron file path.
+        // In that case, the extra property set for this publisher
+        // in Cauldron, will be a string, with its value being
+        // the path to the json extra config file stored in
+        // Cauldron.
+        // For example :
+        //  "extra": "cauldron://config/publishers/maven.json"
+
+        // We just validate that the file exist in Cauldron ...
+        if (!(await cauldron.hasFile({ cauldronFilePath: extra }))) {
+          throw new Error(`File ${extra} does not exist in Cauldron.`)
+        }
+        // ... and that it is a properly formatted json file
+        const cauldronFile = await cauldron.getFile({ cauldronFilePath: extra })
+        await utils.parseJsonFromStringOrFile(cauldronFile.toString())
+        extraObj = extra
+      } else {
+        // Local file path to json file or json string.
+        // In that case, the extra property set for this publisher
+        // in Cauldron, will be the the json string, or the
+        // content of the json file, as such
+        // For example :
+        // "extra": {
+        //   "artifactId": "app-container",
+        //   "groupId": "com.company.app"
+        // }
+        extraObj = await utils.parseJsonFromStringOrFile(extra)
+      }
+    }
 
     const p: ContainerPublisher = await getPublisher(publisher)
 
@@ -69,7 +103,6 @@ export const handler = async ({
       }
     }
 
-    const cauldron = await getActiveCauldron()
     await cauldron.addPublisher(
       publisher,
       p.platforms,

--- a/ern-local-cli/src/commands/publish-container.ts
+++ b/ern-local-cli/src/commands/publish-container.ts
@@ -40,7 +40,7 @@ export const builder = (argv: Argv) => {
     .option('extra', {
       alias: 'e',
       describe:
-        'Optional extra publisher configuration (json string or path to config file)',
+        'Optional extra publisher configuration (json string or local/cauldron path to config file)',
       type: 'string',
     })
     .epilog(utils.epilog(exports))

--- a/ern-local-cli/src/commands/transform-container.ts
+++ b/ern-local-cli/src/commands/transform-container.ts
@@ -17,7 +17,7 @@ export const builder = (argv: Argv) => {
     .option('extra', {
       alias: 'e',
       describe:
-        'Optional extra transformer configuration (json string or path to config file)',
+        'Optional extra transformer configuration (json string or local/cauldron path to config file)',
       type: 'string',
     })
     .option('platform', {

--- a/ern-local-cli/src/lib/utils.ts
+++ b/ern-local-cli/src/lib/utils.ts
@@ -18,7 +18,7 @@ import {
 } from 'ern-core'
 import { publishContainer } from 'ern-container-publisher'
 import { transformContainer } from 'ern-container-transformer'
-import { getActiveCauldron } from 'ern-cauldron-api'
+import { getActiveCauldron, cauldronFileUriScheme } from 'ern-cauldron-api'
 import { RunnerGenerator, RunnerGeneratorConfig } from 'ern-runner-gen'
 import { AndroidRunnerGenerator } from 'ern-runner-gen-android'
 import { IosRunnerGenerator } from 'ern-runner-gen-ios'
@@ -542,9 +542,23 @@ async function performContainerStateUpdateInCauldron(
       containerGenConfig && containerGenConfig.transformers
     if (transformersFromCauldron) {
       for (const transformerFromCauldron of transformersFromCauldron) {
+        let extra = transformerFromCauldron.extra
+        if (
+          extra &&
+          typeof extra === 'string' &&
+          extra.startsWith(cauldronFileUriScheme)
+        ) {
+          if (!(await cauldron.hasFile(extra))) {
+            throw new Error(
+              `Cannot find transformer extra config file ${extra} in Cauldron`
+            )
+          }
+          const extraFile = await cauldron.getFile(extra)
+          extra = parseJsonFromStringOrFile(extraFile.toString())
+        }
         await transformContainer({
           containerPath: outDir,
-          extra: transformerFromCauldron.extra,
+          extra,
           platform: napDescriptor.platform,
           transformer: transformerFromCauldron.name,
         })
@@ -577,6 +591,17 @@ async function performContainerStateUpdateInCauldron(
               groupId: 'com.walmartlabs.ern',
             }
           }
+        } else if (
+          typeof extra === 'string' &&
+          extra.startsWith(cauldronFileUriScheme)
+        ) {
+          if (!(await cauldron.hasFile(extra))) {
+            throw new Error(
+              'Cannot find publisher extra config file ${extra} in Cauldron'
+            )
+          }
+          const extraFile = await cauldron.getFile(extra)
+          extra = parseJsonFromStringOrFile(extraFile.toString())
         }
 
         // ==================================================================
@@ -1251,18 +1276,26 @@ async function unzip(zippedData: Buffer, destPath: string) {
 /**
  * Parse json from a string or a file and return the
  * resulting JavaScript object
- * @param s A json string or a path to a json file
+ * @param s A json string or a local file path to a json file.
+ * Can also be a reference to a file stored in cauldron, using
+ * the cauldron:// file scheme.
  */
 async function parseJsonFromStringOrFile(s: string): Promise<any> {
   let result
   try {
-    if (fs.existsSync(s)) {
+    if (s.startsWith(cauldronFileUriScheme)) {
+      const cauldron = await getActiveCauldron()
+      const file = await cauldron.getFile({
+        cauldronFilePath: s,
+      })
+      result = JSON.parse(file.toString())
+    } else if (fs.existsSync(s)) {
       result = await fileUtils.readJSON(s)
     } else {
       result = JSON.parse(s)
     }
   } catch (e) {
-    throw new Error('[parseJsonFromStringOrFile] Invalid JSON')
+    throw new Error('[parseJsonFromStringOrFile] Invalid JSON or file')
   }
   return result
 }


### PR DESCRIPTION
Update the following commands 

- `cauldron add publisher`
- `publish-container`
- `publish-transformer`

so that the publisher/transformer extra config can be a path to a configuration file stored in Cauldron (using the `cauldron://` file uri scheme).

Update documentation of these commands.

