### PR TITLE
Fix code-push command

### DIFF
--- a/ern-core/src/ReactNativeCli.ts
+++ b/ern-core/src/ReactNativeCli.ts
@@ -46,12 +46,14 @@ export default class ReactNativeCli {
     bundleOutput,
     assetsDest,
     platform,
+    workingDir,
   }: {
     entryFile: string
     dev: boolean
     bundleOutput: string
     assetsDest: string
     platform: string
+    workingDir?: string
   }): Promise<BundlingResult> {
     const bundleCommand = `${this.binaryPath} bundle \
 ${entryFile ? `--entry-file=${entryFile}` : ''} \
@@ -60,7 +62,7 @@ ${platform ? `--platform=${platform}` : ''} \
 ${bundleOutput ? `--bundle-output=${bundleOutput}` : ''} \
 ${assetsDest ? `--assets-dest=${assetsDest}` : ''}`
 
-    await execp(bundleCommand)
+    await execp(bundleCommand, { cwd: workingDir })
     return {
       assetsPath: assetsDest,
       bundlePath: bundleOutput,

--- a/ern-local-cli/src/lib/codepush.ts
+++ b/ern-local-cli/src/lib/codepush.ts
@@ -357,6 +357,7 @@ export async function performCodePushOtaUpdate(
         dev: false,
         entryFile: `index.${platform}.js`,
         platform,
+        workingDir: tmpWorkingDir,
       })
     )
 


### PR DESCRIPTION
Fix a bug introduced in https://github.com/electrode-io/electrode-native/pull/889 impacting `ern code-push` commands.

This issue was due to `react-native bundle` command being executed from a wrong directory.
React Native `bundle` command needs to be launched from a directory containing a React Native application (Composite MiniApp in the case of `ern code-push` command).

Prior to https://github.com/electrode-io/electrode-native/pull/889 , `generateMiniAppComposite` was doing a `cd` inside the Composite MiniApp directory, so the `bundle` command run afterward, was inside the correct directory (but not in the right way). With the move to push/popd this was no longer the case. 

Fixed by refactoring `ReactNativeCli` `bundle` function which now accept a `workingDir` to run from, and passing this `workingDir` to `exec` `cwd`

