### PR TITLE
Introduce Electrode Native version enforcement by Cauldron

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -106,6 +106,7 @@
   - [jsapiimpls](cli/cauldron/update/jsapiimpls.md)
   - [miniapps](cli/cauldron/update/miniapps.md)
   - [nativeapp](cli/cauldron/update/nativeapp.md)
+  - [ernversion](cli/cauldron/update/ernversion.md)
 - [cauldron batch](cli/cauldron/batch.md)
 - [cauldron regen-container](cli/cauldron/regen-container.md)
 - [cauldron upgrade](cli/cauldron/upgrade.md)

--- a/docs/cli/cauldron/update/ernversion.md
+++ b/docs/cli/cauldron/update/ernversion.md
@@ -1,0 +1,26 @@
+## `ern cauldron update ernversion`
+
+#### Description
+
+* Update the Electrode Native version enforced by this Cauldron.
+* Enforcing an Electrode Native is a good practice as it ensures that all clients of this Cauldron are using a similar Electrode Native version.
+* Only enforces Electrode Native versions greater than or equal to 0.24.0
+
+#### Syntax
+
+`ern cauldron update ernversion`  
+
+**Options**  
+
+`--version`
+
+* Specify the version of Electrode Native to be enforced for clients of this Cauldron. 
+* Value can be set as **none** if you wish to disable Electrode Native version enforcement for this Cauldron (thus allowing clients using any version of Electrode Native to access this Cauldron).
+* Only valid (available) Electrode Native versions are allowed.
+* At this time, it is only possible to do a forward version update (for example if the current enforced version is 0.21.0, it is not possible to update enforcement to 0.20.0)
+* **Default** Current Electrode Native version.
+
+`--force`
+
+* Force the Electrode Native version enforcement, even if the version is not an available, or if it is a lower than the currently enforced version.  
+**Default**  false

--- a/ern-cauldron-api/src/CauldronApi.ts
+++ b/ern-cauldron-api/src/CauldronApi.ts
@@ -89,6 +89,11 @@ export default class CauldronApi {
     return cauldron.schemaVersion || '0.0.0'
   }
 
+  public async getElectrodeNativeVersion(): Promise<string | void> {
+    const cauldron = await this.getCauldron()
+    return cauldron.ernVersion
+  }
+
   public async getDescriptor(
     descriptor: NativeApplicationDescriptor
   ): Promise<any> {
@@ -359,6 +364,19 @@ export default class CauldronApi {
     const cauldron = await this.getCauldron()
     cauldron.nativeApps = []
     return this.commit('Clear Cauldron')
+  }
+
+  public async setElectrodeNativeVersion(version?: string): Promise<void> {
+    const cauldron = await this.getCauldron()
+    if (!version) {
+      delete cauldron.ernVersion
+      return this.commit('Removed Electrode Native version enforcement')
+    } else {
+      cauldron.ernVersion = version
+      return this.commit(
+        `Update enforced Electrode Native Version to ${version}`
+      )
+    }
   }
 
   public async addDescriptor(

--- a/ern-cauldron-api/src/CauldronHelper.ts
+++ b/ern-cauldron-api/src/CauldronHelper.ts
@@ -47,6 +47,14 @@ export class CauldronHelper {
     return this.cauldron.upgradeCauldronSchema()
   }
 
+  public async getElectrodeNativeVersion(): Promise<string | void> {
+    return this.cauldron.getElectrodeNativeVersion()
+  }
+
+  public async setElectrodeNativeVersion(version?: string): Promise<void> {
+    return this.cauldron.setElectrodeNativeVersion(version)
+  }
+
   public async isDescriptorInCauldron(
     napDescriptor: NativeApplicationDescriptor
   ): Promise<boolean> {

--- a/ern-cauldron-api/src/types/Cauldron.ts
+++ b/ern-cauldron-api/src/types/Cauldron.ts
@@ -1,5 +1,6 @@
 import { CauldronNativeApp } from './CauldronNativeApp'
 export interface Cauldron {
+  ernVersion?: string
   schemaVersion: string
   config?: any
   nativeApps: CauldronNativeApp[]

--- a/ern-local-cli/src/commands/cauldron/update/ernversion.ts
+++ b/ern-local-cli/src/commands/cauldron/update/ernversion.ts
@@ -1,0 +1,74 @@
+import { utils as coreUtils, log, Platform } from 'ern-core'
+import { getActiveCauldron } from 'ern-cauldron-api'
+import utils from '../../../lib/utils'
+import { Argv } from 'yargs'
+import semver from 'semver'
+
+export const command = 'ernversion'
+export const desc =
+  'Update the Electrode Native version enforced by this Cauldron'
+
+export const builder = (argv: Argv) => {
+  return argv
+    .option('version', {
+      default: Platform.currentVersion,
+      describe: 'Version of Electrode Native to be enforced by the Cauldron',
+      type: 'string',
+    })
+    .option('force', {
+      default: false,
+      describe: 'Force version update',
+      type: 'boolean',
+    })
+}
+
+export const handler = async ({
+  version,
+  force,
+}: {
+  version: string
+  force: boolean
+}) => {
+  try {
+    const cauldron = await getActiveCauldron({
+      ignoreElectrodeNativeVersionMismatch: true,
+    })
+    if (!cauldron) {
+      throw new Error('A Cauldron must be active in order to use this command')
+    }
+
+    if (version === 'none') {
+      await cauldron.setElectrodeNativeVersion()
+      return log.info(
+        'Removed Electrode Native version enforcement from Cauldron'
+      )
+    }
+
+    if (!Platform.isPlatformVersionAvailable(version) && !force) {
+      throw new Error(
+        `${version} is not an available Electrode Native version.
+If you know what you're doing and want to use this version anyway, you can run the command again with the --force flag`
+      )
+    }
+
+    const currentErnVersionEnforcedByCauldron = await cauldron.getElectrodeNativeVersion()
+    if (
+      currentErnVersionEnforcedByCauldron &&
+      semver.lt(version, currentErnVersionEnforcedByCauldron) &&
+      !force
+    ) {
+      throw new Error(
+        `${version} is lower than current version ${currentErnVersionEnforcedByCauldron}.
+  It is only possible to update the enforced version to a version greater than the current one.
+  If you know what you're doing and want to use this version anyway, you can run the command again with the --force flag`
+      )
+    }
+
+    await cauldron.setElectrodeNativeVersion(version)
+    log.info(
+      `Updated Electrode Native version enforced by the Cauldron to ${version}`
+    )
+  } catch (e) {
+    coreUtils.logErrorAndExitProcess(e)
+  }
+}

--- a/ern-local-cli/src/commands/cauldron/upgrade.ts
+++ b/ern-local-cli/src/commands/cauldron/upgrade.ts
@@ -10,6 +10,7 @@ export const builder = (argv: Argv) => {
 export const handler = async () => {
   try {
     const cauldron = await getActiveCauldron({
+      ignoreElectrodeNativeVersionMismatch: true,
       ignoreSchemaVersionMismatch: true,
     })
     if (!cauldron) {


### PR DESCRIPTION
Add a way to enforce a specific Electrode Native version to be used by all clients of a Cauldron.

Enforcement will be active by default on newly created Cauldrons. Existing Cauldrons will have to explicitly opt-in for this feature by using the new `ern cauldron update ernversion` command, to set an initial version to be enforced.

A new command is introduced, part of this feature : `ern cauldron update ernversion`. This command allows to update the version of Electrode Native that is enforced by the Cauldron, thus allowing a Cauldron owner to control the EN version of all clients connecting to the Cauldron.

If Cauldron Electrode Native version enforcement is active, any user running a different version of Electrode Native will be denied any operation involving the Cauldron. They will be prompted to either update their Electrode Native version or to update the Electrode Native version enforced by the Cauldron.

To be noted that version `1000.0.0` of Electrode Native (development version) is bypassing enforcement (meaning that it can access any Cauldron, whatever Electrode Native version enforced by the target Cauldron).

Also to be noted that this enforcement will only work for Electrode Native versions >= 0.24.0, as this feature will be released in this upcoming version. For example, if the Cauldron is enforcing version 0.24.0 but the client is using 0.21.0, the enforcement will be bypassed given that 0.21.0 does not contain the enforcement code.