### PR TITLE
Get rid of dependency on collections in ern-api-gen

### DIFF
--- a/ern-api-gen/package.json
+++ b/ern-api-gen/package.json
@@ -50,7 +50,6 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "collections": "^5.1.2",
     "ern-core": "1000.0.0",
     "inquirer": "^3.0.6",
     "json-stable-stringify": "^1.0.1",

--- a/ern-api-gen/src/CodegenOperation.js
+++ b/ern-api-gen/src/CodegenOperation.js
@@ -93,7 +93,7 @@ export default class CodegenOperation {
    */
   isMemberPath() {
     if (this.pathParams.length !== 1) return false
-    let id = this.pathParams.get(0).baseName
+    let id = this.pathParams[0].baseName
     return '/{' + id + '}' === this.pathWithoutBaseName()
   }
 

--- a/ern-api-gen/src/DefaultCodegen.js
+++ b/ern-api-gen/src/DefaultCodegen.js
@@ -278,7 +278,7 @@ export default class DefaultCodegen {
           for (const intf of cm.interfaces) {
             const intfModel = allModels.get(intf)
             if (intfModel != null) {
-              cm.interfaceModels.add(intfModel)
+              cm.interfaceModels.push(intfModel)
             }
           }
         }
@@ -1241,7 +1241,7 @@ export default class DefaultCodegen {
             parent = _interface
           } else {
             let interfaceRef = this.toModelName(_interface.getSimpleRef())
-            m.interfaces.add(interfaceRef)
+            m.interfaces.push(interfaceRef)
             this.addImport(m, interfaceRef)
             if (allDefinitions != null) {
               if (this.supportsInheritance) {
@@ -1764,7 +1764,7 @@ export default class DefaultCodegen {
           imports.add(r.baseType)
         }
         r.isDefault = response === methodResponse
-        op.responses.add(r)
+        op.responses.push(r)
         if (r.isBinary && r.isDefault) {
           op.isResponseBinary = true
         }
@@ -1877,9 +1877,9 @@ export default class DefaultCodegen {
           cookieParams.push(p.copy())
         } else if (param != null && param instanceof BodyParameter) {
           bodyParam = p.copy()
-          bodyParams.add(p)
+          bodyParams.push(p)
         } else if (param != null && param instanceof FormParameter) {
-          formParams.add(p)
+          formParams.push(p)
         }
         if (p.required == null || !p.required) {
           op.hasOptionalParams = true
@@ -2335,12 +2335,12 @@ export default class DefaultCodegen {
             } else {
               scope.put('hasMore', null)
             }
-            scopes.add(scope)
+            scopes.push(scope)
           }
           sec.scopes = scopes
         }
       }
-      secs.add(sec)
+      secs.push(sec)
     }
     if (sec) sec.hasMore = false
     return secs
@@ -2429,7 +2429,7 @@ export default class DefaultCodegen {
   addHeaders(response, target) {
     if (response.getHeaders() != null) {
       for (const [key, value] of response.getHeaders()) {
-        target.add(this.fromProperty(key, factory(value)))
+        target.push(this.fromProperty(key, factory(value)))
       }
     }
   }
@@ -2484,7 +2484,7 @@ export default class DefaultCodegen {
     }
     co.operationId = uniqueName
     co.operationIdLowerCase = uniqueName.toLowerCase()
-    opList.add(co)
+    opList.push(co)
     co.baseName = tag
   }
 
@@ -2603,7 +2603,12 @@ export default class DefaultCodegen {
       }
 
       let cp = this.fromProperty(key, prop)
-      cp.required = mandatory.contains(key) ? true : null
+      if (mandatory.has) {
+        cp.required = mandatory.has(key) ? true : null
+      } else {
+        cp.required = mandatory.hasOwnProperty(key) ? true : null
+      }
+
       m.hasRequired = m.hasRequired || cp.required
       if (cp.isEnum) {
         m.hasEnums = true
@@ -2627,16 +2632,16 @@ export default class DefaultCodegen {
         innerCp = innerCp.items
       }
 
-      vars.add(cp)
+      vars.push(cp)
       if (cp.required) {
-        m.requiredVars.add(cp)
+        m.requiredVars.push(cp)
       } else {
-        m.optionalVars.add(cp)
+        m.optionalVars.push(cp)
       }
       if (cp.isReadOnly) {
-        m.readOnlyVars.add(cp)
+        m.readOnlyVars.push(cp)
       } else {
-        m.readWriteVars.add(cp)
+        m.readWriteVars.push(cp)
       }
     }
   }
@@ -2830,8 +2835,7 @@ export default class DefaultCodegen {
   buildLibraryCliOption(supportedLibraries) {
     let sb = new StringBuilder('library template (sub-template) to use:')
     for (const [key, lib] of supportedLibraries) {
-      sb
-        .append('\n')
+      sb.append('\n')
         .append(key)
         .append(' - ')
         .append(lib)
@@ -2902,7 +2906,7 @@ export default class DefaultCodegen {
       folder = supportingFile.destinationFilename
     }
     if (!new File(folder).exists()) {
-      this.__supportingFiles.add(supportingFile)
+      this.__supportingFiles.push(supportingFile)
     } else {
       Log.info(
         'Skipped overwriting ' +

--- a/ern-api-gen/src/DefaultGenerator.js
+++ b/ern-api-gen/src/DefaultGenerator.js
@@ -291,6 +291,7 @@ export default class DefaultGenerator extends AbstractGenerator {
             models.putAll(this.config.additionalProperties())
             allProcessedModels.set(name, models)
           } catch (e) {
+            console.log(`ERROR IS ${e}`)
             rethrow(
               e,
               "Could not process model '" +
@@ -308,7 +309,7 @@ export default class DefaultGenerator extends AbstractGenerator {
             if (this.config.importMapping().containsKey(name)) {
               continue
             }
-            allModels.push(models.get('models').get(0))
+            allModels.push(models.value.models[0])
             for (const [
               templateName,
               suffix,
@@ -441,7 +442,7 @@ export default class DefaultGenerator extends AbstractGenerator {
             operation,
             'produces'
           )
-          allOperations.add(operation)
+          allOperations.push(operation)
           for (let i = 0; i < allOperations.length; i++) {
             let oo = allOperations[i]
             if (i < allOperations.length - 1) {
@@ -585,7 +586,7 @@ export default class DefaultGenerator extends AbstractGenerator {
       bundle.put('externalDocs', this.swagger.getExternalDocs())
     }
     for (let i = 0; i < allModels.length - 1; i++) {
-      let cm = allModels.get(i)
+      let cm = allModels[i]
       let m = cm.get('model')
       m.hasMoreModels = true
     }
@@ -810,7 +811,7 @@ export default class DefaultGenerator extends AbstractGenerator {
     let tags = operation.getTags()
     if (tags == null) {
       tags = []
-      tags.add('default')
+      tags.push('default')
     }
     let operationParameters = newHashSet()
     if (operation.getParameters() != null) {
@@ -1011,7 +1012,7 @@ export default class DefaultGenerator extends AbstractGenerator {
       }
     }
     for (const s of importSet) {
-      imports.add(newHashMap(['import', s]))
+      imports.push(newHashMap(['import', s]))
     }
     config.postProcessModels(objs)
 

--- a/ern-api-gen/src/DefaultGenerator.js
+++ b/ern-api-gen/src/DefaultGenerator.js
@@ -11,7 +11,6 @@ import {
   Collections,
   newHashMap,
   newHashSet,
-  TreeMap,
   isNotEmptySet,
 } from './java/javaUtil'
 import IOUtils from './java/IOUtils'
@@ -21,6 +20,7 @@ import InlineModelResolver from './InlineModelResolver'
 import ComposedModel from './models/ComposedModel'
 import GlobalSupportingFile from './GlobalSupportingFile'
 import CodegenIgnoreProcessor from './ignore/CodegenIgnoreProcessor'
+import TreeMap from './java/TreeMap'
 
 const sortOperationId = (a, b) => a.operationId.localeCompare(b.operationId)
 const sortClassName = (a, b) => {
@@ -272,7 +272,6 @@ export default class DefaultGenerator extends AbstractGenerator {
           modelKeys = updatedKeys
         }
         let allProcessedModels = new TreeMap(
-          null,
           new InheritanceTreeSorter(this, definitions)
         )
         for (const name of modelKeys) {
@@ -290,7 +289,7 @@ export default class DefaultGenerator extends AbstractGenerator {
 
             models.put('classname', this.config.toModelName(name))
             models.putAll(this.config.additionalProperties())
-            allProcessedModels.put(name, models)
+            allProcessedModels.set(name, models)
           } catch (e) {
             rethrow(
               e,
@@ -396,7 +395,7 @@ export default class DefaultGenerator extends AbstractGenerator {
         let updatedPaths = new TreeMap()
         for (const [m, p] of paths) {
           if (apisToGenerate.contains(m)) {
-            updatedPaths.put(m, p)
+            updatedPaths.set(m, p)
           }
         }
         paths = updatedPaths
@@ -1032,10 +1031,15 @@ class InheritanceTreeSorter {
     let model1InheritanceDepth = this.getInheritanceDepth(model1)
     let model2InheritanceDepth = this.getInheritanceDepth(model2)
     if (model1InheritanceDepth === model2InheritanceDepth) {
-      return ObjectUtils.compare(
+      const cmp = ObjectUtils.compare(
         this.__parent.config.toModelName(o1),
         this.__parent.config.toModelName(o2)
       )
+      if (cmp === -1) return -1
+      if (cmp === 1) return 1
+      if (cmp === true) return -1
+      if (cmp === false) return 1
+      return cmp
     } else if (model1InheritanceDepth > model2InheritanceDepth) {
       return 1
     } else {

--- a/ern-api-gen/src/auth/AuthParser.js
+++ b/ern-api-gen/src/auth/AuthParser.js
@@ -1,24 +1,30 @@
 import AuthorizationValue from '../models/auth/AuthorizationValue'
 import LoggerFactory from '../java/LoggerFactory'
-import {isNotEmpty} from '../java/StringUtils'
+import { isNotEmpty } from '../java/StringUtils'
 import StringBuilder from '../java/StringBuilder'
-import {URLDecoder, URLEncoder} from '../java/encoders'
+import { URLDecoder, URLEncoder } from '../java/encoders'
 
 export default class AuthParser {
-  static parse (urlEncodedAuthStr) {
+  static parse(urlEncodedAuthStr) {
     const auths = []
     if (isNotEmpty(urlEncodedAuthStr)) {
       for (const part of urlEncodedAuthStr.split(',')) {
         let kvPair = part.split(':', 2)
         if (kvPair.length === 2) {
-          auths.add(new AuthorizationValue(URLDecoder.decode(kvPair[0]), URLDecoder.decode(kvPair[1]), 'header'))
+          auths.push(
+            new AuthorizationValue(
+              URLDecoder.decode(kvPair[0]),
+              URLDecoder.decode(kvPair[1]),
+              'header'
+            )
+          )
         }
       }
     }
     return auths
   }
 
-  static reconstruct (authorizationValueList) {
+  static reconstruct(authorizationValueList) {
     if (authorizationValueList != null) {
       let b = new StringBuilder()
       for (const v of authorizationValueList) {
@@ -26,7 +32,9 @@ export default class AuthParser {
           if (b.toString().length > 0) {
             b.append(',')
           }
-          b.append(URLEncoder.encode(v.getKeyName(), 'UTF-8')).append(':').append(URLEncoder.encode(v.getValue(), 'UTF-8'))
+          b.append(URLEncoder.encode(v.getKeyName(), 'UTF-8'))
+            .append(':')
+            .append(URLEncoder.encode(v.getValue(), 'UTF-8'))
         } catch (e) {
           Log.trace(e)
         }

--- a/ern-api-gen/src/java/TreeMap.js
+++ b/ern-api-gen/src/java/TreeMap.js
@@ -1,0 +1,242 @@
+/**
+ * TreeMap.js
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016-2018 Adrian Wirth
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Modified implementation by @belemaire
+ * - Classify implementation
+ * - Add custom comparator support
+ * - Add iterator
+ */
+export default class TreeMap {
+  constructor(keyComparator) {
+    if (keyComparator && !keyComparator.compare) {
+      throw new Error('keyComparator does not expose a compare function ')
+    }
+    this.keyComparator = keyComparator
+    this.root = null
+    this.keyType = void 0
+    this.length = 0
+  }
+
+  checkKey(key, checkKeyType) {
+    var localKeyType = typeof key
+
+    if (
+      localKeyType !== 'number' &&
+      localKeyType !== 'string' &&
+      localKeyType !== 'boolean'
+    ) {
+      throw new Error("'key' must be a number, a string or a boolean")
+    }
+
+    if (checkKeyType === true && localKeyType !== this.keyType) {
+      throw new Error('All keys must be of the same type')
+    }
+
+    return localKeyType
+  }
+
+  call(callback) {
+    var args = Array.prototype.slice.call(arguments, 1)
+
+    if (typeof callback === 'function') {
+      callback.apply(void 0, args)
+    }
+  }
+
+  getTree() {
+    return this.root
+  }
+
+  getLength() {
+    return this.length
+  }
+
+  each(callback) {
+    this.internalEach(this.root, callback)
+  }
+
+  *[Symbol.iterator]() {
+    const res = []
+    this.each((value, key) => {
+      res.push([key, value])
+    })
+    yield* res
+  }
+
+  internalEach(node, callback, internalCallback) {
+    if (node === null) {
+      return this.call(internalCallback)
+    }
+
+    this.internalEach(node.left, callback, () => {
+      this.call(callback, node.value, node.key)
+
+      this.internalEach(node.right, callback, () => {
+        this.call(internalCallback)
+      })
+    })
+  }
+
+  get(key) {
+    this.checkKey(key)
+    return this.internalGet(key, this.root)
+  }
+
+  internalGet(key, node) {
+    if (node === null) {
+      return void 0
+    }
+
+    if (this.lt(key, node.key)) {
+      return this.internalGet(key, node.left)
+    } else if (this.gt(key, node.key)) {
+      return this.internalGet(key, node.right)
+    } else {
+      return node.value
+    }
+  }
+
+  set(key, value) {
+    if (this.root === null) {
+      this.keyType = this.checkKey(key)
+    } else {
+      this.checkKey(key, true)
+    }
+
+    this.root = this.internalSet(key, value, this.root)
+  }
+
+  internalSet(key, value, node) {
+    if (node === null) {
+      this.length++
+
+      return {
+        key: key,
+        value: value,
+        left: null,
+        right: null,
+      }
+    }
+
+    if (this.lt(key, node.key)) {
+      node.left = this.internalSet(key, value, node.left)
+    } else if (this.gt(key, node.key)) {
+      node.right = this.internalSet(key, value, node.right)
+    } else {
+      node.value = value
+    }
+
+    return node
+  }
+
+  getMaxKey() {
+    var maxNode = this.getMaxNode(this.root)
+
+    if (maxNode !== null) {
+      return maxNode.key
+    }
+
+    return maxNode
+  }
+
+  getMinKey() {
+    var minNode = this.getMinNode(this.root)
+
+    if (minNode !== null) {
+      return minNode.key
+    }
+
+    return minNode
+  }
+
+  getMaxNode(node) {
+    while (node !== null && node.right !== null) {
+      node = node.right
+    }
+
+    return node
+  }
+
+  getMinNode(node) {
+    while (node !== null && node.left !== null) {
+      node = node.left
+    }
+
+    return node
+  }
+
+  remove(key) {
+    this.checkKey(key)
+
+    this.root = this.internalRemove(key, this.root)
+  }
+
+  internalRemove(key, node) {
+    if (node === null) {
+      return null
+    }
+
+    if (this.lt(key, node.key)) {
+      node.left = this.internalRemove(key, node.left)
+    } else if (this.gt(key, node.key)) {
+      node.right = this.internalRemove(key, node.right)
+    } else {
+      if (node.left !== null && node.right !== null) {
+        var maxNode = this.getMaxNode(node.left)
+
+        var maxNodeKey = maxNode.key
+        var maxNodeValue = maxNode.value
+
+        maxNode.key = node.key
+        maxNode.value = node.value
+        node.key = maxNodeKey
+        node.value = maxNodeValue
+
+        node.left = this.internalRemove(key, node.left)
+      } else if (node.left !== null) {
+        this.length--
+        return node.left
+      } else if (node.right !== null) {
+        this.length--
+        return node.right
+      } else {
+        this.length--
+        return null
+      }
+    }
+
+    return node
+  }
+
+  lt(a, b) {
+    return this.keyComparator ? this.keyComparator.compare(a, b) === -1 : a < b
+  }
+
+  gt(a, b) {
+    return this.keyComparator ? this.keyComparator.compare(a, b) === 1 : a > b
+  }
+}

--- a/ern-api-gen/src/java/javaUtil.js
+++ b/ern-api-gen/src/java/javaUtil.js
@@ -1,11 +1,9 @@
-import { SortedMap } from 'collections/sorted-map'
-import SortedArraySet from 'collections/sorted-array-set'
 import _newHashMap, { fakeSet, FakeHashMap, javaIterator } from './fakeMap'
 export const newHashMap = _newHashMap
 const _iterator = javaIterator
 /**
  * This provides a bunch of Java like classes.  Collections, HashMap, HashSet
- * TreeMap and a few conviences.   Attention has been paid to make it look very
+ * and a few conviences.   Attention has been paid to make it look very
  * similar, however they are not identically. Specifically "size" is not a function
  * it still a property.   This is mostly due to fear, of what will break if we change
  * that value.
@@ -15,53 +13,6 @@ const _iterator = javaIterator
  * These classes are meant to be convient hence iteration.
  *
  */
-
-function makeCompare(obj) {
-  const compare = makeSort(obj)
-  return compare ? (a, b) => compare(a, b) === 0 : null
-}
-function makeSort(obj) {
-  return obj && obj.compare.bind(obj)
-}
-
-export class TreeMap extends SortedMap {
-  iterator = _iterator
-
-  //(new SortedMap(null, (a, b) => sorter.compare(a, b) == 0, sorter.compare)
-  constructor(map, comparator) {
-    super(
-      comparator ? map : null,
-      makeCompare(comparator || map),
-      makeSort(comparator || map)
-    )
-  }
-
-  put(k, v) {
-    this.set(k, v)
-  }
-
-  putAll(itr) {
-    for (const [k, v] in itr) {
-      this.set(k, v)
-    }
-  }
-
-  isEmpty() {
-    return this.size === 0
-  }
-
-  keySet() {
-    const hs = new HashSet()
-    for (const [key] of this) {
-      hs.add(key)
-    }
-    return hs
-  }
-
-  [Symbol.iterator]() {
-    return this.entries()
-  }
-}
 
 export class HashSet extends Set {
   iterator = _iterator

--- a/ern-api-gen/src/languages/AndroidClientCodegen.js
+++ b/ern-api-gen/src/languages/AndroidClientCodegen.js
@@ -1,401 +1,788 @@
-import CliOption from "../CliOption";
-import CodegenConstants from "../CodegenConstants";
-import CodegenType from "../CodegenType";
-import SupportingFile from "../SupportingFile";
-import {ArrayProperty, MapProperty} from "../models/properties";
-import StringUtils from "../java/StringUtils";
-import LoggerFactory from "../java/LoggerFactory";
-import File from "../java/File";
-import {Arrays, newHashSet, newHashMap} from "../java/javaUtil";
-import DefaultCodegen from "../DefaultCodegen";
-import {parseBoolean} from "../java/BooleanHelper";
+import CliOption from '../CliOption'
+import CodegenConstants from '../CodegenConstants'
+import CodegenType from '../CodegenType'
+import SupportingFile from '../SupportingFile'
+import { ArrayProperty, MapProperty } from '../models/properties'
+import StringUtils from '../java/StringUtils'
+import LoggerFactory from '../java/LoggerFactory'
+import File from '../java/File'
+import { Arrays, newHashSet, newHashMap } from '../java/javaUtil'
+import DefaultCodegen from '../DefaultCodegen'
+import { parseBoolean } from '../java/BooleanHelper'
 
 export default class AndroidClientCodegen extends DefaultCodegen {
-    static USE_ANDROID_MAVEN_GRADLE_PLUGIN = "useAndroidMavenGradlePlugin";
-    invokerPackage = "io.swagger.client";
-    groupId = "io.swagger";
-    artifactId = "swagger-android-client";
-    artifactVersion = "1.0.0";
-    projectFolder = "src/main";
+  static USE_ANDROID_MAVEN_GRADLE_PLUGIN = 'useAndroidMavenGradlePlugin'
+  invokerPackage = 'io.swagger.client'
+  groupId = 'io.swagger'
+  artifactId = 'swagger-android-client'
+  artifactVersion = '1.0.0'
+  projectFolder = 'src/main'
 
-    useAndroidMavenGradlePlugin = true;
-    requestPackage = "io.swagger.client.request";
-    authPackage = "io.swagger.client.auth";
-    gradleWrapperPackage = "gradle.wrapper";
-    apiDocPath = "docs/";
-    modelDocPath = "docs/";
-    __outputFolder = "generated-code/android";
-    __languageSpecificPrimitives = newHashSet("String", "boolean", "Boolean", "Double", "Integer", "Long", "Float", "byte[]", "Object");
-    __apiPackage = "io.swagger.client.api";
-    __modelPackage = "io.swagger.client.model";
-    __embeddedTemplateDir = "android";
-    __templateDir = "android";
-    __supportedLibraries = newHashMap(
-        ["volley", "HTTP client: Volley 1.0.19 (default)"],
-        ["httpclient", "HTTP client: Apache HttpClient 4.3.6. JSON processing: Gson 2.3.1. IMPORTANT: Android client using HttpClient is not actively maintained and will be depecreated in the next major release."]
-    );
+  useAndroidMavenGradlePlugin = true
+  requestPackage = 'io.swagger.client.request'
+  authPackage = 'io.swagger.client.auth'
+  gradleWrapperPackage = 'gradle.wrapper'
+  apiDocPath = 'docs/'
+  modelDocPath = 'docs/'
+  __outputFolder = 'generated-code/android'
+  __languageSpecificPrimitives = newHashSet(
+    'String',
+    'boolean',
+    'Boolean',
+    'Double',
+    'Integer',
+    'Long',
+    'Float',
+    'byte[]',
+    'Object'
+  )
+  __apiPackage = 'io.swagger.client.api'
+  __modelPackage = 'io.swagger.client.model'
+  __embeddedTemplateDir = 'android'
+  __templateDir = 'android'
+  __supportedLibraries = newHashMap(
+    ['volley', 'HTTP client: Volley 1.0.19 (default)'],
+    [
+      'httpclient',
+      'HTTP client: Apache HttpClient 4.3.6. JSON processing: Gson 2.3.1. IMPORTANT: Android client using HttpClient is not actively maintained and will be depecreated in the next major release.',
+    ]
+  )
 
-    constructor() {
-        super();
-        this.sourceFolder = this.projectFolder + "/java";
-        this.__modelTemplateFiles.put("model.mustache", ".java");
-        this.__apiTemplateFiles.put("api.mustache", ".java");
-        this.setReservedWordsLowerCase(["localVarPostBody", "localVarPath", "localVarQueryParams", "localVarHeaderParams", "localVarFormParams", "localVarContentTypes", "localVarContentType", "localVarResponse", "localVarBuilder", "authNames", "basePath", "apiInvoker", "abstract", "continue", "for", "new", "switch", "assert", "default", "if", "package", "synchronized", "boolean", "do", "goto", "private", "this", "break", "double", "implements", "protected", "throw", "byte", "else", "import", "public", "throws", "case", "enum", "instanceof", "return", "transient", "catch", "extends", "int", "short", "try", "char", "final", "interface", "static", "void", "class", "finally", "long", "strictfp", "volatile", "const", "float", "native", "super", "while"]);
-        this.__instantiationTypes.put("array", "ArrayList");
-        this.__instantiationTypes.put("map", "HashMap");
-        this.__typeMapping.put("date", "Date");
-        this.__typeMapping.put("file", "File");
+  constructor() {
+    super()
+    this.sourceFolder = this.projectFolder + '/java'
+    this.__modelTemplateFiles.put('model.mustache', '.java')
+    this.__apiTemplateFiles.put('api.mustache', '.java')
+    this.setReservedWordsLowerCase([
+      'localVarPostBody',
+      'localVarPath',
+      'localVarQueryParams',
+      'localVarHeaderParams',
+      'localVarFormParams',
+      'localVarContentTypes',
+      'localVarContentType',
+      'localVarResponse',
+      'localVarBuilder',
+      'authNames',
+      'basePath',
+      'apiInvoker',
+      'abstract',
+      'continue',
+      'for',
+      'new',
+      'switch',
+      'assert',
+      'default',
+      'if',
+      'package',
+      'synchronized',
+      'boolean',
+      'do',
+      'goto',
+      'private',
+      'this',
+      'break',
+      'double',
+      'implements',
+      'protected',
+      'throw',
+      'byte',
+      'else',
+      'import',
+      'public',
+      'throws',
+      'case',
+      'enum',
+      'instanceof',
+      'return',
+      'transient',
+      'catch',
+      'extends',
+      'int',
+      'short',
+      'try',
+      'char',
+      'final',
+      'interface',
+      'static',
+      'void',
+      'class',
+      'finally',
+      'long',
+      'strictfp',
+      'volatile',
+      'const',
+      'float',
+      'native',
+      'super',
+      'while',
+    ])
+    this.__instantiationTypes.put('array', 'ArrayList')
+    this.__instantiationTypes.put('map', 'HashMap')
+    this.__typeMapping.put('date', 'Date')
+    this.__typeMapping.put('file', 'File')
+  }
+
+  initalizeCliOptions() {
+    super.initalizeCliOptions()
+    this.__cliOptions.push(
+      new CliOption(
+        CodegenConstants.MODEL_PACKAGE,
+        CodegenConstants.MODEL_PACKAGE_DESC
+      )
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        CodegenConstants.API_PACKAGE,
+        CodegenConstants.API_PACKAGE_DESC
+      )
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        CodegenConstants.INVOKER_PACKAGE,
+        CodegenConstants.INVOKER_PACKAGE_DESC
+      )
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        CodegenConstants.GROUP_ID,
+        'groupId for use in the generated build.gradle and pom.xml'
+      )
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        CodegenConstants.ARTIFACT_ID,
+        'artifactId for use in the generated build.gradle and pom.xml'
+      )
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        CodegenConstants.ARTIFACT_VERSION,
+        'artifact version for use in the generated build.gradle and pom.xml'
+      )
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        CodegenConstants.SOURCE_FOLDER,
+        CodegenConstants.SOURCE_FOLDER_DESC
+      )
+    )
+    this.__cliOptions.push(
+      CliOption.newBoolean(
+        AndroidClientCodegen.USE_ANDROID_MAVEN_GRADLE_PLUGIN,
+        'A flag to toggle android-maven gradle plugin.'
+      ).defaultValue('true')
+    )
+    const library = new CliOption(
+      CodegenConstants.LIBRARY,
+      'library template (sub-template) to use'
+    )
+    library.setEnum(this.__supportedLibraries)
+    this.__cliOptions.push(library)
+  }
+
+  getTag() {
+    return CodegenType.CLIENT
+  }
+
+  getName() {
+    return 'android'
+  }
+
+  getHelp() {
+    return 'Generates an Android client library.'
+  }
+
+  escapeReservedWord(name) {
+    return '_' + name
+  }
+
+  apiFileFolder() {
+    return (
+      this.__outputFolder +
+      '/' +
+      this.sourceFolder +
+      '/' +
+      this.apiPackage()
+        .split('.')
+        .join(File.separator)
+    )
+  }
+
+  modelFileFolder() {
+    return (
+      this.__outputFolder +
+      '/' +
+      this.sourceFolder +
+      '/' +
+      this.modelPackage()
+        .split('.')
+        .join(File.separator)
+    )
+  }
+
+  apiDocFileFolder() {
+    return (this.__outputFolder + '/' + this.apiDocPath)
+      .split('/')
+      .join(File.separator)
+  }
+
+  modelDocFileFolder() {
+    return (this.__outputFolder + '/' + this.modelDocPath)
+      .split('/')
+      .join(File.separator)
+  }
+
+  toApiDocFilename(name) {
+    return this.toApiName(name)
+  }
+
+  toModelDocFilename(name) {
+    return this.toModelName(name)
+  }
+
+  getTypeDeclaration(p) {
+    if (p != null && p instanceof ArrayProperty) {
+      let ap = p
+      let inner = ap.getItems()
+      return this.getSwaggerType(p) + '<' + this.getTypeDeclaration(inner) + '>'
+    } else if (p != null && p instanceof MapProperty) {
+      let mp = p
+      let inner = mp.getAdditionalProperties()
+      return (
+        this.getSwaggerType(p) +
+        '<String, ' +
+        this.getTypeDeclaration(inner) +
+        '>'
+      )
     }
+    return super.getTypeDeclaration(p)
+  }
 
-    initalizeCliOptions() {
-        super.initalizeCliOptions();
-        this.__cliOptions.add(new CliOption(CodegenConstants.MODEL_PACKAGE, CodegenConstants.MODEL_PACKAGE_DESC));
-        this.__cliOptions.add(new CliOption(CodegenConstants.API_PACKAGE, CodegenConstants.API_PACKAGE_DESC));
-        this.__cliOptions.add(new CliOption(CodegenConstants.INVOKER_PACKAGE, CodegenConstants.INVOKER_PACKAGE_DESC));
-        this.__cliOptions.add(new CliOption(CodegenConstants.GROUP_ID, "groupId for use in the generated build.gradle and pom.xml"));
-        this.__cliOptions.add(new CliOption(CodegenConstants.ARTIFACT_ID, "artifactId for use in the generated build.gradle and pom.xml"));
-        this.__cliOptions.add(new CliOption(CodegenConstants.ARTIFACT_VERSION, "artifact version for use in the generated build.gradle and pom.xml"));
-        this.__cliOptions.add(new CliOption(CodegenConstants.SOURCE_FOLDER, CodegenConstants.SOURCE_FOLDER_DESC));
-        this.__cliOptions.add(CliOption.newBoolean(AndroidClientCodegen.USE_ANDROID_MAVEN_GRADLE_PLUGIN, "A flag to toggle android-maven gradle plugin.").defaultValue("true"));
-        const library = new CliOption(CodegenConstants.LIBRARY, "library template (sub-template) to use");
-        library.setEnum(this.__supportedLibraries);
-        this.__cliOptions.add(library);
-
+  getSwaggerType(p) {
+    let swaggerType = super.getSwaggerType(p)
+    let type = null
+    if (this.__typeMapping.containsKey(swaggerType)) {
+      type = this.__typeMapping.get(swaggerType)
+      if (
+        this.__languageSpecificPrimitives.contains(type) ||
+        type.indexOf('.') >= 0 ||
+        type === 'Map' ||
+        type === 'List' ||
+        type === 'File' ||
+        type === 'Date'
+      ) {
+        return type
+      }
+    } else {
+      type = swaggerType
     }
+    return this.toModelName(type)
+  }
 
-
-    getTag() {
-        return CodegenType.CLIENT;
+  toVarName(name) {
+    name = this.sanitizeName(name)
+    name = name.replace(new RegExp('-', 'g'), '_')
+    if (name.match('^[A-Z_]*$')) {
+      return name
     }
-
-    getName() {
-        return "android";
+    name = DefaultCodegen.camelize(name, true)
+    if (this.isReservedWord(name) || name.match('^\\d.*')) {
+      name = this.escapeReservedWord(name)
     }
+    return name
+  }
 
-    getHelp() {
-        return "Generates an Android client library.";
+  toParamName(name) {
+    return this.toVarName(name)
+  }
+
+  toModelName(name) {
+    if (!StringUtils.isEmpty(this.modelNamePrefix)) {
+      name = this.modelNamePrefix + '_' + name
     }
-
-    escapeReservedWord(name) {
-        return "_" + name;
+    if (!StringUtils.isEmpty(this.modelNameSuffix)) {
+      name = name + '_' + this.modelNameSuffix
     }
-
-    apiFileFolder() {
-        return this.__outputFolder + "/" + this.sourceFolder + "/" + this.apiPackage().split('.').join(File.separator);
+    if (name.toUpperCase() == name) {
+      return name
     }
-
-    modelFileFolder() {
-        return this.__outputFolder + "/" + this.sourceFolder + "/" + this.modelPackage().split('.').join(File.separator);
+    name = DefaultCodegen.camelize(this.sanitizeName(name))
+    if (this.isReservedWord(name)) {
+      let modelName = 'Model' + name
+      Log.warn(
+        name +
+          ' (reserved word) cannot be used as model name. Renamed to ' +
+          modelName
+      )
+      return modelName
     }
-
-    apiDocFileFolder() {
-        return (this.__outputFolder + "/" + this.apiDocPath).split('/').join(File.separator);
+    if (name.match('^\\d.*')) {
+      let modelName = 'Model' + name
+      Log.warn(
+        name +
+          ' (model name starts with number) cannot be used as model name. Renamed to ' +
+          modelName
+      )
+      return modelName
     }
+    return name
+  }
 
-    modelDocFileFolder() {
-        return (this.__outputFolder + "/" + this.modelDocPath).split('/').join(File.separator);
+  toModelFilename(name) {
+    return this.toModelName(name)
+  }
+
+  setParameterExampleValue(p) {
+    let example
+    if (p.defaultValue == null) {
+      example = p.example
+    } else {
+      example = p.defaultValue
     }
-
-    toApiDocFilename(name) {
-        return this.toApiName(name);
+    let type = p.baseType
+    if (type == null) {
+      type = p.dataType
     }
-
-    toModelDocFilename(name) {
-        return this.toModelName(name);
+    if ('String' === type) {
+      if (example == null) {
+        example = p.paramName + '_example'
+      }
+      example = '"' + this.escapeText(example) + '"'
+    } else if ('Integer' === type || 'Short' === type) {
+      if (example == null) {
+        example = '56'
+      }
+    } else if ('Long' === type) {
+      if (example == null) {
+        example = '56'
+      }
+      example = example + 'L'
+    } else if ('Float' === type) {
+      if (example == null) {
+        example = '3.4'
+      }
+      example = example + 'F'
+    } else if ('Double' === type) {
+      example = '3.4'
+      example = example + 'D'
+    } else if ('Boolean' === type) {
+      if (example == null) {
+        example = 'true'
+      }
+    } else if ('File' === type) {
+      if (example == null) {
+        example = '/path/to/file'
+      }
+      example = 'new File("' + this.escapeText(example) + '")'
+    } else if ('Date' === type) {
+      example = 'new Date()'
+    } else if (!this.__languageSpecificPrimitives.contains(type)) {
+      example = 'new ' + type + '()'
     }
-
-    getTypeDeclaration(p) {
-
-        if (p != null && p instanceof ArrayProperty) {
-            let ap = p;
-            let inner = ap.getItems();
-            return this.getSwaggerType(p) + "<" + this.getTypeDeclaration(inner) + ">";
-        }
-        else if (p != null && p instanceof MapProperty) {
-            let mp = p;
-            let inner = mp.getAdditionalProperties();
-            return this.getSwaggerType(p) + "<String, " + this.getTypeDeclaration(inner) + ">";
-        }
-        return super.getTypeDeclaration(p);
+    if (example == null) {
+      example = 'null'
+    } else if (p.isListContainer) {
+      example = 'Arrays.asList(' + example + ')'
+    } else if (p.isMapContainer) {
+      example = 'new HashMap()'
     }
+    p.example = example
+  }
 
-    getSwaggerType(p) {
-        let swaggerType = super.getSwaggerType(p);
-        let type = null;
-        if (this.__typeMapping.containsKey(swaggerType)) {
-            type = this.__typeMapping.get(swaggerType);
-            if (this.__languageSpecificPrimitives.contains(type) || type.indexOf(".") >= 0 || (type === "Map") || (type === "List") || (type === "File") || (type === "Date")) {
-                return type;
-            }
-        }
-        else {
-            type = swaggerType;
-        }
-        return this.toModelName(type);
+  toOperationId(operationId) {
+    if (StringUtils.isEmpty(operationId)) {
+      throw new Error('Empty method name (operationId) not allowed')
     }
-
-    toVarName(name) {
-        name = this.sanitizeName(name);
-        name = name.replace(new RegExp("-", 'g'), "_");
-        if (name.match("^[A-Z_]*$")) {
-            return name;
-        }
-        name = DefaultCodegen.camelize(name, true);
-        if (this.isReservedWord(name) || name.match("^\\d.*")) {
-            name = this.escapeReservedWord(name);
-        }
-        return name;
+    operationId = DefaultCodegen.camelize(this.sanitizeName(operationId), true)
+    if (this.isReservedWord(operationId)) {
+      let newOperationId = DefaultCodegen.camelize('call_' + operationId, true)
+      Log.warn(
+        operationId +
+          ' (reserved word) cannot be used as method name. Renamed to ' +
+          newOperationId
+      )
+      return newOperationId
     }
+    return operationId
+  }
 
-    toParamName(name) {
-        return this.toVarName(name);
+  processOpts() {
+    super.processOpts()
+    if (
+      this.__additionalProperties.containsKey(CodegenConstants.INVOKER_PACKAGE)
+    ) {
+      this.setInvokerPackage(
+        this.__additionalProperties.get(CodegenConstants.INVOKER_PACKAGE)
+      )
+    } else {
+      this.__additionalProperties.put(
+        CodegenConstants.INVOKER_PACKAGE,
+        this.invokerPackage
+      )
     }
-
-    toModelName(name) {
-        if (!StringUtils.isEmpty(this.modelNamePrefix)) {
-            name = this.modelNamePrefix + "_" + name;
-        }
-        if (!StringUtils.isEmpty(this.modelNameSuffix)) {
-            name = name + "_" + this.modelNameSuffix;
-        }
-        if (name.toUpperCase() == name) {
-            return name;
-        }
-        name = DefaultCodegen.camelize(this.sanitizeName(name));
-        if (this.isReservedWord(name)) {
-            let modelName = "Model" + name;
-            Log.warn(name + " (reserved word) cannot be used as model name. Renamed to " + modelName);
-            return modelName;
-        }
-        if (name.match("^\\d.*")) {
-            let modelName = "Model" + name;
-            Log.warn(name + " (model name starts with number) cannot be used as model name. Renamed to " + modelName);
-            return modelName;
-        }
-        return name;
+    if (this.__additionalProperties.containsKey(CodegenConstants.GROUP_ID)) {
+      this.setGroupId(
+        this.__additionalProperties.get(CodegenConstants.GROUP_ID)
+      )
+    } else {
+      this.__additionalProperties.put(CodegenConstants.GROUP_ID, this.groupId)
     }
-
-    toModelFilename(name) {
-        return this.toModelName(name);
+    if (this.__additionalProperties.containsKey(CodegenConstants.ARTIFACT_ID)) {
+      this.setArtifactId(
+        this.__additionalProperties.get(CodegenConstants.ARTIFACT_ID)
+      )
+    } else {
+      this.__additionalProperties.put(
+        CodegenConstants.ARTIFACT_ID,
+        this.artifactId
+      )
     }
-
-    setParameterExampleValue(p) {
-        let example;
-        if (p.defaultValue == null) {
-            example = p.example;
-        }
-        else {
-            example = p.defaultValue;
-        }
-        let type = p.baseType;
-        if (type == null) {
-            type = p.dataType;
-        }
-        if (("String" === type)) {
-            if (example == null) {
-                example = p.paramName + "_example";
-            }
-            example = "\"" + this.escapeText(example) + "\"";
-        }
-        else if (("Integer" === type) || ("Short" === type)) {
-            if (example == null) {
-                example = "56";
-            }
-        }
-        else if (("Long" === type)) {
-            if (example == null) {
-                example = "56";
-            }
-            example = example + "L";
-        }
-        else if (("Float" === type)) {
-            if (example == null) {
-                example = "3.4";
-            }
-            example = example + "F";
-        }
-        else if (("Double" === type)) {
-            example = "3.4";
-            example = example + "D";
-        }
-        else if (("Boolean" === type)) {
-            if (example == null) {
-                example = "true";
-            }
-        }
-        else if (("File" === type)) {
-            if (example == null) {
-                example = "/path/to/file";
-            }
-            example = "new File(\"" + this.escapeText(example) + "\")";
-        }
-        else if (("Date" === type)) {
-            example = "new Date()";
-        }
-        else if (!this.__languageSpecificPrimitives.contains(type)) {
-            example = "new " + type + "()";
-        }
-        if (example == null) {
-            example = "null";
-        }
-        else if (( p.isListContainer)) {
-            example = "Arrays.asList(" + example + ")";
-        }
-        else if (( p.isMapContainer)) {
-            example = "new HashMap()";
-        }
-        p.example = example;
+    if (
+      this.__additionalProperties.containsKey(CodegenConstants.ARTIFACT_VERSION)
+    ) {
+      this.setArtifactVersion(
+        this.__additionalProperties.get(CodegenConstants.ARTIFACT_VERSION)
+      )
+    } else {
+      this.__additionalProperties.put(
+        CodegenConstants.ARTIFACT_VERSION,
+        this.artifactVersion
+      )
     }
-
-    toOperationId(operationId) {
-        if (StringUtils.isEmpty(operationId)) {
-            throw new Error("Empty method name (operationId) not allowed");
-        }
-        operationId = DefaultCodegen.camelize(this.sanitizeName(operationId), true);
-        if (this.isReservedWord(operationId)) {
-            let newOperationId = DefaultCodegen.camelize("call_" + operationId, true);
-            Log.warn(operationId + " (reserved word) cannot be used as method name. Renamed to " + newOperationId);
-            return newOperationId;
-        }
-        return operationId;
+    if (
+      this.__additionalProperties.containsKey(CodegenConstants.SOURCE_FOLDER)
+    ) {
+      this.setSourceFolder(
+        this.__additionalProperties.get(CodegenConstants.SOURCE_FOLDER)
+      )
     }
-
-    processOpts() {
-        super.processOpts();
-        if (this.__additionalProperties.containsKey(CodegenConstants.INVOKER_PACKAGE)) {
-            this.setInvokerPackage(this.__additionalProperties.get(CodegenConstants.INVOKER_PACKAGE));
-        }
-        else {
-            this.__additionalProperties.put(CodegenConstants.INVOKER_PACKAGE, this.invokerPackage);
-        }
-        if (this.__additionalProperties.containsKey(CodegenConstants.GROUP_ID)) {
-            this.setGroupId(this.__additionalProperties.get(CodegenConstants.GROUP_ID));
-        }
-        else {
-            this.__additionalProperties.put(CodegenConstants.GROUP_ID, this.groupId);
-        }
-        if (this.__additionalProperties.containsKey(CodegenConstants.ARTIFACT_ID)) {
-            this.setArtifactId(this.__additionalProperties.get(CodegenConstants.ARTIFACT_ID));
-        }
-        else {
-            this.__additionalProperties.put(CodegenConstants.ARTIFACT_ID, this.artifactId);
-        }
-        if (this.__additionalProperties.containsKey(CodegenConstants.ARTIFACT_VERSION)) {
-            this.setArtifactVersion(this.__additionalProperties.get(CodegenConstants.ARTIFACT_VERSION));
-        }
-        else {
-            this.__additionalProperties.put(CodegenConstants.ARTIFACT_VERSION, this.artifactVersion);
-        }
-        if (this.__additionalProperties.containsKey(CodegenConstants.SOURCE_FOLDER)) {
-            this.setSourceFolder(this.__additionalProperties.get(CodegenConstants.SOURCE_FOLDER));
-        }
-        if (this.__additionalProperties.containsKey(AndroidClientCodegen.USE_ANDROID_MAVEN_GRADLE_PLUGIN)) {
-            this.setUseAndroidMavenGradlePlugin(parseBoolean(this.__additionalProperties.get(AndroidClientCodegen.USE_ANDROID_MAVEN_GRADLE_PLUGIN)));
-        }
-        else {
-            this.__additionalProperties.put(AndroidClientCodegen.USE_ANDROID_MAVEN_GRADLE_PLUGIN, this.useAndroidMavenGradlePlugin);
-        }
-        if (this.__additionalProperties.containsKey(CodegenConstants.LIBRARY)) {
-            this.setLibrary(this.__additionalProperties.get(CodegenConstants.LIBRARY));
-        }
-        this.__additionalProperties.put("apiDocPath", this.apiDocPath);
-        this.__additionalProperties.put("modelDocPath", this.modelDocPath);
-        if (StringUtils.isEmpty(this.getLibrary())) {
-            this.setLibrary("volley");
-        } else {
-            this.setLibrary(this.getLibrary());
-        }
-        const f = this[`addSupportingFilesFor${DefaultCodegen.camelize(this.getLibrary())}`];
-        f && f.call(this);
+    if (
+      this.__additionalProperties.containsKey(
+        AndroidClientCodegen.USE_ANDROID_MAVEN_GRADLE_PLUGIN
+      )
+    ) {
+      this.setUseAndroidMavenGradlePlugin(
+        parseBoolean(
+          this.__additionalProperties.get(
+            AndroidClientCodegen.USE_ANDROID_MAVEN_GRADLE_PLUGIN
+          )
+        )
+      )
+    } else {
+      this.__additionalProperties.put(
+        AndroidClientCodegen.USE_ANDROID_MAVEN_GRADLE_PLUGIN,
+        this.useAndroidMavenGradlePlugin
+      )
     }
-
-    addSupportingForFilesHttpclient() {
-        this.addSupportingFilesForHttpClient();
+    if (this.__additionalProperties.containsKey(CodegenConstants.LIBRARY)) {
+      this.setLibrary(this.__additionalProperties.get(CodegenConstants.LIBRARY))
     }
-
-
-    addSupportingFilesForHttpClient() {
-        this.__modelDocTemplateFiles.put("model_doc.mustache", ".md");
-        this.__apiDocTemplateFiles.put("api_doc.mustache", ".md");
-        this.__supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
-        this.__supportingFiles.add(new SupportingFile("pom.mustache", "", "pom.xml"));
-        this.__supportingFiles.add(new SupportingFile("settings.gradle.mustache", "", "settings.gradle"));
-        this.__supportingFiles.add(new SupportingFile("build.mustache", "", "build.gradle"));
-        this.__supportingFiles.add(new SupportingFile("manifest.mustache", this.projectFolder, "AndroidManifest.xml"));
-        this.__supportingFiles.add(new SupportingFile("apiInvoker.mustache", (this.sourceFolder + File.separator + this.invokerPackage).split(".").join(File.separator), "ApiInvoker.java"));
-        this.__supportingFiles.add(new SupportingFile("httpPatch.mustache", (this.sourceFolder + File.separator + this.invokerPackage).split(".").join(File.separator), "HttpPatch.java"));
-        this.__supportingFiles.add(new SupportingFile("jsonUtil.mustache", (this.sourceFolder + File.separator + this.invokerPackage).split(".").join(File.separator), "JsonUtil.java"));
-        this.__supportingFiles.add(new SupportingFile("apiException.mustache", (this.sourceFolder + File.separator + this.invokerPackage).split(".").join(File.separator), "ApiException.java"));
-        this.__supportingFiles.add(new SupportingFile("Pair.mustache", (this.sourceFolder + File.separator + this.invokerPackage).split(".").join(File.separator), "Pair.java"));
-        this.__supportingFiles.add(new SupportingFile("git_push.sh.mustache", "", "git_push.sh"));
-        this.__supportingFiles.add(new SupportingFile("gitignore.mustache", "", ".gitignore"));
-        this.__supportingFiles.add(new SupportingFile("gradlew.mustache", "", "gradlew"));
-        this.__supportingFiles.add(new SupportingFile("gradlew.bat.mustache", "", "gradlew.bat"));
-        this.__supportingFiles.add(new SupportingFile("gradle-wrapper.properties.mustache", this.gradleWrapperPackage.split(".").join(File.separator), "gradle-wrapper.properties"));
-        this.__supportingFiles.add(new SupportingFile("gradle-wrapper.jar", this.gradleWrapperPackage.split(".").join(File.separator), "gradle-wrapper.jar"));
+    this.__additionalProperties.put('apiDocPath', this.apiDocPath)
+    this.__additionalProperties.put('modelDocPath', this.modelDocPath)
+    if (StringUtils.isEmpty(this.getLibrary())) {
+      this.setLibrary('volley')
+    } else {
+      this.setLibrary(this.getLibrary())
     }
+    const f = this[
+      `addSupportingFilesFor${DefaultCodegen.camelize(this.getLibrary())}`
+    ]
+    f && f.call(this)
+  }
 
-    addSupportingFilesForVolley() {
-        this.__modelDocTemplateFiles.put("model_doc.mustache", ".md");
-        this.__apiDocTemplateFiles.put("api_doc.mustache", ".md");
-        this.__supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
-        this.__supportingFiles.add(new SupportingFile("git_push.sh.mustache", "", "git_push.sh"));
-        this.__supportingFiles.add(new SupportingFile("gitignore.mustache", "", ".gitignore"));
-        this.__supportingFiles.add(new SupportingFile("pom.mustache", "", "pom.xml"));
-        this.__supportingFiles.add(new SupportingFile("build.mustache", "", "build.gradle"));
-        this.__supportingFiles.add(new SupportingFile("manifest.mustache", this.projectFolder, "AndroidManifest.xml"));
-        this.__supportingFiles.add(new SupportingFile("apiInvoker.mustache", (this.sourceFolder + File.separator + this.invokerPackage).split(".").join(File.separator), "ApiInvoker.java"));
-        this.__supportingFiles.add(new SupportingFile("jsonUtil.mustache", (this.sourceFolder + File.separator + this.invokerPackage).split(".").join(File.separator), "JsonUtil.java"));
-        this.__supportingFiles.add(new SupportingFile("apiException.mustache", (this.sourceFolder + File.separator + this.invokerPackage).split(".").join(File.separator), "ApiException.java"));
-        this.__supportingFiles.add(new SupportingFile("Pair.mustache", (this.sourceFolder + File.separator + this.invokerPackage).split(".").join(File.separator), "Pair.java"));
-        this.__supportingFiles.add(new SupportingFile("request/getrequest.mustache", (this.sourceFolder + File.separator + this.requestPackage).split(".").join(File.separator), "GetRequest.java"));
-        this.__supportingFiles.add(new SupportingFile("request/postrequest.mustache", (this.sourceFolder + File.separator + this.requestPackage).split(".").join(File.separator), "PostRequest.java"));
-        this.__supportingFiles.add(new SupportingFile("request/putrequest.mustache", (this.sourceFolder + File.separator + this.requestPackage).split(".").join(File.separator), "PutRequest.java"));
-        this.__supportingFiles.add(new SupportingFile("request/deleterequest.mustache", (this.sourceFolder + File.separator + this.requestPackage).split(".").join(File.separator), "DeleteRequest.java"));
-        this.__supportingFiles.add(new SupportingFile("request/patchrequest.mustache", (this.sourceFolder + File.separator + this.requestPackage).split(".").join(File.separator), "PatchRequest.java"));
-        this.__supportingFiles.add(new SupportingFile("auth/apikeyauth.mustache", (this.sourceFolder + File.separator + this.authPackage).split(".").join(File.separator), "ApiKeyAuth.java"));
-        this.__supportingFiles.add(new SupportingFile("auth/httpbasicauth.mustache", (this.sourceFolder + File.separator + this.authPackage).split(".").join(File.separator), "HttpBasicAuth.java"));
-        this.__supportingFiles.add(new SupportingFile("auth/authentication.mustache", (this.sourceFolder + File.separator + this.authPackage).split(".").join(File.separator), "Authentication.java"));
-        this.__supportingFiles.add(new SupportingFile("gradlew.mustache", "", "gradlew"));
-        this.__supportingFiles.add(new SupportingFile("gradlew.bat.mustache", "", "gradlew.bat"));
-        this.__supportingFiles.add(new SupportingFile("gradle-wrapper.properties.mustache", this.gradleWrapperPackage.split(".").join(File.separator), "gradle-wrapper.properties"));
-        this.__supportingFiles.add(new SupportingFile("gradle-wrapper.jar", this.gradleWrapperPackage.split(".").join(File.separator), "gradle-wrapper.jar"));
-    }
+  addSupportingForFilesHttpclient() {
+    this.addSupportingFilesForHttpClient()
+  }
 
-    getUseAndroidMavenGradlePlugin() {
-        return this.useAndroidMavenGradlePlugin;
-    }
+  addSupportingFilesForHttpClient() {
+    this.__modelDocTemplateFiles.put('model_doc.mustache', '.md')
+    this.__apiDocTemplateFiles.put('api_doc.mustache', '.md')
+    this.__supportingFiles.push(
+      new SupportingFile('README.mustache', '', 'README.md')
+    )
+    this.__supportingFiles.push(
+      new SupportingFile('pom.mustache', '', 'pom.xml')
+    )
+    this.__supportingFiles.push(
+      new SupportingFile('settings.gradle.mustache', '', 'settings.gradle')
+    )
+    this.__supportingFiles.push(
+      new SupportingFile('build.mustache', '', 'build.gradle')
+    )
+    this.__supportingFiles.push(
+      new SupportingFile(
+        'manifest.mustache',
+        this.projectFolder,
+        'AndroidManifest.xml'
+      )
+    )
+    this.__supportingFiles.push(
+      new SupportingFile(
+        'apiInvoker.mustache',
+        (this.sourceFolder + File.separator + this.invokerPackage)
+          .split('.')
+          .join(File.separator),
+        'ApiInvoker.java'
+      )
+    )
+    this.__supportingFiles.push(
+      new SupportingFile(
+        'httpPatch.mustache',
+        (this.sourceFolder + File.separator + this.invokerPackage)
+          .split('.')
+          .join(File.separator),
+        'HttpPatch.java'
+      )
+    )
+    this.__supportingFiles.push(
+      new SupportingFile(
+        'jsonUtil.mustache',
+        (this.sourceFolder + File.separator + this.invokerPackage)
+          .split('.')
+          .join(File.separator),
+        'JsonUtil.java'
+      )
+    )
+    this.__supportingFiles.push(
+      new SupportingFile(
+        'apiException.mustache',
+        (this.sourceFolder + File.separator + this.invokerPackage)
+          .split('.')
+          .join(File.separator),
+        'ApiException.java'
+      )
+    )
+    this.__supportingFiles.push(
+      new SupportingFile(
+        'Pair.mustache',
+        (this.sourceFolder + File.separator + this.invokerPackage)
+          .split('.')
+          .join(File.separator),
+        'Pair.java'
+      )
+    )
+    this.__supportingFiles.push(
+      new SupportingFile('git_push.sh.mustache', '', 'git_push.sh')
+    )
+    this.__supportingFiles.push(
+      new SupportingFile('gitignore.mustache', '', '.gitignore')
+    )
+    this.__supportingFiles.push(
+      new SupportingFile('gradlew.mustache', '', 'gradlew')
+    )
+    this.__supportingFiles.push(
+      new SupportingFile('gradlew.bat.mustache', '', 'gradlew.bat')
+    )
+    this.__supportingFiles.push(
+      new SupportingFile(
+        'gradle-wrapper.properties.mustache',
+        this.gradleWrapperPackage.split('.').join(File.separator),
+        'gradle-wrapper.properties'
+      )
+    )
+    this.__supportingFiles.push(
+      new SupportingFile(
+        'gradle-wrapper.jar',
+        this.gradleWrapperPackage.split('.').join(File.separator),
+        'gradle-wrapper.jar'
+      )
+    )
+  }
 
-    setUseAndroidMavenGradlePlugin(useAndroidMavenGradlePlugin) {
-        this.useAndroidMavenGradlePlugin = useAndroidMavenGradlePlugin;
-    }
+  addSupportingFilesForVolley() {
+    this.__modelDocTemplateFiles.put('model_doc.mustache', '.md')
+    this.__apiDocTemplateFiles.put('api_doc.mustache', '.md')
+    this.__supportingFiles.push(
+      new SupportingFile('README.mustache', '', 'README.md')
+    )
+    this.__supportingFiles.push(
+      new SupportingFile('git_push.sh.mustache', '', 'git_push.sh')
+    )
+    this.__supportingFiles.push(
+      new SupportingFile('gitignore.mustache', '', '.gitignore')
+    )
+    this.__supportingFiles.push(
+      new SupportingFile('pom.mustache', '', 'pom.xml')
+    )
+    this.__supportingFiles.push(
+      new SupportingFile('build.mustache', '', 'build.gradle')
+    )
+    this.__supportingFiles.push(
+      new SupportingFile(
+        'manifest.mustache',
+        this.projectFolder,
+        'AndroidManifest.xml'
+      )
+    )
+    this.__supportingFiles.push(
+      new SupportingFile(
+        'apiInvoker.mustache',
+        (this.sourceFolder + File.separator + this.invokerPackage)
+          .split('.')
+          .join(File.separator),
+        'ApiInvoker.java'
+      )
+    )
+    this.__supportingFiles.push(
+      new SupportingFile(
+        'jsonUtil.mustache',
+        (this.sourceFolder + File.separator + this.invokerPackage)
+          .split('.')
+          .join(File.separator),
+        'JsonUtil.java'
+      )
+    )
+    this.__supportingFiles.push(
+      new SupportingFile(
+        'apiException.mustache',
+        (this.sourceFolder + File.separator + this.invokerPackage)
+          .split('.')
+          .join(File.separator),
+        'ApiException.java'
+      )
+    )
+    this.__supportingFiles.push(
+      new SupportingFile(
+        'Pair.mustache',
+        (this.sourceFolder + File.separator + this.invokerPackage)
+          .split('.')
+          .join(File.separator),
+        'Pair.java'
+      )
+    )
+    this.__supportingFiles.push(
+      new SupportingFile(
+        'request/getrequest.mustache',
+        (this.sourceFolder + File.separator + this.requestPackage)
+          .split('.')
+          .join(File.separator),
+        'GetRequest.java'
+      )
+    )
+    this.__supportingFiles.push(
+      new SupportingFile(
+        'request/postrequest.mustache',
+        (this.sourceFolder + File.separator + this.requestPackage)
+          .split('.')
+          .join(File.separator),
+        'PostRequest.java'
+      )
+    )
+    this.__supportingFiles.push(
+      new SupportingFile(
+        'request/putrequest.mustache',
+        (this.sourceFolder + File.separator + this.requestPackage)
+          .split('.')
+          .join(File.separator),
+        'PutRequest.java'
+      )
+    )
+    this.__supportingFiles.push(
+      new SupportingFile(
+        'request/deleterequest.mustache',
+        (this.sourceFolder + File.separator + this.requestPackage)
+          .split('.')
+          .join(File.separator),
+        'DeleteRequest.java'
+      )
+    )
+    this.__supportingFiles.push(
+      new SupportingFile(
+        'request/patchrequest.mustache',
+        (this.sourceFolder + File.separator + this.requestPackage)
+          .split('.')
+          .join(File.separator),
+        'PatchRequest.java'
+      )
+    )
+    this.__supportingFiles.push(
+      new SupportingFile(
+        'auth/apikeyauth.mustache',
+        (this.sourceFolder + File.separator + this.authPackage)
+          .split('.')
+          .join(File.separator),
+        'ApiKeyAuth.java'
+      )
+    )
+    this.__supportingFiles.push(
+      new SupportingFile(
+        'auth/httpbasicauth.mustache',
+        (this.sourceFolder + File.separator + this.authPackage)
+          .split('.')
+          .join(File.separator),
+        'HttpBasicAuth.java'
+      )
+    )
+    this.__supportingFiles.push(
+      new SupportingFile(
+        'auth/authentication.mustache',
+        (this.sourceFolder + File.separator + this.authPackage)
+          .split('.')
+          .join(File.separator),
+        'Authentication.java'
+      )
+    )
+    this.__supportingFiles.push(
+      new SupportingFile('gradlew.mustache', '', 'gradlew')
+    )
+    this.__supportingFiles.push(
+      new SupportingFile('gradlew.bat.mustache', '', 'gradlew.bat')
+    )
+    this.__supportingFiles.push(
+      new SupportingFile(
+        'gradle-wrapper.properties.mustache',
+        this.gradleWrapperPackage.split('.').join(File.separator),
+        'gradle-wrapper.properties'
+      )
+    )
+    this.__supportingFiles.push(
+      new SupportingFile(
+        'gradle-wrapper.jar',
+        this.gradleWrapperPackage.split('.').join(File.separator),
+        'gradle-wrapper.jar'
+      )
+    )
+  }
 
-    setInvokerPackage(invokerPackage) {
-        this.invokerPackage = invokerPackage;
-    }
+  getUseAndroidMavenGradlePlugin() {
+    return this.useAndroidMavenGradlePlugin
+  }
 
-    setGroupId(groupId) {
-        this.groupId = groupId;
-    }
+  setUseAndroidMavenGradlePlugin(useAndroidMavenGradlePlugin) {
+    this.useAndroidMavenGradlePlugin = useAndroidMavenGradlePlugin
+  }
 
-    setArtifactId(artifactId) {
-        this.artifactId = artifactId;
-    }
+  setInvokerPackage(invokerPackage) {
+    this.invokerPackage = invokerPackage
+  }
 
-    setArtifactVersion(artifactVersion) {
-        this.artifactVersion = artifactVersion;
-    }
+  setGroupId(groupId) {
+    this.groupId = groupId
+  }
 
-    setSourceFolder(sourceFolder) {
-        this.sourceFolder = sourceFolder;
-    }
+  setArtifactId(artifactId) {
+    this.artifactId = artifactId
+  }
 
-    escapeQuotationMark(input) {
-        return input.split("\"").join("");
-    }
+  setArtifactVersion(artifactVersion) {
+    this.artifactVersion = artifactVersion
+  }
 
-    escapeUnsafeCharacters(input) {
-        return input.split("*/").join("*_/").split("/*").join("/_*");
-    }
+  setSourceFolder(sourceFolder) {
+    this.sourceFolder = sourceFolder
+  }
+
+  escapeQuotationMark(input) {
+    return input.split('"').join('')
+  }
+
+  escapeUnsafeCharacters(input) {
+    return input
+      .split('*/')
+      .join('*_/')
+      .split('/*')
+      .join('/_*')
+  }
 }
-const Log = LoggerFactory.getLogger(AndroidClientCodegen);
+const Log = LoggerFactory.getLogger(AndroidClientCodegen)

--- a/ern-api-gen/src/languages/ERNMixin.js
+++ b/ern-api-gen/src/languages/ERNMixin.js
@@ -4,175 +4,221 @@ import DefaultCodegen from '../DefaultCodegen'
 import CliOption from '../CliOption'
 const Log = LoggerFactory.getLogger('ERNMixin')
 export const BRDIGE_VERSION = 'bridgeVersion'
-export default function mixit (clz, overide) {
-  const {processOpts, fromOperation, initalizeCliOptions} = clz.prototype
-  Object.assign(clz.prototype, {
-    setBridgeVersion (version) {
-      this.bridgeVersion = version
-    },
-    getBridgeVersion () {
-      return this.bridgeVersion
-    },
-    processOpts () {
-      processOpts.call(this)
-      if (this.__additionalProperties.containsKey(BRDIGE_VERSION)) {
-        this.setBridgeVersion(this.__additionalProperties.get(BRDIGE_VERSION))
-      }
-    },
-    initalizeCliOptions () {
-      initalizeCliOptions && initalizeCliOptions.call(this)
-      this.__cliOptions.add(new CliOption(BRDIGE_VERSION, 'The ERN Bridge Version to use'))
-    },
-    fromOperation (path, httpMethod, operation, definitions, swagger) {
-      const op = fromOperation.call(this, path, httpMethod, operation, definitions)
-      this.updateOperationWithRequestDetails(op)
-      this.updateOperationWithResponseDetails(op)
-      op.nickNameConstant = DefaultCodegen.underscore(op.nickname).toUpperCase()
-      op.camelizedNickName = DefaultCodegen.camelize(op.nickname, false)
-      return op
-    },
+export default function mixit(clz, overide) {
+  const { processOpts, fromOperation, initalizeCliOptions } = clz.prototype
+  Object.assign(
+    clz.prototype,
+    {
+      setBridgeVersion(version) {
+        this.bridgeVersion = version
+      },
+      getBridgeVersion() {
+        return this.bridgeVersion
+      },
+      processOpts() {
+        processOpts.call(this)
+        if (this.__additionalProperties.containsKey(BRDIGE_VERSION)) {
+          this.setBridgeVersion(this.__additionalProperties.get(BRDIGE_VERSION))
+        }
+      },
+      initalizeCliOptions() {
+        initalizeCliOptions && initalizeCliOptions.call(this)
+        this.__cliOptions.push(
+          new CliOption(BRDIGE_VERSION, 'The ERN Bridge Version to use')
+        )
+      },
+      fromOperation(path, httpMethod, operation, definitions, swagger) {
+        const op = fromOperation.call(
+          this,
+          path,
+          httpMethod,
+          operation,
+          definitions
+        )
+        this.updateOperationWithRequestDetails(op)
+        this.updateOperationWithResponseDetails(op)
+        op.nickNameConstant = DefaultCodegen.underscore(
+          op.nickname
+        ).toUpperCase()
+        op.camelizedNickName = DefaultCodegen.camelize(op.nickname, false)
+        return op
+      },
 
-    updateOperationWithRequestDetails (op) {
-      let requestTypeName
-      let requestVarName
-      let requestParam = {}
-      if (op.hasParams) {
-        if (op.allParams.length > 1) {
-          requestTypeName = DefaultCodegen.camelize(op.nickname, false) + 'Data'
-          requestVarName = DefaultCodegen.camelize(op.nickname, true) + 'Data'
-          requestParam.isComposite = true
-        } else if (op.allParams.length == 1) {
-          let p = op.allParams[0]
-          requestTypeName = p.dataType
-          requestVarName = p.baseName
-          requestParam.isComposite = false
-          if (p.isListContainer) {
-            requestParam.isList = true
-            requestParam.baseType = p.baseType
-            requestParam.containerType = 'List'
+      updateOperationWithRequestDetails(op) {
+        let requestTypeName
+        let requestVarName
+        let requestParam = {}
+        if (op.hasParams) {
+          if (op.allParams.length > 1) {
+            requestTypeName =
+              DefaultCodegen.camelize(op.nickname, false) + 'Data'
+            requestVarName = DefaultCodegen.camelize(op.nickname, true) + 'Data'
+            requestParam.isComposite = true
+          } else if (op.allParams.length == 1) {
+            let p = op.allParams[0]
+            requestTypeName = p.dataType
+            requestVarName = p.baseName
+            requestParam.isComposite = false
+            if (p.isListContainer) {
+              requestParam.isList = true
+              requestParam.baseType = p.baseType
+              requestParam.containerType = 'List'
+            }
           }
         }
-      }
 
-      if (!requestTypeName) {
-        requestTypeName = 'None'
-      }
+        if (!requestTypeName) {
+          requestTypeName = 'None'
+        }
 
-      requestParam.dataType = requestTypeName
-      requestParam.paramName = requestTypeName !== 'None' ? requestVarName : ''
-      op.hasRequestParam = requestTypeName !== 'None'
-      op.requestParam = requestParam
-    },
+        requestParam.dataType = requestTypeName
+        requestParam.paramName =
+          requestTypeName !== 'None' ? requestVarName : ''
+        op.hasRequestParam = requestTypeName !== 'None'
+        op.requestParam = requestParam
+      },
 
-    updateOperationWithResponseDetails (op) {
-      let responseType
-      let responseParam = {}
+      updateOperationWithResponseDetails(op) {
+        let responseType
+        let responseParam = {}
 
-      for (const response of op.responses) {
-        if (response.code === '200' || response.code === 'default' || /2\d{2}/.test(response.code)) {
-          responseType = response.dataType
-          if (response.isListContainer || response.containerType === 'array') {
-            responseParam.isList = true
-            responseParam.baseType = response.baseType
-            responseParam.containerType = 'List'
+        for (const response of op.responses) {
+          if (
+            response.code === '200' ||
+            response.code === 'default' ||
+            /2\d{2}/.test(response.code)
+          ) {
+            responseType = response.dataType
+            if (
+              response.isListContainer ||
+              response.containerType === 'array'
+            ) {
+              responseParam.isList = true
+              responseParam.baseType = response.baseType
+              responseParam.containerType = 'List'
+            }
+            break
           }
-          break
         }
-      }
-      if (!responseType) {
-        responseType = 'None'
-      }
-      responseParam.dataType = responseType
-
-      op.responseParam = responseParam
-    },
-
-    apiFilename (templateName, tag) {
-      let suffix = this.apiTemplateFiles().get(templateName)
-      if (templateName === 'apirequests.mustache') {
-        return this.apiFileFolder() + '/' + this.toModelName(tag) + 'Requests' + suffix
-      } else if (templateName === 'apievents.mustache') {
-        return this.apiFileFolder() + '/' + this.toModelName(tag) + 'Events' + suffix
-      } else {
-        return this.apiFileFolder() + '/' + this.toApiFilename(tag) + suffix
-      }
-    },
-
-    shouldGenerateApiFor (templateName, operation) {
-      if (templateName === 'apievents.mustache') {
-        return operation.get('hasEvent')
-      }
-      return true
-    },
-
-    addLicenseFile() {
-        return false;
-    },
-
-    addSwaggerIgnoreFile() {
-        return false;
-    },
-
-    postProcessOperations (operations) {
-      let ops = operations.get('operations').get('operation')
-      let requestDataObjects = []
-      for (const operation of ops) {
-        if (operation.httpMethod === 'EVENT') {
-          operation.isEvent = true
-          operations.put('hasEvent', true)
+        if (!responseType) {
+          responseType = 'None'
         }
+        responseParam.dataType = responseType
 
-        if (operation.hasRequestParam) {
-          let requestDataObject = {}
-          let requiredParams = []
-          let optionalParams = []
+        op.responseParam = responseParam
+      },
 
-          let imports = []
+      apiFilename(templateName, tag) {
+        let suffix = this.apiTemplateFiles().get(templateName)
+        if (templateName === 'apirequests.mustache') {
+          return (
+            this.apiFileFolder() +
+            '/' +
+            this.toModelName(tag) +
+            'Requests' +
+            suffix
+          )
+        } else if (templateName === 'apievents.mustache') {
+          return (
+            this.apiFileFolder() +
+            '/' +
+            this.toModelName(tag) +
+            'Events' +
+            suffix
+          )
+        } else {
+          return this.apiFileFolder() + '/' + this.toApiFilename(tag) + suffix
+        }
+      },
 
-          for (let param of operation.allParams) {
-            let paramCopy = {...param}
-            paramCopy.hasMore = true
-            for (let imp of operation.imports) {
-              if (imp === paramCopy.baseType) {
-                imports.add(this.toModelImport(imp))
+      shouldGenerateApiFor(templateName, operation) {
+        if (templateName === 'apievents.mustache') {
+          return operation.get('hasEvent')
+        }
+        return true
+      },
+
+      addLicenseFile() {
+        return false
+      },
+
+      addSwaggerIgnoreFile() {
+        return false
+      },
+
+      postProcessOperations(operations) {
+        let ops = operations.get('operations').get('operation')
+        let requestDataObjects = []
+        for (const operation of ops) {
+          if (operation.httpMethod === 'EVENT') {
+            operation.isEvent = true
+            operations.put('hasEvent', true)
+          }
+
+          if (operation.hasRequestParam) {
+            let requestDataObject = {}
+            let requiredParams = []
+            let optionalParams = []
+
+            let imports = []
+
+            for (let param of operation.allParams) {
+              let paramCopy = { ...param }
+              paramCopy.hasMore = true
+              for (let imp of operation.imports) {
+                if (imp === paramCopy.baseType) {
+                  imports.push(this.toModelImport(imp))
+                }
+              }
+              if (param.required) {
+                requiredParams.push(paramCopy)
+              } else {
+                optionalParams.push(paramCopy)
               }
             }
-            if (param.required) {
-              requiredParams.push(paramCopy)
-            } else {
-              optionalParams.push(paramCopy)
+
+            if (requiredParams.length) {
+              requiredParams[requiredParams.length - 1].hasMore = false
+            }
+
+            if (optionalParams.length) {
+              optionalParams[optionalParams.length - 1].hasMore = false
+            }
+
+            // When there is more than one param, should generate a container class for the params since the request API can only hold one param.
+            if (operation.allParams.length > 1) {
+              requestDataObject.imports = imports
+              requestDataObject.description = operation.description
+              requestDataObject.requestDataType =
+                operation.requestParam.dataType
+              requestDataObject.allParams = operation.allParams
+              requestDataObject.requiredParams = requiredParams
+              requestDataObject.optionalParams = optionalParams
+              requestDataObject.package = operations.get('package')
+              requestDataObjects.push(requestDataObject)
+            } else if (operation.allParams.length == 1) {
+              operation.hasSingleParam = true
             }
           }
-
-          if (requiredParams.length) {
-            requiredParams[requiredParams.length - 1].hasMore = false
-          }
-
-          if (optionalParams.length) {
-            optionalParams[optionalParams.length - 1].hasMore = false
-          }
-
-                    // When there is more than one param, should generate a container class for the params since the request API can only hold one param.
-          if (operation.allParams.length > 1) {
-            requestDataObject.imports = imports
-            requestDataObject.description = operation.description
-            requestDataObject.requestDataType = operation.requestParam.dataType
-            requestDataObject.allParams = operation.allParams
-            requestDataObject.requiredParams = requiredParams
-            requestDataObject.optionalParams = optionalParams
-            requestDataObject.package = operations.get('package')
-            requestDataObjects.push(requestDataObject)
-          } else if (operation.allParams.length == 1) {
-            operation.hasSingleParam = true
-          }
         }
-      }
-      operations.put('requestDataObjects', requestDataObjects)
-      operations.put('requestsImplClassName', this.toModelName(operations.get('operations').get('pathPrefix') + 'Requests'))
-      operations.put('eventsImplClassName', this.toModelName(operations.get('operations').get('pathPrefix') + 'Events'))
-      operations.put('bridgeVersion', this.getBridgeVersion())
-      return operations
-    }
-  }, overide)
+        operations.put('requestDataObjects', requestDataObjects)
+        operations.put(
+          'requestsImplClassName',
+          this.toModelName(
+            operations.get('operations').get('pathPrefix') + 'Requests'
+          )
+        )
+        operations.put(
+          'eventsImplClassName',
+          this.toModelName(
+            operations.get('operations').get('pathPrefix') + 'Events'
+          )
+        )
+        operations.put('bridgeVersion', this.getBridgeVersion())
+        return operations
+      },
+    },
+    overide
+  )
   return clz
 }

--- a/ern-api-gen/src/languages/JavascriptClientCodegen.js
+++ b/ern-api-gen/src/languages/JavascriptClientCodegen.js
@@ -1,789 +1,1159 @@
-import CliOption from "../CliOption";
-import CodegenConstants from "../CodegenConstants";
-import CodegenModel from "../CodegenModel";
-import CodegenOperation from "../CodegenOperation";
-import CodegenParameter from "../CodegenParameter";
-import CodegenProperty from "../CodegenProperty";
-import CodegenType from "../CodegenType";
-import DefaultCodegen from "../DefaultCodegen";
-import SupportingFile from "../SupportingFile";
-import ArrayModel from "../models/ArrayModel";
-import ModelImpl from "../models/ModelImpl";
+import CliOption from '../CliOption'
+import CodegenConstants from '../CodegenConstants'
+import CodegenModel from '../CodegenModel'
+import CodegenOperation from '../CodegenOperation'
+import CodegenParameter from '../CodegenParameter'
+import CodegenProperty from '../CodegenProperty'
+import CodegenType from '../CodegenType'
+import DefaultCodegen from '../DefaultCodegen'
+import SupportingFile from '../SupportingFile'
+import ArrayModel from '../models/ArrayModel'
+import ModelImpl from '../models/ModelImpl'
 import {
-    ArrayProperty,
-    BooleanProperty,
-    DateProperty,
-    DateTimeProperty,
-    DoubleProperty,
-    FloatProperty,
-    IntegerProperty,
-    LongProperty,
-    MapProperty,
-    RefProperty,
-    StringProperty
-} from "../models/properties";
-import LoggerFactory from "../java/LoggerFactory";
-import File from "../java/File";
-import {newHashSet, newHashMap, Collections} from "../java/javaUtil";
-import StringBuilder from "../java/StringBuilder";
-import {isEmpty} from "../java/StringUtils";
+  ArrayProperty,
+  BooleanProperty,
+  DateProperty,
+  DateTimeProperty,
+  DoubleProperty,
+  FloatProperty,
+  IntegerProperty,
+  LongProperty,
+  MapProperty,
+  RefProperty,
+  StringProperty,
+} from '../models/properties'
+import LoggerFactory from '../java/LoggerFactory'
+import File from '../java/File'
+import { newHashSet, newHashMap, Collections } from '../java/javaUtil'
+import StringBuilder from '../java/StringBuilder'
+import { isEmpty } from '../java/StringUtils'
 
 export default class JavascriptClientCodegen extends DefaultCodegen {
-    static  PROJECT_NAME = "projectName";
-    static  MODULE_NAME = "moduleName";
-    static  PROJECT_DESCRIPTION = "projectDescription";
-    static  PROJECT_VERSION = "projectVersion";
-    static  PROJECT_LICENSE_NAME = "projectLicenseName";
-    static  USE_PROMISES = "usePromises";
-    static  USE_INHERITANCE = "useInheritance";
-    static  EMIT_MODEL_METHODS = "emitModelMethods";
-    static  EMIT_JS_DOC = "emitJSDoc";
+  static PROJECT_NAME = 'projectName'
+  static MODULE_NAME = 'moduleName'
+  static PROJECT_DESCRIPTION = 'projectDescription'
+  static PROJECT_VERSION = 'projectVersion'
+  static PROJECT_LICENSE_NAME = 'projectLicenseName'
+  static USE_PROMISES = 'usePromises'
+  static USE_INHERITANCE = 'useInheritance'
+  static EMIT_MODEL_METHODS = 'emitModelMethods'
+  static EMIT_JS_DOC = 'emitJSDoc'
 
-    sourceFolder = "src";
-    localVariablePrefix = "";
-    emitJSDoc = true;
-    apiDocPath = "docs/";
-    modelDocPath = "docs/";
-    apiTestPath = "api/";
-    modelTestPath = "model/";
-    usePromises = false;
-    emitModelMethods = false;
-    __outputFolder = "generated-code/js";
-    __templateDir = "Javascript";
-    __apiPackage = "api";
-    __modelPackage = "model";
-    __typeMapping = newHashMap(
-        ["array", "Array"],
-        ["map", "Object"],
-        ["List", "Array"],
-        ["boolean", "Boolean"],
-        ["string", "String"],
-        ["int", "Integer"],
-        ["float", "Number"],
-        ["number", "Number"],
-        ["DateTime", "Date"],
-        ["date", "Date"],
-        ["long", "Integer"],
-        ["short", "Integer"],
-        ["char", "String"],
-        ["double", "Number"],
-        ["object", "Object"],
-        ["integer", "Integer"],
-        ["ByteArray", "String"],
-        ["binary", "String"],
-        ["UUID", "String"]);
+  sourceFolder = 'src'
+  localVariablePrefix = ''
+  emitJSDoc = true
+  apiDocPath = 'docs/'
+  modelDocPath = 'docs/'
+  apiTestPath = 'api/'
+  modelTestPath = 'model/'
+  usePromises = false
+  emitModelMethods = false
+  __outputFolder = 'generated-code/js'
+  __templateDir = 'Javascript'
+  __apiPackage = 'api'
+  __modelPackage = 'model'
+  __typeMapping = newHashMap(
+    ['array', 'Array'],
+    ['map', 'Object'],
+    ['List', 'Array'],
+    ['boolean', 'Boolean'],
+    ['string', 'String'],
+    ['int', 'Integer'],
+    ['float', 'Number'],
+    ['number', 'Number'],
+    ['DateTime', 'Date'],
+    ['date', 'Date'],
+    ['long', 'Integer'],
+    ['short', 'Integer'],
+    ['char', 'String'],
+    ['double', 'Number'],
+    ['object', 'Object'],
+    ['integer', 'Integer'],
+    ['ByteArray', 'String'],
+    ['binary', 'String'],
+    ['UUID', 'String']
+  )
 
-    _swaggerToFlowMapping =  new newHashMap(
-        ["Integer", "number"],
-        ["Number", "number"],
-        ["String", "string"],
-        ["Boolean", "boolean"]
+  _swaggerToFlowMapping = new newHashMap(
+    ['Integer', 'number'],
+    ['Number', 'number'],
+    ['String', 'string'],
+    ['Boolean', 'boolean']
+  )
+
+  __languageSpecificPrimitives = newHashSet(
+    'String',
+    'Boolean',
+    'Integer',
+    'Number',
+    'Array',
+    'Object',
+    'Date',
+    'File'
+  )
+
+  constructor() {
+    super()
+    this.__modelTemplateFiles.put('model.mustache', '.js')
+    this.__modelTestTemplateFiles.put('model_test.mustache', '.js')
+    this.__apiTemplateFiles.put('api.mustache', '.js')
+    this.__apiTestTemplateFiles.put('api_test.mustache', '.js')
+    this.__modelDocTemplateFiles.put('model_doc.mustache', '.md')
+    this.__apiDocTemplateFiles.put('api_doc.mustache', '.md')
+    this.__defaultIncludes = newHashSet(...this.__languageSpecificPrimitives)
+    this.__instantiationTypes.put('array', 'Array')
+    this.__instantiationTypes.put('list', 'Array')
+    this.__instantiationTypes.put('map', 'Object')
+    this.__supportingFiles.push(
+      new SupportingFile('git_push.sh.mustache', '', 'git_push.sh')
     )
+    this.__supportingFiles.push(
+      new SupportingFile('README.mustache', '', 'README.md')
+    )
+    this.__supportingFiles.push(
+      new SupportingFile('mocha.opts', '', 'mocha.opts')
+    )
+    this.__supportingFiles.push(
+      new SupportingFile('travis.yml', '', '.travis.yml')
+    )
+    // this.__supportingFiles.push(new SupportingFile("package.mustache", "", "package.json"));
 
-    __languageSpecificPrimitives = newHashSet("String", "Boolean", "Integer", "Number", "Array", "Object", "Date", "File");
+    this.setReservedWordsLowerCase([
+      'abstract',
+      'arguments',
+      'boolean',
+      'break',
+      'byte',
+      'case',
+      'catch',
+      'char',
+      'class',
+      'const',
+      'continue',
+      'debugger',
+      'default',
+      'delete',
+      'do',
+      'double',
+      'else',
+      'enum',
+      'eval',
+      'export',
+      'extends',
+      'false',
+      'final',
+      'finally',
+      'float',
+      'for',
+      'function',
+      'goto',
+      'if',
+      'implements',
+      'import',
+      'in',
+      'instanceof',
+      'int',
+      'interface',
+      'let',
+      'long',
+      'native',
+      'new',
+      'null',
+      'package',
+      'private',
+      'protected',
+      'public',
+      'return',
+      'short',
+      'static',
+      'super',
+      'switch',
+      'synchronized',
+      'this',
+      'throw',
+      'throws',
+      'transient',
+      'true',
+      'try',
+      'typeof',
+      'var',
+      'void',
+      'volatile',
+      'while',
+      'with',
+      'yield',
+      'Array',
+      'Date',
+      'eval',
+      'function',
+      'hasOwnProperty',
+      'Infinity',
+      'isFinite',
+      'isNaN',
+      'isPrototypeOf',
+      'Math',
+      'NaN',
+      'Number',
+      'Object',
+      'prototype',
+      'String',
+      'toString',
+      'undefined',
+      'valueOf',
+    ])
+  }
 
-    constructor() {
-        super();
-        this.__modelTemplateFiles.put("model.mustache", ".js");
-        this.__modelTestTemplateFiles.put("model_test.mustache", ".js");
-        this.__apiTemplateFiles.put("api.mustache", ".js");
-        this.__apiTestTemplateFiles.put("api_test.mustache", ".js");
-        this.__modelDocTemplateFiles.put("model_doc.mustache", ".md");
-        this.__apiDocTemplateFiles.put("api_doc.mustache", ".md");
-        this.__defaultIncludes = newHashSet(...this.__languageSpecificPrimitives);
-        this.__instantiationTypes.put("array", "Array");
-        this.__instantiationTypes.put("list", "Array");
-        this.__instantiationTypes.put("map", "Object");
-        this.__supportingFiles.add(new SupportingFile("git_push.sh.mustache", "", "git_push.sh"));
-        this.__supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
-        this.__supportingFiles.add(new SupportingFile("mocha.opts", "", "mocha.opts"));
-        this.__supportingFiles.add(new SupportingFile("travis.yml", "", ".travis.yml"));
-        // this.__supportingFiles.add(new SupportingFile("package.mustache", "", "package.json"));
+  initalizeCliOptions() {
+    super.initalizeCliOptions()
+    this.__cliOptions.push(
+      new CliOption(
+        CodegenConstants.SOURCE_FOLDER,
+        CodegenConstants.SOURCE_FOLDER_DESC
+      ).defaultValue('src')
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        CodegenConstants.LOCAL_VARIABLE_PREFIX,
+        CodegenConstants.LOCAL_VARIABLE_PREFIX_DESC
+      )
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        CodegenConstants.INVOKER_PACKAGE,
+        CodegenConstants.INVOKER_PACKAGE_DESC
+      )
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        CodegenConstants.API_PACKAGE,
+        CodegenConstants.API_PACKAGE_DESC
+      )
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        CodegenConstants.MODEL_PACKAGE,
+        CodegenConstants.MODEL_PACKAGE_DESC
+      )
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        JavascriptClientCodegen.PROJECT_NAME,
+        'name of the project (Default: generated from info.title or "swagger-js-client")'
+      )
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        JavascriptClientCodegen.MODULE_NAME,
+        'module name for AMD, Node or globals (Default: generated from <projectName>)'
+      )
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        JavascriptClientCodegen.PROJECT_DESCRIPTION,
+        'description of the project (Default: using info.description or "Client library of <projectName>")'
+      )
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        JavascriptClientCodegen.PROJECT_VERSION,
+        'version of the project (Default: using info.version or "1.0.0")'
+      )
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        JavascriptClientCodegen.PROJECT_LICENSE_NAME,
+        'name of the license the project uses (Default: using info.license.name)'
+      )
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        JavascriptClientCodegen.USE_PROMISES,
+        'use Promises as return values from the client API, instead of superagent callbacks'
+      ).defaultValue('false')
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        JavascriptClientCodegen.EMIT_MODEL_METHODS,
+        'generate getters and setters for model properties'
+      ).defaultValue('false')
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        JavascriptClientCodegen.EMIT_JS_DOC,
+        'generate JSDoc comments'
+      ).defaultValue('true')
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        JavascriptClientCodegen.USE_INHERITANCE,
+        'use JavaScript prototype chains & delegation for inheritance'
+      ).defaultValue('true')
+    )
+  }
 
-        this.setReservedWordsLowerCase(["abstract", "arguments", "boolean", "break", "byte", "case", "catch", "char", "class", "const", "continue", "debugger", "default", "delete", "do", "double", "else", "enum", "eval", "export", "extends", "false", "final", "finally", "float", "for", "function", "goto", "if", "implements", "import", "in", "instanceof", "int", "interface", "let", "long", "native", "new", "null", "package", "private", "protected", "public", "return", "short", "static", "super", "switch", "synchronized", "this", "throw", "throws", "transient", "true", "try", "typeof", "var", "void", "volatile", "while", "with", "yield", "Array", "Date", "eval", "function", "hasOwnProperty", "Infinity", "isFinite", "isNaN", "isPrototypeOf", "Math", "NaN", "Number", "Object", "prototype", "String", "toString", "undefined", "valueOf"]);
+  getTag() {
+    return CodegenType.CLIENT
+  }
+
+  getName() {
+    return 'javascript'
+  }
+
+  getHelp() {
+    return 'Generates a Javascript client library.'
+  }
+
+  processOpts() {
+    super.processOpts()
+    if (
+      this.__additionalProperties.containsKey(
+        JavascriptClientCodegen.PROJECT_NAME
+      )
+    ) {
+      this.setProjectName(
+        this.__additionalProperties.get(JavascriptClientCodegen.PROJECT_NAME)
+      )
+    }
+    if (
+      this.__additionalProperties.containsKey(
+        JavascriptClientCodegen.MODULE_NAME
+      )
+    ) {
+      this.setModuleName(
+        this.__additionalProperties.get(JavascriptClientCodegen.MODULE_NAME)
+      )
+    }
+    if (
+      this.__additionalProperties.containsKey(
+        JavascriptClientCodegen.PROJECT_DESCRIPTION
+      )
+    ) {
+      this.setProjectDescription(
+        this.__additionalProperties.get(
+          JavascriptClientCodegen.PROJECT_DESCRIPTION
+        )
+      )
+    }
+    if (
+      this.__additionalProperties.containsKey(
+        JavascriptClientCodegen.PROJECT_VERSION
+      )
+    ) {
+      this.setProjectVersion(
+        this.__additionalProperties.get(JavascriptClientCodegen.PROJECT_VERSION)
+      )
+    }
+    if (
+      this.__additionalProperties.containsKey(
+        JavascriptClientCodegen.PROJECT_LICENSE_NAME
+      )
+    ) {
+      this.setProjectLicenseName(
+        this.__additionalProperties.get(
+          JavascriptClientCodegen.PROJECT_LICENSE_NAME
+        )
+      )
+    }
+    if (
+      this.__additionalProperties.containsKey(
+        CodegenConstants.LOCAL_VARIABLE_PREFIX
+      )
+    ) {
+      this.setLocalVariablePrefix(
+        this.__additionalProperties.get(CodegenConstants.LOCAL_VARIABLE_PREFIX)
+      )
+    }
+    if (
+      this.__additionalProperties.containsKey(CodegenConstants.SOURCE_FOLDER)
+    ) {
+      this.setSourceFolder(
+        this.__additionalProperties.get(CodegenConstants.SOURCE_FOLDER)
+      )
+    }
+    if (
+      this.__additionalProperties.containsKey(CodegenConstants.INVOKER_PACKAGE)
+    ) {
+      this.setInvokerPackage(
+        this.__additionalProperties.get(CodegenConstants.INVOKER_PACKAGE)
+      )
+    }
+    if (
+      this.__additionalProperties.containsKey(
+        JavascriptClientCodegen.USE_PROMISES
+      )
+    ) {
+      this.usePromises = parseBoolean(
+        this.__additionalProperties.get(JavascriptClientCodegen.USE_PROMISES)
+      )
+    }
+    if (
+      this.__additionalProperties.containsKey(
+        JavascriptClientCodegen.USE_INHERITANCE
+      )
+    ) {
+      this.supportsInheritance = parseBoolean(
+        this.__additionalProperties.get(JavascriptClientCodegen.USE_INHERITANCE)
+      )
+    } else {
+      this.supportsInheritance = true
+    }
+    if (
+      this.__additionalProperties.containsKey(
+        JavascriptClientCodegen.EMIT_MODEL_METHODS
+      )
+    ) {
+      this.setEmitModelMethods(
+        parseBoolean(
+          this.__additionalProperties.get(
+            JavascriptClientCodegen.EMIT_MODEL_METHODS
+          )
+        )
+      )
+    }
+    if (
+      this.__additionalProperties.containsKey(
+        JavascriptClientCodegen.EMIT_JS_DOC
+      )
+    ) {
+      this.setEmitJSDoc(
+        parseBoolean(
+          this.__additionalProperties.get(JavascriptClientCodegen.EMIT_JS_DOC)
+        )
+      )
+    }
+  }
+
+  preprocessSwagger(swagger) {
+    super.preprocessSwagger(swagger)
+    if (swagger.getInfo() != null) {
+      let info = swagger.getInfo()
+      if (isEmpty(this.projectName) && info.getTitle() != null) {
+        this.projectName = this.sanitizeName(this.dashize(info.getTitle()))
+      }
+      if (isEmpty(this.projectVersion)) {
+        this.projectVersion = this.escapeUnsafeCharacters(
+          this.escapeQuotationMark(info.getVersion())
+        )
+      }
+      if (this.projectDescription == null && info.getDescription()) {
+        this.projectDescription = this.sanitizeName(info.getDescription())
+      }
+      if (
+        this.__additionalProperties.get(
+          JavascriptClientCodegen.PROJECT_LICENSE_NAME
+        ) == null
+      ) {
+        if (info.getLicense() != null) {
+          let license = info.getLicense()
+          this.__additionalProperties.put(
+            JavascriptClientCodegen.PROJECT_LICENSE_NAME,
+            this.sanitizeName(license.getName())
+          )
+        }
+      }
+    }
+    if (isEmpty(this.projectName)) {
+      this.projectName = 'swagger-js-client'
+    }
+    if (isEmpty(this.moduleName)) {
+      this.moduleName = DefaultCodegen.camelize(
+        DefaultCodegen.underscore(this.projectName)
+      )
+    }
+    if (isEmpty(this.projectVersion)) {
+      this.projectVersion = '1.0.0'
+    }
+    if (this.projectDescription == null) {
+      this.projectDescription = 'Client library of ' + this.projectName
+    }
+    this.__additionalProperties.put(
+      JavascriptClientCodegen.PROJECT_NAME,
+      this.projectName
+    )
+    this.__additionalProperties.put(
+      JavascriptClientCodegen.MODULE_NAME,
+      this.moduleName
+    )
+    this.__additionalProperties.put(
+      JavascriptClientCodegen.PROJECT_DESCRIPTION,
+      this.escapeText(this.projectDescription)
+    )
+    this.__additionalProperties.put(
+      JavascriptClientCodegen.PROJECT_VERSION,
+      this.projectVersion
+    )
+    this.__additionalProperties.put(
+      CodegenConstants.API_PACKAGE,
+      this.__apiPackage
+    )
+    this.__additionalProperties.put(
+      CodegenConstants.INVOKER_PACKAGE,
+      this.invokerPackage
+    )
+    this.__additionalProperties.put(
+      CodegenConstants.LOCAL_VARIABLE_PREFIX,
+      this.localVariablePrefix
+    )
+    this.__additionalProperties.put(
+      CodegenConstants.MODEL_PACKAGE,
+      this.__modelPackage
+    )
+    this.__additionalProperties.put(
+      CodegenConstants.SOURCE_FOLDER,
+      this.sourceFolder
+    )
+    this.__additionalProperties.put(
+      JavascriptClientCodegen.USE_PROMISES,
+      this.usePromises
+    )
+    this.__additionalProperties.put(
+      JavascriptClientCodegen.USE_INHERITANCE,
+      this.supportsInheritance
+    )
+    this.__additionalProperties.put(
+      JavascriptClientCodegen.EMIT_MODEL_METHODS,
+      this.emitModelMethods
+    )
+    this.__additionalProperties.put(
+      JavascriptClientCodegen.EMIT_JS_DOC,
+      this.emitJSDoc
+    )
+    this.__additionalProperties.put('apiDocPath', this.apiDocPath)
+    this.__additionalProperties.put('modelDocPath', this.modelDocPath)
+    this.__supportingFiles.push(
+      new SupportingFile(
+        'index.mustache',
+        this.createPath(this.sourceFolder, this.invokerPackage),
+        'index.js'
+      )
+    )
+    this.__supportingFiles.push(
+      new SupportingFile(
+        'ApiClient.mustache',
+        this.createPath(this.sourceFolder, this.invokerPackage),
+        'ApiClient.js'
+      )
+    )
+  }
+
+  escapeReservedWord(name) {
+    return '_' + name
+  }
+
+  /**
+   * Concatenates an array of path segments into a path string.
+   * @param segments The path segments to concatenate. A segment may contain either of the file separator characters '\' or '/'.
+   * A segment is ignored if it is <code>null</code>, empty or &quot;.&quot;.
+   * @return A path string using the correct platform-specific file separator character.
+   */
+  createPath(...segments) {
+    let buf = new StringBuilder()
+    for (const segment of segments) {
+      if (!isEmpty(segment) && !(segment === '.')) {
+        if (buf.length() !== 0) buf.append(File.separatorChar)
+        buf.append(segment)
+      }
+    }
+    for (let i = 0; i < buf.length(); i++) {
+      let c = buf.charAt(i)
+      if ((c === '/' || c === '\\') && c !== File.separatorChar)
+        buf.setCharAt(i, File.separatorChar)
+    }
+    return buf.toString()
+  }
+
+  apiTestFileFolder() {
+    return (this.__outputFolder + '/test/' + this.apiTestPath)
+      .split('/')
+      .join(File.separatorChar)
+  }
+
+  modelTestFileFolder() {
+    return (this.__outputFolder + '/test/' + this.modelTestPath)
+      .split('/')
+      .join(File.separatorChar)
+  }
+
+  apiFileFolder() {
+    return this.createPath(
+      this.__outputFolder,
+      this.sourceFolder,
+      this.invokerPackage,
+      this.apiPackage()
+    )
+  }
+
+  modelFileFolder() {
+    return this.createPath(
+      this.__outputFolder,
+      this.sourceFolder,
+      this.invokerPackage,
+      this.modelPackage()
+    )
+  }
+
+  apiDocFileFolder() {
+    return this.createPath(this.__outputFolder, this.apiDocPath)
+  }
+
+  modelDocFileFolder() {
+    return this.createPath(this.__outputFolder, this.modelDocPath)
+  }
+
+  toApiDocFilename(name) {
+    return this.toApiName(name)
+  }
+
+  toModelDocFilename(name) {
+    return this.toModelName(name)
+  }
+
+  toApiTestFilename(name) {
+    return this.toApiName(name) + '.spec'
+  }
+
+  toModelTestFilename(name) {
+    return this.toModelName(name) + '.spec'
+  }
+
+  toVarName(name) {
+    name = this.sanitizeName(name)
+    if ('_' === name) {
+      name = '_u'
+    }
+    if (name.match('^[A-Z_]*$')) {
+      return name
+    }
+    name = DefaultCodegen.camelize(name, true)
+    if (this.isReservedWord(name) || name.match('^\\d.*')) {
+      name = this.escapeReservedWord(name)
+    }
+    return name
+  }
+
+  toParamName(name) {
+    return this.toVarName(name)
+  }
+
+  toModelName(name) {
+    name = this.sanitizeName(name)
+    if (!isEmpty(this.modelNamePrefix)) {
+      name = this.modelNamePrefix + '_' + name
+    }
+    if (!isEmpty(this.modelNameSuffix)) {
+      name = name + '_' + this.modelNameSuffix
+    }
+    name = DefaultCodegen.camelize(name)
+    if (this.isReservedWord(name)) {
+      let modelName = 'Model' + name
+      Log.warn(
+        name +
+          ' (reserved word) cannot be used as model name. Renamed to ' +
+          modelName
+      )
+      return modelName
+    }
+    if (name.match('^\\d.*')) {
+      let modelName = 'Model' + name
+      Log.warn(
+        name +
+          ' (model name starts with number) cannot be used as model name. Renamed to ' +
+          modelName
+      )
+      return modelName
+    }
+    return name
+  }
+
+  toModelFilename(name) {
+    return this.toModelName(name)
+  }
+
+  toModelImport(name) {
+    return name
+  }
+
+  toApiImport(name) {
+    return this.toApiName(name)
+  }
+
+  getTypeDeclaration(p) {
+    if (p != null && p instanceof ArrayProperty) {
+      const inner = p.getItems()
+      return '[' + this.getTypeDeclaration(inner) + ']'
+    } else if (p != null && p instanceof MapProperty) {
+      const inner = p.getAdditionalProperties()
+      return '{String: ' + this.getTypeDeclaration(inner) + '}'
+    }
+    return super.getTypeDeclaration(p)
+  }
+
+  toDefaultValue(p) {
+    const dp = p.getDefault()
+    if (dp != null) {
+      if (p instanceof StringProperty) {
+        return JSON.stringify(dp) + ''
+      }
+      if (
+        p instanceof BooleanProperty ||
+        p instanceof DoubleProperty ||
+        p instanceof FloatProperty ||
+        p instanceof IntegerProperty ||
+        p instanceof LongProperty
+      ) {
+        return dp.toString()
+      }
     }
 
-    initalizeCliOptions() {
-        super.initalizeCliOptions();
-        this.__cliOptions.add(new CliOption(CodegenConstants.SOURCE_FOLDER, CodegenConstants.SOURCE_FOLDER_DESC).defaultValue("src"));
-        this.__cliOptions.add(new CliOption(CodegenConstants.LOCAL_VARIABLE_PREFIX, CodegenConstants.LOCAL_VARIABLE_PREFIX_DESC));
-        this.__cliOptions.add(new CliOption(CodegenConstants.INVOKER_PACKAGE, CodegenConstants.INVOKER_PACKAGE_DESC));
-        this.__cliOptions.add(new CliOption(CodegenConstants.API_PACKAGE, CodegenConstants.API_PACKAGE_DESC));
-        this.__cliOptions.add(new CliOption(CodegenConstants.MODEL_PACKAGE, CodegenConstants.MODEL_PACKAGE_DESC));
-        this.__cliOptions.add(new CliOption(JavascriptClientCodegen.PROJECT_NAME, "name of the project (Default: generated from info.title or \"swagger-js-client\")"));
-        this.__cliOptions.add(new CliOption(JavascriptClientCodegen.MODULE_NAME, "module name for AMD, Node or globals (Default: generated from <projectName>)"));
-        this.__cliOptions.add(new CliOption(JavascriptClientCodegen.PROJECT_DESCRIPTION, "description of the project (Default: using info.description or \"Client library of <projectName>\")"));
-        this.__cliOptions.add(new CliOption(JavascriptClientCodegen.PROJECT_VERSION, "version of the project (Default: using info.version or \"1.0.0\")"));
-        this.__cliOptions.add(new CliOption(JavascriptClientCodegen.PROJECT_LICENSE_NAME, "name of the license the project uses (Default: using info.license.name)"));
-        this.__cliOptions.add(new CliOption(JavascriptClientCodegen.USE_PROMISES, "use Promises as return values from the client API, instead of superagent callbacks").defaultValue("false"));
-        this.__cliOptions.add(new CliOption(JavascriptClientCodegen.EMIT_MODEL_METHODS, "generate getters and setters for model properties").defaultValue("false"));
-        this.__cliOptions.add(new CliOption(JavascriptClientCodegen.EMIT_JS_DOC, "generate JSDoc comments").defaultValue("true"));
-        this.__cliOptions.add(new CliOption(JavascriptClientCodegen.USE_INHERITANCE, "use JavaScript prototype chains & delegation for inheritance").defaultValue("true"));
-    }
+    return dp
+  }
 
-    getTag() {
-        return CodegenType.CLIENT;
+  toDefaultValueWithParam(name, p) {
+    let type = this.normalizeType(this.getTypeDeclaration(p))
+    if (p instanceof RefProperty) {
+      return ' = ' + type + ".constructFromObject(data['" + name + "']);"
+    } else {
+      return " = ApiClient.convertToType(data['" + name + "'], " + type + ');'
     }
+  }
 
-    getName() {
-        return "javascript";
+  setParameterExampleValue(p) {
+    let example
+    if (p.defaultValue == null) {
+      example = p.example
+    } else {
+      example = p.defaultValue
     }
-
-    getHelp() {
-        return "Generates a Javascript client library.";
+    let type = p.baseType
+    if (type == null) {
+      type = p.dataType
     }
-
-    processOpts() {
-        super.processOpts();
-        if (this.__additionalProperties.containsKey(JavascriptClientCodegen.PROJECT_NAME)) {
-            this.setProjectName(this.__additionalProperties.get(JavascriptClientCodegen.PROJECT_NAME));
-        }
-        if (this.__additionalProperties.containsKey(JavascriptClientCodegen.MODULE_NAME)) {
-            this.setModuleName(this.__additionalProperties.get(JavascriptClientCodegen.MODULE_NAME));
-        }
-        if (this.__additionalProperties.containsKey(JavascriptClientCodegen.PROJECT_DESCRIPTION)) {
-            this.setProjectDescription(this.__additionalProperties.get(JavascriptClientCodegen.PROJECT_DESCRIPTION));
-        }
-        if (this.__additionalProperties.containsKey(JavascriptClientCodegen.PROJECT_VERSION)) {
-            this.setProjectVersion(this.__additionalProperties.get(JavascriptClientCodegen.PROJECT_VERSION));
-        }
-        if (this.__additionalProperties.containsKey(JavascriptClientCodegen.PROJECT_LICENSE_NAME)) {
-            this.setProjectLicenseName(this.__additionalProperties.get(JavascriptClientCodegen.PROJECT_LICENSE_NAME));
-        }
-        if (this.__additionalProperties.containsKey(CodegenConstants.LOCAL_VARIABLE_PREFIX)) {
-            this.setLocalVariablePrefix(this.__additionalProperties.get(CodegenConstants.LOCAL_VARIABLE_PREFIX));
-        }
-        if (this.__additionalProperties.containsKey(CodegenConstants.SOURCE_FOLDER)) {
-            this.setSourceFolder(this.__additionalProperties.get(CodegenConstants.SOURCE_FOLDER));
-        }
-        if (this.__additionalProperties.containsKey(CodegenConstants.INVOKER_PACKAGE)) {
-            this.setInvokerPackage(this.__additionalProperties.get(CodegenConstants.INVOKER_PACKAGE));
-        }
-        if (this.__additionalProperties.containsKey(JavascriptClientCodegen.USE_PROMISES)) {
-            this.usePromises = parseBoolean(this.__additionalProperties.get(JavascriptClientCodegen.USE_PROMISES));
-        }
-        if (this.__additionalProperties.containsKey(JavascriptClientCodegen.USE_INHERITANCE)) {
-            this.supportsInheritance = parseBoolean(this.__additionalProperties.get(JavascriptClientCodegen.USE_INHERITANCE));
-        }
-        else {
-            this.supportsInheritance = true;
-        }
-        if (this.__additionalProperties.containsKey(JavascriptClientCodegen.EMIT_MODEL_METHODS)) {
-            this.setEmitModelMethods(parseBoolean(this.__additionalProperties.get(JavascriptClientCodegen.EMIT_MODEL_METHODS)));
-        }
-        if (this.__additionalProperties.containsKey(JavascriptClientCodegen.EMIT_JS_DOC)) {
-            this.setEmitJSDoc(parseBoolean(this.__additionalProperties.get(JavascriptClientCodegen.EMIT_JS_DOC)));
-        }
+    if ('String' === type) {
+      if (example == null) {
+        example = p.paramName + '_example'
+      }
+      example = '"' + this.escapeText(example) + '"'
+    } else if ('Integer' === type) {
+      if (example == null) {
+        example = '56'
+      }
+    } else if ('Number' === type) {
+      if (example == null) {
+        example = '3.4'
+      }
+    } else if ('Boolean' === type) {
+      if (example == null) {
+        example = 'true'
+      }
+    } else if ('File' === type) {
+      if (example == null) {
+        example = '/path/to/file'
+      }
+      example = '"' + this.escapeText(example) + '"'
+    } else if ('Date' === type) {
+      if (example == null) {
+        example = '2013-10-20T19:20:30+01:00'
+      }
+      example = 'new Date("' + this.escapeText(example) + '")'
+    } else if (!this.__languageSpecificPrimitives.contains(type)) {
+      example = 'new ' + this.moduleName + '.' + type + '()'
     }
+    if (example == null) {
+      example = 'null'
+    } else if (p.isListContainer) {
+      example = '[' + example + ']'
+    } else if (p.isMapContainer) {
+      example = '{key: ' + example + '}'
+    }
+    p.example = example
+  }
 
-    preprocessSwagger(swagger) {
-        super.preprocessSwagger(swagger);
-        if (swagger.getInfo() != null) {
-            let info = swagger.getInfo();
-            if (isEmpty(this.projectName) && info.getTitle() != null) {
-                this.projectName = this.sanitizeName(this.dashize(info.getTitle()));
+  /**
+   * Normalize type by wrapping primitive types with single quotes.
+   *
+   * @param type Primitive type
+   * @return Normalized type
+   */
+  normalizeType(type) {
+    return type.replace(
+      new RegExp('\\b(Boolean|Integer|Number|String|Date)\\b', 'g'),
+      "'$1'"
+    )
+  }
+
+  getSwaggerType(p) {
+    let swaggerType = super.getSwaggerType(p)
+    let type = null
+    if (this.__typeMapping.containsKey(swaggerType)) {
+      type = this.__typeMapping.get(swaggerType)
+      if (!this.needToImport(type)) {
+        return type
+      }
+    } else {
+      type = swaggerType
+    }
+    if (null == type) {
+      Log.error('No Type defined for Property ' + p)
+    }
+    return this.toModelName(type)
+  }
+
+  toOperationId(operationId) {
+    if (isEmpty(operationId)) {
+      throw new Error('Empty method/operation name (operationId) not allowed')
+    }
+    operationId = DefaultCodegen.camelize(this.sanitizeName(operationId), true)
+    if (this.isReservedWord(operationId)) {
+      let newOperationId = DefaultCodegen.camelize('call_' + operationId, true)
+      Log.warn(
+        operationId +
+          ' (reserved word) cannot be used as method name. Renamed to ' +
+          newOperationId
+      )
+      return newOperationId
+    }
+    return operationId
+  }
+
+  fromOperation(path, httpMethod, operation, definitions, swagger) {
+    if (arguments.length > 4) {
+      let op = super.fromOperation(
+        path,
+        httpMethod,
+        operation,
+        definitions,
+        swagger
+      )
+      if (op.returnType != null) {
+        op.returnType = this.normalizeType(op.returnType)
+      }
+      op.path = this.sanitizePath(op.path)
+      let lastRequired = null
+      let lastOptional = null
+      for (const p of op.allParams) {
+        if (p.required) {
+          lastRequired = p
+        } else {
+          lastOptional = p
+        }
+      }
+      for (const p of op.allParams) {
+        if (p === lastRequired) {
+          p._hasMoreRequired = false
+        } else if (p === lastOptional) {
+          p._hasMoreOptional = false
+        } else {
+          p._hasMoreRequired = true
+          p._hasMoreOptional = true
+        }
+      }
+      op._hasRequiredParams = lastRequired != null
+      return op
+    }
+    return super.fromOperation(path, httpMethod, operation, definitions)
+  }
+
+  fromModel(name, model, allDefinitions) {
+    if (arguments.length > 2) {
+      let codegenModel = super.fromModel(name, model, allDefinitions)
+      if (
+        allDefinitions != null &&
+        codegenModel != null &&
+        codegenModel.parent != null &&
+        codegenModel.hasEnums
+      ) {
+        let parentModel = allDefinitions.get(codegenModel.parentSchema)
+        let parentCodegenModel = super.fromModel(
+          codegenModel.parent,
+          parentModel,
+          allDefinitions
+        )
+        codegenModel = JavascriptClientCodegen.reconcileInlineEnums(
+          codegenModel,
+          parentCodegenModel
+        )
+      }
+      if (model != null && model instanceof ArrayModel) {
+        let am = model
+        if (am.getItems() != null) {
+          codegenModel._isArray = true
+          codegenModel._itemType = this.getSwaggerType(am.getItems())
+        }
+      } else if (model != null && model instanceof ModelImpl) {
+        let mm = model
+        if (mm.getAdditionalProperties() != null) {
+          codegenModel._isMap = true
+          codegenModel._itemType = this.getSwaggerType(
+            mm.getAdditionalProperties()
+          )
+        }
+      }
+      return codegenModel
+    } else return super.fromModel(name, model)
+  }
+
+  sanitizePath(p) {
+    return p.replace(new RegExp("'", 'g'), '%27')
+  }
+
+  trimBrackets(s) {
+    if (s != null) {
+      let beginIdx = s[0] === '[' ? 1 : 0
+      let endIdx = s.length
+      if (s[endIdx - 1] === ']') endIdx--
+      return s.substring(beginIdx, endIdx)
+    }
+    return null
+  }
+
+  getModelledType(dataType) {
+    return (
+      'module:' +
+      (isEmpty(this.invokerPackage) ? '' : this.invokerPackage + '/') +
+      (isEmpty(this.__modelPackage) ? '' : this.__modelPackage + '/') +
+      dataType
+    )
+  }
+
+  getJSDocType(cm, cp) {
+    if (
+      ((cm != null && cm instanceof CodegenModel) || cm === null) &&
+      ((cp != null && cp instanceof CodegenProperty) || cp === null)
+    ) {
+      if (cp.isContainer) {
+        if (cp.containerType === 'array')
+          return 'Array.<' + this.getJSDocType(cm, cp.items) + '>'
+        else if (cp.containerType === 'map')
+          return 'Object.<String, ' + this.getJSDocType(cm, cp.items) + '>'
+      }
+      let dataType = this.trimBrackets(cp.datatypeWithEnum)
+      if (cp.isEnum) {
+        dataType = cm.classname + '.' + dataType
+      }
+      if (this.isModelledType(cp)) dataType = this.getModelledType(dataType)
+      return dataType
+    } else if (
+      ((cm != null && cm instanceof CodegenParameter) || cm === null) &&
+      cp === undefined
+    ) {
+      let dataType = this.trimBrackets(cm.dataType)
+      if (this.isModelledType(cm)) dataType = this.getModelledType(dataType)
+      if (cm.isListContainer) {
+        return 'Array.<' + dataType + '>'
+      } else if (cm.isMapContainer) {
+        return 'Object.<String, ' + dataType + '>'
+      }
+      return dataType
+    } else if (
+      ((cm != null && cm instanceof CodegenOperation) || cm === null) &&
+      cp === undefined
+    ) {
+      let returnType = this.trimBrackets(cm.returnType)
+      if (returnType != null) {
+        if (this.isModelledType(cm))
+          returnType = this.getModelledType(returnType)
+        if (cm.isListContainer) {
+          return 'Array.<' + returnType + '>'
+        } else if (cm.isMapContainer) {
+          return 'Object.<String, ' + returnType + '>'
+        }
+      }
+      return returnType
+    } else throw new Error('invalid overload')
+  }
+
+  isModelledType(cp) {
+    if ((cp != null && cp instanceof CodegenProperty) || cp === null) {
+      return (
+        cp.isEnum ||
+        !this.__languageSpecificPrimitives.contains(
+          cp.baseType == null ? cp.datatype : cp.baseType
+        )
+      )
+    } else if ((cp != null && cp instanceof CodegenParameter) || cp === null) {
+      return (
+        cp.isEnum ||
+        !this.__languageSpecificPrimitives.contains(
+          cp.baseType == null ? cp.dataType : cp.baseType
+        )
+      )
+    } else if ((cp != null && cp instanceof CodegenOperation) || cp === null) {
+      return !cp.returnTypeIsPrimitive
+    }
+    throw new Error('invalid overload')
+  }
+
+  postProcessOperations(objs) {
+    let operations = objs.get('operations')
+    if (operations != null) {
+      let ops = operations.get('operation')
+      for (const operation of ops) {
+        let argList = []
+        let hasOptionalParams = false
+        for (const p of operation.allParams) {
+          if (p.required) {
+            let flowsify = p.paramName
+            const swaggerType = p.dataType
+            if (this._swaggerToFlowMapping.containsKey(swaggerType)) {
+              flowsify += `: ${this._swaggerToFlowMapping.get(swaggerType)}`
+            } else {
+              flowsify += ': any'
             }
-            if (isEmpty(this.projectVersion)) {
-                this.projectVersion = this.escapeUnsafeCharacters(this.escapeQuotationMark(info.getVersion()));
+            argList.push(flowsify)
+          } else {
+            hasOptionalParams = true
+          }
+        }
+        if (hasOptionalParams) {
+          argList.push('opts: any')
+        }
+        if (!this.usePromises) {
+          argList.push('callback: Function')
+        }
+        operation._argList = argList.join(', ')
+        for (const cp of operation.allParams) {
+          cp._jsDocType = this.getJSDocType(cp)
+        }
+        operation.hasOptionalParams = hasOptionalParams
+        operation.hasParams = operation.allParams.length > 0
+        operation._jsDocType = this.getJSDocType(operation)
+      }
+    }
+    Collections.sort(objs.get('imports'), (a, b) => {
+      const a1 = a.get('import'),
+        b1 = b.get('import')
+      return a1.localeCompare(b1)
+    })
+    return objs
+  }
+
+  postProcessModels(objs) {
+    objs = super.postProcessModelsEnum(objs)
+    let models = objs.get('models')
+    for (const mo of models) {
+      let cm = mo.get('model')
+      let required = []
+      let allRequired = this.supportsInheritance ? [] : required
+      cm._required = required
+
+      cm._allRequired = allRequired
+
+      for (const __var of cm.vars) {
+        let jsDocType = this.getJSDocType(cm, __var)
+        __var._jsDocType = jsDocType
+
+        if (__var.required) {
+          required.push(__var)
+        }
+      }
+      if (this.supportsInheritance) {
+        for (const vars of cm.allVars) {
+          if (vars.required) {
+            allRequired.push(vars)
+          }
+        }
+      }
+      let lastRequired = null
+      for (const vars of cm.vars) {
+        if (vars.required != null && vars.required) {
+          lastRequired = vars
+        }
+      }
+      for (const vars of cm.vars) {
+        if (vars === lastRequired) {
+          vars._hasMoreRequired = false
+        } else if (vars.required != null && vars.required) {
+          vars._hasMoreRequired = true
+        }
+      }
+    }
+    return objs
+  }
+
+  needToImport(type) {
+    return (
+      !this.__defaultIncludes.contains(type) &&
+      !this.__languageSpecificPrimitives.contains(type)
+    )
+  }
+
+  static reconcileInlineEnums(codegenModel, parentCodegenModel) {
+    if (parentCodegenModel.hasEnums) {
+      let parentModelCodegenProperties = parentCodegenModel.vars
+      let codegenProperties = codegenModel.vars
+      let removedChildEnum = false
+      for (const parentModelCodegenPropery of parentModelCodegenProperties) {
+        if (parentModelCodegenPropery.isEnum) {
+          for (let i = codegenProperties.length; i--; ) {
+            const codegenProperty = codegenProperties[i]
+            if (
+              codegenProperty.isEnum &&
+              codegenProperty.equals(parentModelCodegenPropery)
+            ) {
+              codegenProperties.splice(i, 1)
+              removedChildEnum = true
             }
-            if (this.projectDescription == null && info.getDescription()) {
-                this.projectDescription = this.sanitizeName(info.getDescription());
-            }
-            if (this.__additionalProperties.get(JavascriptClientCodegen.PROJECT_LICENSE_NAME) == null) {
-                if (info.getLicense() != null) {
-                    let license = info.getLicense();
-                    this.__additionalProperties.put(JavascriptClientCodegen.PROJECT_LICENSE_NAME, this.sanitizeName(license.getName()));
-                }
-            }
+          }
         }
-        if (isEmpty(this.projectName)) {
-            this.projectName = "swagger-js-client";
+      }
+      if (removedChildEnum) {
+        let codegenProperty
+        for (codegenProperty of codegenProperties) {
+          codegenProperty.hasMore = true
         }
-        if (isEmpty(this.moduleName)) {
-            this.moduleName = DefaultCodegen.camelize(DefaultCodegen.underscore(this.projectName));
-        }
-        if (isEmpty(this.projectVersion)) {
-            this.projectVersion = "1.0.0";
-        }
-        if (this.projectDescription == null) {
-            this.projectDescription = "Client library of " + this.projectName;
-        }
-        this.__additionalProperties.put(JavascriptClientCodegen.PROJECT_NAME, this.projectName);
-        this.__additionalProperties.put(JavascriptClientCodegen.MODULE_NAME, this.moduleName);
-        this.__additionalProperties.put(JavascriptClientCodegen.PROJECT_DESCRIPTION, this.escapeText(this.projectDescription));
-        this.__additionalProperties.put(JavascriptClientCodegen.PROJECT_VERSION, this.projectVersion);
-        this.__additionalProperties.put(CodegenConstants.API_PACKAGE, this.__apiPackage);
-        this.__additionalProperties.put(CodegenConstants.INVOKER_PACKAGE, this.invokerPackage);
-        this.__additionalProperties.put(CodegenConstants.LOCAL_VARIABLE_PREFIX, this.localVariablePrefix);
-        this.__additionalProperties.put(CodegenConstants.MODEL_PACKAGE, this.__modelPackage);
-        this.__additionalProperties.put(CodegenConstants.SOURCE_FOLDER, this.sourceFolder);
-        this.__additionalProperties.put(JavascriptClientCodegen.USE_PROMISES, this.usePromises);
-        this.__additionalProperties.put(JavascriptClientCodegen.USE_INHERITANCE, this.supportsInheritance);
-        this.__additionalProperties.put(JavascriptClientCodegen.EMIT_MODEL_METHODS, this.emitModelMethods);
-        this.__additionalProperties.put(JavascriptClientCodegen.EMIT_JS_DOC, this.emitJSDoc);
-        this.__additionalProperties.put("apiDocPath", this.apiDocPath);
-        this.__additionalProperties.put("modelDocPath", this.modelDocPath);
-        this.__supportingFiles.add(new SupportingFile("index.mustache", this.createPath(this.sourceFolder, this.invokerPackage), "index.js"));
-        this.__supportingFiles.add(new SupportingFile("ApiClient.mustache", this.createPath(this.sourceFolder, this.invokerPackage), "ApiClient.js"));
-
+        codegenProperty.hasMore = false
+        codegenModel.vars = codegenProperties
+      }
     }
+    return codegenModel
+  }
 
-    escapeReservedWord(name) {
-        return "_" + name;
+  staticsanitizePackageName(packageName) {
+    packageName = packageName.trim()
+    packageName = packageName.replace(new RegExp('[^a-zA-Z0-9_\\.]', 'g'), '_')
+    if (isEmpty(packageName)) {
+      return 'invalidPackageName'
     }
+    return packageName
+  }
 
-    /**
-     * Concatenates an array of path segments into a path string.
-     * @param segments The path segments to concatenate. A segment may contain either of the file separator characters '\' or '/'.
-     * A segment is ignored if it is <code>null</code>, empty or &quot;.&quot;.
-     * @return A path string using the correct platform-specific file separator character.
-     */
-    createPath(...segments) {
-        let buf = new StringBuilder();
-        for (const segment of segments) {
-            if (!isEmpty(segment) && !(segment === ".")) {
-                if (buf.length() !== 0)
-                    buf.append(File.separatorChar);
-                buf.append(segment);
-            }
-        }
-        for (let i = 0; i < buf.length(); i++) {
-            let c = buf.charAt(i);
-            if ((c === '/' || c === '\\') && c !== File.separatorChar)
-                buf.setCharAt(i, File.separatorChar);
-        }
-        return buf.toString();
+  toEnumName(property) {
+    return this.sanitizeName(DefaultCodegen.camelize(property.name)) + 'Enum'
+  }
+
+  toEnumVarName(value, datatype) {
+    return value
+  }
+
+  toEnumValue(value, datatype) {
+    if ('Integer' === datatype || 'Number' === datatype) {
+      return value
+    } else {
+      return '"' + this.escapeText(value) + '"'
     }
+  }
 
-    apiTestFileFolder() {
-        return (this.__outputFolder + "/test/" + this.apiTestPath).split('/').join(File.separatorChar);
-    }
+  escapeQuotationMark(input) {
+    return (
+      input &&
+      input
+        .split('"')
+        .join('')
+        .split("'")
+        .join('')
+    )
+  }
 
-    modelTestFileFolder() {
-        return (this.__outputFolder + "/test/" + this.modelTestPath).split('/').join(File.separatorChar);
-    }
-
-    apiFileFolder() {
-        return this.createPath(this.__outputFolder, this.sourceFolder, this.invokerPackage, this.apiPackage());
-    }
-
-    modelFileFolder() {
-        return this.createPath(this.__outputFolder, this.sourceFolder, this.invokerPackage, this.modelPackage());
-    }
-
-    apiDocFileFolder() {
-        return this.createPath(this.__outputFolder, this.apiDocPath);
-    }
-
-    modelDocFileFolder() {
-        return this.createPath(this.__outputFolder, this.modelDocPath);
-    }
-
-    toApiDocFilename(name) {
-        return this.toApiName(name);
-    }
-
-    toModelDocFilename(name) {
-        return this.toModelName(name);
-    }
-
-    toApiTestFilename(name) {
-        return this.toApiName(name) + ".spec";
-    }
-
-    toModelTestFilename(name) {
-        return this.toModelName(name) + ".spec";
-    }
-
-    toVarName(name) {
-        name = this.sanitizeName(name);
-        if (("_" === name)) {
-            name = "_u";
-        }
-        if (name.match("^[A-Z_]*$")) {
-            return name;
-        }
-        name = DefaultCodegen.camelize(name, true);
-        if (this.isReservedWord(name) || name.match("^\\d.*")) {
-            name = this.escapeReservedWord(name);
-        }
-        return name;
-    }
-
-    toParamName(name) {
-        return this.toVarName(name);
-    }
-
-    toModelName(name) {
-        name = this.sanitizeName(name);
-        if (!isEmpty(this.modelNamePrefix)) {
-            name = this.modelNamePrefix + "_" + name;
-        }
-        if (!isEmpty(this.modelNameSuffix)) {
-            name = name + "_" + this.modelNameSuffix;
-        }
-        name = DefaultCodegen.camelize(name);
-        if (this.isReservedWord(name)) {
-            let modelName = "Model" + name;
-            Log.warn(name + " (reserved word) cannot be used as model name. Renamed to " + modelName);
-            return modelName;
-        }
-        if (name.match("^\\d.*")) {
-            let modelName = "Model" + name;
-            Log.warn(name + " (model name starts with number) cannot be used as model name. Renamed to " + modelName);
-            return modelName;
-        }
-        return name;
-    }
-
-    toModelFilename(name) {
-        return this.toModelName(name);
-    }
-
-    toModelImport(name) {
-        return name;
-    }
-
-    toApiImport(name) {
-        return this.toApiName(name);
-    }
-
-    getTypeDeclaration(p) {
-        if (p != null && p instanceof ArrayProperty) {
-            const inner = p.getItems();
-            return "[" + this.getTypeDeclaration(inner) + "]";
-        }
-        else if (p != null && p instanceof MapProperty) {
-            const inner = p.getAdditionalProperties();
-            return "{String: " + this.getTypeDeclaration(inner) + "}";
-        }
-        return super.getTypeDeclaration(p);
-    }
-
-    toDefaultValue(p) {
-        const dp = p.getDefault();
-        if (dp != null) {
-            if (p instanceof StringProperty) {
-                return JSON.stringify(dp) + '';
-            }
-            if (p instanceof BooleanProperty || p instanceof DoubleProperty || p instanceof FloatProperty || p instanceof IntegerProperty || p instanceof LongProperty) {
-                return dp.toString();
-            }
-        }
-
-        return dp;
-    }
-
-    toDefaultValueWithParam(name, p) {
-        let type = this.normalizeType(this.getTypeDeclaration(p));
-        if (p instanceof RefProperty) {
-            return " = " + type + ".constructFromObject(data[\'" + name + "\']);";
-        }
-        else {
-            return " = ApiClient.convertToType(data[\'" + name + "\'], " + type + ");";
-        }
-    }
-
-    setParameterExampleValue(p) {
-        let example;
-        if (p.defaultValue == null) {
-            example = p.example;
-        }
-        else {
-            example = p.defaultValue;
-        }
-        let type = p.baseType;
-        if (type == null) {
-            type = p.dataType;
-        }
-        if (("String" === type)) {
-            if (example == null) {
-                example = p.paramName + "_example";
-            }
-            example = "\"" + this.escapeText(example) + "\"";
-        }
-        else if (("Integer" === type)) {
-            if (example == null) {
-                example = "56";
-            }
-        }
-        else if (("Number" === type)) {
-            if (example == null) {
-                example = "3.4";
-            }
-        }
-        else if (("Boolean" === type)) {
-            if (example == null) {
-                example = "true";
-            }
-        }
-        else if (("File" === type)) {
-            if (example == null) {
-                example = "/path/to/file";
-            }
-            example = "\"" + this.escapeText(example) + "\"";
-        }
-        else if (("Date" === type)) {
-            if (example == null) {
-                example = "2013-10-20T19:20:30+01:00";
-            }
-            example = "new Date(\"" + this.escapeText(example) + "\")";
-        }
-        else if (!this.__languageSpecificPrimitives.contains(type)) {
-            example = "new " + this.moduleName + "." + type + "()";
-        }
-        if (example == null) {
-            example = "null";
-        }
-        else if ((p.isListContainer)) {
-            example = "[" + example + "]";
-        }
-        else if ((p.isMapContainer)) {
-            example = "{key: " + example + "}";
-        }
-        p.example = example;
-    }
-
-    /**
-     * Normalize type by wrapping primitive types with single quotes.
-     *
-     * @param type Primitive type
-     * @return Normalized type
-     */
-    normalizeType(type) {
-        return type.replace(new RegExp("\\b(Boolean|Integer|Number|String|Date)\\b", 'g'), "\'$1\'");
-    }
-
-    getSwaggerType(p) {
-        let swaggerType = super.getSwaggerType(p);
-        let type = null;
-        if (this.__typeMapping.containsKey(swaggerType)) {
-            type = this.__typeMapping.get(swaggerType);
-            if (!this.needToImport(type)) {
-                return type;
-            }
-        }
-        else {
-            type = swaggerType;
-        }
-        if (null == type) {
-            Log.error("No Type defined for Property " + p);
-        }
-        return this.toModelName(type);
-    }
-
-    toOperationId(operationId) {
-        if (isEmpty(operationId)) {
-            throw new Error("Empty method/operation name (operationId) not allowed");
-        }
-        operationId = DefaultCodegen.camelize(this.sanitizeName(operationId), true);
-        if (this.isReservedWord(operationId)) {
-            let newOperationId = DefaultCodegen.camelize("call_" + operationId, true);
-            Log.warn(operationId + " (reserved word) cannot be used as method name. Renamed to " + newOperationId);
-            return newOperationId;
-        }
-        return operationId;
-    }
-
-    fromOperation(path, httpMethod, operation, definitions, swagger) {
-        if (arguments.length > 4) {
-            let op = super.fromOperation(path, httpMethod, operation, definitions, swagger);
-            if (op.returnType != null) {
-                op.returnType = this.normalizeType(op.returnType);
-            }
-            op.path = this.sanitizePath(op.path);
-            let lastRequired = null;
-            let lastOptional = null;
-            for (const p of  op.allParams) {
-                if (p.required) {
-                    lastRequired = p;
-                }
-                else {
-                    lastOptional = p;
-                }
-            }
-            for (const p of  op.allParams) {
-                if (p === lastRequired) {
-                    p._hasMoreRequired = false;
-                }
-                else if (p === lastOptional) {
-                    p._hasMoreOptional = false;
-                }
-                else {
-                    p._hasMoreRequired = true;
-                    p._hasMoreOptional = true;
-                }
-            }
-            op._hasRequiredParams = lastRequired != null;
-            return op;
-        }
-        return super.fromOperation(path, httpMethod, operation, definitions);
-    }
-
-
-    fromModel(name, model, allDefinitions) {
-        if (arguments.length > 2) {
-            let codegenModel = super.fromModel(name, model, allDefinitions);
-            if (allDefinitions != null && codegenModel != null && codegenModel.parent != null && codegenModel.hasEnums) {
-                let parentModel = allDefinitions.get(codegenModel.parentSchema);
-                let parentCodegenModel = super.fromModel(codegenModel.parent, parentModel, allDefinitions);
-                codegenModel = JavascriptClientCodegen.reconcileInlineEnums(codegenModel, parentCodegenModel);
-            }
-            if (model != null && model instanceof ArrayModel) {
-                let am = model;
-                if (am.getItems() != null) {
-                    codegenModel._isArray = true;
-                    codegenModel._itemType = this.getSwaggerType(am.getItems());
-                }
-            }
-            else if (model != null && model instanceof ModelImpl) {
-                let mm = model;
-                if (mm.getAdditionalProperties() != null) {
-                    codegenModel._isMap = true;
-                    codegenModel._itemType = this.getSwaggerType(mm.getAdditionalProperties());
-                }
-            }
-            return codegenModel;
-        }
-        else
-            return super.fromModel(name, model);
-    }
-
-
-    sanitizePath(p) {
-        return p.replace(new RegExp("\'", 'g'), "%27");
-    }
-
-    trimBrackets(s) {
-        if (s != null) {
-            let beginIdx = s[0] === '[' ? 1 : 0;
-            let endIdx = s.length;
-            if (s[endIdx - 1] === ']')
-                endIdx--;
-            return s.substring(beginIdx, endIdx);
-        }
-        return null;
-    }
-
-    getModelledType(dataType) {
-        return "module:" + (isEmpty(this.invokerPackage) ? "" : (this.invokerPackage + "/")) + (isEmpty(this.__modelPackage) ? "" : (this.__modelPackage + "/")) + dataType;
-    }
-
-    getJSDocType(cm, cp) {
-        if (((cm != null && cm instanceof CodegenModel) || cm === null) && ((cp != null && cp instanceof CodegenProperty) || cp === null)) {
-            if ((cp.isContainer)) {
-                if ((cp.containerType === "array"))
-                    return "Array.<" + this.getJSDocType(cm, cp.items) + ">";
-                else if ((cp.containerType === "map"))
-                    return "Object.<String, " + this.getJSDocType(cm, cp.items) + ">";
-            }
-            let dataType = this.trimBrackets(cp.datatypeWithEnum);
-            if (cp.isEnum) {
-                dataType = cm.classname + '.' + dataType;
-            }
-            if (this.isModelledType(cp))
-                dataType = this.getModelledType(dataType);
-            return dataType;
-        }
-        else if (((cm != null && cm instanceof CodegenParameter) || cm === null) && cp === undefined) {
-            let dataType = this.trimBrackets(cm.dataType);
-            if (this.isModelledType(cm))
-                dataType = this.getModelledType(dataType);
-            if ((cm.isListContainer)) {
-                return "Array.<" + dataType + ">";
-            }
-            else if ((cm.isMapContainer)) {
-                return "Object.<String, " + dataType + ">";
-            }
-            return dataType;
-        }
-        else if (((cm != null && cm instanceof CodegenOperation) || cm === null) && cp === undefined) {
-            let returnType = this.trimBrackets(cm.returnType);
-            if (returnType != null) {
-                if (this.isModelledType(cm))
-                    returnType = this.getModelledType(returnType);
-                if ((cm.isListContainer)) {
-                    return "Array.<" + returnType + ">";
-                }
-                else if ((cm.isMapContainer)) {
-                    return "Object.<String, " + returnType + ">";
-                }
-            }
-            return returnType;
-        }
-        else
-            throw new Error('invalid overload');
-    }
-
-    isModelledType(cp) {
-        if (((cp != null && cp instanceof CodegenProperty) || cp === null)) {
-            return cp.isEnum || !this.__languageSpecificPrimitives.contains(cp.baseType == null ? cp.datatype : cp.baseType);
-        }
-        else if (((cp != null && cp instanceof CodegenParameter) || cp === null)) {
-            return cp.isEnum || !this.__languageSpecificPrimitives.contains(cp.baseType == null ? cp.dataType : cp.baseType);
-        }
-        else if (((cp != null && cp instanceof CodegenOperation) || cp === null)) {
-            return !(cp.returnTypeIsPrimitive);
-        }
-        throw new Error('invalid overload');
-    }
-
-    postProcessOperations(objs) {
-        let operations = objs.get("operations");
-        if (operations != null) {
-            let ops = operations.get("operation");
-            for (const operation of ops) {
-                let argList = [];
-                let hasOptionalParams = false;
-                for (const p of operation.allParams) {
-                    if (p.required) {
-                        let flowsify = p.paramName;
-                        const swaggerType = p.dataType;
-                        if(this._swaggerToFlowMapping.containsKey(swaggerType)){
-                            flowsify += `: ${this._swaggerToFlowMapping.get(swaggerType)}`;
-                        } else {
-                            flowsify += ": any";
-                        }
-                        argList.push(flowsify);
-                    }
-                    else {
-                        hasOptionalParams = true;
-                    }
-                }
-                if (hasOptionalParams) {
-                    argList.push("opts: any");
-                }
-                if (!this.usePromises) {
-                    argList.push("callback: Function");
-                }
-                operation._argList = argList.join(", ");
-                for (const cp of operation.allParams) {
-                    cp._jsDocType = this.getJSDocType(cp);
-                }
-                operation.hasOptionalParams = hasOptionalParams;
-                operation.hasParams = operation.allParams.length > 0;
-                operation._jsDocType = this.getJSDocType(operation);
-            }
-        }
-        Collections.sort(objs.get("imports"), (a, b) => {
-            const a1 = a.get("import"), b1 = b.get("import");
-            return a1.localeCompare(b1);
-        });
-        return objs;
-    }
-
-    postProcessModels(objs) {
-        objs = super.postProcessModelsEnum(objs);
-        let models = objs.get("models");
-        for (const mo of models) {
-
-            let cm = mo.get("model");
-            let required = [];
-            let allRequired = this.supportsInheritance ? [] : required;
-            cm._required = required;
-
-            cm._allRequired = allRequired;
-
-            for (const __var of cm.vars) {
-                let jsDocType = this.getJSDocType(cm, __var);
-                __var._jsDocType = jsDocType;
-
-                if ((__var.required)) {
-                    required.push(__var);
-                }
-            }
-            if (this.supportsInheritance) {
-                for (const vars of cm.allVars) {
-                    if (vars.required) {
-                        allRequired.push(vars);
-                    }
-                }
-            }
-            let lastRequired = null;
-            for (const vars of cm.vars) {
-                if (vars.required != null && vars.required) {
-                    lastRequired = vars;
-                }
-            }
-            for (const vars of cm.vars) {
-                if (vars === lastRequired) {
-                    vars._hasMoreRequired = false;
-                }
-                else if (vars.required != null && vars.required) {
-                    vars._hasMoreRequired = true;
-                }
-            }
-
-        }
-        return objs;
-    }
-
-    needToImport(type) {
-        return !this.__defaultIncludes.contains(type) && !this.__languageSpecificPrimitives.contains(type);
-    }
-
-    static reconcileInlineEnums(codegenModel, parentCodegenModel) {
-        if (parentCodegenModel.hasEnums) {
-            let parentModelCodegenProperties = parentCodegenModel.vars;
-            let codegenProperties = codegenModel.vars;
-            let removedChildEnum = false;
-            for (const parentModelCodegenPropery of parentModelCodegenProperties) {
-                if (parentModelCodegenPropery.isEnum) {
-                    for (let i = codegenProperties.length; i--;) {
-                        const codegenProperty = codegenProperties[i];
-                        if (codegenProperty.isEnum && codegenProperty.equals(parentModelCodegenPropery)) {
-                            codegenProperties.splice(i, 1);
-                            removedChildEnum = true;
-                        }
-                    }
-                }
-            }
-            if (removedChildEnum) {
-                let codegenProperty;
-                for (codegenProperty of codegenProperties) {
-                    codegenProperty.hasMore = true;
-                }
-                codegenProperty.hasMore = false;
-                codegenModel.vars = codegenProperties;
-            }
-        }
-        return codegenModel;
-    }
-
-    staticsanitizePackageName(packageName) {
-        packageName = packageName.trim();
-        packageName = packageName.replace(new RegExp("[^a-zA-Z0-9_\\.]", 'g'), "_");
-        if (isEmpty(packageName)) {
-            return "invalidPackageName";
-        }
-        return packageName;
-    }
-
-    toEnumName(property) {
-        return this.sanitizeName(DefaultCodegen.camelize(property.name)) + "Enum";
-    }
-
-    toEnumVarName(value, datatype) {
-        return value;
-    }
-
-    toEnumValue(value, datatype) {
-        if (("Integer" === datatype) || ("Number" === datatype)) {
-            return value;
-        }
-        else {
-            return "\"" + this.escapeText(value) + "\"";
-        }
-    }
-
-    escapeQuotationMark(input) {
-        return input && input.split("\"").join("").split("\'").join("");
-    }
-
-    escapeUnsafeCharacters(input) {
-        return input && input.split("*/").join("*_/").split("/*").join("/_*");
-    }
+  escapeUnsafeCharacters(input) {
+    return (
+      input &&
+      input
+        .split('*/')
+        .join('*_/')
+        .split('/*')
+        .join('/_*')
+    )
+  }
 }
 
-
-const Log = LoggerFactory.getLogger(JavascriptClientCodegen);
+const Log = LoggerFactory.getLogger(JavascriptClientCodegen)

--- a/ern-api-gen/src/languages/SwiftCodegen.js
+++ b/ern-api-gen/src/languages/SwiftCodegen.js
@@ -1,431 +1,665 @@
-import CliOption from "../CliOption";
-import CodegenConstants from "../CodegenConstants";
-import CodegenType from "../CodegenType";
-import DefaultCodegen from "../DefaultCodegen";
-import SupportingFile from "../SupportingFile";
-import {ArrayProperty, MapProperty} from "../models/properties";
-import StringUtils, {capitalizeFully} from "../java/StringUtils";
-import File from "../java/File";
-import {HeaderParameter} from "../models/parameters";
-import {parseBoolean} from "../java/BooleanHelper";
-import Pattern from "../java/Pattern";
-import StringBuilder from "../java/StringBuilder";
-import LoggerFactory from "../java/LoggerFactory";
-import {newHashMap, newHashSet} from '../java/javaUtil';
+import CliOption from '../CliOption'
+import CodegenConstants from '../CodegenConstants'
+import CodegenType from '../CodegenType'
+import DefaultCodegen from '../DefaultCodegen'
+import SupportingFile from '../SupportingFile'
+import { ArrayProperty, MapProperty } from '../models/properties'
+import StringUtils, { capitalizeFully } from '../java/StringUtils'
+import File from '../java/File'
+import { HeaderParameter } from '../models/parameters'
+import { parseBoolean } from '../java/BooleanHelper'
+import Pattern from '../java/Pattern'
+import StringBuilder from '../java/StringBuilder'
+import LoggerFactory from '../java/LoggerFactory'
+import { newHashMap, newHashSet } from '../java/javaUtil'
 
-const PATH_PARAM_PATTERN = Pattern.compile("\\{[a-zA-Z_\\-]+\\}");
+const PATH_PARAM_PATTERN = Pattern.compile('\\{[a-zA-Z_\\-]+\\}')
 
 const ArrayUtils = {
-    contains(arr, val){
-        return arr && arr.indexOf(val) > -1;
-    }
-};
-export default class SwiftCodegen extends DefaultCodegen {
-    projectName = "SwaggerClient";
-    responseAs = [];
-    sourceFolder = "Classes" + File.separator + "Swaggers";
-    unwrapRequired = false;
-    swiftUseApiNamespace = false;
-    __outputFolder = "generated-code" + File.separator + "swift";
-    __embeddedTemplateDir = "swift";
-    __templateDir = "swift";
-    __apiPackage = File.separator + "APIs";
-    __modelPackage = File.separator + "Models";
-    __typeMapping = newHashMap(
-        ["array", "Array"],
-        ["List", "Array"],
-        ["map", "Dictionary"],
-        ["date", "NSDate"],
-        ["Date", "NSDate"],
-        ["DateTime", "NSDate"],
-        ["boolean", "Bool"],
-        ["string", "String"],
-        ["char", "Character"],
-        ["short", "Int"],
-        ["int", "Int32"],
-        ["long", "Int64"],
-        ["integer", "Int32"],
-        ["Integer", "Int32"],
-        ["float", "Float"],
-        ["number", "Double"],
-        ["double", "Double"],
-        ["object", "AnyObject"],
-        ["file", "NSURL"],
-        ["binary", "NSData"],
-        ["ByteArray", "NSData"],
-        ["UUID", "NSUUID"]);
-    __defaultIncludes = newHashSet("NSData", "NSDate", "NSURL", "NSUUID", "Array", "Dictionary", "Set", "Any", "Empty", "AnyObject");
-    __reservedWords = newHashSet("Int", "Int32", "Int64", "Int64", "Float", "Double", "Bool", "Void", "String", "Character", "AnyObject", "class", "Class", "break", "as", "associativity", "deinit", "case", "dynamicType", "convenience", "enum", "continue", "false", "dynamic", "extension", "default", "is", "didSet", "func", "do", "nil", "final", "import", "else", "self", "get", "init", "fallthrough", "Self", "infix", "internal", "for", "super", "inout", "let", "if", "true", "lazy", "operator", "in", "COLUMN", "left", "private", "return", "FILE", "mutating", "protocol", "switch", "FUNCTION", "none", "public", "where", "LINE", "nonmutating", "static", "while", "optional", "struct", "override", "subscript", "postfix", "typealias", "precedence", "var", "prefix", "Protocol", "required", "right", "set", "Type", "unowned", "weak");
-    __importMapping = newHashMap();
-    __languageSpecificPrimitives = newHashSet("Int", "Int32", "Int64", "Float", "Double", "Bool", "Void", "String", "Character", "AnyObject");
-
-    constructor() {
-        super();
-        this.__modelTemplateFiles.put("model.mustache", ".swift");
-        this.__apiTemplateFiles.put("api.mustache", ".swift");
-    }
-
-    initalizeCliOptions() {
-        super.initalizeCliOptions();
-        this.__cliOptions.add(new CliOption(SwiftCodegen.PROJECT_NAME, "Project name in Xcode"));
-        this.__cliOptions.add(new CliOption(SwiftCodegen.RESPONSE_AS, "Optionally use libraries to manage response.  Currently " + StringUtils.join(SwiftCodegen.RESPONSE_LIBRARIES, ", ") + " are available."));
-        this.__cliOptions.add(new CliOption(SwiftCodegen.UNWRAP_REQUIRED, "Treat \'required\' properties in response as non-optional (which would crash the app if api returns null as opposed to required option specified in json schema"));
-        this.__cliOptions.add(new CliOption(SwiftCodegen.POD_SOURCE, "Source information used for Podspec"));
-        this.__cliOptions.add(new CliOption(CodegenConstants.POD_VERSION, "Version used for Podspec"));
-        this.__cliOptions.add(new CliOption(SwiftCodegen.POD_AUTHORS, "Authors used for Podspec"));
-        this.__cliOptions.add(new CliOption(SwiftCodegen.POD_SOCIAL_MEDIA_URL, "Social Media URL used for Podspec"));
-        this.__cliOptions.add(new CliOption(SwiftCodegen.POD_DOCSET_URL, "Docset URL used for Podspec"));
-        this.__cliOptions.add(new CliOption(SwiftCodegen.POD_LICENSE, "License used for Podspec"));
-        this.__cliOptions.add(new CliOption(SwiftCodegen.POD_HOMEPAGE, "Homepage used for Podspec"));
-        this.__cliOptions.add(new CliOption(SwiftCodegen.POD_SUMMARY, "Summary used for Podspec"));
-        this.__cliOptions.add(new CliOption(SwiftCodegen.POD_DESCRIPTION, "Description used for Podspec"));
-        this.__cliOptions.add(new CliOption(SwiftCodegen.POD_SCREENSHOTS, "Screenshots used for Podspec"));
-        this.__cliOptions.add(new CliOption(SwiftCodegen.POD_DOCUMENTATION_URL, "Documentation URL used for Podspec"));
-        this.__cliOptions.add(new CliOption(SwiftCodegen.SWIFT_USE_API_NAMESPACE, "Flag to make all the API classes inner-class of {{projectName}}API"));
-
-    }
-
-    getTag() {
-        return CodegenType.CLIENT;
-    }
-
-    getName() {
-        return "Swift";
-    }
-
-    getHelp() {
-        return "Generates a swift client library.";
-    }
-
-    processOpts() {
-        super.processOpts();
-        if (this.__additionalProperties.containsKey(SwiftCodegen.PROJECT_NAME)) {
-            this.setProjectName(this.__additionalProperties.get(SwiftCodegen.PROJECT_NAME));
-        }
-        else {
-            this.__additionalProperties.put(SwiftCodegen.PROJECT_NAME, this.projectName);
-        }
-        this.sourceFolder = this.projectName + File.separator + this.sourceFolder;
-        if (this.__additionalProperties.containsKey(SwiftCodegen.UNWRAP_REQUIRED)) {
-            this.setUnwrapRequired(parseBoolean(this.__additionalProperties.get(SwiftCodegen.UNWRAP_REQUIRED)));
-        }
-        this.__additionalProperties.put(SwiftCodegen.UNWRAP_REQUIRED, this.unwrapRequired);
-        if (this.__additionalProperties.containsKey(SwiftCodegen.RESPONSE_AS)) {
-            let responseAsObject = this.__additionalProperties.get(SwiftCodegen.RESPONSE_AS);
-            if (typeof responseAsObject === 'string') {
-                this.setResponseAs(responseAsObject.split(","));
-            }
-            else {
-                this.setResponseAs(responseAsObject);
-            }
-        }
-        this.__additionalProperties.put(SwiftCodegen.RESPONSE_AS, this.responseAs);
-        if (ArrayUtils.contains(this.responseAs, SwiftCodegen.LIBRARY_PROMISE_KIT)) {
-            this.__additionalProperties.put("usePromiseKit", true);
-        }
-        if (this.__additionalProperties.containsKey(SwiftCodegen.SWIFT_USE_API_NAMESPACE)) {
-            this.swiftUseApiNamespace = parseBoolean(this.__additionalProperties.get(SwiftCodegen.SWIFT_USE_API_NAMESPACE));
-        }
-        this.__additionalProperties.put(SwiftCodegen.SWIFT_USE_API_NAMESPACE, this.swiftUseApiNamespace);
-        if (!this.__additionalProperties.containsKey(SwiftCodegen.POD_AUTHORS)) {
-            this.__additionalProperties.put(SwiftCodegen.POD_AUTHORS, SwiftCodegen.DEFAULT_POD_AUTHORS);
-        }
-    }
-
-    isReservedWord(word) {
-        return word != null && this.__reservedWords.contains(word);
-    }
-
-    escapeReservedWord(name) {
-        return "_" + name;
-    }
-
-    modelFileFolder() {
-        return this.__outputFolder + File.separator + this.sourceFolder + this.modelPackage().split('.').join(File.separatorChar);
-    }
-
-    apiFileFolder() {
-        return this.__outputFolder + File.separator + this.sourceFolder + this.apiPackage().split('.').join(File.separatorChar);
-    }
-
-    getTypeDeclaration(p) {
-        if (p != null) {
-            if (p instanceof ArrayProperty) {
-                let inner = p.getItems();
-                return "[" + this.getTypeDeclaration(inner) + "]";
-            }
-            else if (p instanceof MapProperty) {
-                let inner = p.getAdditionalProperties();
-                return "[String:" + this.getTypeDeclaration(inner) + "]";
-            }
-        }
-        return super.getTypeDeclaration(p);
-    }
-
-    getSwaggerType(p) {
-        let swaggerType = super.getSwaggerType(p);
-        let type = null;
-        if (this.__typeMapping.containsKey(swaggerType)) {
-            type = this.__typeMapping.get(swaggerType);
-            if (this.__languageSpecificPrimitives.contains(type) || this.__defaultIncludes.contains(type))
-                return type;
-        }
-        else
-            type = swaggerType;
-        return this.toModelName(type);
-    }
-
-    isDataTypeBinary(dataType) {
-        return dataType != null && (dataType === "NSData");
-    }
-
-    /**
-     * Output the proper model name (capitalized)
-     *
-     * @param name the name of the model
-     * @return capitalized model name
-     */
-    toModelName(name) {
-        name = this.sanitizeName(name);
-        if (!StringUtils.isEmpty(this.modelNameSuffix)) {
-            name = name + "_" + this.modelNameSuffix;
-        }
-        if (!StringUtils.isEmpty(this.modelNamePrefix)) {
-            name = this.modelNamePrefix + "_" + name;
-        }
-        name = DefaultCodegen.camelize(name);
-        if (this.isReservedWord(name)) {
-            let modelName = "Model" + name;
-            DefaultCodegen.Log().warn(name + " (reserved word) cannot be used as model name. Renamed to " + modelName);
-            return modelName;
-        }
-        if (name.match("^\\d.*")) {
-            let modelName = "Model" + name;
-            DefaultCodegen.Log().warn(name + " (model name starts with number) cannot be used as model name. Renamed to " + modelName);
-            return modelName;
-        }
-        return name;
-    }
-
-    /**
-     * Return the capitalized file name of the model
-     *
-     * @param name the model name
-     * @return the file name of the model
-     */
-    toModelFilename(name) {
-        return this.toModelName(name);
-    }
-
-    toDefaultValue(p) {
-        return null;
-    }
-
-    toInstantiationType(p) {
-
-        if (p instanceof MapProperty) {
-            let inner = this.getSwaggerType(p.getAdditionalProperties());
-            return "[String:" + inner + "]";
-        }
-        else if (p instanceof ArrayProperty) {
-            let inner = this.getSwaggerType(p.getItems());
-            return "[" + inner + "]";
-        }
-
-        return null;
-    }
-
-    fromProperty(name, p) {
-        let codegenProperty = super.fromProperty(name, p);
-        if (codegenProperty.isContainer) {
-            return codegenProperty;
-        }
-        if (codegenProperty.isEnum) {
-            let swiftEnums = [];
-            let values = codegenProperty.allowableValues.get("values");
-            for (const value of values) {
-                swiftEnums.push(newHashMap(["enum", this.toSwiftyEnumName('' + value)], ["raw", '' + value]));
-            }
-            codegenProperty.allowableValues.put("values", swiftEnums);
-            codegenProperty.datatypeWithEnum = this.toEnumName(codegenProperty);
-            if (this.isReservedWord(codegenProperty.datatypeWithEnum) || (this.toVarName(name) === codegenProperty.datatypeWithEnum)) {
-                codegenProperty.datatypeWithEnum = codegenProperty.datatypeWithEnum + "Enum";
-            }
-        }
-        return codegenProperty;
-    }
-
-    toSwiftyEnumName(value) {
-        if (value.match("[A-Z][a-z0-9]+[a-zA-Z0-9]*")) {
-            return value;
-        }
-        const separators = ['-', '_', ' ', ':'];
-        return capitalizeFully(value.toLowerCase(), separators).replace(new RegExp("[-_  :]", 'g'), "");
-    }
-
-    toApiName(name) {
-        if (name.length === 0)
-            return "DefaultAPI";
-        return this.initialCaps(name) + "API";
-    }
-
-    toOperationId(operationId) {
-        operationId = DefaultCodegen.camelize(this.sanitizeName(operationId), true);
-        if (StringUtils.isEmpty(operationId)) {
-            throw new Error("Empty method name (operationId) not allowed");
-        }
-        if (this.isReservedWord(operationId)) {
-            let newOperationId = DefaultCodegen.camelize(("call_" + operationId), true);
-            Log.warn(operationId + " (reserved word) cannot be used as method name. Renamed to " + newOperationId);
-            return newOperationId;
-        }
-        return operationId;
-    }
-
-    toVarName(name) {
-        name = this.sanitizeName(name);
-        if (name.match("^[A-Z_]*$")) {
-            return name;
-        }
-        name = DefaultCodegen.camelize(name, true);
-        if (this.isReservedWord(name) || name.match("^\\d.*")) {
-            name = this.escapeReservedWord(name);
-        }
-        return name;
-    }
-
-    toParamName(name) {
-        name = this.sanitizeName(name);
-        name = name.replace(new RegExp("-", 'g'), "_");
-        if (name.match("^[A-Z_]*$")) {
-            return name;
-        }
-        name = DefaultCodegen.camelize(name, true);
-        if (this.isReservedWord(name) || name.match("^\\d.*")) {
-            name = this.escapeReservedWord(name);
-        }
-        return name;
-    }
-
-    fromOperation(path, httpMethod, operation, definitions, swagger) {
-        if (arguments.length > 4) {
-            path = SwiftCodegen.normalizePath(path);
-            let parameters = operation.getParameters();
-            parameters = parameters.filter(isHeader);
-            operation.setParameters(parameters);
-            return super.fromOperation(path, httpMethod, operation, definitions, swagger);
-        }
-        return super.fromOperation(path, httpMethod, operation, definitions);
-    }
-
-    static normalizePath(path) {
-        const builder = new StringBuilder();
-
-        let cursor = 0;
-        //Matcher matcher = PATH_PARAM_PATTERN.matcher(path);
-        const matcher = PATH_PARAM_PATTERN.matcher(path);
-        let found = matcher.find();
-        while (found) {
-            let stringBeforeMatch = path.substring(cursor, matcher.start());
-            builder.append(stringBeforeMatch);
-
-            let group = matcher.group().substring(1, matcher.group().length - 1);
-            group = DefaultCodegen.camelize(group, true);
-            builder.append("{").append(group).append("}");
-
-            cursor = matcher.end();
-            found = matcher.find();
-        }
-
-        let stringAfterMatch = path.substring(cursor);
-        builder.append(stringAfterMatch);
-
-        return builder.toString();
-    }
-
-    setProjectName(projectName) {
-        this.projectName = projectName;
-    }
-
-    setUnwrapRequired(unwrapRequired) {
-        this.unwrapRequired = unwrapRequired;
-    }
-
-    setResponseAs(responseAs) {
-        this.responseAs = responseAs;
-    }
-
-    toEnumValue(value, datatype) {
-        if (("int" === datatype) || ("double" === datatype) || ("float" === datatype)) {
-            return value;
-        }
-        else {
-            return "\'" + this.escapeText(value) + "\'";
-        }
-    }
-
-    toEnumDefaultValue(value, datatype) {
-        return datatype + "_" + value;
-    }
-
-    toEnumVarName(name, datatype) {
-        if (("int" === datatype) || ("double" === datatype) || ("float" === datatype)) {
-            let varName = new String(name);
-            varName = varName.replace(new RegExp("-", 'g'), "MINUS_");
-            varName = varName.replace(new RegExp("\\+", 'g'), "PLUS_");
-            varName = varName.replace(new RegExp("\\.", 'g'), "_DOT_");
-            return varName;
-        }
-        let enumName = this.sanitizeName(DefaultCodegen.underscore(name).toUpperCase());
-        enumName = enumName.replace(/^_/, "");
-        enumName = enumName.replace(/_$/, "");
-        if (enumName.match("\\d.*")) {
-            return "_" + enumName;
-        }
-        else {
-            return enumName;
-        }
-    }
-
-    toEnumName(property) {
-        let enumName = this.toModelName(property.name);
-        if (enumName.match("\\d.*")) {
-            return "_" + enumName;
-        }
-        else {
-            return enumName;
-        }
-    }
-
-    postProcessModels(objs) {
-        return this.postProcessModelsEnum(objs);
-    }
-
-    escapeQuotationMark(input) {
-        return input.split("\"").join("");
-    }
-
-    escapeUnsafeCharacters(input) {
-        return input.split("*/").join("*_/").split("/*").join("/_*");
-    }
+  contains(arr, val) {
+    return arr && arr.indexOf(val) > -1
+  },
 }
-SwiftCodegen.PROJECT_NAME = "projectName";
-SwiftCodegen.RESPONSE_AS = "responseAs";
-SwiftCodegen.UNWRAP_REQUIRED = "unwrapRequired";
-SwiftCodegen.POD_SOURCE = "podSource";
-SwiftCodegen.POD_AUTHORS = "podAuthors";
-SwiftCodegen.POD_SOCIAL_MEDIA_URL = "podSocialMediaURL";
-SwiftCodegen.POD_DOCSET_URL = "podDocsetURL";
-SwiftCodegen.POD_LICENSE = "podLicense";
-SwiftCodegen.POD_HOMEPAGE = "podHomepage";
-SwiftCodegen.POD_SUMMARY = "podSummary";
-SwiftCodegen.POD_DESCRIPTION = "podDescription";
-SwiftCodegen.POD_SCREENSHOTS = "podScreenshots";
-SwiftCodegen.POD_DOCUMENTATION_URL = "podDocumentationURL";
-SwiftCodegen.SWIFT_USE_API_NAMESPACE = "swiftUseApiNamespace";
-SwiftCodegen.DEFAULT_POD_AUTHORS = "Swagger Codegen";
-SwiftCodegen.LIBRARY_PROMISE_KIT = "PromiseKit";
-SwiftCodegen.RESPONSE_LIBRARIES = [SwiftCodegen.LIBRARY_PROMISE_KIT];
+export default class SwiftCodegen extends DefaultCodegen {
+  projectName = 'SwaggerClient'
+  responseAs = []
+  sourceFolder = 'Classes' + File.separator + 'Swaggers'
+  unwrapRequired = false
+  swiftUseApiNamespace = false
+  __outputFolder = 'generated-code' + File.separator + 'swift'
+  __embeddedTemplateDir = 'swift'
+  __templateDir = 'swift'
+  __apiPackage = File.separator + 'APIs'
+  __modelPackage = File.separator + 'Models'
+  __typeMapping = newHashMap(
+    ['array', 'Array'],
+    ['List', 'Array'],
+    ['map', 'Dictionary'],
+    ['date', 'NSDate'],
+    ['Date', 'NSDate'],
+    ['DateTime', 'NSDate'],
+    ['boolean', 'Bool'],
+    ['string', 'String'],
+    ['char', 'Character'],
+    ['short', 'Int'],
+    ['int', 'Int32'],
+    ['long', 'Int64'],
+    ['integer', 'Int32'],
+    ['Integer', 'Int32'],
+    ['float', 'Float'],
+    ['number', 'Double'],
+    ['double', 'Double'],
+    ['object', 'AnyObject'],
+    ['file', 'NSURL'],
+    ['binary', 'NSData'],
+    ['ByteArray', 'NSData'],
+    ['UUID', 'NSUUID']
+  )
+  __defaultIncludes = newHashSet(
+    'NSData',
+    'NSDate',
+    'NSURL',
+    'NSUUID',
+    'Array',
+    'Dictionary',
+    'Set',
+    'Any',
+    'Empty',
+    'AnyObject'
+  )
+  __reservedWords = newHashSet(
+    'Int',
+    'Int32',
+    'Int64',
+    'Int64',
+    'Float',
+    'Double',
+    'Bool',
+    'Void',
+    'String',
+    'Character',
+    'AnyObject',
+    'class',
+    'Class',
+    'break',
+    'as',
+    'associativity',
+    'deinit',
+    'case',
+    'dynamicType',
+    'convenience',
+    'enum',
+    'continue',
+    'false',
+    'dynamic',
+    'extension',
+    'default',
+    'is',
+    'didSet',
+    'func',
+    'do',
+    'nil',
+    'final',
+    'import',
+    'else',
+    'self',
+    'get',
+    'init',
+    'fallthrough',
+    'Self',
+    'infix',
+    'internal',
+    'for',
+    'super',
+    'inout',
+    'let',
+    'if',
+    'true',
+    'lazy',
+    'operator',
+    'in',
+    'COLUMN',
+    'left',
+    'private',
+    'return',
+    'FILE',
+    'mutating',
+    'protocol',
+    'switch',
+    'FUNCTION',
+    'none',
+    'public',
+    'where',
+    'LINE',
+    'nonmutating',
+    'static',
+    'while',
+    'optional',
+    'struct',
+    'override',
+    'subscript',
+    'postfix',
+    'typealias',
+    'precedence',
+    'var',
+    'prefix',
+    'Protocol',
+    'required',
+    'right',
+    'set',
+    'Type',
+    'unowned',
+    'weak'
+  )
+  __importMapping = newHashMap()
+  __languageSpecificPrimitives = newHashSet(
+    'Int',
+    'Int32',
+    'Int64',
+    'Float',
+    'Double',
+    'Bool',
+    'Void',
+    'String',
+    'Character',
+    'AnyObject'
+  )
 
-const isHeader = (parameter) => !(parameter instanceof HeaderParameter);
-const Log = LoggerFactory.getLogger(SwiftCodegen);
+  constructor() {
+    super()
+    this.__modelTemplateFiles.put('model.mustache', '.swift')
+    this.__apiTemplateFiles.put('api.mustache', '.swift')
+  }
+
+  initalizeCliOptions() {
+    super.initalizeCliOptions()
+    this.__cliOptions.push(
+      new CliOption(SwiftCodegen.PROJECT_NAME, 'Project name in Xcode')
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        SwiftCodegen.RESPONSE_AS,
+        'Optionally use libraries to manage response.  Currently ' +
+          StringUtils.join(SwiftCodegen.RESPONSE_LIBRARIES, ', ') +
+          ' are available.'
+      )
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        SwiftCodegen.UNWRAP_REQUIRED,
+        "Treat 'required' properties in response as non-optional (which would crash the app if api returns null as opposed to required option specified in json schema"
+      )
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        SwiftCodegen.POD_SOURCE,
+        'Source information used for Podspec'
+      )
+    )
+    this.__cliOptions.push(
+      new CliOption(CodegenConstants.POD_VERSION, 'Version used for Podspec')
+    )
+    this.__cliOptions.push(
+      new CliOption(SwiftCodegen.POD_AUTHORS, 'Authors used for Podspec')
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        SwiftCodegen.POD_SOCIAL_MEDIA_URL,
+        'Social Media URL used for Podspec'
+      )
+    )
+    this.__cliOptions.push(
+      new CliOption(SwiftCodegen.POD_DOCSET_URL, 'Docset URL used for Podspec')
+    )
+    this.__cliOptions.push(
+      new CliOption(SwiftCodegen.POD_LICENSE, 'License used for Podspec')
+    )
+    this.__cliOptions.push(
+      new CliOption(SwiftCodegen.POD_HOMEPAGE, 'Homepage used for Podspec')
+    )
+    this.__cliOptions.push(
+      new CliOption(SwiftCodegen.POD_SUMMARY, 'Summary used for Podspec')
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        SwiftCodegen.POD_DESCRIPTION,
+        'Description used for Podspec'
+      )
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        SwiftCodegen.POD_SCREENSHOTS,
+        'Screenshots used for Podspec'
+      )
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        SwiftCodegen.POD_DOCUMENTATION_URL,
+        'Documentation URL used for Podspec'
+      )
+    )
+    this.__cliOptions.push(
+      new CliOption(
+        SwiftCodegen.SWIFT_USE_API_NAMESPACE,
+        'Flag to make all the API classes inner-class of {{projectName}}API'
+      )
+    )
+  }
+
+  getTag() {
+    return CodegenType.CLIENT
+  }
+
+  getName() {
+    return 'Swift'
+  }
+
+  getHelp() {
+    return 'Generates a swift client library.'
+  }
+
+  processOpts() {
+    super.processOpts()
+    if (this.__additionalProperties.containsKey(SwiftCodegen.PROJECT_NAME)) {
+      this.setProjectName(
+        this.__additionalProperties.get(SwiftCodegen.PROJECT_NAME)
+      )
+    } else {
+      this.__additionalProperties.put(
+        SwiftCodegen.PROJECT_NAME,
+        this.projectName
+      )
+    }
+    this.sourceFolder = this.projectName + File.separator + this.sourceFolder
+    if (this.__additionalProperties.containsKey(SwiftCodegen.UNWRAP_REQUIRED)) {
+      this.setUnwrapRequired(
+        parseBoolean(
+          this.__additionalProperties.get(SwiftCodegen.UNWRAP_REQUIRED)
+        )
+      )
+    }
+    this.__additionalProperties.put(
+      SwiftCodegen.UNWRAP_REQUIRED,
+      this.unwrapRequired
+    )
+    if (this.__additionalProperties.containsKey(SwiftCodegen.RESPONSE_AS)) {
+      let responseAsObject = this.__additionalProperties.get(
+        SwiftCodegen.RESPONSE_AS
+      )
+      if (typeof responseAsObject === 'string') {
+        this.setResponseAs(responseAsObject.split(','))
+      } else {
+        this.setResponseAs(responseAsObject)
+      }
+    }
+    this.__additionalProperties.put(SwiftCodegen.RESPONSE_AS, this.responseAs)
+    if (
+      ArrayUtils.contains(this.responseAs, SwiftCodegen.LIBRARY_PROMISE_KIT)
+    ) {
+      this.__additionalProperties.put('usePromiseKit', true)
+    }
+    if (
+      this.__additionalProperties.containsKey(
+        SwiftCodegen.SWIFT_USE_API_NAMESPACE
+      )
+    ) {
+      this.swiftUseApiNamespace = parseBoolean(
+        this.__additionalProperties.get(SwiftCodegen.SWIFT_USE_API_NAMESPACE)
+      )
+    }
+    this.__additionalProperties.put(
+      SwiftCodegen.SWIFT_USE_API_NAMESPACE,
+      this.swiftUseApiNamespace
+    )
+    if (!this.__additionalProperties.containsKey(SwiftCodegen.POD_AUTHORS)) {
+      this.__additionalProperties.put(
+        SwiftCodegen.POD_AUTHORS,
+        SwiftCodegen.DEFAULT_POD_AUTHORS
+      )
+    }
+  }
+
+  isReservedWord(word) {
+    return word != null && this.__reservedWords.contains(word)
+  }
+
+  escapeReservedWord(name) {
+    return '_' + name
+  }
+
+  modelFileFolder() {
+    return (
+      this.__outputFolder +
+      File.separator +
+      this.sourceFolder +
+      this.modelPackage()
+        .split('.')
+        .join(File.separatorChar)
+    )
+  }
+
+  apiFileFolder() {
+    return (
+      this.__outputFolder +
+      File.separator +
+      this.sourceFolder +
+      this.apiPackage()
+        .split('.')
+        .join(File.separatorChar)
+    )
+  }
+
+  getTypeDeclaration(p) {
+    if (p != null) {
+      if (p instanceof ArrayProperty) {
+        let inner = p.getItems()
+        return '[' + this.getTypeDeclaration(inner) + ']'
+      } else if (p instanceof MapProperty) {
+        let inner = p.getAdditionalProperties()
+        return '[String:' + this.getTypeDeclaration(inner) + ']'
+      }
+    }
+    return super.getTypeDeclaration(p)
+  }
+
+  getSwaggerType(p) {
+    let swaggerType = super.getSwaggerType(p)
+    let type = null
+    if (this.__typeMapping.containsKey(swaggerType)) {
+      type = this.__typeMapping.get(swaggerType)
+      if (
+        this.__languageSpecificPrimitives.contains(type) ||
+        this.__defaultIncludes.contains(type)
+      )
+        return type
+    } else type = swaggerType
+    return this.toModelName(type)
+  }
+
+  isDataTypeBinary(dataType) {
+    return dataType != null && dataType === 'NSData'
+  }
+
+  /**
+   * Output the proper model name (capitalized)
+   *
+   * @param name the name of the model
+   * @return capitalized model name
+   */
+  toModelName(name) {
+    name = this.sanitizeName(name)
+    if (!StringUtils.isEmpty(this.modelNameSuffix)) {
+      name = name + '_' + this.modelNameSuffix
+    }
+    if (!StringUtils.isEmpty(this.modelNamePrefix)) {
+      name = this.modelNamePrefix + '_' + name
+    }
+    name = DefaultCodegen.camelize(name)
+    if (this.isReservedWord(name)) {
+      let modelName = 'Model' + name
+      DefaultCodegen.Log().warn(
+        name +
+          ' (reserved word) cannot be used as model name. Renamed to ' +
+          modelName
+      )
+      return modelName
+    }
+    if (name.match('^\\d.*')) {
+      let modelName = 'Model' + name
+      DefaultCodegen.Log().warn(
+        name +
+          ' (model name starts with number) cannot be used as model name. Renamed to ' +
+          modelName
+      )
+      return modelName
+    }
+    return name
+  }
+
+  /**
+   * Return the capitalized file name of the model
+   *
+   * @param name the model name
+   * @return the file name of the model
+   */
+  toModelFilename(name) {
+    return this.toModelName(name)
+  }
+
+  toDefaultValue(p) {
+    return null
+  }
+
+  toInstantiationType(p) {
+    if (p instanceof MapProperty) {
+      let inner = this.getSwaggerType(p.getAdditionalProperties())
+      return '[String:' + inner + ']'
+    } else if (p instanceof ArrayProperty) {
+      let inner = this.getSwaggerType(p.getItems())
+      return '[' + inner + ']'
+    }
+
+    return null
+  }
+
+  fromProperty(name, p) {
+    let codegenProperty = super.fromProperty(name, p)
+    if (codegenProperty.isContainer) {
+      return codegenProperty
+    }
+    if (codegenProperty.isEnum) {
+      let swiftEnums = []
+      let values = codegenProperty.allowableValues.get('values')
+      for (const value of values) {
+        swiftEnums.push(
+          newHashMap(
+            ['enum', this.toSwiftyEnumName('' + value)],
+            ['raw', '' + value]
+          )
+        )
+      }
+      codegenProperty.allowableValues.put('values', swiftEnums)
+      codegenProperty.datatypeWithEnum = this.toEnumName(codegenProperty)
+      if (
+        this.isReservedWord(codegenProperty.datatypeWithEnum) ||
+        this.toVarName(name) === codegenProperty.datatypeWithEnum
+      ) {
+        codegenProperty.datatypeWithEnum =
+          codegenProperty.datatypeWithEnum + 'Enum'
+      }
+    }
+    return codegenProperty
+  }
+
+  toSwiftyEnumName(value) {
+    if (value.match('[A-Z][a-z0-9]+[a-zA-Z0-9]*')) {
+      return value
+    }
+    const separators = ['-', '_', ' ', ':']
+    return capitalizeFully(value.toLowerCase(), separators).replace(
+      new RegExp('[-_  :]', 'g'),
+      ''
+    )
+  }
+
+  toApiName(name) {
+    if (name.length === 0) return 'DefaultAPI'
+    return this.initialCaps(name) + 'API'
+  }
+
+  toOperationId(operationId) {
+    operationId = DefaultCodegen.camelize(this.sanitizeName(operationId), true)
+    if (StringUtils.isEmpty(operationId)) {
+      throw new Error('Empty method name (operationId) not allowed')
+    }
+    if (this.isReservedWord(operationId)) {
+      let newOperationId = DefaultCodegen.camelize('call_' + operationId, true)
+      Log.warn(
+        operationId +
+          ' (reserved word) cannot be used as method name. Renamed to ' +
+          newOperationId
+      )
+      return newOperationId
+    }
+    return operationId
+  }
+
+  toVarName(name) {
+    name = this.sanitizeName(name)
+    if (name.match('^[A-Z_]*$')) {
+      return name
+    }
+    name = DefaultCodegen.camelize(name, true)
+    if (this.isReservedWord(name) || name.match('^\\d.*')) {
+      name = this.escapeReservedWord(name)
+    }
+    return name
+  }
+
+  toParamName(name) {
+    name = this.sanitizeName(name)
+    name = name.replace(new RegExp('-', 'g'), '_')
+    if (name.match('^[A-Z_]*$')) {
+      return name
+    }
+    name = DefaultCodegen.camelize(name, true)
+    if (this.isReservedWord(name) || name.match('^\\d.*')) {
+      name = this.escapeReservedWord(name)
+    }
+    return name
+  }
+
+  fromOperation(path, httpMethod, operation, definitions, swagger) {
+    if (arguments.length > 4) {
+      path = SwiftCodegen.normalizePath(path)
+      let parameters = operation.getParameters()
+      parameters = parameters.filter(isHeader)
+      operation.setParameters(parameters)
+      return super.fromOperation(
+        path,
+        httpMethod,
+        operation,
+        definitions,
+        swagger
+      )
+    }
+    return super.fromOperation(path, httpMethod, operation, definitions)
+  }
+
+  static normalizePath(path) {
+    const builder = new StringBuilder()
+
+    let cursor = 0
+    //Matcher matcher = PATH_PARAM_PATTERN.matcher(path);
+    const matcher = PATH_PARAM_PATTERN.matcher(path)
+    let found = matcher.find()
+    while (found) {
+      let stringBeforeMatch = path.substring(cursor, matcher.start())
+      builder.append(stringBeforeMatch)
+
+      let group = matcher.group().substring(1, matcher.group().length - 1)
+      group = DefaultCodegen.camelize(group, true)
+      builder
+        .append('{')
+        .append(group)
+        .append('}')
+
+      cursor = matcher.end()
+      found = matcher.find()
+    }
+
+    let stringAfterMatch = path.substring(cursor)
+    builder.append(stringAfterMatch)
+
+    return builder.toString()
+  }
+
+  setProjectName(projectName) {
+    this.projectName = projectName
+  }
+
+  setUnwrapRequired(unwrapRequired) {
+    this.unwrapRequired = unwrapRequired
+  }
+
+  setResponseAs(responseAs) {
+    this.responseAs = responseAs
+  }
+
+  toEnumValue(value, datatype) {
+    if ('int' === datatype || 'double' === datatype || 'float' === datatype) {
+      return value
+    } else {
+      return "'" + this.escapeText(value) + "'"
+    }
+  }
+
+  toEnumDefaultValue(value, datatype) {
+    return datatype + '_' + value
+  }
+
+  toEnumVarName(name, datatype) {
+    if ('int' === datatype || 'double' === datatype || 'float' === datatype) {
+      let varName = new String(name)
+      varName = varName.replace(new RegExp('-', 'g'), 'MINUS_')
+      varName = varName.replace(new RegExp('\\+', 'g'), 'PLUS_')
+      varName = varName.replace(new RegExp('\\.', 'g'), '_DOT_')
+      return varName
+    }
+    let enumName = this.sanitizeName(
+      DefaultCodegen.underscore(name).toUpperCase()
+    )
+    enumName = enumName.replace(/^_/, '')
+    enumName = enumName.replace(/_$/, '')
+    if (enumName.match('\\d.*')) {
+      return '_' + enumName
+    } else {
+      return enumName
+    }
+  }
+
+  toEnumName(property) {
+    let enumName = this.toModelName(property.name)
+    if (enumName.match('\\d.*')) {
+      return '_' + enumName
+    } else {
+      return enumName
+    }
+  }
+
+  postProcessModels(objs) {
+    return this.postProcessModelsEnum(objs)
+  }
+
+  escapeQuotationMark(input) {
+    return input.split('"').join('')
+  }
+
+  escapeUnsafeCharacters(input) {
+    return input
+      .split('*/')
+      .join('*_/')
+      .split('/*')
+      .join('/_*')
+  }
+}
+SwiftCodegen.PROJECT_NAME = 'projectName'
+SwiftCodegen.RESPONSE_AS = 'responseAs'
+SwiftCodegen.UNWRAP_REQUIRED = 'unwrapRequired'
+SwiftCodegen.POD_SOURCE = 'podSource'
+SwiftCodegen.POD_AUTHORS = 'podAuthors'
+SwiftCodegen.POD_SOCIAL_MEDIA_URL = 'podSocialMediaURL'
+SwiftCodegen.POD_DOCSET_URL = 'podDocsetURL'
+SwiftCodegen.POD_LICENSE = 'podLicense'
+SwiftCodegen.POD_HOMEPAGE = 'podHomepage'
+SwiftCodegen.POD_SUMMARY = 'podSummary'
+SwiftCodegen.POD_DESCRIPTION = 'podDescription'
+SwiftCodegen.POD_SCREENSHOTS = 'podScreenshots'
+SwiftCodegen.POD_DOCUMENTATION_URL = 'podDocumentationURL'
+SwiftCodegen.SWIFT_USE_API_NAMESPACE = 'swiftUseApiNamespace'
+SwiftCodegen.DEFAULT_POD_AUTHORS = 'Swagger Codegen'
+SwiftCodegen.LIBRARY_PROMISE_KIT = 'PromiseKit'
+SwiftCodegen.RESPONSE_LIBRARIES = [SwiftCodegen.LIBRARY_PROMISE_KIT]
+
+const isHeader = parameter => !(parameter instanceof HeaderParameter)
+const Log = LoggerFactory.getLogger(SwiftCodegen)

--- a/yarn.lock
+++ b/yarn.lock
@@ -887,12 +887,6 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-collections@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/collections/-/collections-5.1.2.tgz#25735f3571c9c1a2854d072203f2520e507a52f0"
-  dependencies:
-    weak-map "~1.0.x"
-
 color-convert@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
@@ -5758,10 +5752,6 @@ wcwidth@^1.0.0:
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
   dependencies:
     defaults "^1.0.3"
-
-weak-map@~1.0.x:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/weak-map/-/weak-map-1.0.5.tgz#79691584d98607f5070bd3b70a40e6bb22e401eb"
 
 which-module@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR removes the dependency on [collections](https://github.com/montagejs/collections) from `ern-api-gen`.

This dependency was leading to some weird issues with the standard output stream (noticed part of some work in progress). After investigation it is probably due to the fact that this library is altering some of JavaScript core types (`Array`, `Function`, `Object`, `RegEx`) through [shims](https://github.com/montagejs/collections/blob/master/shim.js). For example, adding the `add` function on the `Array` prototype.

Altering core JS objects is never a good idea. Very risky especially in large codebases. If it can be avoided it should.

`ern-api-gen` was only requiring this dependency to use the `TreeMap `data structure from it.
Found a good alternative implementation of this data structure and modified it a bit to fit `ern-api-gen` usage of it. This way I was able to get rid of the dependency on `collections`.

However this wasn't the trickiest part.
By removing this dependency, all the shims were removed in the process. The problem was that `ern-api-gen` was making some use of these non standard JS functions on core types -when it could and should not have- (for example it was calling `Array.add` in some places instead of `Array.push`. The former does not exist in JS and was only made possible because of `collections` core JS types alteration). 

Given that `ern-api-gen` is not typed (not using TypeScript nor flow), the process to figure out what to change was not made easy. Fortunately thanks to existing unit tests and system tests, it was possible to find out the troublemakers.

Also regenerated locally some of our production APIs just to make sure nothing was broken by the changes (even if unit / system tests are covering most of the use cases).


✅ Unit tests 
✅ System tests 
✅ Mental sanity 