### PR TITLE
Explode ern-orchestrator utils

### DIFF
--- a/ern-core/src/getDefaultMavenLocalDirectory.ts
+++ b/ern-core/src/getDefaultMavenLocalDirectory.ts
@@ -1,0 +1,7 @@
+import os from 'os'
+import path from 'path'
+
+export function getDefaultMavenLocalDirectory() {
+  const pathToRepository = path.join(os.homedir(), '.m2', 'repository')
+  return `file://${pathToRepository}`
+}

--- a/ern-core/src/index.ts
+++ b/ern-core/src/index.ts
@@ -40,6 +40,7 @@ export {
 } from './packageJsonFileUtils'
 export { ModuleFactory } from './ModuleFactory'
 export { isPackagePublished } from './isPackagePublished'
+export { getDefaultMavenLocalDirectory } from './getDefaultMavenLocalDirectory'
 
 export const config = _config
 export const Platform = _Platform

--- a/ern-local-cli/src/commands/run-android.ts
+++ b/ern-local-cli/src/commands/run-android.ts
@@ -1,6 +1,6 @@
 import { epilog } from '../lib'
 import { deviceConfig, utils as coreUtils } from 'ern-core'
-import { utils as orchestratorUtils } from 'ern-orchestrator'
+import { runMiniApp } from 'ern-orchestrator'
 import { Argv } from 'yargs'
 
 export const command = 'run-android'
@@ -74,7 +74,7 @@ export const handler = async ({
   try {
     deviceConfig.updateDeviceConfig('android', usePreviousDevice)
 
-    await orchestratorUtils.runMiniApp('android', {
+    await runMiniApp('android', {
       dependencies,
       descriptor,
       dev,

--- a/ern-local-cli/src/commands/run-ios.ts
+++ b/ern-local-cli/src/commands/run-ios.ts
@@ -1,6 +1,6 @@
-import { epilog, logErrorAndExitIfNotSatisfied } from '../lib'
+import { epilog } from '../lib'
 import { utils as coreUtils, deviceConfig, log } from 'ern-core'
-import { utils as orchestratorUtils } from 'ern-orchestrator'
+import { runMiniApp } from 'ern-orchestrator'
 import { Argv } from 'yargs'
 
 export const command = 'run-ios'
@@ -77,7 +77,7 @@ export const handler = async ({
     }
     deviceConfig.updateDeviceConfig('ios', usePreviousDevice)
 
-    await orchestratorUtils.runMiniApp('ios', {
+    await runMiniApp('ios', {
       dependencies,
       descriptor,
       dev,

--- a/ern-orchestrator/src/buildIosRunner.ts
+++ b/ern-orchestrator/src/buildIosRunner.ts
@@ -1,0 +1,33 @@
+import { log } from 'ern-core'
+import { spawn } from 'child_process'
+
+export async function buildIosRunner(pathToIosRunner: string, udid: string) {
+  return new Promise((resolve, reject) => {
+    const xcodebuildProc = spawn(
+      'xcodebuild',
+      [
+        `-scheme`,
+        'ErnRunner',
+        'build',
+        `-destination`,
+        `id=${udid}`,
+        `SYMROOT=${pathToIosRunner}/build`,
+      ],
+      { cwd: pathToIosRunner }
+    )
+
+    xcodebuildProc.stdout.on('data', data => {
+      log.debug(data.toString())
+    })
+    xcodebuildProc.stderr.on('data', data => {
+      log.debug(data.toString())
+    })
+    xcodebuildProc.on('close', code => {
+      code === 0
+        ? resolve()
+        : reject(
+            new Error(`XCode xcbuild command failed with exit code ${code}`)
+          )
+    })
+  })
+}

--- a/ern-orchestrator/src/generateContainerForRunner.ts
+++ b/ern-orchestrator/src/generateContainerForRunner.ts
@@ -1,0 +1,35 @@
+import {
+  PackagePath,
+  NativeApplicationDescriptor,
+  NativePlatform,
+} from 'ern-core'
+
+import { runLocalContainerGen, runCauldronContainerGen } from './container'
+
+export async function generateContainerForRunner(
+  platform: NativePlatform,
+  {
+    napDescriptor,
+    dependenciesObjs = [],
+    miniAppsPaths = [],
+    jsApiImplsPaths = [],
+    outDir,
+  }: {
+    napDescriptor?: NativeApplicationDescriptor
+    dependenciesObjs: PackagePath[]
+    miniAppsPaths: PackagePath[]
+    jsApiImplsPaths: PackagePath[]
+    outDir: string
+  }
+) {
+  if (napDescriptor) {
+    await runCauldronContainerGen(napDescriptor, {
+      outDir,
+    })
+  } else {
+    await runLocalContainerGen(miniAppsPaths, jsApiImplsPaths, platform, {
+      extraNativeDependencies: dependenciesObjs,
+      outDir,
+    })
+  }
+}

--- a/ern-orchestrator/src/getRunnerGeneratorForPlatform.ts
+++ b/ern-orchestrator/src/getRunnerGeneratorForPlatform.ts
@@ -1,0 +1,16 @@
+import { RunnerGenerator } from 'ern-runner-gen'
+import { AndroidRunnerGenerator } from 'ern-runner-gen-android'
+import { IosRunnerGenerator } from 'ern-runner-gen-ios'
+
+export function getRunnerGeneratorForPlatform(
+  platform: string
+): RunnerGenerator {
+  switch (platform) {
+    case 'android':
+      return new AndroidRunnerGenerator()
+    case 'ios':
+      return new IosRunnerGenerator()
+    default:
+      throw new Error(`Unsupported platform : ${platform}`)
+  }
+}

--- a/ern-orchestrator/src/index.ts
+++ b/ern-orchestrator/src/index.ts
@@ -27,11 +27,16 @@ export { parseJsonFromStringOrFile } from './parseJsonFromStringOrFile'
 export {
   performContainerStateUpdateInCauldron,
 } from './performContainerStateUpdateInCauldron'
+export { buildIosRunner } from './buildIosRunner'
+export { generateContainerForRunner } from './generateContainerForRunner'
+export { getRunnerGeneratorForPlatform } from './getRunnerGeneratorForPlatform'
+export { launchOnDevice } from './launchOnDevice'
+export { launchOnSimulator } from './launchOnSimulator'
+export { launchRunner } from './launchRunner'
+export { runMiniApp } from './runMiniApp'
 
-import _utils from './utils'
 import _start from './start'
 import _Ensure from './Ensure'
 
-export const utils = _utils
 export const start = _start
 export const Ensure = _Ensure

--- a/ern-orchestrator/src/launchOnDevice.ts
+++ b/ern-orchestrator/src/launchOnDevice.ts
@@ -1,0 +1,42 @@
+import { ios, kax, shell } from 'ern-core'
+import { buildIosRunner } from './buildIosRunner'
+import { spawnSync } from 'child_process'
+
+export async function launchOnDevice(pathToIosRunner: string, devices) {
+  const iPhoneDevice = await ios.askUserToSelectAniPhoneDevice(devices)
+  shell.pushd(pathToIosRunner)
+
+  try {
+    await kax
+      .task('Building iOS Runner project')
+      .run(buildIosRunner(pathToIosRunner, iPhoneDevice.udid))
+
+    const kaxDeployTask = kax.task(
+      `Installing iOS Runner on ${iPhoneDevice.name}`
+    )
+    try {
+      const iosDeployInstallArgs = [
+        '--bundle',
+        `${pathToIosRunner}/build/Debug-iphoneos/ErnRunner.app`,
+        '--id',
+        iPhoneDevice.udid,
+        '--justlaunch',
+      ]
+      const iosDeployOutput = spawnSync('ios-deploy', iosDeployInstallArgs, {
+        encoding: 'utf8',
+      })
+      if (iosDeployOutput.error) {
+        kaxDeployTask.fail(
+          `Installation failed. Make sure you have run 'npm install -g ios-deploy'.`
+        )
+      } else {
+        kaxDeployTask.succeed()
+      }
+    } catch (e) {
+      kaxDeployTask.fail(e.message)
+      throw e
+    }
+  } finally {
+    shell.popd()
+  }
+}

--- a/ern-orchestrator/src/launchOnSimulator.ts
+++ b/ern-orchestrator/src/launchOnSimulator.ts
@@ -1,0 +1,31 @@
+import { ios, kax, shell } from 'ern-core'
+import { buildIosRunner } from './buildIosRunner'
+
+export async function launchOnSimulator(pathToIosRunner: string) {
+  const iPhoneSim = await ios.askUserToSelectAniPhoneSimulator()
+  await kax
+    .task('Killing all running Simulators')
+    .run(ios.killAllRunningSimulators())
+  await kax
+    .task('Booting iOS Simulator')
+    .run(ios.launchSimulator(iPhoneSim.udid))
+  shell.pushd(pathToIosRunner)
+  try {
+    await kax
+      .task('Building iOS Runner project')
+      .run(buildIosRunner(pathToIosRunner, iPhoneSim.udid))
+    await kax
+      .task('Installing iOS Runner on Simulator')
+      .run(
+        ios.installApplicationOnSimulator(
+          iPhoneSim.udid,
+          `${pathToIosRunner}/build/Debug-iphonesimulator/ErnRunner.app`
+        )
+      )
+    await kax
+      .task('Launching Runner')
+      .run(ios.launchApplication(iPhoneSim.udid, 'com.yourcompany.ernrunner'))
+  } finally {
+    shell.popd()
+  }
+}

--- a/ern-orchestrator/src/launchRunner.ts
+++ b/ern-orchestrator/src/launchRunner.ts
@@ -1,0 +1,39 @@
+import { android, ios } from 'ern-core'
+import { launchOnDevice } from './launchOnDevice'
+import { launchOnSimulator } from './launchOnSimulator'
+
+const { runAndroidProject } = android
+
+export async function launchRunner({
+  platform,
+  pathToRunner,
+  host,
+  port,
+}: {
+  platform: string
+  pathToRunner: string
+  host?: string
+  port?: string
+}) {
+  if (platform === 'android') {
+    return launchAndroidRunner(pathToRunner)
+  } else if (platform === 'ios') {
+    return launchIosRunner(pathToRunner)
+  }
+}
+
+async function launchAndroidRunner(pathToAndroidRunner: string) {
+  return runAndroidProject({
+    packageName: 'com.walmartlabs.ern',
+    projectPath: pathToAndroidRunner,
+  })
+}
+
+async function launchIosRunner(pathToIosRunner: string) {
+  const iosDevices = ios.getiPhoneRealDevices()
+  if (iosDevices && iosDevices.length > 0) {
+    launchOnDevice(pathToIosRunner, iosDevices)
+  } else {
+    launchOnSimulator(pathToIosRunner)
+  }
+}


### PR DESCRIPTION
**Refactoring**
- Extract each function contained in `ern-orchestrator` `utils.ts` in its dedicated source file.
- Remove `utils.ts` from `ern-orchestrator`