### PR TITLE
Only regenerate JS bundle when no native dependencies changed

### DIFF
--- a/ern-container-gen/src/getContainerMetadata.ts
+++ b/ern-container-gen/src/getContainerMetadata.ts
@@ -1,10 +1,13 @@
 import { ContainerMetadata } from './types'
 import { fileUtils } from 'ern-core'
 import { getContainerMetadataPath } from './getContainerMetadataPath'
+import fs from 'fs'
 
 export async function getContainerMetadata(
   containerPath: string
-): Promise<ContainerMetadata> {
+): Promise<ContainerMetadata | void> {
   const pathToMetadataFile = getContainerMetadataPath(containerPath)
-  return fileUtils.readJSON(pathToMetadataFile)
+  if (fs.existsSync(pathToMetadataFile)) {
+    return fileUtils.readJSON(pathToMetadataFile)
+  }
 }

--- a/ern-container-gen/src/types/ContainerGenResult.ts
+++ b/ern-container-gen/src/types/ContainerGenResult.ts
@@ -2,7 +2,11 @@ import { BundlingResult } from 'ern-core'
 
 export interface ContainerGenResult {
   /**
-   *  Metadata resulting from the bundling
+   * Metadata resulting from the bundling
    */
   bundlingResult: BundlingResult
+  /**
+   * Indicates whether only the JS bundle was generated
+   */
+  generatedJsBundleOnly: boolean
 }

--- a/ern-container-gen/src/types/ContainerGeneratorConfig.ts
+++ b/ern-container-gen/src/types/ContainerGeneratorConfig.ts
@@ -37,4 +37,9 @@ export interface ContainerGeneratorConfig {
    * Path to the current yarn lock
    */
   pathToYarnLock?: string
+  /**
+   * Forces full Container generation even if no native dependencies versions
+   * have changed compared to a previous cached generation
+   */
+  forceFullGeneration?: boolean
 }

--- a/ern-local-cli/src/commands/cauldron/regen-container.ts
+++ b/ern-local-cli/src/commands/cauldron/regen-container.ts
@@ -116,7 +116,7 @@ export const handler = async ({
       },
       napDescriptor,
       `Regenerate Container of ${napDescriptor.toString()} native application`,
-      { containerVersion }
+      { containerVersion, forceFullGeneration: true }
     )
     log.debug(`Container was succesfully regenerated !`)
   } catch (e) {


### PR DESCRIPTION
Improves Container generation speed when no native dependencies have changed compared to previous generation. If that is the case, only the JS bundle will be regenerated.

This feature does not apply for the `cauldron regen-container` command, given that this command is meant to fully regenerate a container even if nothing has changed within the Container (mostly of use in case of invalid plugin injection configuration).

Here are some performance metrics, for a complex reference Container :
- Full generation : 17 minutes
- Using cached packages feature (EN 0.21) : 11 minutes
- Using cache packages + this PR : 8 minutes

Please note that as for cached packages features, the directory of the previous generated container (`~/.ern/containergen` by default, or custom directory if modified through config) needs to be present for this feature to work. Therefore, if you are generating Container from a CI job, make sure that the `~/.ern` (or custom ern home directory) is not wiped out after or before a build.