### PR TITLE
Downgrade joi version

### DIFF
--- a/ern-cauldron-api/package.json
+++ b/ern-cauldron-api/package.json
@@ -50,7 +50,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "joi": "^13.6.0",
+    "joi": "^12.0.0",
     "lodash": "^4.17.10",
     "semver": "^5.5.0",
     "ern-core": "1000.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2129,10 +2129,6 @@ hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
-hoek@5.x.x:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-5.0.4.tgz#0f7fa270a1cafeb364a4b2ddfaa33f864e4157da"
-
 hosted-git-info@^2.1.4, hosted-git-info@^2.1.5, hosted-git-info@^2.4.2, hosted-git-info@^2.5.0, hosted-git-info@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.6.0.tgz#23235b29ab230c576aab0d4f13fc046b0b038222"
@@ -2572,13 +2568,13 @@ jison@0.4.13:
     lex-parser "~0.1.3"
     nomnom "1.5.2"
 
-joi@^13.6.0:
-  version "13.6.0"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-13.6.0.tgz#877d820e3ad688a49c32421ffefc746bfbe2d0a0"
+joi@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-12.0.0.tgz#46f55e68f4d9628f01bbb695902c8b307ad8d33a"
   dependencies:
-    hoek "5.x.x"
+    hoek "4.x.x"
     isemail "3.x.x"
-    topo "3.x.x"
+    topo "2.x.x"
 
 js-base64@^2.1.9:
   version "2.4.3"
@@ -5159,11 +5155,11 @@ to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
 
-topo@3.x.x:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/topo/-/topo-3.0.0.tgz#37e48c330efeac784538e0acd3e62ca5e231fe7a"
+topo@2.x.x:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/topo/-/topo-2.0.2.tgz#cd5615752539057c0dc0491a621c3bc6fbe1d182"
   dependencies:
-    hoek "5.x.x"
+    hoek "4.x.x"
 
 touch@0.0.3:
   version "0.0.3"


### PR DESCRIPTION
Fix `error joi@13.7.0: The engine "node" is incompatible with this module. Expected version ">=8.9.0"` when trying to install Electrode Native with a Node version lower than `8.9.0` ... by downgrading  the version of `joi` used  by Electrode Native. Given that Electrode Native support Node 6+, it should not contain any dependency version that impose a node engine version constraint > Node 6.

[joi v12.0.0 requires node engine >= 4.0.0](https://github.com/hapijs/joi/blob/v12.0.0/package.json#L14)
[joi v13.0.0 requires node engine >= 8.4.0](https://github.com/hapijs/joi/blob/v13.0.0/package.json#L14)

