### PR TITLE
add method to remove a mini app view from electrode activity delegate…

### DIFF
--- a/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactActivityDelegate.java
+++ b/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactActivityDelegate.java
@@ -135,6 +135,24 @@ public class ElectrodeReactActivityDelegate extends ReactActivityDelegate {
         }
     }
 
+    /**
+     * Removes the {@link ReactRootView} for the given miniapp (if present) from the list and also unmounts the application..
+     *
+     * @param applicationName {@link String} miniapp name
+     */
+    public void removeMiniAppView(@NonNull String applicationName) {
+        ReactRootView reactRootView;
+        synchronized (mReactRootViews) {
+            reactRootView = mReactRootViews.get(applicationName);
+            if (reactRootView != null) {
+                mReactRootViews.remove(applicationName);
+            }
+        }
+        if (reactRootView != null) {
+            reactRootView.unmountReactApplication();
+        }
+    }
+
     @Override
     protected void loadApp(String appKey) {
         ReactRootView rootView = (ReactRootView) getReactAppView(appKey, getLaunchOptions());


### PR DESCRIPTION
…. This helps activities with multiple fragments to easily destroy views when a fragment is destroyed.