### PR TITLE
Fix Runner config dev mode with multiple MiniApps

### DIFF
--- a/ern-local-cli/src/lib/utils.ts
+++ b/ern-local-cli/src/lib/utils.ts
@@ -819,16 +819,16 @@ async function runMiniApp(
 
   let napDescriptor: NativeApplicationDescriptor | void
 
-  if (miniapps && miniapps.length > 1 && !mainMiniAppName) {
+  if (miniapps && !mainMiniAppName) {
     throw new Error(
-      'If you provide multiple MiniApps you need to provide the name of the MiniApp to launch'
+      'If you run multiple MiniApps you need to provide the name of the MiniApp to launch'
     )
   }
 
-  if (miniapps && miniapps.length > 1 && dev) {
+  if (miniapps && dev) {
     dev = false
     log.warn(
-      'Turning off dev mode since you are running multiple MiniApps. \nIf you want to start a packager, execute `ern start` command with all the miniapps in a separate terminal.\nCheck this link for more details: https://electrode.gitbooks.io/electrode-native/content/cli/start.html\n'
+      'Turning off dev mode since you are running multiple MiniApps. \nIf you want to start a packager, execute `ern start` command with all the miniapps in a separate terminal.\nCheck this link for more details: https://native.electrode.io/cli-commands/start'
     )
   }
 


### PR DESCRIPTION
Fix a bug in `runMiniApp` func (used by `run-ios` and `run-android` commands) that was leading to the `dev` flag to be still turned on in Runner configuration, when using `run-ios`/`run-android` commands with more than one MiniApp (as done in Getting Started guide). This is causing the dev mode to be enabled, therefore failing Getting Started on iOS when running both MiniApps (MovieList/MovieDetails) together, as React Native iOS will load the bundle from packager if dev mode is enabled and not fallback to the bundle stored in the binary as it is the case for Android.
Because there are multiple MiniApps in the Runner, Electrode Native does not launch a packager but rather creates a bundle stored in the binary.

The bugged code was not considering the local MiniApp in addition to the `miniapps` provided array. As long as there is at least one entry in the `miniapps` array, then it means that this is a runner for multiple miniapps, as the local MiniApp will always count for one.