### PR TITLE
Expose API swift files as public headers in ElectrodeContainer

### DIFF
--- a/ern-api-impl-gen/package.json
+++ b/ern-api-impl-gen/package.json
@@ -58,7 +58,7 @@
     "mustache": "^2.3.0",
     "semver": "5.5.0",
     "xcode": "^0.9.1",
-    "xcode-ern": "^1.0.4",
+    "xcode-ern": "^1.0.8",
     "@yarnpkg/lockfile": "^1.0.1"
   },
   "devDependencies": {

--- a/ern-container-gen-ios/package.json
+++ b/ern-container-gen-ios/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "ern-container-gen": "1000.0.0",
     "ern-core": "1000.0.0",
-    "xcode-ern": "^1.0.4",
+    "xcode-ern": "^1.0.8",
     "lodash":"^4.17.10",
     "fs-readdir-recursive": "^1.1.0"
   },

--- a/ern-container-gen/package.json
+++ b/ern-container-gen/package.json
@@ -69,7 +69,7 @@
     "fs-readdir-recursive": "^1.1.0",
     "mustache": "^2.3.0",
     "semver": "^5.5.0",
-    "xcode-ern": "^1.0.4"
+    "xcode-ern": "^1.0.8"
   },
   "devDependencies": {
     "ern-util-dev": "1000.0.0",

--- a/ern-core/package.json
+++ b/ern-core/package.json
@@ -63,7 +63,7 @@
     "simple-git": "^1.95.0",
     "tmp": "^0.0.33",
     "uuid":"^3.2.1",
-    "xcode-ern": "^1.0.4",
+    "xcode-ern": "^1.0.8",
     "yarn": "^1.7.0"
   },
   "devDependencies": {

--- a/ern-core/src/Manifest.ts
+++ b/ern-core/src/Manifest.ts
@@ -225,7 +225,15 @@ export interface IosPluginAddFileDirective {
  */
 export interface IosPluginAddHeaderDirective {
   /**
-   * Relative path (from plugin root) to the header to add
+   * Source directory and filename widlcard to add
+   * ex: IOS/*.swift
+   *
+   */
+  from?: string
+  /**
+   * Relative path (from plugin root) to the source file(s) to add
+   * If `from` is specified, this is the path of the target directory
+   * If `from` is not specified, this is the path of the source file
    */
   path: string
   /**
@@ -243,15 +251,19 @@ export interface IosPluginAddHeaderDirective {
  */
 export interface IosPluginAddSourceDirective {
   /**
-   * ??? TODO : Check if this is really used
+   * Source directory and filename widlcard to add
+   * ex: IOS/*.swift
+   *
    */
-  from: string
+  from?: string
   /**
    * Target iOS project group to add the source file to
    */
   group: string
   /**
-   * Relative path (from plugin root) to the source file to add
+   * Relative path (from plugin root) to the source file(s) to add
+   * If `from` is specified, this is the path of the target directory
+   * If `from` is not specified, this is the path of the source file
    */
   path: string
 }
@@ -659,6 +671,14 @@ export class Manifest {
           },
         ],
         pbxproj: {
+          addHeader: [
+            {
+              from: 'IOS/*.swift',
+              group: 'APIs',
+              path: 'APIs',
+              public: true,
+            },
+          ],
           addSource: [
             {
               from: 'IOS/*.swift',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5864,9 +5864,9 @@ write-pkg@^3.1.0:
     sort-keys "^2.0.0"
     write-json-file "^2.2.0"
 
-xcode-ern@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/xcode-ern/-/xcode-ern-1.0.4.tgz#23e9e4c5b784e49f97f933d78882c6d9143915c9"
+xcode-ern@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/xcode-ern/-/xcode-ern-1.0.8.tgz#73541eee61ee7f9ab9bdc68b0bc625f2ae3a8fe2"
   dependencies:
     pegjs "^0.10.0"
     simple-plist "^0.2.1"


### PR DESCRIPTION
This is needed for Fat Binary proper support and is also more handy for some other use cases.
This feature requires `xcode-ern` version `1.0.8`, so the version of this dependency has been adequately bumped.