### PR TITLE
Add time taken by tasks for debug and trace log levels

### DIFF
--- a/ern-core/package.json
+++ b/ern-core/package.json
@@ -56,7 +56,7 @@
     "mustache": "^2.3.0",
     "node-fetch": "^2.1.2",
     "node-simctl": "^3.12.0",
-    "kax": "^1.2.6",
+    "kax": "^1.2.7",
     "react-native-cli": "^2.0.1",
     "shelljs": "^0.8.2",
     "semver": "^5.5.0",

--- a/ern-local-cli/package.json
+++ b/ern-local-cli/package.json
@@ -70,7 +70,7 @@
     "fast-levenshtein": "^2.0.6",
     "fs-readdir-recursive": "^1.1.0",
     "inquirer": "^3.0.6",
-    "kax":"^1.2.6",
+    "kax":"^1.2.7",
     "lodash": "^4.17.10",
     "semver": "^5.5.0",
     "validate-npm-package-name": "^3.0.0",

--- a/ern-local-cli/src/index.ts
+++ b/ern-local-cli/src/index.ts
@@ -79,6 +79,25 @@ Manifest.getOverrideManifestConfig = async (): Promise<ManifestOverrideConfig | 
   }
 }
 
+const kaxRendererConfig = {
+  colorScheme: {
+    error: 'red',
+    info: 'cyan',
+    task: 'white',
+    warning: 'yellow',
+  },
+  shouldLogTime: true,
+  symbolScheme: {
+    error: 'error',
+    info: 'info',
+    taskFailure: 'error',
+    taskRunning: 'dots',
+    taskSuccess: 'success',
+    warning: 'warning',
+  },
+  symbolizeMultiLine: true,
+}
+
 // ==============================================================================
 // Entry point
 // =============================================================================
@@ -90,27 +109,11 @@ export default function run() {
   shell.config.fatal = true
   shell.config.verbose = logLevel === 'trace'
   shell.config.silent = !(logLevel === 'trace' || logLevel === 'debug')
+
   kax.renderer =
     logLevel === 'trace' || logLevel === 'debug'
-      ? new KaxSimpleRenderer()
-      : new KaxAdvancedRenderer({
-          colorScheme: {
-            error: 'red',
-            info: 'cyan',
-            task: 'white',
-            warning: 'yellow',
-          },
-          shouldLogTime: true,
-          symbolScheme: {
-            error: 'error',
-            info: 'info',
-            taskFailure: 'error',
-            taskRunning: 'dots',
-            taskSuccess: 'success',
-            warning: 'warning',
-          },
-          symbolizeMultiLine: true,
-        })
+      ? new KaxSimpleRenderer(kaxRendererConfig)
+      : new KaxAdvancedRenderer(kaxRendererConfig)
 
   if (config.getValue('showBanner', true)) {
     showBanner()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2907,9 +2907,9 @@ just-extend@^1.1.27:
   version "1.1.27"
   resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.27.tgz#ec6e79410ff914e472652abfa0e603c03d60e905"
 
-kax@^1.2.6:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/kax/-/kax-1.2.6.tgz#6ad68faac14381310ed31907a907a2adf98a1501"
+kax@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/kax/-/kax-1.2.7.tgz#8e12dd73997dec6471d5e5f2b44269f1110302f9"
   dependencies:
     chalk "^2.4.1"
     cli-spinners "^1.3.1"


### PR DESCRIPTION
Time taken by tasks was only logged for non `debug`/`trace` log levels (the ones using spinners).
This PR updates `kax` which now allows to log time taken by tasks when using `KaxSimpleRenderer` (the renderer used for `debug`/trace` levels.