### PR TITLE
Make shell silent for some log levels

### DIFF
--- a/ern-local-cli/src/index.ts
+++ b/ern-local-cli/src/index.ts
@@ -87,6 +87,7 @@ export default function run() {
   log.setLogLevel(logLevel)
   shell.config.fatal = true
   shell.config.verbose = logLevel === 'trace'
+  shell.config.silent = !(logLevel === 'trace' || logLevel === 'debug')
 
   if (config.getValue('showBanner', true)) {
     showBanner()


### PR DESCRIPTION
Turn `shelljs` silent for all log levels but `trace` and `debug`, to make sure that log output is not polluted for common user log levels.

This gets rids of the annoyings 

pwd
pwd

that were logged when running commands with the default info log level. 