### PR TITLE
Bump xcode-ern version

### DIFF
--- a/ern-api-impl-gen/package.json
+++ b/ern-api-impl-gen/package.json
@@ -58,7 +58,7 @@
     "mustache": "^2.3.1",
     "semver": "5.5.0",
     "xcode": "^1.0.0",
-    "xcode-ern": "^1.0.9",
+    "xcode-ern": "^1.0.10",
     "@yarnpkg/lockfile": "^1.0.2"
   },
   "devDependencies": {

--- a/ern-container-gen-ios/package.json
+++ b/ern-container-gen-ios/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "ern-container-gen": "1000.0.0",
     "ern-core": "1000.0.0",
-    "xcode-ern": "^1.0.9",
+    "xcode-ern": "^1.0.10",
     "lodash":"^4.17.10",
     "fs-readdir-recursive": "^1.1.0"
   },

--- a/ern-container-gen/package.json
+++ b/ern-container-gen/package.json
@@ -69,7 +69,7 @@
     "fs-readdir-recursive": "^1.1.0",
     "mustache": "^2.3.1",
     "semver": "^5.5.0",
-    "xcode-ern": "^1.0.9"
+    "xcode-ern": "^1.0.10"
   },
   "devDependencies": {
     "ern-util-dev": "1000.0.0",

--- a/ern-core/package.json
+++ b/ern-core/package.json
@@ -63,7 +63,7 @@
     "simple-git": "^1.96.0",
     "tmp": "^0.0.33",
     "uuid":"^3.3.2",
-    "xcode-ern": "^1.0.9",
+    "xcode-ern": "^1.0.10",
     "yarn": "^1.9.4"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5990,9 +5990,9 @@ write-pkg@^3.1.0:
     sort-keys "^2.0.0"
     write-json-file "^2.2.0"
 
-xcode-ern@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/xcode-ern/-/xcode-ern-1.0.9.tgz#f70243736c169db605a4bb6f1575807561333e48"
+xcode-ern@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/xcode-ern/-/xcode-ern-1.0.10.tgz#1110691d525152d183d66c2968b179e1dc56b50b"
   dependencies:
     pegjs "^0.10.0"
     simple-plist "^0.2.1"


### PR DESCRIPTION
Bump `xcode-ern` version from `1.0.9` to `1.0.10` as it contains a fix for the `addFramework` plugin injection directive, which was leading to `.` to be added to the Frameworks Search Path of the ElectrodeContainer, multiple times, once for every framework added.