### PR TITLE
Enable package cache by default

### DIFF
--- a/docs/cli/platform/config/set.md
+++ b/docs/cli/platform/config/set.md
@@ -47,7 +47,7 @@ Only apply if the package cache is enabled (`package-cache-enabled` configuratio
 - `package-cache-enabled` [boolean]
 Indicates whether the package cache should be enabled.  
 Enabling the package cache will lead to faster Containers generation, given that all packages versions used for a Container generation, will be retrieved from the cache if available rather than being downloaded upon every generation.
-**default** : false  
+**default** : true  
 
 #### Remarks
  

--- a/ern-core/src/MiniApp.ts
+++ b/ern-core/src/MiniApp.ts
@@ -52,7 +52,10 @@ export class MiniApp {
 
   public static async fromPackagePath(packagePath: PackagePath) {
     let fsPackagePath
-    if (!packagePath.isFilePath && config.getValue('package-cache-enabled')) {
+    if (
+      !packagePath.isFilePath &&
+      config.getValue('package-cache-enabled', true)
+    ) {
       if (!(await packageCache.isInCache(packagePath))) {
         fsPackagePath = await packageCache.addToCache(packagePath)
       } else {

--- a/ern-core/src/utils.ts
+++ b/ern-core/src/utils.ts
@@ -96,16 +96,18 @@ export function getDefaultPackageNameForCamelCaseString(
   const splitArray = splitCamelCaseString(moduleName)
   switch (moduleType) {
     case ModuleType.MINIAPP:
-      return _
-        .filter(splitArray, token => !['mini', 'app'].includes(token))
-        .join('-')
+      return _.filter(
+        splitArray,
+        token => !['mini', 'app'].includes(token)
+      ).join('-')
     case ModuleType.API:
       return _.filter(splitArray, token => !['api'].includes(token)).join('-')
     case ModuleType.JS_API_IMPL:
     case ModuleType.NATIVE_API_IMPL:
-      return _
-        .filter(splitArray, token => !['api', 'impl'].includes(token))
-        .join('-')
+      return _.filter(
+        splitArray,
+        token => !['api', 'impl'].includes(token)
+      ).join('-')
     default:
       return splitArray.join('-')
   }
@@ -278,7 +280,7 @@ export async function downloadPluginSource(pluginOrigin: any): Promise<string> {
         version: pluginOrigin.version,
       })
       const p = PackagePath.fromString(dependency.toString())
-      if (config.getValue('package-cache-enabled')) {
+      if (config.getValue('package-cache-enabled', true)) {
         if (!(await packageCache.isInCache(p))) {
           absolutePluginOutPath = await packageCache.addToCache(p)
         } else {

--- a/ern-local-cli/src/lib/constants.ts
+++ b/ern-local-cli/src/lib/constants.ts
@@ -22,7 +22,7 @@ export const availableUserConfigKeys = [
     values: [true, false],
   },
   {
-    desc: 'Enable package cache [EXPERIMENTAL]',
+    desc: 'Enable package cache',
     name: 'package-cache-enabled',
     values: [true, false],
   },


### PR DESCRIPTION
Remove `EXPERIMENTAL` status of package cache feature now that it has been battle tested by multiple users without any issue.

Also, package cache feature will now be enabled by default. Users can still opt out from it if desired, through configuration, but given that this feature greatly speeds up container generation without any drawbacks, there is no more reason to have it disabled by default.