### PR TITLE
Fix unclosed tag error when using regen-container

### DIFF
--- a/ern-container-gen/src/generateContainer.ts
+++ b/ern-container-gen/src/generateContainer.ts
@@ -54,6 +54,8 @@ export async function generateContainer(
           generatedJsBundleOnly = true
         }
       }
+    } else {
+      shell.rm('-rf', path.join(config.outDir, '{.*,*}'))
     }
   }
 


### PR DESCRIPTION
Fix the following kind of error :

```
✖ runCauldronContainerGen failed: Error: Unclosed tag at 29169
✖ [performContainerStateUpdateInCauldron] An error occurred: Error: Unclosed tag at 29169
✖ An error occurred: Unclosed tag at 29169
```

experienced when using `regen-container` under certain circumstances.