### PR TITLE
Replace all cd commands with pushd/popd

### DIFF
--- a/ern-api-impl-gen/src/ApiImpl.ts
+++ b/ern-api-impl-gen/src/ApiImpl.ts
@@ -118,28 +118,30 @@ async function createNodePackage(
   hasConfig: boolean,
   scope?: string
 ) {
-  const currentDirectory = process.cwd()
-  shell.cd(outputDirectoryPath)
-  await yarn.init()
-  await yarn.add(apiDependency)
-  shell.cp(
-    path.join(
-      Platform.currentPlatformVersionPath,
-      'ern-api-impl-gen',
-      'resources',
-      'gitignore'
-    ),
-    path.join(outputDirectoryPath, '.gitignore')
-  )
-  ernifyPackageJson(
-    outputDirectoryPath,
-    apiImplName,
-    packageName,
-    nativeOnly,
-    hasConfig,
-    scope
-  )
-  shell.cd(currentDirectory)
+  shell.pushd(outputDirectoryPath)
+  try {
+    await yarn.init()
+    await yarn.add(apiDependency)
+    shell.cp(
+      path.join(
+        Platform.currentPlatformVersionPath,
+        'ern-api-impl-gen',
+        'resources',
+        'gitignore'
+      ),
+      path.join(outputDirectoryPath, '.gitignore')
+    )
+    ernifyPackageJson(
+      outputDirectoryPath,
+      apiImplName,
+      packageName,
+      nativeOnly,
+      hasConfig,
+      scope
+    )
+  } finally {
+    shell.popd()
+  }
 }
 
 function createWorkingDirectory(workingDirectoryPath: string) {

--- a/ern-api-impl-gen/src/generators/android/ApiImplAndroidGenerator.ts
+++ b/ern-api-impl-gen/src/generators/android/ApiImplAndroidGenerator.ts
@@ -83,12 +83,12 @@ export default class ApiImplAndroidGenerator implements ApiImplGeneratable {
     pluginsPaths: PackagePath[],
     apis: any[]
   ) {
+    shell.pushd(ROOT_DIR)
+
     try {
       log.debug(
         `[=== Starting hull filling for api impl gen for ${this.platform} ===]`
       )
-
-      shell.cd(ROOT_DIR)
 
       const outputDirectory = path.join(paths.outDirectory, 'android')
       log.debug(
@@ -130,8 +130,8 @@ export default class ApiImplAndroidGenerator implements ApiImplGeneratable {
       await this.updateFilePermissions(srcOutputDirectory, editableFiles)
 
       await this.updateBuildGradle(paths, reactNativeVersion, outputDirectory)
-    } catch (e) {
-      throw new Error(`Error during apiimpl hull: ${e}`)
+    } finally {
+      shell.popd()
     }
   }
 

--- a/ern-api-impl-gen/src/generators/js/ApiImplJsGenerator.ts
+++ b/ern-api-impl-gen/src/generators/js/ApiImplJsGenerator.ts
@@ -33,43 +33,47 @@ export default class ApiImplJsGenerator implements ApiImplGeneratable {
   }
 
   public async fillHull(apiDependency: PackagePath, paths: any, apis: any[]) {
-    shell.cd(shell.pwd())
-    const outputDirectory = path.join(paths.outDirectory, 'js')
-    log.debug(`Creating out directory(${outputDirectory}) for JS.`)
-    if (!fs.existsSync(outputDirectory)) {
-      shell.mkdir(outputDirectory)
-    }
-    const mustacheFile = path.join(
-      Platform.currentPlatformVersionPath,
-      'ern-api-impl-gen',
-      'resources',
-      'js',
-      'apiimpl.mustache'
-    )
-
-    for (const api of apis) {
-      api.packageName = apiDependency.basePath
-      await mustacheUtils.mustacheRenderToOutputFileUsingTemplateFile(
-        mustacheFile,
-        api,
-        path.join(outputDirectory, `${api.apiName}ApiImpl.js`)
+    shell.pushd(shell.pwd())
+    try {
+      const outputDirectory = path.join(paths.outDirectory, 'js')
+      log.debug(`Creating out directory(${outputDirectory}) for JS.`)
+      if (!fs.existsSync(outputDirectory)) {
+        shell.mkdir(outputDirectory)
+      }
+      const mustacheFile = path.join(
+        Platform.currentPlatformVersionPath,
+        'ern-api-impl-gen',
+        'resources',
+        'js',
+        'apiimpl.mustache'
       )
-    }
 
-    const indexMustacheFile = path.join(
-      Platform.currentPlatformVersionPath,
-      'ern-api-impl-gen',
-      'resources',
-      'js',
-      'index.mustache'
-    )
-    const apisMustacheView = {
-      apis,
+      for (const api of apis) {
+        api.packageName = apiDependency.basePath
+        await mustacheUtils.mustacheRenderToOutputFileUsingTemplateFile(
+          mustacheFile,
+          api,
+          path.join(outputDirectory, `${api.apiName}ApiImpl.js`)
+        )
+      }
+
+      const indexMustacheFile = path.join(
+        Platform.currentPlatformVersionPath,
+        'ern-api-impl-gen',
+        'resources',
+        'js',
+        'index.mustache'
+      )
+      const apisMustacheView = {
+        apis,
+      }
+      await mustacheUtils.mustacheRenderToOutputFileUsingTemplateFile(
+        indexMustacheFile,
+        apisMustacheView,
+        path.join(paths.outDirectory, 'index.js')
+      )
+    } finally {
+      shell.popd()
     }
-    await mustacheUtils.mustacheRenderToOutputFileUsingTemplateFile(
-      indexMustacheFile,
-      apisMustacheView,
-      path.join(paths.outDirectory, 'index.js')
-    )
   }
 }

--- a/ern-container-gen/src/bundleMiniApps.ts
+++ b/ern-container-gen/src/bundleMiniApps.ts
@@ -46,7 +46,7 @@ export async function bundleMiniApps(
     .task('Running Metro Bundler')
     .run(
       platform === 'android'
-        ? reactNativeBundleAndroid(outDir)
-        : reactNativeBundleIos(outDir)
+        ? reactNativeBundleAndroid({ workingDir: compositeMiniAppDir, outDir })
+        : reactNativeBundleIos({ workingDir: compositeMiniAppDir, outDir })
     )
 }

--- a/ern-container-gen/src/generateMiniAppsComposite.ts
+++ b/ern-container-gen/src/generateMiniAppsComposite.ts
@@ -39,226 +39,233 @@ export async function generateMiniAppsComposite(
     shell.mkdir('-p', outDir)
   }
 
-  shell.cd(outDir)
+  shell.pushd(outDir)
 
-  let compositePackageJson: any = {}
+  try {
+    let compositePackageJson: any = {}
 
-  if (pathToYarnLock && _.some(miniappsPaths, p => p.isFilePath)) {
-    log.warn(
-      'Yarn lock will not be used as some of the MiniApp paths are file based'
-    )
-    pathToYarnLock = undefined
-  }
-
-  if (pathToYarnLock) {
-    if (_.some(miniappsPaths, m => !m.version)) {
-      throw new Error(
-        '[generateMiniAppsComposite] When providing a yarn lock you cannot pass MiniApps without an explicit version'
+    if (pathToYarnLock && _.some(miniappsPaths, p => p.isFilePath)) {
+      log.warn(
+        'Yarn lock will not be used as some of the MiniApp paths are file based'
       )
+      pathToYarnLock = undefined
     }
 
-    if (!fs.existsSync(pathToYarnLock)) {
-      throw new Error(
-        `[generateMiniAppsComposite] Path to yarn.lock does not exist (${pathToYarnLock})`
+    if (pathToYarnLock) {
+      if (_.some(miniappsPaths, m => !m.version)) {
+        throw new Error(
+          '[generateMiniAppsComposite] When providing a yarn lock you cannot pass MiniApps without an explicit version'
+        )
+      }
+
+      if (!fs.existsSync(pathToYarnLock)) {
+        throw new Error(
+          `[generateMiniAppsComposite] Path to yarn.lock does not exist (${pathToYarnLock})`
+        )
+      }
+
+      log.debug(`Copying yarn.lock to ${outDir}`)
+      shell.cp(pathToYarnLock, path.join(outDir, 'yarn.lock'))
+
+      const yarnLock = fs.readFileSync(pathToYarnLock, 'utf8')
+      const miniAppsDeltas: MiniAppsDeltas = getMiniAppsDeltas(
+        miniappsPaths,
+        yarnLock
       )
+
+      log.debug(
+        `[generateMiniAppsComposite] miniAppsDeltas: ${JSON.stringify(
+          miniAppsDeltas
+        )}`
+      )
+
+      compositePackageJson.dependencies = getPackageJsonDependenciesUsingMiniAppDeltas(
+        miniAppsDeltas,
+        yarnLock
+      )
+      compositePackageJson.scripts = {
+        start: 'node node_modules/react-native/local-cli/cli.js start',
+      }
+
+      log.debug(JSON.stringify(compositePackageJson.dependencies, null, 2))
+
+      await writePackageJson(outDir, compositePackageJson)
+
+      // Now that the composite package.json is similar to the one used to generated yarn.lock
+      // we can run yarn install to get back to the exact same dependency graph as the previously
+      // generated composite
+      await yarn.install()
+      await runYarnUsingMiniAppDeltas(miniAppsDeltas)
+    } else {
+      // No yarn.lock path was provided, just add miniapps one by one
+      log.debug('[generateMiniAppsComposite] no yarn lock provided')
+      await yarn.init()
+      for (const miniappPath of miniappsPaths) {
+        await yarn.add(miniappPath)
+      }
+
+      const packageJson = await readPackageJson(outDir)
+      packageJson.scripts = {
+        start: 'node node_modules/react-native/local-cli/cli.js start',
+      }
+      await writePackageJson(outDir, packageJson)
     }
 
-    log.debug(`Copying yarn.lock to ${outDir}`)
-    shell.cp(pathToYarnLock, path.join(outDir, 'yarn.lock'))
-
-    const yarnLock = fs.readFileSync(pathToYarnLock, 'utf8')
-    const miniAppsDeltas: MiniAppsDeltas = getMiniAppsDeltas(
-      miniappsPaths,
-      yarnLock
-    )
-
-    log.debug(
-      `[generateMiniAppsComposite] miniAppsDeltas: ${JSON.stringify(
-        miniAppsDeltas
-      )}`
-    )
-
-    compositePackageJson.dependencies = getPackageJsonDependenciesUsingMiniAppDeltas(
-      miniAppsDeltas,
-      yarnLock
-    )
-    compositePackageJson.scripts = {
-      start: 'node node_modules/react-native/local-cli/cli.js start',
+    for (const extraJsDependency of extraJsDependencies) {
+      await yarn.add(extraJsDependency)
     }
 
-    log.debug(JSON.stringify(compositePackageJson.dependencies, null, 2))
+    let entryIndexJsContent = ''
 
-    await writePackageJson(outDir, compositePackageJson)
-
-    // Now that the composite package.json is similar to the one used to generated yarn.lock
-    // we can run yarn install to get back to the exact same dependency graph as the previously
-    // generated composite
-    await yarn.install()
-    await runYarnUsingMiniAppDeltas(miniAppsDeltas)
-  } else {
-    // No yarn.lock path was provided, just add miniapps one by one
-    log.debug('[generateMiniAppsComposite] no yarn lock provided')
-    await yarn.init()
-    for (const miniappPath of miniappsPaths) {
-      await yarn.add(miniappPath)
+    compositePackageJson = await readPackageJson('.')
+    for (const dependency of Object.keys(compositePackageJson.dependencies)) {
+      entryIndexJsContent += `import '${dependency}'\n`
     }
 
-    const packageJson = await readPackageJson(outDir)
-    packageJson.scripts = {
-      start: 'node node_modules/react-native/local-cli/cli.js start',
+    if (jsApiImplDependencies) {
+      log.debug('Adding imports for JS API implementations.')
+      for (const apiImpl of jsApiImplDependencies!) {
+        await yarn.add(apiImpl)
+        entryIndexJsContent += `import '${apiImpl.basePath}'\n`
+      }
     }
-    await writePackageJson(outDir, packageJson)
-  }
 
-  for (const extraJsDependency of extraJsDependencies) {
-    await yarn.add(extraJsDependency)
-  }
+    await runAfterJsCompositeGenerationScript(outDir)
 
-  let entryIndexJsContent = ''
+    log.debug('Removing .babelrc files from all modules')
+    shell.rm('-rf', path.join('node_modules', '**', '.babelrc'))
 
-  compositePackageJson = await readPackageJson('.')
-  for (const dependency of Object.keys(compositePackageJson.dependencies)) {
-    entryIndexJsContent += `import '${dependency}'\n`
-  }
-
-  if (jsApiImplDependencies) {
-    log.debug('Adding imports for JS API implementations.')
-    for (const apiImpl of jsApiImplDependencies!) {
-      await yarn.add(apiImpl)
-      entryIndexJsContent += `import '${apiImpl.basePath}'\n`
+    log.debug('Creating top level composite .babelrc')
+    const compositeBabelRc: { plugins: string[]; presets: string[] } = {
+      plugins: [],
+      presets: ['react-native'],
     }
-  }
 
-  await runAfterJsCompositeGenerationScript(outDir)
-
-  log.debug('Removing .babelrc files from all modules')
-  shell.rm('-rf', path.join('node_modules', '**', '.babelrc'))
-
-  log.debug('Creating top level composite .babelrc')
-  const compositeBabelRc: { plugins: string[]; presets: string[] } = {
-    plugins: [],
-    presets: ['react-native'],
-  }
-
-  // Ugly hacky way of handling module-resolver babel plugin
-  // At least it has some guarantees to make it safer but its just a temporary
-  // solution until we figure out a more proper way of handling this plugin
-  log.debug('Taking care of potential Babel plugins used by MiniApps')
-  let moduleResolverAliases = {}
-  for (const dependency of Object.keys(compositePackageJson.dependencies)) {
-    const miniAppPackagePath = path.join(outDir, 'node_modules', dependency)
-    let miniAppPackageJson
-    try {
-      miniAppPackageJson = await readPackageJson(miniAppPackagePath)
-    } catch (e) {
-      // swallow (for test. to be fixed)
-      continue
-    }
-    const miniAppName = miniAppPackageJson.name
-    if (miniAppPackageJson.babel) {
-      if (miniAppPackageJson.babel.plugins) {
-        for (const babelPlugin of miniAppPackageJson.babel.plugins) {
-          if (Array.isArray(babelPlugin)) {
-            if (babelPlugin.includes('module-resolver')) {
-              // Copy over module-resolver plugin & config to top level composite .babelrc
-              log.debug(
-                `Taking care of module-resolver Babel plugin for ${miniAppName} MiniApp`
-              )
-              if (compositeBabelRc.plugins.length === 0) {
-                // First MiniApp to add module-resolver plugin & config
-                // easy enough, we just copy over the plugin & config
-                compositeBabelRc.plugins.push(<any>babelPlugin)
-                for (const x of babelPlugin) {
-                  if (x instanceof Object && x.alias) {
-                    moduleResolverAliases = x.alias
-                    break
+    // Ugly hacky way of handling module-resolver babel plugin
+    // At least it has some guarantees to make it safer but its just a temporary
+    // solution until we figure out a more proper way of handling this plugin
+    log.debug('Taking care of potential Babel plugins used by MiniApps')
+    let moduleResolverAliases = {}
+    for (const dependency of Object.keys(compositePackageJson.dependencies)) {
+      const miniAppPackagePath = path.join(outDir, 'node_modules', dependency)
+      let miniAppPackageJson
+      try {
+        miniAppPackageJson = await readPackageJson(miniAppPackagePath)
+      } catch (e) {
+        // swallow (for test. to be fixed)
+        continue
+      }
+      const miniAppName = miniAppPackageJson.name
+      if (miniAppPackageJson.babel) {
+        if (miniAppPackageJson.babel.plugins) {
+          for (const babelPlugin of miniAppPackageJson.babel.plugins) {
+            if (Array.isArray(babelPlugin)) {
+              if (babelPlugin.includes('module-resolver')) {
+                // Copy over module-resolver plugin & config to top level composite .babelrc
+                log.debug(
+                  `Taking care of module-resolver Babel plugin for ${miniAppName} MiniApp`
+                )
+                if (compositeBabelRc.plugins.length === 0) {
+                  // First MiniApp to add module-resolver plugin & config
+                  // easy enough, we just copy over the plugin & config
+                  compositeBabelRc.plugins.push(<any>babelPlugin)
+                  for (const x of babelPlugin) {
+                    if (x instanceof Object && x.alias) {
+                      moduleResolverAliases = x.alias
+                      break
+                    }
                   }
-                }
-              } else {
-                // Another MiniApp  has already declared module-resolver
-                // plugin & config. If we have conflicts for aliases, we'll just abort
-                // bundling as of now to avoid generating a potentially unstable bundle
-                for (const item of babelPlugin) {
-                  if (item instanceof Object && item.alias) {
-                    for (const aliasKey of Object.keys(item.alias)) {
-                      if (
-                        moduleResolverAliases[aliasKey] &&
-                        moduleResolverAliases[aliasKey] !== item.alias[aliasKey]
-                      ) {
-                        throw new Error('Babel module-resolver alias conflict')
-                      } else if (!moduleResolverAliases[aliasKey]) {
-                        moduleResolverAliases[aliasKey] = item.alias[aliasKey]
+                } else {
+                  // Another MiniApp  has already declared module-resolver
+                  // plugin & config. If we have conflicts for aliases, we'll just abort
+                  // bundling as of now to avoid generating a potentially unstable bundle
+                  for (const item of babelPlugin) {
+                    if (item instanceof Object && item.alias) {
+                      for (const aliasKey of Object.keys(item.alias)) {
+                        if (
+                          moduleResolverAliases[aliasKey] &&
+                          moduleResolverAliases[aliasKey] !==
+                            item.alias[aliasKey]
+                        ) {
+                          throw new Error(
+                            'Babel module-resolver alias conflict'
+                          )
+                        } else if (!moduleResolverAliases[aliasKey]) {
+                          moduleResolverAliases[aliasKey] = item.alias[aliasKey]
+                        }
                       }
                     }
                   }
                 }
+              } else {
+                log.warn(
+                  `Unsupported Babel plugin type ${babelPlugin.toString()} in ${miniAppName} MiniApp`
+                )
               }
             } else {
               log.warn(
                 `Unsupported Babel plugin type ${babelPlugin.toString()} in ${miniAppName} MiniApp`
               )
             }
-          } else {
-            log.warn(
-              `Unsupported Babel plugin type ${babelPlugin.toString()} in ${miniAppName} MiniApp`
-            )
           }
         }
+        log.debug(
+          `Removing babel object from ${miniAppName} MiniApp package.json`
+        )
+        delete miniAppPackageJson.babel
+        await writePackageJson(miniAppPackagePath, miniAppPackageJson)
       }
-      log.debug(
-        `Removing babel object from ${miniAppName} MiniApp package.json`
-      )
-      delete miniAppPackageJson.babel
-      await writePackageJson(miniAppPackagePath, miniAppPackageJson)
     }
-  }
 
-  await writeFile('.babelrc', JSON.stringify(compositeBabelRc, null, 2))
+    await writeFile('.babelrc', JSON.stringify(compositeBabelRc, null, 2))
 
-  const pathToCodePushNodeModuleDir = path.join(
-    outDir,
-    'node_modules',
-    'react-native-code-push'
-  )
-  const pathToReactNativeNodeModuleDir = path.join(
-    outDir,
-    'node_modules',
-    'react-native'
-  )
-
-  // If code push plugin is present we need to do some additional work
-  if (fs.existsSync(pathToCodePushNodeModuleDir)) {
-    const reactNativePackageJson = await readPackageJson(
-      pathToReactNativeNodeModuleDir
+    const pathToCodePushNodeModuleDir = path.join(
+      outDir,
+      'node_modules',
+      'react-native-code-push'
+    )
+    const pathToReactNativeNodeModuleDir = path.join(
+      outDir,
+      'node_modules',
+      'react-native'
     )
 
-    //
-    // The following code will need to be uncommented and properly reworked or included
-    // in a different way, once Cart and TYP don't directly depend on code push directly
-    // We will work with Cart team in that direction
-    //
-    // await yarn.add(codePushPlugin.name, codePushPlugin.version)
-    // content += `import codePush from "react-native-code-push"\n`
-    // content += `codePush.sync()`
+    // If code push plugin is present we need to do some additional work
+    if (fs.existsSync(pathToCodePushNodeModuleDir)) {
+      const reactNativePackageJson = await readPackageJson(
+        pathToReactNativeNodeModuleDir
+      )
 
-    // We need to add some info to package.json for CodePush
-    // In order to run, code push needs to find the following in package.json
-    // - name & version
-    // - react-native in the dependency block
-    // TODO :For now we hardcode these values for demo purposes. That being said it
-    // might not be needed to do something better because it seems like
-    // code push is not making a real use of this data
-    // Investigate further.
-    // https://github.com/Microsoft/code-push/blob/master/cli/script/command-executor.ts#L1246
-    compositePackageJson.dependencies['react-native'] =
-      reactNativePackageJson.version
-    compositePackageJson.name = 'container'
-    compositePackageJson.version = '0.0.1'
-    await writePackageJson('.', compositePackageJson)
+      //
+      // The following code will need to be uncommented and properly reworked or included
+      // in a different way, once Cart and TYP don't directly depend on code push directly
+      // We will work with Cart team in that direction
+      //
+      // await yarn.add(codePushPlugin.name, codePushPlugin.version)
+      // content += `import codePush from "react-native-code-push"\n`
+      // content += `codePush.sync()`
+
+      // We need to add some info to package.json for CodePush
+      // In order to run, code push needs to find the following in package.json
+      // - name & version
+      // - react-native in the dependency block
+      // TODO :For now we hardcode these values for demo purposes. That being said it
+      // might not be needed to do something better because it seems like
+      // code push is not making a real use of this data
+      // Investigate further.
+      // https://github.com/Microsoft/code-push/blob/master/cli/script/command-executor.ts#L1246
+      compositePackageJson.dependencies['react-native'] =
+        reactNativePackageJson.version
+      compositePackageJson.name = 'container'
+      compositePackageJson.version = '0.0.1'
+      await writePackageJson('.', compositePackageJson)
+    }
+
+    log.debug('Creating index.android.js')
+    await writeFile('index.android.js', entryIndexJsContent)
+    log.debug('Creating index.ios.js')
+    await writeFile('index.ios.js', entryIndexJsContent)
+  } finally {
+    shell.popd()
   }
-
-  log.debug('Creating index.android.js')
-  await writeFile('index.android.js', entryIndexJsContent)
-  log.debug('Creating index.ios.js')
-  await writeFile('index.ios.js', entryIndexJsContent)
 }

--- a/ern-container-gen/src/reactNativeBundleAndroid.ts
+++ b/ern-container-gen/src/reactNativeBundleAndroid.ts
@@ -1,9 +1,18 @@
 import { BundlingResult, reactnative, shell } from 'ern-core'
 import path from 'path'
 
-export async function reactNativeBundleAndroid(
+export async function reactNativeBundleAndroid({
+  workingDir,
+  outDir,
+}: {
+  workingDir?: string
   outDir: string
-): Promise<BundlingResult> {
+}): Promise<BundlingResult> {
+  if (!outDir) {
+    throw new Error(
+      '[reactNativeBundleAndroid] missing mandatory outDir parameter'
+    )
+  }
   const libSrcMainPath = path.join(outDir, 'lib', 'src', 'main')
   const bundleOutput = path.join(
     libSrcMainPath,
@@ -12,11 +21,21 @@ export async function reactNativeBundleAndroid(
   )
   const assetsDest = path.join(libSrcMainPath, 'res')
 
-  return reactnative.bundle({
-    assetsDest,
-    bundleOutput,
-    dev: false,
-    entryFile: 'index.android.js',
-    platform: 'android',
-  })
+  if (workingDir) {
+    shell.pushd(workingDir)
+  }
+  try {
+    const result = await reactnative.bundle({
+      assetsDest,
+      bundleOutput,
+      dev: false,
+      entryFile: 'index.android.js',
+      platform: 'android',
+    })
+    return result
+  } finally {
+    if (workingDir) {
+      shell.popd()
+    }
+  }
 }

--- a/ern-container-gen/src/reactNativeBundleIos.ts
+++ b/ern-container-gen/src/reactNativeBundleIos.ts
@@ -2,9 +2,18 @@ import { BundlingResult, reactnative, shell } from 'ern-core'
 import fs from 'fs'
 import path from 'path'
 
-export async function reactNativeBundleIos(
+export async function reactNativeBundleIos({
+  workingDir,
+  outDir,
+}: {
+  workingDir?: string
   outDir: string
-): Promise<BundlingResult> {
+}): Promise<BundlingResult> {
+  if (!outDir) {
+    throw new Error(
+      '[reactNativeBundleAndroid] missing mandatory outDir parameter'
+    )
+  }
   const miniAppOutPath = path.join(
     outDir,
     'ElectrodeContainer',
@@ -18,11 +27,21 @@ export async function reactNativeBundleIos(
     shell.mkdir('-p', miniAppOutPath)
   }
 
-  return reactnative.bundle({
-    assetsDest,
-    bundleOutput,
-    dev: false,
-    entryFile: 'index.ios.js',
-    platform: 'ios',
-  })
+  if (workingDir) {
+    shell.pushd(workingDir)
+  }
+  try {
+    const result = await reactnative.bundle({
+      assetsDest,
+      bundleOutput,
+      dev: false,
+      entryFile: 'index.ios.js',
+      platform: 'ios',
+    })
+    return result
+  } finally {
+    if (workingDir) {
+      shell.popd()
+    }
+  }
 }

--- a/ern-core/src/android.ts
+++ b/ern-core/src/android.ts
@@ -221,9 +221,13 @@ export async function androidGetBootAnimProp() {
 // - projectPath : Absolute or relative path to the root of the Android project
 // containing the application
 export async function buildAndInstallApp(projectPath: string) {
-  shell.cd(projectPath)
-  const gradlew = getGradleByPlatform()
-  return execp(`${gradlew} installDebug`)
+  shell.pushd(projectPath)
+  try {
+    const gradlew = getGradleByPlatform()
+    return execp(`${gradlew} installDebug`)
+  } finally {
+    shell.popd()
+  }
 }
 
 export function getGradleByPlatform(): string {

--- a/ern-core/src/iosUtil.ts
+++ b/ern-core/src/iosUtil.ts
@@ -26,254 +26,277 @@ export async function fillProjectHull(
   mustacheView?: any
 ) {
   log.debug(`[=== Starting iOS framework project hull filling ===]`)
-  shell.cd(pathSpec.rootDir)
+  shell.pushd(pathSpec.rootDir)
 
-  if (!fs.existsSync(pathSpec.outputDir)) {
-    shell.mkdir(pathSpec.outputDir)
-  }
-
-  shell.cp('-R', pathSpec.projectHullDir, pathSpec.outputDir)
-
-  if (mustacheView) {
-    log.debug(`iOS: reading template files to be rendered for plugins`)
-    const files = readDir(pathSpec.outputDir)
-    for (const file of files) {
-      if (file.endsWith('.h') || file.endsWith('.m')) {
-        const pathToOutputFile = path.join(pathSpec.outputDir, file)
-        await mustacheUtils.mustacheRenderToOutputFileUsingTemplateFile(
-          pathToOutputFile,
-          mustacheView,
-          pathToOutputFile
-        )
-      }
-    }
-  }
-  const projectPath = path.join(
-    pathSpec.outputDir,
-    `${projectSpec.projectName}.xcodeproj`,
-    'project.pbxproj'
-  )
-  const librariesPath = path.join(
-    pathSpec.outputDir,
-    projectSpec.projectName,
-    'Libraries'
-  )
-  const iosProject = await getIosProject(projectPath)
-  const target = iosProject.findTargetKey(projectSpec.projectName)
-
-  const injectPluginsTaskMsg = 'Injecting Native Dependencies'
-  const injectPluginsKaxTask = kax.task(injectPluginsTaskMsg)
-  for (const plugin of plugins) {
-    if (await isDependencyJsApiImpl(plugin)) {
-      log.debug('JS api implementation identified, skipping fill hull.')
-      continue
+  try {
+    if (!fs.existsSync(pathSpec.outputDir)) {
+      shell.mkdir(pathSpec.outputDir)
     }
 
-    const pluginConfig = await manifest.getPluginConfig(
-      plugin,
-      projectSpec.projectName
-    )
+    shell.cp('-R', pathSpec.projectHullDir, pathSpec.outputDir)
 
-    shell.cd(pathSpec.pluginsDownloadDirectory)
-    if (pluginConfig.ios) {
-      log.debug(`Retrieving ${plugin.basePath}`)
-      const pluginSourcePath = await downloadPluginSource(pluginConfig.origin)
-      if (!pluginSourcePath) {
-        throw new Error(`Was not able to download ${plugin.basePath}`)
-      }
-
-      injectPluginsKaxTask.text = `${injectPluginsTaskMsg} [${plugin.basePath}]`
-
-      if (pluginConfig.ios.copy) {
-        for (const copy of pluginConfig.ios.copy) {
-          if (switchToOldDirectoryStructure(pluginSourcePath, copy.source)) {
-            log.debug(
-              `Handling copy directive: Falling back to old directory structure for API(Backward compatibility)`
-            )
-            copy.source = path.join('IOS', 'IOS', 'Classes', 'SwaggersAPIs')
-          }
-        }
-        handleCopyDirective(
-          pluginSourcePath,
-          pathSpec.outputDir,
-          pluginConfig.ios.copy
-        )
-      }
-
-      if (pluginConfig.ios.replaceInFile) {
-        for (const r of pluginConfig.ios.replaceInFile) {
-          const pathToFile = path.join(pathSpec.outputDir, r.path)
-          const fileContent = fs.readFileSync(pathToFile, 'utf8')
-          const patchedFileContent = fileContent.replace(
-            RegExp(r.string, 'g'),
-            r.replaceWith
+    if (mustacheView) {
+      log.debug(`iOS: reading template files to be rendered for plugins`)
+      const files = readDir(pathSpec.outputDir)
+      for (const file of files) {
+        if (file.endsWith('.h') || file.endsWith('.m')) {
+          const pathToOutputFile = path.join(pathSpec.outputDir, file)
+          await mustacheUtils.mustacheRenderToOutputFileUsingTemplateFile(
+            pathToOutputFile,
+            mustacheView,
+            pathToOutputFile
           )
-          fs.writeFileSync(pathToFile, patchedFileContent, { encoding: 'utf8' })
-        }
-      }
-
-      if (pluginConfig.ios.pbxproj) {
-        if (pluginConfig.ios.pbxproj.addSource) {
-          for (const source of pluginConfig.ios.pbxproj.addSource) {
-            // Multiple source files
-            if (source.from) {
-              if (
-                switchToOldDirectoryStructure(pluginSourcePath, source.from)
-              ) {
-                log.debug(
-                  `Source Copy: Falling back to old directory structure for API(Backward compatibility)`
-                )
-                source.from = path.join(
-                  'IOS',
-                  'IOS',
-                  'Classes',
-                  'SwaggersAPIs',
-                  '*.swift'
-                )
-              }
-              const relativeSourcePath = path.dirname(source.from)
-              const pathToSourceFiles = path.join(
-                pluginSourcePath,
-                relativeSourcePath
-              )
-              const fileNames = _.filter(fs.readdirSync(pathToSourceFiles), f =>
-                f.endsWith(path.extname(source.from!))
-              )
-              for (const fileName of fileNames) {
-                const fileNamePath = path.join(source.path, fileName)
-                iosProject.addSourceFile(
-                  fileNamePath,
-                  null,
-                  iosProject.findPBXGroupKey({ name: source.group })
-                )
-              }
-            } else {
-              // Single source file
-              iosProject.addSourceFile(
-                source.path,
-                null,
-                iosProject.findPBXGroupKey({ name: source.group })
-              )
-            }
-          }
-        }
-
-        if (pluginConfig.ios.pbxproj.addHeader) {
-          for (const header of pluginConfig.ios.pbxproj.addHeader) {
-            // Multiple header files
-            if (header.from) {
-              if (
-                switchToOldDirectoryStructure(pluginSourcePath, header.from)
-              ) {
-                log.debug(
-                  `Header Copy: Falling back to old directory structure for API(Backward compatibility)`
-                )
-                header.from = path.join(
-                  'IOS',
-                  'IOS',
-                  'Classes',
-                  'SwaggersAPIs',
-                  '*.swift'
-                )
-              }
-              const relativeHeaderPath = path.dirname(header.from)
-              const pathToHeaderFiles = path.join(
-                pluginSourcePath,
-                relativeHeaderPath
-              )
-              const fileNames = _.filter(fs.readdirSync(pathToHeaderFiles), f =>
-                f.endsWith(path.extname(header.from!))
-              )
-              for (const fileName of fileNames) {
-                const fileNamePath = path.join(header.path, fileName)
-                iosProject.addHeaderFile(
-                  fileNamePath,
-                  { public: header.public },
-                  iosProject.findPBXGroupKey({ name: header.group })
-                )
-              }
-            } else {
-              const headerPath = header.path
-              iosProject.addHeaderFile(
-                headerPath,
-                { public: header.public },
-                iosProject.findPBXGroupKey({ name: header.group })
-              )
-            }
-          }
-        }
-
-        if (pluginConfig.ios.pbxproj.addFile) {
-          for (const file of pluginConfig.ios.pbxproj.addFile) {
-            iosProject.addFile(
-              file.path,
-              iosProject.findPBXGroupKey({ name: file.group })
-            )
-            // Add target dep in any case for now, will rework later
-            iosProject.addTargetDependency(target, [
-              `"${path.basename(file.path)}"`,
-            ])
-          }
-        }
-
-        if (pluginConfig.ios.pbxproj.addFramework) {
-          for (const framework of pluginConfig.ios.pbxproj.addFramework) {
-            iosProject.addFramework(framework, {
-              customFramework: true,
-            })
-          }
-        }
-
-        if (pluginConfig.ios.pbxproj.addProject) {
-          for (const project of pluginConfig.ios.pbxproj.addProject) {
-            const projectAbsolutePath = path.join(
-              librariesPath,
-              project.path,
-              'project.pbxproj'
-            )
-            const options = {
-              addAsTargetDependency: project.addAsTargetDependency,
-              frameworks: project.frameworks,
-              projectAbsolutePath,
-              staticLibs: project.staticLibs,
-            }
-            iosProject.addProject(project.path, project.group, target, options)
-          }
-        }
-
-        if (pluginConfig.ios.pbxproj.addStaticLibrary) {
-          for (const lib of pluginConfig.ios.pbxproj.addStaticLibrary) {
-            iosProject.addStaticLibrary(lib)
-          }
-        }
-
-        if (pluginConfig.ios.pbxproj.addHeaderSearchPath) {
-          for (const p of pluginConfig.ios.pbxproj.addHeaderSearchPath) {
-            iosProject.addToHeaderSearchPaths(p)
-          }
-        }
-
-        if (pluginConfig.ios.pbxproj.addFrameworkReference) {
-          for (const frameworkReference of pluginConfig.ios.pbxproj
-            .addFrameworkReference) {
-            iosProject.addFramework(frameworkReference, {
-              customFramework: true,
-            })
-          }
-        }
-
-        if (pluginConfig.ios.pbxproj.addFrameworkSearchPath) {
-          for (const p of pluginConfig.ios.pbxproj.addFrameworkSearchPath) {
-            iosProject.addToFrameworkSearchPaths(p)
-          }
         }
       }
     }
-  }
-  injectPluginsKaxTask.succeed(injectPluginsTaskMsg)
+    const projectPath = path.join(
+      pathSpec.outputDir,
+      `${projectSpec.projectName}.xcodeproj`,
+      'project.pbxproj'
+    )
+    const librariesPath = path.join(
+      pathSpec.outputDir,
+      projectSpec.projectName,
+      'Libraries'
+    )
+    const iosProject = await getIosProject(projectPath)
+    const target = iosProject.findTargetKey(projectSpec.projectName)
 
-  log.debug(`[=== Completed framework generation ===]`)
-  return { iosProject, projectPath }
+    const injectPluginsTaskMsg = 'Injecting Native Dependencies'
+    const injectPluginsKaxTask = kax.task(injectPluginsTaskMsg)
+    for (const plugin of plugins) {
+      if (await isDependencyJsApiImpl(plugin)) {
+        log.debug('JS api implementation identified, skipping fill hull.')
+        continue
+      }
+
+      const pluginConfig = await manifest.getPluginConfig(
+        plugin,
+        projectSpec.projectName
+      )
+
+      shell.pushd(pathSpec.pluginsDownloadDirectory)
+      try {
+        if (pluginConfig.ios) {
+          log.debug(`Retrieving ${plugin.basePath}`)
+          const pluginSourcePath = await downloadPluginSource(
+            pluginConfig.origin
+          )
+          if (!pluginSourcePath) {
+            throw new Error(`Was not able to download ${plugin.basePath}`)
+          }
+
+          injectPluginsKaxTask.text = `${injectPluginsTaskMsg} [${
+            plugin.basePath
+          }]`
+
+          if (pluginConfig.ios.copy) {
+            for (const copy of pluginConfig.ios.copy) {
+              if (
+                switchToOldDirectoryStructure(pluginSourcePath, copy.source)
+              ) {
+                log.debug(
+                  `Handling copy directive: Falling back to old directory structure for API(Backward compatibility)`
+                )
+                copy.source = path.join('IOS', 'IOS', 'Classes', 'SwaggersAPIs')
+              }
+            }
+            handleCopyDirective(
+              pluginSourcePath,
+              pathSpec.outputDir,
+              pluginConfig.ios.copy
+            )
+          }
+
+          if (pluginConfig.ios.replaceInFile) {
+            for (const r of pluginConfig.ios.replaceInFile) {
+              const pathToFile = path.join(pathSpec.outputDir, r.path)
+              const fileContent = fs.readFileSync(pathToFile, 'utf8')
+              const patchedFileContent = fileContent.replace(
+                RegExp(r.string, 'g'),
+                r.replaceWith
+              )
+              fs.writeFileSync(pathToFile, patchedFileContent, {
+                encoding: 'utf8',
+              })
+            }
+          }
+
+          if (pluginConfig.ios.pbxproj) {
+            if (pluginConfig.ios.pbxproj.addSource) {
+              for (const source of pluginConfig.ios.pbxproj.addSource) {
+                // Multiple source files
+                if (source.from) {
+                  if (
+                    switchToOldDirectoryStructure(pluginSourcePath, source.from)
+                  ) {
+                    log.debug(
+                      `Source Copy: Falling back to old directory structure for API(Backward compatibility)`
+                    )
+                    source.from = path.join(
+                      'IOS',
+                      'IOS',
+                      'Classes',
+                      'SwaggersAPIs',
+                      '*.swift'
+                    )
+                  }
+                  const relativeSourcePath = path.dirname(source.from)
+                  const pathToSourceFiles = path.join(
+                    pluginSourcePath,
+                    relativeSourcePath
+                  )
+                  const fileNames = _.filter(
+                    fs.readdirSync(pathToSourceFiles),
+                    f => f.endsWith(path.extname(source.from!))
+                  )
+                  for (const fileName of fileNames) {
+                    const fileNamePath = path.join(source.path, fileName)
+                    iosProject.addSourceFile(
+                      fileNamePath,
+                      null,
+                      iosProject.findPBXGroupKey({ name: source.group })
+                    )
+                  }
+                } else {
+                  // Single source file
+                  iosProject.addSourceFile(
+                    source.path,
+                    null,
+                    iosProject.findPBXGroupKey({ name: source.group })
+                  )
+                }
+              }
+            }
+
+            if (pluginConfig.ios.pbxproj.addHeader) {
+              for (const header of pluginConfig.ios.pbxproj.addHeader) {
+                // Multiple header files
+                if (header.from) {
+                  if (
+                    switchToOldDirectoryStructure(pluginSourcePath, header.from)
+                  ) {
+                    log.debug(
+                      `Header Copy: Falling back to old directory structure for API(Backward compatibility)`
+                    )
+                    header.from = path.join(
+                      'IOS',
+                      'IOS',
+                      'Classes',
+                      'SwaggersAPIs',
+                      '*.swift'
+                    )
+                  }
+                  const relativeHeaderPath = path.dirname(header.from)
+                  const pathToHeaderFiles = path.join(
+                    pluginSourcePath,
+                    relativeHeaderPath
+                  )
+                  const fileNames = _.filter(
+                    fs.readdirSync(pathToHeaderFiles),
+                    f => f.endsWith(path.extname(header.from!))
+                  )
+                  for (const fileName of fileNames) {
+                    const fileNamePath = path.join(header.path, fileName)
+                    iosProject.addHeaderFile(
+                      fileNamePath,
+                      { public: header.public },
+                      iosProject.findPBXGroupKey({ name: header.group })
+                    )
+                  }
+                } else {
+                  const headerPath = header.path
+                  iosProject.addHeaderFile(
+                    headerPath,
+                    { public: header.public },
+                    iosProject.findPBXGroupKey({ name: header.group })
+                  )
+                }
+              }
+            }
+
+            if (pluginConfig.ios.pbxproj.addFile) {
+              for (const file of pluginConfig.ios.pbxproj.addFile) {
+                iosProject.addFile(
+                  file.path,
+                  iosProject.findPBXGroupKey({ name: file.group })
+                )
+                // Add target dep in any case for now, will rework later
+                iosProject.addTargetDependency(target, [
+                  `"${path.basename(file.path)}"`,
+                ])
+              }
+            }
+
+            if (pluginConfig.ios.pbxproj.addFramework) {
+              for (const framework of pluginConfig.ios.pbxproj.addFramework) {
+                iosProject.addFramework(framework, {
+                  customFramework: true,
+                })
+              }
+            }
+
+            if (pluginConfig.ios.pbxproj.addProject) {
+              for (const project of pluginConfig.ios.pbxproj.addProject) {
+                const projectAbsolutePath = path.join(
+                  librariesPath,
+                  project.path,
+                  'project.pbxproj'
+                )
+                const options = {
+                  addAsTargetDependency: project.addAsTargetDependency,
+                  frameworks: project.frameworks,
+                  projectAbsolutePath,
+                  staticLibs: project.staticLibs,
+                }
+                iosProject.addProject(
+                  project.path,
+                  project.group,
+                  target,
+                  options
+                )
+              }
+            }
+
+            if (pluginConfig.ios.pbxproj.addStaticLibrary) {
+              for (const lib of pluginConfig.ios.pbxproj.addStaticLibrary) {
+                iosProject.addStaticLibrary(lib)
+              }
+            }
+
+            if (pluginConfig.ios.pbxproj.addHeaderSearchPath) {
+              for (const p of pluginConfig.ios.pbxproj.addHeaderSearchPath) {
+                iosProject.addToHeaderSearchPaths(p)
+              }
+            }
+
+            if (pluginConfig.ios.pbxproj.addFrameworkReference) {
+              for (const frameworkReference of pluginConfig.ios.pbxproj
+                .addFrameworkReference) {
+                iosProject.addFramework(frameworkReference, {
+                  customFramework: true,
+                })
+              }
+            }
+
+            if (pluginConfig.ios.pbxproj.addFrameworkSearchPath) {
+              for (const p of pluginConfig.ios.pbxproj.addFrameworkSearchPath) {
+                iosProject.addToFrameworkSearchPaths(p)
+              }
+            }
+          }
+        }
+      } finally {
+        shell.popd()
+      }
+    }
+    injectPluginsKaxTask.succeed(injectPluginsTaskMsg)
+
+    log.debug(`[=== Completed framework generation ===]`)
+    return { iosProject, projectPath }
+  } finally {
+    shell.popd()
+  }
 }
 
 async function getIosProject(projectPath: string): Promise<any> {

--- a/ern-local-cli/src/commands/list/dependencies.ts
+++ b/ern-local-cli/src/commands/list/dependencies.ts
@@ -23,8 +23,12 @@ export const handler = async ({ module }: { module?: string }) => {
     let pathToModule = process.cwd()
     if (module) {
       pathToModule = createTmpDir()
-      shell.cd(pathToModule)
-      await yarn.add(PackagePath.fromString(module))
+      shell.pushd(pathToModule)
+      try {
+        await yarn.add(PackagePath.fromString(module))
+      } finally {
+        shell.popd()
+      }
     }
     const dependencies = await findNativeDependencies(
       path.join(pathToModule, 'node_modules')


### PR DESCRIPTION
Replace usage of `cd` with `pushd/popd` combo.
`cd` is pretty bad as it can lead to side effects hard to debug, so it's better to use `pushd` to enter a directory and then `popd` once work in directory is complete.