### PR TITLE
Update iOS API Impl Generator for Swift 4 compatibility

### DIFF
--- a/ern-api-impl-gen/resources/ios/apiController.mustache
+++ b/ern-api-impl-gen/resources/ios/apiController.mustache
@@ -26,6 +26,7 @@ import Foundation
     
     private var requestHandler: {{apiName}}ApiRequestHandlerProvider?
     
+    @objc
     public func register(config: {{apiName}}ApiConfig? = nil)
     {
         // Only register once.


### PR DESCRIPTION
For Swift 4 compatibility, all functions that needs to be invoked from objc, needs to be marked with 
mark with `@objc`, or it will not generate class function in Swift bridge header.

The `register` func in the generated `Controller` class does not have the `@objc` so it leads to an issue when trying to invoke it (with XCode 9.3) : 
<img width="404" alt="screen shot 2018-08-22 at 1 25 11 pm" src="https://user-images.githubusercontent.com/1390588/44489006-262cf180-a60f-11e8-806d-0a7a53b35200.png">
<img width="980" alt="screen shot 2018-08-22 at 1 24 57 pm" src="https://user-images.githubusercontent.com/1390588/44489004-24fbc480-a60f-11e8-9513-34b359bd112c.png">

Fix is just to add the `@objc` to the func.

<img width="410" alt="screen shot 2018-08-22 at 1 27 47 pm" src="https://user-images.githubusercontent.com/1390588/44489014-2cbb6900-a60f-11e8-9e7d-693928d365dd.png">

Just updated the template accordingly. Also compatible with Swift < 4.
