### PR TITLE
Refactor publishers and transformers factories

### DIFF
--- a/ern-container-publisher/src/getPublisher.ts
+++ b/ern-container-publisher/src/getPublisher.ts
@@ -1,52 +1,16 @@
-import { PackagePath, Platform, shell, yarn, readPackageJson } from 'ern-core'
+import { ModuleFactory, Platform, PackagePath } from 'ern-core'
 import { ContainerPublisher } from './types'
-import fs from 'fs'
-import path from 'path'
 
 const ERN_PUBLISHER_PACKAGE_PREFIX = 'ern-container-publisher-'
-const REGISTRY_PATH_VERSION_RE = new RegExp(/^(.+)@(.+)$/)
+const ERN_PUBLISHER_CACHE_DIRECTORY = Platform.containerPublishersCacheDirectory
+
+const transformerFactory = new ModuleFactory<ContainerPublisher>(
+  ERN_PUBLISHER_PACKAGE_PREFIX,
+  ERN_PUBLISHER_CACHE_DIRECTORY
+)
 
 export default async function getPublisher(
   publisher: string
 ): Promise<ContainerPublisher> {
-  let pathToPublisherEntry
-  if (fs.existsSync(publisher)) {
-    const pathWithSrc = path.join(publisher, 'src')
-    pathToPublisherEntry = fs.existsSync(pathWithSrc) ? pathWithSrc : publisher
-  } else {
-    try {
-      shell.pushd(Platform.containerPublishersCacheDirectory)
-      if (
-        !publisher.startsWith('@') &&
-        !publisher.startsWith(ERN_PUBLISHER_PACKAGE_PREFIX)
-      ) {
-        publisher = `${ERN_PUBLISHER_PACKAGE_PREFIX}${publisher}`
-      }
-      const publisherPackagePath = PackagePath.fromString(publisher)
-      const packageJson = await readPackageJson(
-        Platform.containerPublishersCacheDirectory
-      )
-      if (
-        packageJson.dependencies &&
-        packageJson.dependencies[publisherPackagePath.basePath]
-      ) {
-        await yarn.upgrade(publisherPackagePath)
-      } else {
-        await yarn.add(publisherPackagePath)
-      }
-      const pkgName = REGISTRY_PATH_VERSION_RE.test(publisher)
-        ? REGISTRY_PATH_VERSION_RE.exec(publisher)![1]
-        : publisher
-      pathToPublisherEntry = path.join(
-        Platform.containerPublishersCacheDirectory,
-        'node_modules',
-        pkgName
-      )
-    } finally {
-      shell.popd()
-    }
-  }
-
-  const Publisher = require(pathToPublisherEntry).default
-  return new Publisher()
+  return transformerFactory.getModuleInstance(PackagePath.fromString(publisher))
 }

--- a/ern-container-publisher/src/publishContainer.ts
+++ b/ern-container-publisher/src/publishContainer.ts
@@ -1,15 +1,6 @@
 import { ContainerPublisherConfig } from './types'
 import getPublisher from './getPublisher'
-import {
-  createTmpDir,
-  gitCli,
-  shell,
-  log,
-  Platform,
-  yarn,
-  PackagePath,
-} from 'ern-core'
-import fs from 'fs'
+import { createTmpDir, shell, Platform } from 'ern-core'
 import path from 'path'
 
 export default async function publishContainer(conf: ContainerPublisherConfig) {
@@ -31,16 +22,6 @@ export default async function publishContainer(conf: ContainerPublisherConfig) {
   )
   conf.containerPath = publicationWorkingDir
   conf.ernVersion = Platform.currentVersion
-
-  if (!fs.existsSync(Platform.containerPublishersCacheDirectory)) {
-    shell.mkdir('-p', Platform.containerPublishersCacheDirectory)
-    try {
-      shell.pushd(Platform.containerPublishersCacheDirectory)
-      await yarn.init()
-    } finally {
-      shell.popd()
-    }
-  }
 
   const publisher = await getPublisher(conf.publisher)
 

--- a/ern-container-transformer/src/getTransformer.ts
+++ b/ern-container-transformer/src/getTransformer.ts
@@ -1,54 +1,19 @@
-import { PackagePath, Platform, shell, yarn, readPackageJson } from 'ern-core'
+import { ModuleFactory, Platform, PackagePath } from 'ern-core'
 import { ContainerTransformer } from './types'
-import fs from 'fs'
-import path from 'path'
 
 const ERN_TRANSFORMER_PACKAGE_PREFIX = 'ern-container-transformer-'
-const REGISTRY_PATH_VERSION_RE = new RegExp(/^(.+)@(.+)$/)
+const ERN_TRANSFORMER_CACHE_DIRECTORY =
+  Platform.containerTransformersCacheDirectory
+
+const transformerFactory = new ModuleFactory<ContainerTransformer>(
+  ERN_TRANSFORMER_PACKAGE_PREFIX,
+  ERN_TRANSFORMER_CACHE_DIRECTORY
+)
 
 export default async function getTransformer(
   transformer: string
 ): Promise<ContainerTransformer> {
-  let pathToTransformerEntry
-  if (fs.existsSync(transformer)) {
-    const pathWithSrc = path.join(transformer, 'src')
-    pathToTransformerEntry = fs.existsSync(pathWithSrc)
-      ? pathWithSrc
-      : transformer
-  } else {
-    try {
-      shell.pushd(Platform.containerTransformersCacheDirectory)
-      if (
-        !transformer.startsWith('@') &&
-        !transformer.startsWith(ERN_TRANSFORMER_PACKAGE_PREFIX)
-      ) {
-        transformer = `${ERN_TRANSFORMER_PACKAGE_PREFIX}${transformer}`
-      }
-      const transformerPackagePath = PackagePath.fromString(transformer)
-      const packageJson = await readPackageJson(
-        Platform.containerTransformersCacheDirectory
-      )
-      if (
-        packageJson.dependencies &&
-        packageJson.dependencies[transformerPackagePath.basePath]
-      ) {
-        await yarn.upgrade(transformerPackagePath)
-      } else {
-        await yarn.add(transformerPackagePath)
-      }
-      const pkgName = REGISTRY_PATH_VERSION_RE.test(transformer)
-        ? REGISTRY_PATH_VERSION_RE.exec(transformer)![1]
-        : transformer
-      pathToTransformerEntry = path.join(
-        Platform.containerTransformersCacheDirectory,
-        'node_modules',
-        pkgName
-      )
-    } finally {
-      shell.popd()
-    }
-  }
-
-  const Transformer = require(pathToTransformerEntry).default
-  return new Transformer()
+  return transformerFactory.getModuleInstance(
+    PackagePath.fromString(transformer)
+  )
 }

--- a/ern-container-transformer/src/transformContainer.ts
+++ b/ern-container-transformer/src/transformContainer.ts
@@ -1,23 +1,11 @@
 import { ContainerTransformerConfig } from './types'
 import getTransformer from './getTransformer'
-import { createTmpDir, shell, Platform, yarn } from 'ern-core'
-import fs from 'fs'
-import path from 'path'
+import { Platform } from 'ern-core'
 
 export default async function transformContainer(
   conf: ContainerTransformerConfig
 ) {
   conf.ernVersion = Platform.currentVersion
-
-  if (!fs.existsSync(Platform.containerTransformersCacheDirectory)) {
-    shell.mkdir('-p', Platform.containerTransformersCacheDirectory)
-    try {
-      shell.pushd(Platform.containerTransformersCacheDirectory)
-      await yarn.init()
-    } finally {
-      shell.popd()
-    }
-  }
 
   const transformer = await getTransformer(conf.transformer)
 

--- a/ern-core/src/ModuleFactory.ts
+++ b/ern-core/src/ModuleFactory.ts
@@ -1,0 +1,101 @@
+import fs from 'fs'
+import path from 'path'
+import shell from './shell'
+import { yarn } from './clients'
+import { PackagePath } from './PackagePath'
+import { readPackageJson } from './packageJsonFileUtils'
+
+export class ModuleFactory<T> {
+  public constructor(
+    readonly packagePrefix: string,
+    readonly packageCachePath: string
+  ) {}
+
+  public async getModuleInstance(p: PackagePath): Promise<T> {
+    if (!p.isFilePath && !p.isRegistryPath) {
+      throw new Error(`Not a supported package path : ${p.toString()}`)
+    }
+    const pathToModule = await this.getLocalPathToPackage(p)
+    return this.instantiateModule(pathToModule)
+  }
+
+  private instantiateModule(pathToModule: string): T {
+    const Module = require(pathToModule).default
+    return new Module()
+  }
+
+  private async getLocalPathToPackage(p: PackagePath): Promise<string> {
+    return p.isFilePath
+      ? this.getPathToLocalPackage(p)
+      : await this.getPathToRegistryPackage(p)
+  }
+
+  private getPathToLocalPackage(p: PackagePath): string {
+    const pathWithSrc = path.join(p.basePath, 'src')
+    return fs.existsSync(pathWithSrc) ? pathWithSrc : p.basePath
+  }
+
+  private async getPathToRegistryPackage(p: PackagePath): Promise<string> {
+    if (!this.doesPackageCacheExist()) {
+      await this.createPackageCache()
+    }
+
+    const modulePackagePath = this.processPackageRegistryPath(p)
+    await this.refreshCacheFor(modulePackagePath)
+
+    return path.join(
+      this.packageCachePath,
+      'node_modules',
+      modulePackagePath.basePath
+    )
+  }
+
+  private doesPackageCacheExist(): boolean {
+    return fs.existsSync(this.packageCachePath)
+  }
+
+  private async createPackageCache() {
+    shell.mkdir('-p', this.packageCachePath)
+    try {
+      shell.pushd(this.packageCachePath)
+      await yarn.init()
+    } finally {
+      shell.popd()
+    }
+  }
+
+  private async refreshCacheFor(p: PackagePath) {
+    const packageJson = await readPackageJson(this.packageCachePath)
+    return packageJson.dependencies && packageJson.dependencies[p.basePath]
+      ? this.upgradeCachedPackage(p)
+      : this.addPackageToCache(p)
+  }
+
+  private async addPackageToCache(p: PackagePath) {
+    shell.pushd(this.packageCachePath)
+    try {
+      await yarn.add(p)
+    } finally {
+      shell.popd()
+    }
+  }
+
+  private async upgradeCachedPackage(p: PackagePath) {
+    shell.pushd(this.packageCachePath)
+    try {
+      await yarn.upgrade(p)
+    } finally {
+      shell.popd()
+    }
+  }
+
+  private processPackageRegistryPath(p: PackagePath): PackagePath {
+    if (
+      !p.fullPath.startsWith('@') &&
+      !p.fullPath.startsWith(this.packagePrefix)
+    ) {
+      return PackagePath.fromString(`${this.packagePrefix}${p.fullPath}`)
+    }
+    return p
+  }
+}

--- a/ern-core/src/PackagePath.ts
+++ b/ern-core/src/PackagePath.ts
@@ -35,7 +35,7 @@ export class PackagePath {
    * Package path without version
    * - File path        : path without scheme prefix
    * - Git path         : path without branch/tag/commit
-   * - Registry path    : package name (unscoped)
+   * - Registry path    : package name (including scope if any)
    */
   public readonly basePath: string
 

--- a/ern-core/src/index.ts
+++ b/ern-core/src/index.ts
@@ -38,6 +38,7 @@ export {
   writePackageJson,
   writePackageJsonSync,
 } from './packageJsonFileUtils'
+export { ModuleFactory } from './ModuleFactory'
 
 export const config = _config
 export const Platform = _Platform

--- a/ern-core/test/ModuleFactory-test.ts
+++ b/ern-core/test/ModuleFactory-test.ts
@@ -1,0 +1,164 @@
+import path from 'path'
+import sinon from 'sinon'
+import shell from 'shelljs'
+import fs from 'fs'
+import { assert, expect } from 'chai'
+import { ModuleFactory } from '../src/ModuleFactory'
+import { doesThrow } from 'ern-util-dev'
+import { PackagePath } from 'ern-core/dist/PackagePath'
+import { YarnCli } from '../src/YarnCli'
+
+describe('ModuleFactory', () => {
+  const PACKAGE_PREFIX = 'package-prefix-'
+  const PACKAGE_CACHE_PATH = path.join(__dirname, 'ModuleFactoryCache')
+  const FIXTURES_PATH = path.join(__dirname, 'fixtures', 'ModuleFactory')
+
+  const sandbox = sinon.createSandbox()
+
+  // Spies
+  let yarnAddStub
+  let yarnUpgradeStub
+  let instantiateModuleStub
+
+  const removeTestPackageCacheDirectory = () =>
+    shell.rm('-rf', PACKAGE_CACHE_PATH)
+
+  beforeEach(() => {
+    yarnAddStub = sandbox.stub(YarnCli.prototype, 'add')
+    yarnUpgradeStub = sandbox.stub(YarnCli.prototype, 'upgrade')
+    instantiateModuleStub = sandbox.stub(
+      ModuleFactory.prototype,
+      'instantiateModule'
+    )
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  after(() => {
+    removeTestPackageCacheDirectory()
+  })
+
+  describe('constructor', () => {
+    it('should successfully instantiate a ModuleFactory', () => {
+      assert.doesNotThrow(
+        () => new ModuleFactory(PACKAGE_PREFIX, PACKAGE_CACHE_PATH),
+        Error
+      )
+    })
+  })
+
+  describe('getModuleInstance', () => {
+    it('should throw if provided PackagePath is a git path', async () => {
+      const sut = new ModuleFactory(PACKAGE_PREFIX, PACKAGE_CACHE_PATH)
+      assert(
+        await doesThrow(
+          sut.getModuleInstance,
+          sut,
+          PackagePath.fromString('git+ssh://gihub.com/user/repo.git')
+        )
+      )
+    })
+
+    it('should properly instantiate a local package module [without src directory]', async () => {
+      const sut = new ModuleFactory(PACKAGE_PREFIX, PACKAGE_CACHE_PATH)
+      const modulePath = path.join(FIXTURES_PATH, 'moduleWithoutSrc')
+      await sut.getModuleInstance(PackagePath.fromString(modulePath))
+      sandbox.assert.calledWith(instantiateModuleStub, modulePath)
+    })
+
+    it('should properly instantiate a local package module [with src directory]', async () => {
+      const sut = new ModuleFactory(PACKAGE_PREFIX, PACKAGE_CACHE_PATH)
+      const modulePath = path.join(FIXTURES_PATH, 'moduleWithSrc')
+      await sut.getModuleInstance(PackagePath.fromString(modulePath))
+      sandbox.assert.calledWith(
+        instantiateModuleStub,
+        path.join(modulePath, 'src')
+      )
+    })
+
+    it('should create the cache directory if it does not exist [remote registry package]', async () => {
+      // Ensure directory has not already been created
+      removeTestPackageCacheDirectory()
+      sandbox.stub(YarnCli.prototype, 'init').callsFake(() => {
+        fs.writeFileSync('package.json', '{}')
+      })
+      const sut = new ModuleFactory(PACKAGE_PREFIX, PACKAGE_CACHE_PATH)
+      await sut.getModuleInstance(PackagePath.fromString('foo-package'))
+      assert(fs.existsSync(PACKAGE_CACHE_PATH))
+    })
+
+    it('should yarn add the package to the cache if not already cached [remote registry package - add prefix]', async () => {
+      removeTestPackageCacheDirectory()
+      sandbox.stub(YarnCli.prototype, 'init').callsFake(() => {
+        fs.writeFileSync('package.json', '{}')
+      })
+      const sut = new ModuleFactory(PACKAGE_PREFIX, PACKAGE_CACHE_PATH)
+      await sut.getModuleInstance(PackagePath.fromString('foo-package'))
+      sandbox.assert.called(yarnAddStub)
+      expect(yarnAddStub.args[0].toString()).eql('package-prefix-foo-package')
+    })
+
+    it('should yarn add the package to the cache if not already cached [remote registry package - add prefix - with version]', async () => {
+      removeTestPackageCacheDirectory()
+      sandbox.stub(YarnCli.prototype, 'init').callsFake(() => {
+        fs.writeFileSync('package.json', '{}')
+      })
+      const sut = new ModuleFactory(PACKAGE_PREFIX, PACKAGE_CACHE_PATH)
+      await sut.getModuleInstance(PackagePath.fromString('foo-package@^1.0.0'))
+      sandbox.assert.called(yarnAddStub)
+      expect(yarnAddStub.args[0].toString()).eql(
+        'package-prefix-foo-package@^1.0.0'
+      )
+    })
+
+    it('should yarn add the package to the cache if not already cached [remote registry package - do not add prefix]', async () => {
+      removeTestPackageCacheDirectory()
+      sandbox.stub(YarnCli.prototype, 'init').callsFake(() => {
+        fs.writeFileSync('package.json', '{}')
+      })
+      const sut = new ModuleFactory(PACKAGE_PREFIX, PACKAGE_CACHE_PATH)
+      await sut.getModuleInstance(
+        PackagePath.fromString('package-prefix-foo-package')
+      )
+      sandbox.assert.called(yarnAddStub)
+      expect(yarnAddStub.args[0].toString()).eql('package-prefix-foo-package')
+    })
+
+    it('should yarn upgrade the package in the cache if already cached [remote registry package - with version]', async () => {
+      removeTestPackageCacheDirectory()
+      sandbox.stub(YarnCli.prototype, 'init').callsFake(() => {
+        fs.writeFileSync(
+          'package.json',
+          '{ "dependencies": { "package-prefix-foo-package" : "1.0.0" } }'
+        )
+      })
+      const sut = new ModuleFactory(PACKAGE_PREFIX, PACKAGE_CACHE_PATH)
+      await sut.getModuleInstance(
+        PackagePath.fromString('package-prefix-foo-package@^1.0.0')
+      )
+      sandbox.assert.called(yarnUpgradeStub)
+      expect(yarnUpgradeStub.args[0].toString()).eql(
+        'package-prefix-foo-package@^1.0.0'
+      )
+    })
+
+    it('should properly instantiate a remote registry package module from cache', async () => {
+      removeTestPackageCacheDirectory()
+      sandbox.stub(YarnCli.prototype, 'init').callsFake(() => {
+        fs.writeFileSync('package.json', '{}')
+      })
+      const sut = new ModuleFactory(PACKAGE_PREFIX, PACKAGE_CACHE_PATH)
+      await sut.getModuleInstance(
+        PackagePath.fromString('package-prefix-foo-package')
+      )
+      const localPathToModuleInCache = path.join(
+        PACKAGE_CACHE_PATH,
+        'node_modules',
+        'package-prefix-foo-package'
+      )
+      sandbox.assert.calledWith(instantiateModuleStub, localPathToModuleInCache)
+    })
+  })
+})

--- a/ern-core/test/fixtures/ModuleFactory/moduleWithSrc/src/index.js
+++ b/ern-core/test/fixtures/ModuleFactory/moduleWithSrc/src/index.js
@@ -1,0 +1,1 @@
+console.log('Hello World !')

--- a/ern-core/test/fixtures/ModuleFactory/moduleWithoutSrc/index.js
+++ b/ern-core/test/fixtures/ModuleFactory/moduleWithoutSrc/index.js
@@ -1,0 +1,1 @@
+console.log('Hello world !')


### PR DESCRIPTION
Refactor `getTransformer` and `getPublisher` (these methods were close duplicates) by introducing a new class `ModuleFactory` in `ern-core` which generalize the duplicated logic.
By the same occasion refactor the code to split it into smaller granular functions and unit test it fully.