### PR TITLE
Fix default local Container Generator out path

### DIFF
--- a/ern-local-cli/src/lib/container.ts
+++ b/ern-local-cli/src/lib/container.ts
@@ -28,7 +28,7 @@ export async function runLocalContainerGen(
   jsApiImplsPackagePaths: PackagePath[],
   platform: NativePlatform,
   {
-    outDir = path.join(Platform.rootDirectory, 'containergen'),
+    outDir = path.join(Platform.rootDirectory, 'containergen', 'out', platform),
     extraNativeDependencies = [],
     ignoreRnpmAssets = false,
   }: {


### PR DESCRIPTION
Fix invalid default output path for `runLocalContainerGen`. 

It was using `~/.ern/containergen` instead of `~/.ern/containergen/out/ios` or `~/.ern/containergen/out/android`.

This bug was only impacting Containers created locally through `create-container --minapps` command use (without providing an explicit out path). 

For Containers generated from Cauldron, the default path is the proper one.