### PR TITLE
Introduce MiniApp git branch tracking feature

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -28,6 +28,8 @@ Package in remote git repository:
 - `https://github.com/electrode-io/MovieListMiniApp.git`
 - `https://github.com/electrode-io/MovieListMiniApp.git#0.0.9`
 
+The string following the optional `#` denotes a branch/tag or specific commit SHA.
+
 Package on local file system :
 
 - `file:/Users/blemair/Code/MovieListMiniApp`

--- a/docs/cli/cauldron/add/miniapps.md
+++ b/docs/cli/cauldron/add/miniapps.md
@@ -5,7 +5,6 @@
 * Add one or more MiniApps to a non-released native application version in a Cauldron  
 * Perform multiple checks, including MiniApp dependencies analysis, to ensure compatibility with the target native application container  
 * Generate and publish a new Container version  
-  The native application uses the new Container version to access the new MiniApp.
 
 #### Syntax
 
@@ -16,6 +15,7 @@
 `<miniapps..>`
 
 * One or more package path to MiniApps (delimited by spaces) to add to a target native application version in the Cauldron.
+* Any MiniApp path will be added to the Container in the Cauldron, as such, with the exception of a git path including a branch. In that case, the MiniApp path that will be added to the Container in the Cauldron will contain the commit SHA of the HEAD of the branch, rather than the branch itself.
 
 **Example**  
 
@@ -26,8 +26,7 @@
 `--containerVersion/-v <version>`
 
 * Specify a version for the new container  
-* **Default**  Incremental patch number of the current container version  
-Example: If the current container version is 1.2.3 and a version is not included in the command, the new container version will be 1.2.4.  
+* **Default**  Increment the patch digit of the current container version  
 
 `--descriptor/-d <descriptor>`
 

--- a/docs/cli/cauldron/regen-container.md
+++ b/docs/cli/cauldron/regen-container.md
@@ -2,7 +2,12 @@
 
 #### Description
 
-Triggers the regeneration of a Container from the Cauldron.  
+Triggers the regeneration of a Container from the Cauldron.
+
+#### Use Cases
+
+* In case one or more MiniApps in the Container of a native application version are tracking a specific git branch (for example https://github.com/electrode-io/MovieListMiniApp#master), using the `regen-container` command will trigger a new Container generation that will include the latest commits of the branch(es), if any.
+* In case there was a problem with one of the plugin configuration stored in the Manifest, or if you are using a different version of Electrode Native with an updated native Container template, the only way to propagate these native changes to the Container would be to use this command (just make sure to use the `--fullRegen` flag in that case, to force a native Container project regeneration even though there was no changes to the list of native dependencies to be included in the Container).
 
 #### Syntax
 

--- a/docs/platform-parts/cauldron/structure.md
+++ b/docs/platform-parts/cauldron/structure.md
@@ -26,7 +26,10 @@ The following is an example of a `cauldron.json` document.
          "url": "git@github.com:user/ern-custom-manifest.git",
          "type": "partial"
        }
-     }
+     },
+     "codePush": {
+      "entriesLimit": 10
+    },
   },
   "nativeApps": [
     {
@@ -39,41 +42,76 @@ The following is an example of a `cauldron.json` document.
               "containerVersion": "1.2.3",
               "publishers": [
                 {
-                  "name": "github",
+                  "name": "git",
                   "url": "git@github.com:user/myweatherapp-android-container.git"
                 },
                 {
                   "name": "maven",
                   "url": "http://user.nexus.repo.com:8081/nexus/content/repositories"
                 }
+              ],
+              "transformers": [
+                {
+                  "name": "build-config",
+                  "extra": {
+                    "configurations": [
+                      "ElectrodeContainer-Debug",
+                      "ElectrodeContainer-Release"
+                    ],
+                    "settings": {
+                      "ENABLE_BITCODE": "NO",
+                      "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym"
+                    }
+                  }
+                }
               ]
             }
           },
           "versions": [
             {
-              "name": "1.0.0",
-              "ernPlatformVersion": "0.5.0",
-              "containerVersion": "1.2.3",
+             "name": "1.0.0",
+
               "isReleased": true,
-              "yarnlock": "3ed0a5981a22d89d3b30d6e2011b5b581581771c",
-              "nativeDeps": [
-                "react-native@0.42.0",
-                "react-native-electrode-bridge@1.5.0",
-                "react-native-ern-weather-api@0.19.0",
-                "react-native-vector-icons@4.0.0",
-                "react-native-code-push@1.17.1-beta"
-              ],
-              "miniApps": {
-                "container": [
-                  "react-native-weather-overview@1.0.0",
-                  "react-native-weather-details@2.1.3",
-                ],
-                "codePush": [
-                 [
-                   "react-native-weather-overview@1.0.0",
-                   "react-native-weather-details@2.0.0",
-                 ]
+              "binary": null,
+              "yarnLocks": {
+                "container": "3f5f0e4bac859b9e83adacacc2141e594ac1403d"
+              },
+              "codePush": {
+                "Production": [
+                  {
+                    "metadata": {
+                      "deploymentName": "Production",
+                      "isMandatory": true,
+                      "appVersion": "1.0.0",
+                      "size": 1877208,
+                      "releaseMethod": "Release",
+                      "label": "v16",
+                      "releasedBy": "whoever@whatever.com",
+                      "rollout": 100
+                    },
+                    "miniapps": [
+                      "movielistminiapp@0.0.11",
+                      "https://github.com/electrode-io/MovieDetailsMiniApp#0.0.9"
+                    ],
+                    "jsApiImpls": []
+                  }
                 ]
+              },
+              "containerVersion": "1.0.9",
+              "container": {
+                "nativeDeps": [
+                  "react-native-code-push@5.2.1",
+                  "react-native-ernmovie-api@0.0.9",
+                  "react-native-ernnavigation-api@0.0.4",
+                  "react-native@0.52.2",
+                  "react-native-electrode-bridge@1.5.9"
+                ],
+                "miniApps": [
+                  "movielistminiapp@0.0.10",
+                  "https://github.com/electrode-io/MovieDetailsMiniApp#0.0.9"
+                ],
+                "jsApiImpls": [],
+                "ernPlatformVersion": "0.24.0"
               }
             }
           ]
@@ -92,17 +130,16 @@ This example `cauldron.json` document shows the following:
 The configuration also shows the different objects stored in the cauldron--level by level.
 
 * A config object (optional) and a nativeApps array  
-* Currently the cauldron top level configuration object can only hold a manifest configuration. For details about the manifest and its configuration, see the information about the  [Electrode Native Manifest](./manifest.md).  
 
-* The `nativeapps` array contains the data of all mobile applications that are part of the cauldron. A cauldron can store multiple mobile applications, however it is not recommended--instead, we recommend that you use one cauldron per mobile application.  
+* The `nativeapps` array contains the data of all mobile applications that are part of the cauldron. A cauldron can store multiple mobile applications, however it is not recommended--instead, we recommend that you use one cauldron per mobile application. It can also be a good idea to go even more granular and have one Cauldron per native application platform (i.e `MyWeatherApp Android` / `MyWeatherApp iOS`)
 
 * For each mobile application, the second level is the platforms array. Electrode Native supports two platforms: Android and iOS. For each platform, there can be multiple versions of a mobile application. Most of the Cauldron data is stored at this level (mobile application + platform + version).
 
-* At the platform level of the `MyWeatherApp` application (Android), an optional config object contains configuration for the Container generator that applies to every version of the `MyWeatherApp` for the Android platform. It also contains CodePush configuration. For information about CodePush, see the [CodePush documentation](https://microsoft.github.io/code-push/) for more details. For information about the container generator configuration, see the [Container documentation](./container.md).
+* At the platform level of the `MyWeatherApp` application (Android), an optional config object contains configuration for the Container generator that applies to every version of the `MyWeatherApp` for the Android platform. Likewise it contains some configuration for a Container transformer. It also contains CodePush configuration. For information about CodePush, see the [CodePush documentation](https://microsoft.github.io/code-push/) for more details. For information about  Container Generator and Transformers configuration, refer to the [Container documentation](./container.md).
 
-For each version of a mobile application, the cauldron stores the following:
+For each version of a mobile application, the cauldron stores the following data:
 
 - `isReleased` : `true` if this version is released to users and `false` otherwise (this version is in development)
 - `yarnlock` : The SHA of the `yarn.lock` file stored in the cauldron file store - this is used by Electrode Native when generating the composite JavaScript bundle.
 - `nativeDeps` : An array of native dependencies descriptors, corresponding to the native dependencies (and their versions) stored in the current container of this mobile application version
-- `miniApps` : MiniApps package descriptors corresponding to the MiniApps currently part of the current Container version or released through CodePush updates
+- `miniApps` : MiniApps package descriptors corresponding to the MiniApps currently part of the current Container version or released through CodePush updates. The `miniApps` array only contains immutable versions. What this means is that any MiniApp path refer to a specific version. For example in the case of a MiniApp added as a registry path, a fixed version must be specified (ex: `movielistminiapp@0.0.10`). This cannot be a range version (ex : `movielistminiapp@^0.0.10`). In the same way, this cannot be a branch (ex : `"https://github.com/electrode-io/MovieDetailsMiniApp#master`). While it is possible to add a MiniApp this way; Electrode Native will track the branch and only keep a commit SHA in the `miniApps` array (ex : `"https://github.com/electrode-io/MovieDetailsMiniApp#ce08c19e2b707fc96a4db016c47a6f3ae8d66262`). This is done to make sure that one can know exactly what versions (and thus code) of the MiniApps are included in a given Container. Indeed, using a version range such as `^0.0.10` or a branch such as `master` would not allow one to know exactly what is included in a given Container version.

--- a/ern-cauldron-api/src/CauldronApi.ts
+++ b/ern-cauldron-api/src/CauldronApi.ts
@@ -843,7 +843,7 @@ export default class CauldronApi {
     if (
       !version.container.miniAppsBranches ||
       !version.container.miniAppsBranches
-        .map(PackagePath.fromString)
+        .map(p => PackagePath.fromString(p))
         .find(m => m.basePath === miniapp.basePath)
     ) {
       return this.addContainerMiniAppBranch(descriptor, miniapp)

--- a/ern-cauldron-api/src/CauldronHelper.ts
+++ b/ern-cauldron-api/src/CauldronHelper.ts
@@ -811,6 +811,27 @@ export class CauldronHelper {
     }
   }
 
+  public async addContainerMiniAppBranch(
+    napDescriptor: NativeApplicationDescriptor,
+    miniApp: PackagePath
+  ): Promise<void> {
+    return this.cauldron.addContainerMiniAppBranch(napDescriptor, miniApp)
+  }
+
+  public async updateContainerMiniAppBranch(
+    napDescriptor: NativeApplicationDescriptor,
+    miniApp: PackagePath
+  ): Promise<void> {
+    return this.cauldron.updateContainerMiniAppBranch(napDescriptor, miniApp)
+  }
+
+  public async removeContainerMiniAppBranch(
+    napDescriptor: NativeApplicationDescriptor,
+    miniApp: PackagePath
+  ): Promise<void> {
+    return this.cauldron.removeContainerMiniAppBranch(napDescriptor, miniApp)
+  }
+
   public async addContainerMiniApp(
     napDescriptor: NativeApplicationDescriptor,
     miniApp: PackagePath

--- a/ern-cauldron-api/src/types/CauldronContainer.ts
+++ b/ern-cauldron-api/src/types/CauldronContainer.ts
@@ -1,5 +1,10 @@
 export interface CauldronContainer {
   miniApps: string[]
+  /**
+   * MiniApp git branches feature.
+   * Introduced in 0.25.0.
+   */
+  miniAppsBranches?: string[]
   nativeDeps: string[]
   jsApiImpls: string[]
   /**

--- a/ern-core/src/GitManifest.ts
+++ b/ern-core/src/GitManifest.ts
@@ -1,6 +1,6 @@
 import { PackagePath } from './PackagePath'
 import shell from './shell'
-import gitCli from './gitCli'
+import { gitCli } from './gitCli'
 import _ from 'lodash'
 import fs from 'fs'
 import path from 'path'

--- a/ern-core/src/gitCli.ts
+++ b/ern-core/src/gitCli.ts
@@ -2,7 +2,7 @@ import simpleGit = require('simple-git')
 import Prom from 'bluebird'
 import log from './log'
 
-export default function gitCli(workingDir?: string) {
+export function gitCli(workingDir?: string) {
   const simpleGitInstance = simpleGit(workingDir)
   simpleGitInstance.silent(log.level !== 'trace')
   return Prom.promisifyAll(simpleGitInstance)

--- a/ern-core/src/index.ts
+++ b/ern-core/src/index.ts
@@ -10,7 +10,6 @@ import _createTmpDir from './createTmpDir'
 import * as _dependencyLookup from './dependencyLookup'
 import * as _deviceConfig from './deviceConfig'
 import * as _fileUtils from './fileUtil'
-import _gitCli from './gitCli'
 import _handleCopyDirective from './handleCopyDirective'
 import * as _ios from './ios'
 import * as _iosUtil from './iosUtil'
@@ -40,6 +39,7 @@ export {
 export { ModuleFactory } from './ModuleFactory'
 export { isPackagePublished } from './isPackagePublished'
 export { getDefaultMavenLocalDirectory } from './getDefaultMavenLocalDirectory'
+export { gitCli } from './gitCli'
 
 export const config = _config
 export const Platform = _Platform
@@ -47,7 +47,6 @@ export const log = _log
 export const shell = _shell
 export const kax = _kax
 export const createTmpDir = _createTmpDir
-export const gitCli = _gitCli
 export const fileUtils = _fileUtils
 export const promptUtils = _promptUtils
 export const utils = _utils

--- a/ern-core/src/utils.ts
+++ b/ern-core/src/utils.ts
@@ -1,6 +1,6 @@
 import { yarn } from './clients'
 import { PackagePath } from './PackagePath'
-import gitCli from './gitCli'
+import { gitCli } from './gitCli'
 import http from 'http'
 import _ from 'lodash'
 import { manifest } from './Manifest'
@@ -415,4 +415,29 @@ export function coerceToPackagePathArray(
 
 export function coerceToPackagePath(v: string | PackagePath): PackagePath {
   return typeof v === 'string' ? PackagePath.fromString(v) : v
+}
+
+const gitRefBranch = (branch: string) => `refs/heads/${branch}`
+const gitRefTag = (tag: string) => `refs/tags/${tag}`
+
+export async function isGitBranch(p: PackagePath): Promise<boolean> {
+  if (!p.isGitPath) {
+    throw new Error(`${p} is not a git path`)
+  }
+  if (!p.version) {
+    throw new Error(`${p} does not include the branch to check`)
+  }
+  const heads = await gitCli().listRemoteAsync(['--heads', p.basePath])
+  return heads.includes(gitRefBranch(p.version))
+}
+
+export async function isGitTag(p: PackagePath): Promise<boolean> {
+  if (!p.isGitPath) {
+    throw new Error(`${p} is not a git path`)
+  }
+  if (!p.version) {
+    throw new Error(`${p} does not include the tag to check`)
+  }
+  const tags = await gitCli().listRemoteAsync(['--tags', p.basePath])
+  return tags.includes(gitRefTag(p.version))
 }

--- a/ern-core/src/utils.ts
+++ b/ern-core/src/utils.ts
@@ -419,6 +419,7 @@ export function coerceToPackagePath(v: string | PackagePath): PackagePath {
 
 const gitRefBranch = (branch: string) => `refs/heads/${branch}`
 const gitRefTag = (tag: string) => `refs/tags/${tag}`
+const gitShaLength = 40
 
 export async function isGitBranch(p: PackagePath): Promise<boolean> {
   if (!p.isGitPath) {
@@ -440,4 +441,20 @@ export async function isGitTag(p: PackagePath): Promise<boolean> {
   }
   const tags = await gitCli().listRemoteAsync(['--tags', p.basePath])
   return tags.includes(gitRefTag(p.version))
+}
+
+export async function getCommitShaOfGitBranchHead(
+  p: PackagePath
+): Promise<string> {
+  if (!p.isGitPath) {
+    throw new Error(`${p} is not a git path`)
+  }
+  if (!p.version) {
+    throw new Error(`${p} does not include a branch`)
+  }
+  const result = await gitCli().listRemoteAsync([p.basePath, p.version])
+  if (!result || result === '') {
+    throw new Error(`${p.version} branch was not found`)
+  }
+  return result.substring(0, gitShaLength)
 }

--- a/ern-core/test/Utils-test.ts
+++ b/ern-core/test/Utils-test.ts
@@ -4,7 +4,9 @@ import log from '../src/log'
 import { NativeApplicationDescriptor } from '../src/NativeApplicationDescriptor'
 import { PackagePath } from '../src/PackagePath'
 const sandbox = sinon.createSandbox()
-import { expect } from 'chai'
+import { expect, assert } from 'chai'
+import { doesThrow } from 'ern-util-dev'
+import * as git from '../src/gitCli'
 
 let processExitStub
 let logStub
@@ -139,6 +141,120 @@ describe('Core Utils', () => {
         .of.length(2)
       expect(result[0]).eql(depA)
       expect(result[1]).eql(depB)
+    })
+  })
+
+  describe('isGitBranch', () => {
+    const sampleHeadsRefs = `
+31d04959d8786113bfeaee997a1d1eaa8cb6c5f5        refs/heads/master
+6319d9ef0c237907c784a8c472b000d5ff83b49a        refs/heads/v0.10
+81ac6c5ef280e46a1d643f86f47c66b11aa1f8b4        refs/heads/v0.11`
+
+    it('should throw if the package path is not a git path', async () => {
+      assert(
+        await doesThrow(
+          coreUtils.isGitBranch,
+          null,
+          PackagePath.fromString('registry-package@1.2.3')
+        )
+      )
+    })
+
+    it('should throw if the package path does not include a branch', async () => {
+      assert(
+        await doesThrow(
+          coreUtils.isGitBranch,
+          null,
+          PackagePath.fromString(
+            'https://github.com/electrode-io/electrode-native.git'
+          )
+        )
+      )
+    })
+
+    it('shoud return true if the branch exist', async () => {
+      sandbox.stub(git, 'gitCli').returns({
+        listRemoteAsync: async () => {
+          return Promise.resolve(sampleHeadsRefs)
+        },
+      })
+      const result = await coreUtils.isGitBranch(
+        PackagePath.fromString(
+          'https://github.com/electrode-io/electrode-native.git#v0.10'
+        )
+      )
+      expect(result).true
+    })
+
+    it('shoud return false if the branch does not exist', async () => {
+      sandbox.stub(git, 'gitCli').returns({
+        listRemoteAsync: async () => {
+          return Promise.resolve(sampleHeadsRefs)
+        },
+      })
+      const result = await coreUtils.isGitBranch(
+        PackagePath.fromString(
+          'https://github.com/electrode-io/electrode-native.git#foo'
+        )
+      )
+      expect(result).false
+    })
+  })
+
+  describe('isGitTag', () => {
+    const sampleTagsRefs = `
+c4191b97e0f77f8cd128275977e7f284277131e0        refs/tags/v0.1.0
+4cc7a6f041ebd9a7f4ec267cdc2e57cf0ddc61fa        refs/tags/v0.1.1
+d9fa903349bbb9e7f86535cb69256e064d0fba65        refs/tags/v0.1.2`
+
+    it('should throw if the package path is not a git path', async () => {
+      assert(
+        await doesThrow(
+          coreUtils.isGitTag,
+          null,
+          PackagePath.fromString('registry-package@1.2.3')
+        )
+      )
+    })
+
+    it('should throw if the package path does not include a tag', async () => {
+      assert(
+        await doesThrow(
+          coreUtils.isGitTag,
+          null,
+          PackagePath.fromString(
+            'https://github.com/electrode-io/electrode-native.git'
+          )
+        )
+      )
+    })
+
+    it('shoud return true if the tag exist', async () => {
+      sandbox.stub(git, 'gitCli').returns({
+        listRemoteAsync: async () => {
+          return Promise.resolve(sampleTagsRefs)
+        },
+      })
+      const result = await coreUtils.isGitTag(
+        PackagePath.fromString(
+          'https://github.com/electrode-io/electrode-native.git#v0.1.2'
+        )
+      )
+      expect(result).true
+    })
+
+    it('shoud return false if the tag does not exist', async () => {
+      sandbox.stub(git, 'gitCli').returns({
+        listRemoteAsync: async () => {
+          return Promise.resolve(sampleTagsRefs)
+        },
+      })
+      const result = await coreUtils.isGitBranch(
+        PackagePath.fromString(
+          'https://github.com/electrode-io/electrode-native.git#foo'
+        )
+      )
+      expect(result).false
     })
   })
 })

--- a/ern-core/test/Utils-test.ts
+++ b/ern-core/test/Utils-test.ts
@@ -257,4 +257,61 @@ d9fa903349bbb9e7f86535cb69256e064d0fba65        refs/tags/v0.1.2`
       expect(result).false
     })
   })
+
+  describe('getCommitShaOfGitBranchHead', () => {
+    const sampleRef = `31d04959d8786113bfeaee997a1d1eaa8cb6c5f5        refs/heads/master`
+
+    it('should throw if the package path is not a git path', async () => {
+      assert(
+        await doesThrow(
+          coreUtils.getCommitShaOfGitBranchHead,
+          null,
+          PackagePath.fromString('registry-package@1.2.3')
+        )
+      )
+    })
+
+    it('should throw if the package path does not include a branch', async () => {
+      assert(
+        await doesThrow(
+          coreUtils.getCommitShaOfGitBranchHead,
+          null,
+          PackagePath.fromString(
+            'https://github.com/electrode-io/electrode-native.git'
+          )
+        )
+      )
+    })
+
+    it('should throw if the branch was not found', async () => {
+      sandbox.stub(git, 'gitCli').returns({
+        listRemoteAsync: async () => {
+          return Promise.resolve('')
+        },
+      })
+      assert(
+        await doesThrow(
+          coreUtils.getCommitShaOfGitBranchHead,
+          null,
+          PackagePath.fromString(
+            'https://github.com/electrode-io/electrode-native.git#foo'
+          )
+        )
+      )
+    })
+
+    it('should return the commit SHA of the branch HEAD', async () => {
+      sandbox.stub(git, 'gitCli').returns({
+        listRemoteAsync: async () => {
+          return Promise.resolve(sampleRef)
+        },
+      })
+      const result = await coreUtils.getCommitShaOfGitBranchHead(
+        PackagePath.fromString(
+          'https://github.com/electrode-io/electrode-native.git#master'
+        )
+      )
+      expect(result).eql('31d04959d8786113bfeaee997a1d1eaa8cb6c5f5')
+    })
+  })
 })

--- a/ern-util-dev/fixtures/default-cauldron-fixture.json
+++ b/ern-util-dev/fixtures/default-cauldron-fixture.json
@@ -153,10 +153,14 @@
                 "react-native@0.42.0",
                 "react-native-code-push@1.17.1-beta"
               ],
+              "miniAppsBranches": [
+                "https://github.com/foo/foo.git#master"
+              ],
               "miniApps": [
                 "@test/react-native-foo@5.0.0",
                 "react-native-bar@3.0.0",
-                "git+ssh://git@github.com:electrode-io/gitMiniApp.git#0.0.9"
+                "git+ssh://git@github.com:electrode-io/gitMiniApp.git#0.0.9",
+                "https://github.com/foo/foo.git#6319d9ef0c237907c784a8c472b000d5ff83b49a"
               ],
               "jsApiImpls": [
                 "react-native-my-api-impl@1.0.0"


### PR DESCRIPTION
This PR adds a new feature to Electrode Native, namely `branch tracking`.

While it is currently possible to add MiniApps as git paths in the Container of a native application version in the Cauldron, one of the problem is that when adding a MiniApp as a reference to a git branch (mutable), the information of what's exactly inside a given Container version is lost, thus contradicting the purpose of the Container structure stored in Cauldron meant to precisely reflect the content of the Container. For example, adding a MiniApp as `https://github.com/electrode-io/MovieListMiniApp.git#master` will work, but unfortunately it makes it impossible to know (without some efforts) up to which commit on `master` is included in the Container. All that one can know is that the Container contains MiniApp code that was pushed to master, but up to which point in time.

In addition to the loss of information regarding what's exactly included in the Container, this cause additional issues such as :

- Impossibility to perform Container Generation speed optimizations (because when one call `regen-container`, Electrode Native has no other choice but to pull everything from `master` for the MiniApp even if there were no changes compared to current Container -as Electrode Native has no way of knowing this-)
- Impossibility to properly use `code-push`, because `code-push` needs to know exact versions to use. `master` is not an exact version, so if there are two MiniApps let's say `MiniAppA@1.0.0` and `https://github.com/foo/MiniAppB.git#master` and one do a `code-push` for `MiniAppA@2.0.0`, Electrode Native cannot know what code to get for `MiniAppB#master` as it does not precisely know what exactly from `master` (point in time) was shipped with the Container.

For all these reasons, there was a need to come up with a proper solution, given that using branches for MiniApps is a development workflow we wish to push forward for Electrode Native.

The new branch tracking feature for MiniApps, part of this PR, works as follow :

- A new array has been added next to the Container `miniApps` array in the Cauldron : `miniAppsBranches`.  This array is used to contain any MiniApp added as a reference to a git branch, for example `https://github.com/fooMiniApp.git#master`. 

- When adding a MiniApp as a branch in the Container of a native application version in the Cauldron, for example `https://github.com/foo/MiniApp.git#master`, Electrode Native will get the latest SHA on the tip (HEAD) of the branch, and will add the MiniApp with a reference to the commit SHA rather than the branch to the `miniApps` array of the Container in the Cauldron, for example `https://github.com/foo/MiniApp.git#ea2e2d248c6af5eb14d76e4108ec922febd096f5`.

This way, Electrode Native knows both the branch that it "tracks" for the MiniApp as well as the current commit (immutable version) included in the Container.

- Any time `cauldron regen-container` command is called, Electrode Native will look at all MiniApps that points to a git branch, and for these MiniApps it will look at the HEAD of their respective branches. If the head is different than the current commit SHAs included in the Container, it will properly pull the latest of the branch and update the commit(s) SHA(s) in the `miniApps` array. If there was no changes to the branch (no new commits pushed to the branch compared to current Container), it will skip retrieval of the MiniApp and not do anything.

This feature will be extended at some point to JS Api Implementations, which are similar to MiniApps in certain ways (but not needed right now for our immediate business needs), and will also be extended to allow registry ranges (which are also mutable) in addition to git branches (for example to allow using `MiniApp@^1.0.0`).