### PR TITLE
Add ECDevice scheme to iOS Container

### DIFF
--- a/ern-container-gen-ios/src/hull/ElectrodeContainer.xcodeproj/xcshareddata/xcschemes/ECDevice.xcscheme
+++ b/ern-container-gen-ios/src/hull/ElectrodeContainer.xcodeproj/xcshareddata/xcschemes/ECDevice.xcscheme
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "83CBBA2D1A601D0E00E9B192"
+               BuildableName = "libReact.a"
+               BlueprintName = "React"
+               ReferencedContainer = "container:ElectrodeContainer/Libraries/ReactNative/React/React.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "485009E21E2FF23B009B6610"
+               BuildableName = "ElectrodeContainer.framework"
+               BlueprintName = "ElectrodeContainer"
+               ReferencedContainer = "container:ElectrodeContainer.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "485009EB1E2FF23C009B6610"
+               BuildableName = "ElectrodeContainerTests.xctest"
+               BlueprintName = "ElectrodeContainerTests"
+               ReferencedContainer = "container:ElectrodeContainer.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "485009E21E2FF23B009B6610"
+            BuildableName = "ElectrodeContainer.framework"
+            BlueprintName = "ElectrodeContainer"
+            ReferencedContainer = "container:ElectrodeContainer.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "485009E21E2FF23B009B6610"
+            BuildableName = "ElectrodeContainer.framework"
+            BlueprintName = "ElectrodeContainer"
+            ReferencedContainer = "container:ElectrodeContainer.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "485009E21E2FF23B009B6610"
+            BuildableName = "ElectrodeContainer.framework"
+            BlueprintName = "ElectrodeContainer"
+            ReferencedContainer = "container:ElectrodeContainer.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
This scheme is needed for the Fat Binary script which will be moved to a transformer soon.
It is duplicated from the ElectrodeContainer scheme with the difference that the default run configuration is release (instead of debug).
iOS system tests fixture donot need to be regenerated (ran iOS Container system tests locally without any issue).