### PR TITLE
Change algorithm for partial container generation

### DIFF
--- a/docs/cli/cauldron/regen-container.md
+++ b/docs/cli/cauldron/regen-container.md
@@ -23,10 +23,9 @@ Example: If the current container version is 1.2.3 and a version is not included
 **Default**  Lists all non-released native application versions from the Cauldron and  prompts you to choose one.
 **Example** `ern cauldron regen-api -d MyNativeApp:android:1.0.0`  
 
-`--force/-f`
+`--fullRegen`
 
-* Bypass compatibility checks and force update native dependencies versions.
-**Caution**  Before using the `--force/-f` option, be sure that you can bypass compatibility checks.
+* Performs a complete Container generation even if there was no native dependencies changes. 
 
 #### Remarks
 

--- a/ern-container-gen/src/bundleMiniApps.ts
+++ b/ern-container-gen/src/bundleMiniApps.ts
@@ -12,7 +12,7 @@ import { generateMiniAppsComposite } from './generateMiniAppsComposite'
 
 export async function bundleMiniApps(
   // The miniapps to be bundled
-  miniapps: MiniApp[],
+  miniapps: PackagePath[],
   compositeMiniAppDir: string,
   outDir: string,
   platform: NativePlatform,
@@ -24,16 +24,11 @@ export async function bundleMiniApps(
   // JavaScript API implementations
   jsApiImplDependencies?: PackagePath[]
 ): Promise<BundlingResult> {
-  const miniAppsPaths: PackagePath[] = []
-  for (const miniapp of miniapps) {
-    miniAppsPaths.push(miniapp.packagePath)
-  }
-
   await kax
     .task('Generating MiniApps Composite')
     .run(
       generateMiniAppsComposite(
-        miniAppsPaths,
+        miniapps,
         compositeMiniAppDir,
         { pathToYarnLock },
         jsApiImplDependencies

--- a/ern-container-gen/src/index.ts
+++ b/ern-container-gen/src/index.ts
@@ -9,6 +9,7 @@ import { populateApiImplMustacheView as _populateApiImplMustacheView } from './p
 import { sortDependenciesByName as _sortDependenciesByName } from './sortDependenciesByName'
 import { generateContainer as _generateContainer } from './generateContainer'
 import { getContainerMetadata as _getContainerMetadata } from './getContainerMetadata'
+import { getContainerMetadataPath as _getContainerMetadataPath } from './getContainerMetadataPath'
 
 export const addContainerMetadata = _addContainerMetadata
 export const bundleMiniApps = _bundleMiniApps
@@ -21,6 +22,7 @@ export const populateApiImplMustacheView = _populateApiImplMustacheView
 export const sortDependenciesByName = _sortDependenciesByName
 export const generateContainer = _generateContainer
 export const getContainerMetadata = _getContainerMetadata
+export const getContainerMetadataPath = _getContainerMetadataPath
 
 export default {
   addContainerMetadata: _addContainerMetadata,
@@ -30,6 +32,7 @@ export default {
   generateMiniAppsComposite: _generateMiniAppsComposite,
   generatePluginsMustacheViews: _generatePluginsMustacheViews,
   getContainerMetadata: _getContainerMetadata,
+  getContainerMetadataPath: _getContainerMetadataPath,
   getContainerPlatform: _getContainerPlatform,
   injectReactNativeVersionKeysInObject: _injectReactNativeVersionKeysInObject,
   populateApiImplMustacheView: _populateApiImplMustacheView,

--- a/ern-container-gen/src/types/ContainerGenResult.ts
+++ b/ern-container-gen/src/types/ContainerGenResult.ts
@@ -5,8 +5,4 @@ export interface ContainerGenResult {
    * Metadata resulting from the bundling
    */
   bundlingResult: BundlingResult
-  /**
-   * Indicates whether only the JS bundle was generated
-   */
-  generatedJsBundleOnly: boolean
 }

--- a/ern-container-gen/src/types/ContainerGeneratorConfig.ts
+++ b/ern-container-gen/src/types/ContainerGeneratorConfig.ts
@@ -37,9 +37,4 @@ export interface ContainerGeneratorConfig {
    * Path to the current yarn lock
    */
   pathToYarnLock?: string
-  /**
-   * Forces full Container generation even if no native dependencies versions
-   * have changed compared to a previous cached generation
-   */
-  forceFullGeneration?: boolean
 }

--- a/ern-core/src/resolveNativeDependenciesVersions.ts
+++ b/ern-core/src/resolveNativeDependenciesVersions.ts
@@ -3,7 +3,6 @@ import _ from 'lodash'
 import { NativeDependencies } from './nativeDependenciesLookup'
 import { MiniApp } from './MiniApp'
 import { PackagePath } from './PackagePath'
-import { AssertionError } from 'assert'
 
 export function containsVersionMismatch(
   versions: string[],

--- a/ern-local-cli/src/commands/cauldron/add/miniapps.ts
+++ b/ern-local-cli/src/commands/cauldron/add/miniapps.ts
@@ -80,7 +80,7 @@ export const commandHandler = async ({
     miniAppNotInNativeApplicationVersionContainer: {
       descriptor,
       extraErrorMessage:
-        'If you want to update MiniApp(s) version(s), use -ern cauldron update miniapps- instead',
+        'To update MiniApp(s) use -ern cauldron update miniapps- command',
       miniApp: miniapps,
     },
     napDescriptorExistInCauldron: {
@@ -99,17 +99,9 @@ export const commandHandler = async ({
   }
 
   const cauldron = await getActiveCauldron()
-  const miniAppsInCauldron = await cauldron.getContainerMiniApps(descriptor)
-  const miniAppsInCauldronObjs: MiniApp[] = []
-  for (const miniAppInCauldron of miniAppsInCauldron) {
-    const m = await kax
-      .task(`Retrieving ${miniAppInCauldron.toString()} MiniApp`)
-      .run(MiniApp.fromPackagePath(miniAppInCauldron))
-    miniAppsInCauldronObjs.push(m)
-  }
 
   const nativeDependencies = await resolver.resolveNativeDependenciesVersionsOfMiniApps(
-    [...miniAppsObjs, ...miniAppsInCauldronObjs]
+    miniAppsObjs
   )
   const cauldronDependencies = await cauldron.getNativeDependencies(descriptor)
   const finalNativeDependencies = resolver.retainHighestVersions(

--- a/ern-local-cli/src/commands/cauldron/regen-container.ts
+++ b/ern-local-cli/src/commands/cauldron/regen-container.ts
@@ -41,15 +41,21 @@ export const builder = (argv: Argv) => {
         'Force regen even if some conflicting native dependencies versions have been found',
       type: 'boolean',
     })
+    .option('fullRegen', {
+      describe: 'Perform complete regeneration',
+      type: 'boolean',
+    })
     .epilog(epilog(exports))
 }
 
 export const commandHandler = async ({
   containerVersion,
   descriptor,
+  fullRegen,
 }: {
   containerVersion?: string
   descriptor?: NativeApplicationDescriptor
+  fullRegen?: boolean
 }) => {
   descriptor =
     descriptor ||
@@ -111,7 +117,7 @@ export const commandHandler = async ({
     },
     descriptor,
     `Regenerate Container of ${descriptor} native application`,
-    { containerVersion, forceFullGeneration: true }
+    { containerVersion, forceFullGeneration: fullRegen }
   )
   log.info(`${descriptor} container was successfully regenerated`)
 }

--- a/ern-local-cli/src/commands/cauldron/update/miniapps.ts
+++ b/ern-local-cli/src/commands/cauldron/update/miniapps.ts
@@ -107,22 +107,9 @@ export const commandHandler = async ({
   }
 
   const cauldron = await getActiveCauldron()
-  const miniAppsInCauldron = await cauldron.getContainerMiniApps(descriptor)
-  const nonUpdatedMiniAppsInCauldron = _.xorBy(
-    miniapps,
-    miniAppsInCauldron,
-    'basePath'
-  )
-  const nonUpdatedMiniAppsInCauldronObjs: MiniApp[] = []
-  for (const nonUpdatedMiniAppInCauldron of nonUpdatedMiniAppsInCauldron) {
-    const m = await kax
-      .task(`Retrieving ${nonUpdatedMiniAppInCauldron.toString()} MiniApp`)
-      .run(MiniApp.fromPackagePath(nonUpdatedMiniAppInCauldron))
-    nonUpdatedMiniAppsInCauldronObjs.push(m)
-  }
 
   const nativeDependencies = await resolver.resolveNativeDependenciesVersionsOfMiniApps(
-    [...miniAppsObjs, ...nonUpdatedMiniAppsInCauldronObjs]
+    miniAppsObjs
   )
   const cauldronDependencies = await cauldron.getNativeDependencies(descriptor)
   const finalNativeDependencies = resolver.retainHighestVersions(


### PR DESCRIPTION
Instead of looking locally in the file system for previous Container, the algorithm instead retrieves the Container from the Cauldron (if a git publisher has been configured). This is better and safer as this optimization will work (only regenerating bundle), even in environments where the file system is wiped before a new generation is triggered (typically CI environments).

Also includes other smallish optimizations such as :
- Only retrieve MiniApps once during a session (command execution), by keeping a session cache. This is only of use if package-cache is not enabled (which can be the case on CI environments) and will speed up certain command execution paths.
- For `add miniapps` and `update miniapps` there is no real need to retrieve all MiniApps to check for their native dependencies. Indeed, only the added/updated MiniApps needs to be retrieved, as other unchanged MiniApps won't contain native dependencies changes.