### PR TITLE
Avoid manually building container generator directory

### DIFF
--- a/ern-core/src/Platform.ts
+++ b/ern-core/src/Platform.ts
@@ -1,6 +1,7 @@
 import config from './config'
 import shell from './shell'
 import log from './log'
+import { NativePlatform } from './NativePlatform'
 import { execSync } from 'child_process'
 
 import fs from 'fs'
@@ -51,6 +52,10 @@ export default class Platform {
 
   static get containerGenDirectory(): string {
     return path.join(this.rootDirectory, 'containergen')
+  }
+
+  public static getContainerGenOutDirectory(platform: NativePlatform): string {
+    return path.join(this.containerGenDirectory, 'out', platform)
   }
 
   static get latestVersion(): string {

--- a/ern-local-cli/src/commands/publish-container.ts
+++ b/ern-local-cli/src/commands/publish-container.ts
@@ -3,7 +3,6 @@ import { publishContainer } from 'ern-container-publisher'
 import { parseJsonFromStringOrFile } from 'ern-orchestrator'
 import { epilog, logErrorAndExitIfNotSatisfied } from '../lib'
 import fs from 'fs'
-import path from 'path'
 import { Argv } from 'yargs'
 
 export const command = 'publish-container'
@@ -67,23 +66,11 @@ export const handler = async ({
       isValidContainerVersion: { containerVersion: version },
     })
 
-    if (!containerPath) {
-      containerPath = path.join(
-        Platform.rootDirectory,
-        'containergen',
-        'out',
-        platform
-      )
-    }
-
-    if (!fs.existsSync(containerPath)) {
-      throw new Error('containerPath path does not exist')
-    }
-
     const extraObj = extra && (await parseJsonFromStringOrFile(extra))
 
     await publishContainer({
-      containerPath,
+      containerPath:
+        containerPath || Platform.getContainerGenOutDirectory(platform),
       containerVersion: version,
       extra: extraObj,
       platform,

--- a/ern-local-cli/src/commands/transform-container.ts
+++ b/ern-local-cli/src/commands/transform-container.ts
@@ -49,23 +49,11 @@ export const handler = async ({
   transformer: string
 }) => {
   try {
-    if (!containerPath) {
-      containerPath = path.join(
-        Platform.rootDirectory,
-        'containergen',
-        'out',
-        platform
-      )
-    }
-
-    if (!fs.existsSync(path.resolve(containerPath))) {
-      throw new Error('containerPath path does not exist')
-    }
-
     const extraObj = extra && (await parseJsonFromStringOrFile(extra))
 
     await transformContainer({
-      containerPath,
+      containerPath:
+        containerPath || Platform.getContainerGenOutDirectory(platform),
       extra: extraObj,
       platform,
       transformer,

--- a/ern-orchestrator/src/container.ts
+++ b/ern-orchestrator/src/container.ts
@@ -28,7 +28,7 @@ export async function runLocalContainerGen(
   jsApiImplsPackagePaths: PackagePath[],
   platform: NativePlatform,
   {
-    outDir = path.join(Platform.rootDirectory, 'containergen', 'out', platform),
+    outDir = Platform.getContainerGenOutDirectory(platform),
     extraNativeDependencies = [],
     ignoreRnpmAssets = false,
   }: {
@@ -193,9 +193,7 @@ export async function runCauldronContainerGen(
             containerGeneratorConfig.ignoreRnpmAssets,
           jsApiImpls,
           miniApps: miniAppsInstances,
-          outDir:
-            outDir ||
-            path.join(Platform.rootDirectory, 'containergen', 'out', platform),
+          outDir: outDir || Platform.getContainerGenOutDirectory(platform),
           pathToYarnLock: pathToYarnLock || undefined,
           plugins,
           pluginsDownloadDir: createTmpDir(),

--- a/ern-orchestrator/src/performContainerStateUpdateInCauldron.ts
+++ b/ern-orchestrator/src/performContainerStateUpdateInCauldron.ts
@@ -37,12 +37,7 @@ export async function performContainerStateUpdateInCauldron(
   }
 
   const platform = napDescriptor.platform
-  const outDir = path.join(
-    Platform.rootDirectory,
-    'containergen',
-    'out',
-    platform
-  )
+  const outDir = Platform.getContainerGenOutDirectory(platform)
   let cauldronContainerVersion
   let cauldron
   let containerGenConfig

--- a/ern-orchestrator/src/runMiniApp.ts
+++ b/ern-orchestrator/src/runMiniApp.ts
@@ -152,12 +152,7 @@ export async function runMiniApp(
       []
   }
 
-  const outDir = path.join(
-    Platform.rootDirectory,
-    'containergen',
-    'out',
-    platform
-  )
+  const outDir = Platform.getContainerGenOutDirectory(platform)
   await generateContainerForRunner(platform, {
     dependenciesObjs,
     jsApiImplsPaths,


### PR DESCRIPTION
Make use of Container Generator Directory from the `Platform` utility class, rather than manually building it, to guarantee path consistency and avoid duplication.