### PR TITLE
unit test for platform config command and refactor

### DIFF
--- a/docs/cli/platform/config/set.md
+++ b/docs/cli/platform/config/set.md
@@ -6,7 +6,7 @@
 
 #### Syntax
 
-`ern platform config set <key> [value]`
+`ern platform config set <key> <value>`
 
 **Arguments**
 
@@ -14,9 +14,9 @@
 
 * The key of the configuration element to set
 
-`[value]`
+`<value>`
 
-* If specified, will set the config value associated to this key. If not specified, will retrieve the config value (get) associated to this key.
+* If specified, will set the config value associated to this key. 
 
 **Configurable properties**
 
@@ -41,6 +41,6 @@ Code push access key associated with your account
 
 #### Remarks
 
-* The `ern platform config set <key> [value]` command is rarely used.  
+* The `ern platform config set <key> <value>` command is rarely used.  
 * All current configuration values are already set and retrieved transparently through the use of commands that rely on the local platform configuration.  
-* If a value is provided, the `ern platform config set <key> [value]` command sets the value associated with the given key with the specified value, overwriting any existing value stored for this key.
+* If a value is provided, the `ern platform config set <key> <value>` command sets the value associated with the given key with the specified value, overwriting any existing value stored for this key.

--- a/ern-core/src/config.ts
+++ b/ern-core/src/config.ts
@@ -26,7 +26,7 @@ export class ErnConfig {
   public setValue(key: string, value: any) {
     const c = this.obj
     c[key] = value
-    fs.writeFileSync(this.ernRcFilePath, JSON.stringify(c, null, 2))
+    this.writeConfig(c)
   }
 
   public writeConfig(obj: any) {
@@ -37,7 +37,7 @@ export class ErnConfig {
     const c = this.obj
     if (key && c.hasOwnProperty(key)) {
       delete c[key]
-      fs.writeFileSync(this.ernRcFilePath, JSON.stringify(c, null, 2))
+      this.writeConfig(c)
       return true
     }
     return false

--- a/ern-local-cli/src/commands/platform/config/set.ts
+++ b/ern-local-cli/src/commands/platform/config/set.ts
@@ -2,7 +2,7 @@ import { config as ernConfig, utils as coreUtils, log } from 'ern-core'
 import utils, { platformSupportedConfigAsString } from '../../../lib/utils'
 import { Argv } from 'yargs'
 
-export const command = 'set <key> [value]'
+export const command = 'set <key> <value>'
 export const desc = 'Sets the key to the value in the configuration file'
 
 export const builder = (argv: Argv) => {
@@ -14,11 +14,8 @@ export const handler = async ({
   value,
 }: {
   key: string
-  value?: string
+  value: string
 }) => {
-  if (!value) {
-    coreUtils.logErrorAndExitProcess(new Error(`Pass value for ${key}`))
-  }
   await utils.logErrorAndExitIfNotSatisfied({
     isValidPlatformConfig: {
       key,

--- a/ern-local-cli/src/lib/Ensure.ts
+++ b/ern-local-cli/src/lib/Ensure.ts
@@ -9,6 +9,8 @@ import _ from 'lodash'
 import semver from 'semver'
 import validateNpmPackageName from 'validate-npm-package-name'
 import fs from 'fs'
+import levenshtein from 'fast-levenshtein'
+import * as constants from './constants'
 export default class Ensure {
   public static isValidElectrodeNativeModuleName(
     name: string,
@@ -456,6 +458,26 @@ export default class Ensure {
     if (targetBinaryVersion && descriptors && descriptors.length > 1) {
       throw new Error(
         'targetBinaryVersion must specify only 1 target native application version for the push'
+      )
+    }
+  }
+
+  public static isValidPlatformConfig(
+    key: string,
+    extraErrorMessage: string = ''
+  ) {
+    const availablePlatformKeys = () =>
+      constants.availableUserConfigKeys.map(e => e.name)
+    if (!availablePlatformKeys().includes(key)) {
+      const closestKeyName = k =>
+        availablePlatformKeys().reduce(
+          (acc, cur) =>
+            levenshtein.get(acc, k) > levenshtein.get(cur, k) ? cur : acc
+        )
+      throw new Error(
+        `Configuration key ${key} does not exists. Did you mean ${closestKeyName(
+          key
+        )}?`
       )
     }
   }

--- a/ern-local-cli/src/lib/utils.ts
+++ b/ern-local-cli/src/lib/utils.ts
@@ -37,7 +37,6 @@ import yauzl from 'yauzl'
 import yazl from 'yazl'
 import readDir from 'fs-readdir-recursive'
 import os from 'os'
-import levenshtein from 'fast-levenshtein'
 
 const { runAndroidProject } = android
 
@@ -395,24 +394,8 @@ async function logErrorAndExitIfNotSatisfied({
       await Ensure.isDirectoryPath(isDirectoryPath.p)
     }
     if (isValidPlatformConfig) {
-      const availablePlatformKeys = () =>
-        constants.availableUserConfigKeys.map(e => e.name)
-      if (!availablePlatformKeys().includes(isValidPlatformConfig.key)) {
-        const closestKeyName = key =>
-          availablePlatformKeys().reduce(
-            (acc, cur) =>
-              levenshtein.get(acc, key) > levenshtein.get(cur, key) ? cur : acc
-          )
-        coreUtils.logErrorAndExitProcess(
-          new Error(
-            `Configuration key ${
-              isValidPlatformConfig.key
-            } does not exists. Did you mean ${closestKeyName(
-              isValidPlatformConfig.key
-            )}?\n${platformSupportedConfigAsString()}`
-          )
-        )
-      }
+      spinner.text = 'Ensuring that config key is whitelisted'
+      Ensure.isValidPlatformConfig(isValidPlatformConfig.key)
     }
     spinner.succeed('Validity checks have passed')
   } catch (e) {

--- a/ern-local-cli/test/utils-test.js
+++ b/ern-local-cli/test/utils-test.js
@@ -485,10 +485,55 @@ describe('utils.js', () => {
     it('[isValidPlatformConfig] Should log error and exit if key is not whitelisted', async () => {
       await utils.logErrorAndExitIfNotSatisfied({
         isValidPlatformConfig: {
-          p: 'keyNotWhiteListed',
+          key: 'keyNotWhiteListed',
         },
       })
       assertLoggedErrorAndExitedProcess()
+    })
+
+    it('[isValidPlatformConfig] Should not log error and nor exit if key is whitelisted', async () => {
+      await utils.logErrorAndExitIfNotSatisfied({
+        isValidPlatformConfig: {
+          key: 'showBanner',
+        },
+      })
+      assertNoErrorLoggedAndNoProcessExit()
+    })
+
+    it('[isValidPlatformConfig] Should not log error and nor exit if key is whitelisted', async () => {
+      await utils.logErrorAndExitIfNotSatisfied({
+        isValidPlatformConfig: {
+          key: 'logLevel',
+        },
+      })
+      assertNoErrorLoggedAndNoProcessExit()
+    })
+
+    it('[isValidPlatformConfig] Should not log error and nor exit if key is whitelisted', async () => {
+      await utils.logErrorAndExitIfNotSatisfied({
+        isValidPlatformConfig: {
+          key: 'tmp-dir',
+        },
+      })
+      assertNoErrorLoggedAndNoProcessExit()
+    })
+
+    it('[isValidPlatformConfig] Should not log error and nor exit if key is whitelisted', async () => {
+      await utils.logErrorAndExitIfNotSatisfied({
+        isValidPlatformConfig: {
+          key: 'retain-tmp-dir',
+        },
+      })
+      assertNoErrorLoggedAndNoProcessExit()
+    })
+
+    it('[isValidPlatformConfig] Should not log error and nor exit if key is whitelisted', async () => {
+      await utils.logErrorAndExitIfNotSatisfied({
+        isValidPlatformConfig: {
+          key: 'codePushAccessKey',
+        },
+      })
+      assertNoErrorLoggedAndNoProcessExit()
     })
   })
 


### PR DESCRIPTION
unit test for platform config command and refactor

- make `<value>` mandatory
- refactor logic for checking validity of whitelisted `key` to `Ensure`
- unit test supported `config` & test for unsupported key