### PR TITLE
Add branch tracking feature for JS API Implementations

### DIFF
--- a/docs/cli/cauldron/add/jsapiimpls.md
+++ b/docs/cli/cauldron/add/jsapiimpls.md
@@ -14,6 +14,11 @@
 `<jsapiimpls..>`
 
 * One or more package path to JS API implementation(s) (delimited by spaces) to add to a target native application version in the Cauldron.
+* The following types of JS API Implementation paths are not supported by this command :
+  - File path (ex `file://Users/foo/JsApiImpl`)
+  - Git path missing branch/tag or commit sha (ex: `https://github.com/foo/JsApiImpl.git`)
+  - Registry path missing version (ex: `JsApiImpl`)
+  - Registry path using a version range (ex: `JsApiImpl@^1.0.0`)
 
 **Example**  
 

--- a/docs/cli/cauldron/add/miniapps.md
+++ b/docs/cli/cauldron/add/miniapps.md
@@ -15,7 +15,12 @@
 `<miniapps..>`
 
 * One or more package path to MiniApps (delimited by spaces) to add to a target native application version in the Cauldron.
-* Any MiniApp path will be added to the Container in the Cauldron, as such, with the exception of a git path including a branch. In that case, the MiniApp path that will be added to the Container in the Cauldron will contain the commit SHA of the HEAD of the branch, rather than the branch itself.
+* Any MiniApp path (but file path) will be added to the Container in the Cauldron, as such, with the exception of a git path including a branch. In that case, the MiniApp path that will be added to the Container in the Cauldron will contain the commit SHA of the HEAD of the branch, rather than the branch itself.
+* The following types of MiniApp paths are not supported by this command :
+  - File path (ex `file://Users/foo/MiniApp`)
+  - Git path missing branch/tag or commit sha (ex: `https://github.com/foo/MiniApp.git`)
+  - Registry path missing version (ex: `MiniApp`)
+  - Registry path using a version range (ex: `MiniApp@^1.0.0`)
 
 **Example**  
 

--- a/docs/cli/cauldron/batch.md
+++ b/docs/cli/cauldron/batch.md
@@ -48,6 +48,12 @@
 5) [updateMiniapps]  
 6) [addMiniapps]
 
+* The following types of MiniApp paths are not supported by `--addMiniapps` and `--updateMiniApps` :
+  - File path (ex `file://Users/foo/MiniApp`)
+  - Git path missing branch/tag or commit sha (ex: `https://github.com/foo/MiniApp.git`)
+  - Registry path missing version (ex: `MiniApp`)
+  - Registry path using a version range (ex: `MiniApp@^1.0.0`)
+
 [delDependencies]: del/dependencies.md
 [delMiniapps]: del/miniapps.md
 [updateDependencies]: update/dependencies.md

--- a/docs/cli/cauldron/update/jsapiimpls.md
+++ b/docs/cli/cauldron/update/jsapiimpls.md
@@ -14,7 +14,11 @@
 `<jsapiimpls..>`
 
 * One or more package path to JS API implementations(s) (delimited by spaces) to update in a target native application version in the Cauldron.
-* The version of each JS API implementation is corresponding to the version to update to. 
+* The following types of JS API Implementation paths are not supported by this command :
+  - File path (ex `file://Users/foo/JsApiImpl`)
+  - Git path missing branch/tag or commit sha (ex: `https://github.com/foo/JsApiImpl.git`)
+  - Registry path missing version (ex: `JsApiImpl`)
+  - Registry path using a version range (ex: `JsApiImpl@^1.0.0`)
 
 **Options**  
 

--- a/docs/cli/cauldron/update/miniapps.md
+++ b/docs/cli/cauldron/update/miniapps.md
@@ -15,7 +15,12 @@
 `<miniapps..>`
 
 * One or more package path to MiniApp(s) (delimited by spaces) to update in a target native application version in the Cauldron.
-* The version of each MiniApp is corresponding to the version to update to. 
+* The following types of MiniApp paths are not supported by this command :
+  - File path (ex `file://Users/foo/MiniApp`)
+  - Git path missing branch/tag or commit sha (ex: `https://github.com/foo/MiniApp.git`)
+  - Registry path missing version (ex: `MiniApp`)
+  - Registry path using a version range (ex: `MiniApp@^1.0.0`)
+
 
 **Options**  
 

--- a/ern-cauldron-api/src/types/CauldronContainer.ts
+++ b/ern-cauldron-api/src/types/CauldronContainer.ts
@@ -1,12 +1,17 @@
 export interface CauldronContainer {
   miniApps: string[]
   /**
-   * MiniApp git branches feature.
+   * MiniApp git branch tracking feature.
    * Introduced in 0.25.0.
    */
   miniAppsBranches?: string[]
   nativeDeps: string[]
   jsApiImpls: string[]
+  /**
+   * JS API Impls branch tracking feature.
+   * Introduced in 0.25.0.
+   */
+  jsApiImplsBranches?: string[]
   /**
    * The ern version used to generate this Container.
    * Introduced in 0.19.0. Required from this version onward.

--- a/ern-cauldron-api/test/CauldronApi-test.ts
+++ b/ern-cauldron-api/test/CauldronApi-test.ts
@@ -1162,14 +1162,14 @@ describe('CauldronApi.js', () => {
   })
 
   // ==========================================================
-  // removeContainerNativeDependency
+  // removeNativeDependencyFromContainer
   // ==========================================================
-  describe('removeContainerNativeDependency', () => {
+  describe('removeNativeDependencyFromContainer', () => {
     it('should remove the native dependency', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).removeContainerNativeDependency(
+      await cauldronApi(tmpFixture).removeNativeDependencyFromContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
-        'react-native-electrode-bridge'
+        PackagePath.fromString('react-native-electrode-bridge')
       )
       const dependenciesArr = jp.query(
         tmpFixture,
@@ -1183,9 +1183,9 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.removeContainerNativeDependency(
+      await api.removeNativeDependencyFromContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
-        'react-native-electrode-bridge'
+        PackagePath.fromString('react-native-electrode-bridge')
       )
       sinon.assert.calledOnce(commitStub)
     })
@@ -1194,10 +1194,10 @@ describe('CauldronApi.js', () => {
       const api = cauldronApi()
       assert(
         await doesThrow(
-          api.removeContainerNativeDependency,
+          api.removeNativeDependencyFromContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android:17.7.0'),
-          'unexisting'
+          PackagePath.fromString('unexisting')
         )
       )
     })
@@ -1206,7 +1206,7 @@ describe('CauldronApi.js', () => {
       const api = cauldronApi()
       assert(
         await doesThrow(
-          api.removeContainerNativeDependency,
+          api.removeNativeDependencyFromContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android:17.20.0'),
           'react-native-electrode-bridge'
@@ -1216,15 +1216,14 @@ describe('CauldronApi.js', () => {
   })
 
   // ==========================================================
-  // updateContainerNativeDependencyVersion
+  // updateNativeDependencyVersionInContainer
   // ==========================================================
-  describe('updateContainerNativeDependencyVersion', () => {
+  describe('updateNativeDependencyVersionInContainer', () => {
     it('should update the native dependency', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).updateContainerNativeDependencyVersion(
+      await cauldronApi(tmpFixture).updateNativeDependencyVersionInContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
-        'react-native-electrode-bridge',
-        '1.5.0'
+        PackagePath.fromString('react-native-electrode-bridge@1.5.0')
       )
       const dependenciesArr = jp.query(
         tmpFixture,
@@ -1240,10 +1239,9 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.updateContainerNativeDependencyVersion(
+      await api.updateNativeDependencyVersionInContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
-        'react-native-electrode-bridge',
-        '1.5.0'
+        PackagePath.fromString('react-native-electrode-bridge@1.5.0')
       )
       sinon.assert.calledOnce(commitStub)
     })
@@ -1252,11 +1250,10 @@ describe('CauldronApi.js', () => {
       const api = cauldronApi()
       assert(
         await doesThrow(
-          api.updateContainerNativeDependencyVersion,
+          api.updateNativeDependencyVersionInContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android:17.7.0'),
-          'unexisting',
-          '1.5.0'
+          PackagePath.fromString('unexisting@1.5.0')
         )
       )
     })
@@ -1265,23 +1262,22 @@ describe('CauldronApi.js', () => {
       const api = cauldronApi()
       assert(
         await doesThrow(
-          api.updateContainerNativeDependencyVersion,
+          api.updateNativeDependencyVersionInContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android:17.20.0'),
-          'react-native-electrode-bridge',
-          '1.5.0'
+          PackagePath.fromString('react-native-electrode-bridge@1.5.0')
         )
       )
     })
   })
 
   // ==========================================================
-  // updateContainerMiniAppVersion
+  // updateMiniAppVersionInContainer
   // ==========================================================
-  describe('updateContainerMiniAppVersion', () => {
+  describe('updateMiniAppVersionInContainer', () => {
     it('should update the MiniApp version', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).updateContainerMiniAppVersion(
+      await cauldronApi(tmpFixture).updateMiniAppVersionInContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('react-native-bar@3.0.0')
       )
@@ -1297,7 +1293,7 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.updateContainerMiniAppVersion(
+      await api.updateMiniAppVersionInContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('react-native-bar@3.0.0')
       )
@@ -1308,7 +1304,7 @@ describe('CauldronApi.js', () => {
       const api = cauldronApi()
       assert(
         await doesThrow(
-          api.updateContainerMiniAppVersion,
+          api.updateMiniAppVersionInContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android:17.7.0'),
           PackagePath.fromString('react-native-foo@3.0.0')
@@ -1320,7 +1316,7 @@ describe('CauldronApi.js', () => {
       const api = cauldronApi()
       assert(
         await doesThrow(
-          api.updateContainerMiniAppVersion,
+          api.updateMiniAppVersionInContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android:17.20.0'),
           PackagePath.fromString('react-native-bar@3.0.0')
@@ -1435,14 +1431,14 @@ describe('CauldronApi.js', () => {
   })
 
   // ==========================================================
-  // removeContainerMiniApp
+  // removeMiniAppFromContainer
   // ==========================================================
-  describe('removeContainerMiniApp', () => {
+  describe('removeMiniAppFromContainer', () => {
     it('should remove the MiniApp from the container of the native application version', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).removeContainerMiniApp(
+      await cauldronApi(tmpFixture).removeMiniAppFromContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
-        'react-native-bar'
+        PackagePath.fromString('react-native-bar')
       )
       const miniAppsArr = jp.query(
         tmpFixture,
@@ -1455,9 +1451,9 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.removeContainerMiniApp(
+      await api.removeMiniAppFromContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
-        'react-native-bar'
+        PackagePath.fromString('react-native-bar')
       )
       sinon.assert.calledOnce(commitStub)
     })
@@ -1466,10 +1462,10 @@ describe('CauldronApi.js', () => {
       const api = cauldronApi()
       assert(
         await doesThrow(
-          api.removeContainerMiniApp,
+          api.removeMiniAppFromContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android:17.7.0'),
-          'unexisting'
+          PackagePath.fromString('unexisting')
         )
       )
     })
@@ -1478,22 +1474,22 @@ describe('CauldronApi.js', () => {
       const api = cauldronApi()
       assert(
         await doesThrow(
-          api.removeContainerMiniApp,
+          api.removeMiniAppFromContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android:17.20.0'),
-          'react-native-bar'
+          PackagePath.fromString('react-native-bar')
         )
       )
     })
   })
 
   // ==========================================================
-  // addContainerMiniApp
+  // addMiniAppToContainer
   // ==========================================================
-  describe('addContainerMiniApp', () => {
+  describe('addMiniAppToContainer', () => {
     it('should add the MiniApp to the container of the native application version', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).addContainerMiniApp(
+      await cauldronApi(tmpFixture).addMiniAppToContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('newMiniApp@1.0.0')
       )
@@ -1508,7 +1504,7 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.addContainerMiniApp(
+      await api.addMiniAppToContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('newMiniApp@1.0.0')
       )
@@ -1519,7 +1515,7 @@ describe('CauldronApi.js', () => {
       const api = cauldronApi()
       assert(
         await doesThrow(
-          api.addContainerMiniApp,
+          api.addMiniAppToContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android:17.7.0'),
           PackagePath.fromString('react-native-bar@2.0.0')
@@ -1531,7 +1527,7 @@ describe('CauldronApi.js', () => {
       const api = cauldronApi()
       assert(
         await doesThrow(
-          api.addContainerMiniApp,
+          api.addMiniAppToContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android:17.20.0'),
           PackagePath.fromString('newMiniApp@1.0.0')
@@ -1541,12 +1537,12 @@ describe('CauldronApi.js', () => {
   })
 
   // ==========================================================
-  // addContainerNativeDependency
+  // addNativeDependencyToContainer
   // ==========================================================
-  describe('addContainerNativeDependency', () => {
+  describe('addNativeDependencyToContainer', () => {
     it('should add the native dependency to the container of the native application version', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).addContainerNativeDependency(
+      await cauldronApi(tmpFixture).addNativeDependencyToContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('testDep@1.0.0')
       )
@@ -1561,7 +1557,7 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.addContainerNativeDependency(
+      await api.addNativeDependencyToContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('testDep@1.0.0')
       )
@@ -1572,7 +1568,7 @@ describe('CauldronApi.js', () => {
       const api = cauldronApi()
       assert(
         await doesThrow(
-          api.addContainerNativeDependency,
+          api.addNativeDependencyToContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android:17.7.0'),
           PackagePath.fromString('react-native-electrode-bridge@1.4.9')
@@ -1584,7 +1580,7 @@ describe('CauldronApi.js', () => {
       const api = cauldronApi()
       assert(
         await doesThrow(
-          api.addContainerNativeDependency,
+          api.addNativeDependencyToContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android:17.20.0'),
           PackagePath.fromString('testDep@1.0.0')
@@ -1594,14 +1590,14 @@ describe('CauldronApi.js', () => {
   })
 
   // ==========================================================
-  // addContainerJsApiImpl
+  // addJsApiImplToContainer
   // ==========================================================
-  describe('addContainerJsApiImpl', () => {
+  describe('addJsApiImplToContainer', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi()
       assert(
         await doesThrow(
-          api.addContainerJsApiImpl,
+          api.addJsApiImplToContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android:17.20.0'),
           PackagePath.fromString('react-native-new-js-api-impl@1.0.0')
@@ -1613,7 +1609,7 @@ describe('CauldronApi.js', () => {
       const api = cauldronApi()
       assert(
         await doesThrow(
-          api.addContainerJsApiImpl,
+          api.addJsApiImplToContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android:17.7.0'),
           PackagePath.fromString('react-native-my-api-impl@1.0.0')
@@ -1625,7 +1621,7 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.addContainerJsApiImpl(
+      await api.addJsApiImplToContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('react-native-new-js-api-impl@1.0.0')
       )
@@ -1634,7 +1630,7 @@ describe('CauldronApi.js', () => {
 
     it('should add the JS API impl to the container of the native application version', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).addContainerJsApiImpl(
+      await cauldronApi(tmpFixture).addJsApiImplToContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('react-native-new-js-api-impl@1.0.0')
       )
@@ -1648,17 +1644,17 @@ describe('CauldronApi.js', () => {
   })
 
   // ==========================================================
-  // removeContainerJsApiImpl
+  // removeJsApiImplFromContainer
   // ==========================================================
-  describe('removeContainerJsApiImpl', () => {
+  describe('removeJsApiImplFromContainer', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi()
       assert(
         await doesThrow(
-          api.removeContainerJsApiImpl,
+          api.removeJsApiImplFromContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android:17.20.0'),
-          'react-native-my-api-impl@1.0.0'
+          PackagePath.fromString('react-native-my-api-impl@1.0.0')
         )
       )
     })
@@ -1667,10 +1663,10 @@ describe('CauldronApi.js', () => {
       const api = cauldronApi()
       assert(
         await doesThrow(
-          api.removeContainerJsApiImpl,
+          api.removeJsApiImplFromContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android:17.7.0'),
-          'react-native-unknown-api-impl'
+          PackagePath.fromString('react-native-unknown-api-impl')
         )
       )
     })
@@ -1679,10 +1675,10 @@ describe('CauldronApi.js', () => {
       const api = cauldronApi()
       assert(
         await doesThrow(
-          api.removeContainerJsApiImpl,
+          api.removeJsApiImplFromContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android:17.7.0'),
-          'react-native-unknown-api-impl@1.0.0'
+          PackagePath.fromString('react-native-unknown-api-impl@1.0.0')
         )
       )
     })
@@ -1691,18 +1687,18 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.removeContainerJsApiImpl(
+      await api.removeJsApiImplFromContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
-        'react-native-my-api-impl@1.0.0'
+        PackagePath.fromString('react-native-my-api-impl@1.0.0')
       )
       sinon.assert.calledOnce(commitStub)
     })
 
     it('should remove the JS API impl from the container of the native application version [1]', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).removeContainerJsApiImpl(
+      await cauldronApi(tmpFixture).removeJsApiImplFromContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
-        'react-native-my-api-impl'
+        PackagePath.fromString('react-native-my-api-impl')
       )
       const dependenciesArr = jp.query(
         tmpFixture,
@@ -1713,9 +1709,9 @@ describe('CauldronApi.js', () => {
 
     it('should remove the JS API impl from the container of the native application version [2]', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).removeContainerJsApiImpl(
+      await cauldronApi(tmpFixture).removeJsApiImplFromContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
-        'react-native-my-api-impl@1.0.0'
+        PackagePath.fromString('react-native-my-api-impl@1.0.0')
       )
       const dependenciesArr = jp.query(
         tmpFixture,
@@ -1726,18 +1722,17 @@ describe('CauldronApi.js', () => {
   })
 
   // ==========================================================
-  // updateContainerJsApiImplVersion
+  // updateJsApiImplVersionInContainer
   // ==========================================================
-  describe('updateContainerJsApiImplVersion', () => {
+  describe('updateJsApiImplVersionInContainer', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi()
       assert(
         await doesThrow(
-          api.updateContainerJsApiImplVersion,
+          api.updateJsApiImplVersionInContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android:17.20.0'),
-          'react-native-my-api-impl',
-          '2.0.0'
+          PackagePath.fromString('react-native-my-api-impl@2.0.0')
         )
       )
     })
@@ -1746,11 +1741,10 @@ describe('CauldronApi.js', () => {
       const api = cauldronApi()
       assert(
         await doesThrow(
-          api.updateContainerJsApiImplVersion,
+          api.updateJsApiImplVersionInContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android:17.7.0'),
-          'react-native-unknown-api-impl',
-          '1.0.0'
+          PackagePath.fromString('react-native-unknown-api-impl@1.0.0')
         )
       )
     })
@@ -1759,20 +1753,18 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       const commitStub = sandbox.stub(documentStore, 'commit')
-      await api.updateContainerJsApiImplVersion(
+      await api.updateJsApiImplVersionInContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
-        'react-native-my-api-impl',
-        '2.0.0'
+        PackagePath.fromString('react-native-my-api-impl@2.0.0')
       )
       sinon.assert.calledOnce(commitStub)
     })
 
     it('should update the JS API impl version', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).updateContainerJsApiImplVersion(
+      await cauldronApi(tmpFixture).updateJsApiImplVersionInContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
-        'react-native-my-api-impl',
-        '2.0.0'
+        PackagePath.fromString('react-native-my-api-impl@2.0.0')
       )
       const dependenciesArr = jp.query(
         tmpFixture,
@@ -2524,14 +2516,14 @@ describe('CauldronApi.js', () => {
   })
 
   // ==========================================================
-  // addContainerMiniAppBranch
+  // addMiniAppBranchToContainer
   // ==========================================================
-  describe('addContainerMiniAppBranch', () => {
+  describe('addMiniAppBranchToContainer', () => {
     it('should throw if the native application descriptor is partial', async () => {
       const api = cauldronApi()
       assert(
         await doesThrow(
-          api.addContainerMiniAppBranch,
+          api.addMiniAppBranchToContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android'),
           PackagePath.fromString('https://github.com/foo/MiniApp.git#master')
@@ -2543,7 +2535,7 @@ describe('CauldronApi.js', () => {
       const api = cauldronApi()
       assert(
         await doesThrow(
-          api.addContainerMiniAppBranch,
+          api.addMiniAppBranchToContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android:17.7.0'),
           PackagePath.fromString('https://github.com/foo/MiniApp.git')
@@ -2553,7 +2545,7 @@ describe('CauldronApi.js', () => {
 
     it('should add the MiniApp to the target container miniAppsBranches array', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).addContainerMiniAppBranch(
+      await cauldronApi(tmpFixture).addMiniAppBranchToContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('https://github.com/foo/MiniApp.git#master')
       )
@@ -2568,13 +2560,13 @@ describe('CauldronApi.js', () => {
     it('should throw if the MiniApp already has a branch specified', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
-      await api.addContainerMiniAppBranch(
+      await api.addMiniAppBranchToContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('https://github.com/foo/MiniApp.git#master')
       )
       assert(
         await doesThrow(
-          api.addContainerMiniAppBranch,
+          api.addMiniAppBranchToContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android:17.7.0'),
           PackagePath.fromString(
@@ -2586,14 +2578,79 @@ describe('CauldronApi.js', () => {
   })
 
   // ==========================================================
-  // updateContainerMiniAppBranch
+  // addJsApiImplBranchToContainer
   // ==========================================================
-  describe('updateContainerMiniAppBranch', () => {
+  describe('addJsApiImplBranchToContainer', () => {
     it('should throw if the native application descriptor is partial', async () => {
       const api = cauldronApi()
       assert(
         await doesThrow(
-          api.updateContainerMiniAppBranch,
+          api.addJsApiImplBranchToContainer,
+          api,
+          NativeApplicationDescriptor.fromString('test:android'),
+          PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master')
+        )
+      )
+    })
+
+    it('should throw if the JS API Impl path does not include a branch', async () => {
+      const api = cauldronApi()
+      assert(
+        await doesThrow(
+          api.addJsApiImplBranchToContainer,
+          api,
+          NativeApplicationDescriptor.fromString('test:android:17.7.0'),
+          PackagePath.fromString('https://github.com/foo/JsApiImpl.git')
+        )
+      )
+    })
+
+    it('should add the JS API Impl to the target container jsApiImplsBranches array', async () => {
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      await cauldronApi(tmpFixture).addJsApiImplBranchToContainer(
+        NativeApplicationDescriptor.fromString('test:android:17.7.0'),
+        PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master')
+      )
+      const jsApiImplsBranchesArr = jp.query(
+        tmpFixture,
+        '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].container.jsApiImplsBranches'
+      )[0]
+      expect(
+        jsApiImplsBranchesArr.includes(
+          'https://github.com/foo/JsApiImpl.git#master'
+        )
+      ).true
+    })
+
+    it('should throw if the JS API impl already has a branch specified', async () => {
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      const api = cauldronApi(tmpFixture)
+      await api.addJsApiImplBranchToContainer(
+        NativeApplicationDescriptor.fromString('test:android:17.7.0'),
+        PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master')
+      )
+      assert(
+        await doesThrow(
+          api.addJsApiImplBranchToContainer,
+          api,
+          NativeApplicationDescriptor.fromString('test:android:17.7.0'),
+          PackagePath.fromString(
+            'https://github.com/foo/JsApiImpl.git#development'
+          )
+        )
+      )
+    })
+  })
+
+  // ==========================================================
+  // updateMiniAppBranchInContainer
+  // ==========================================================
+  describe('updateMiniAppBranchInContainer', () => {
+    it('should throw if the native application descriptor is partial', async () => {
+      const api = cauldronApi()
+      assert(
+        await doesThrow(
+          api.updateMiniAppBranchInContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android'),
           PackagePath.fromString('https://github.com/foo/MiniApp.git#master')
@@ -2605,7 +2662,7 @@ describe('CauldronApi.js', () => {
       const api = cauldronApi()
       assert(
         await doesThrow(
-          api.updateContainerMiniAppBranch,
+          api.updateMiniAppBranchInContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android:17.7.0'),
           PackagePath.fromString('https://github.com/foo/MiniApp.git')
@@ -2615,11 +2672,11 @@ describe('CauldronApi.js', () => {
 
     it('should update the MiniApp branch in the target container miniAppsBranches array', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).addContainerMiniAppBranch(
+      await cauldronApi(tmpFixture).addMiniAppBranchToContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('https://github.com/foo/MiniApp.git#master')
       )
-      await cauldronApi(tmpFixture).updateContainerMiniAppBranch(
+      await cauldronApi(tmpFixture).updateMiniAppBranchInContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('https://github.com/foo/MiniApp.git#development')
       )
@@ -2634,19 +2691,71 @@ describe('CauldronApi.js', () => {
   })
 
   // ==========================================================
-  // removeContainerMiniAppBranch
+  // updateJsApiImplBranchInContainer
   // ==========================================================
-  describe('removeContainerMiniAppBranch', () => {
+  describe('updateJsApiImplBranchInContainer', () => {
+    it('should throw if the native application descriptor is partial', async () => {
+      const api = cauldronApi()
+      assert(
+        await doesThrow(
+          api.updateJsApiImplBranchInContainer,
+          api,
+          NativeApplicationDescriptor.fromString('test:android'),
+          PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master')
+        )
+      )
+    })
+
+    it('should throw if the JS API Impl path does not include a branch', async () => {
+      const api = cauldronApi()
+      assert(
+        await doesThrow(
+          api.updateJsApiImplBranchInContainer,
+          api,
+          NativeApplicationDescriptor.fromString('test:android:17.7.0'),
+          PackagePath.fromString('https://github.com/foo/JsApiImpl.git')
+        )
+      )
+    })
+
+    it('should update the JS API Impl branch in the target container jsApiImplsBranches array', async () => {
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      await cauldronApi(tmpFixture).addJsApiImplBranchToContainer(
+        NativeApplicationDescriptor.fromString('test:android:17.7.0'),
+        PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master')
+      )
+      await cauldronApi(tmpFixture).updateJsApiImplBranchInContainer(
+        NativeApplicationDescriptor.fromString('test:android:17.7.0'),
+        PackagePath.fromString(
+          'https://github.com/foo/JsApiImpl.git#development'
+        )
+      )
+      const jsApiImplsBranchesArr = jp.query(
+        tmpFixture,
+        '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].container.jsApiImplsBranches'
+      )[0]
+      expect(
+        jsApiImplsBranchesArr.includes(
+          'https://github.com/foo/JsApiImpl.git#development'
+        )
+      ).true
+    })
+  })
+
+  // ==========================================================
+  // removeMiniAppBranchFromContainer
+  // ==========================================================
+  describe('removeMiniAppBranchFromContainer', () => {
     it('should throw if the native application descriptor is partial', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
-      await api.addContainerMiniAppBranch(
+      await api.addMiniAppBranchToContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('https://github.com/foo/MiniApp.git#master')
       )
       assert(
         await doesThrow(
-          api.removeContainerMiniAppBranch,
+          api.removeMiniAppBranchFromContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android'),
           PackagePath.fromString('https://github.com/foo/MiniApp.git#master')
@@ -2657,13 +2766,13 @@ describe('CauldronApi.js', () => {
     it('should throw if the MiniApp does not exist in the miniAppsBranches array', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
-      await cauldronApi(tmpFixture).addContainerMiniAppBranch(
+      await cauldronApi(tmpFixture).addMiniAppBranchToContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('https://github.com/foo/MiniApp.git#master')
       )
       assert(
         await doesThrow(
-          api.removeContainerMiniAppBranch,
+          api.removeMiniAppBranchFromContainer,
           api,
           NativeApplicationDescriptor.fromString('test:android:17.7.0'),
           PackagePath.fromString('https://github.com/foo/foo.git')
@@ -2673,11 +2782,11 @@ describe('CauldronApi.js', () => {
 
     it('should remove the MiniApp branch from the target container miniAppsBranches array [branch specified]', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).addContainerMiniAppBranch(
+      await cauldronApi(tmpFixture).addMiniAppBranchToContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('https://github.com/foo/MiniApp.git#master')
       )
-      await cauldronApi(tmpFixture).removeContainerMiniAppBranch(
+      await cauldronApi(tmpFixture).removeMiniAppBranchFromContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('https://github.com/foo/MiniApp.git#master')
       )
@@ -2690,11 +2799,11 @@ describe('CauldronApi.js', () => {
 
     it('should remove the MiniApp branch from the target container miniAppsBranches array [branch not specified]', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-      await cauldronApi(tmpFixture).addContainerMiniAppBranch(
+      await cauldronApi(tmpFixture).addMiniAppBranchToContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('https://github.com/foo/MiniApp.git#master')
       )
-      await cauldronApi(tmpFixture).removeContainerMiniAppBranch(
+      await cauldronApi(tmpFixture).removeMiniAppBranchFromContainer(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),
         PackagePath.fromString('https://github.com/foo/MiniApp.git')
       )
@@ -2703,6 +2812,79 @@ describe('CauldronApi.js', () => {
         '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].container.miniAppsBranches'
       )[0]
       expect(miniAppsArr).empty
+    })
+  })
+
+  // ==========================================================
+  // removeJsApiImplBranchFromContainer
+  // ==========================================================
+  describe('removeJsApiImplBranchFromContainer', () => {
+    it('should throw if the native application descriptor is partial', async () => {
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      const api = cauldronApi(tmpFixture)
+      await api.addJsApiImplBranchToContainer(
+        NativeApplicationDescriptor.fromString('test:android:17.7.0'),
+        PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master')
+      )
+      assert(
+        await doesThrow(
+          api.removeJsApiImplBranchFromContainer,
+          api,
+          NativeApplicationDescriptor.fromString('test:android'),
+          PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master')
+        )
+      )
+    })
+
+    it('should throw if the JS API Impl does not exist in the jsApiImplsBranches array', async () => {
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      const api = cauldronApi(tmpFixture)
+      await cauldronApi(tmpFixture).addJsApiImplBranchToContainer(
+        NativeApplicationDescriptor.fromString('test:android:17.7.0'),
+        PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master')
+      )
+      assert(
+        await doesThrow(
+          api.removeJsApiImplBranchFromContainer,
+          api,
+          NativeApplicationDescriptor.fromString('test:android:17.7.0'),
+          PackagePath.fromString('https://github.com/foo/foo.git')
+        )
+      )
+    })
+
+    it('should remove the JS API Impl branch from the target container jsApiImplsBranches array [branch specified]', async () => {
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      await cauldronApi(tmpFixture).addJsApiImplBranchToContainer(
+        NativeApplicationDescriptor.fromString('test:android:17.7.0'),
+        PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master')
+      )
+      await cauldronApi(tmpFixture).removeJsApiImplBranchFromContainer(
+        NativeApplicationDescriptor.fromString('test:android:17.7.0'),
+        PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master')
+      )
+      const jsApiImplBranchesArr = jp.query(
+        tmpFixture,
+        '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].container.jsApiImplsBranches'
+      )[0]
+      expect(jsApiImplBranchesArr).empty
+    })
+
+    it('should remove the JS API Impl branch from the target container miniAppsBranches array [branch not specified]', async () => {
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      await cauldronApi(tmpFixture).addJsApiImplBranchToContainer(
+        NativeApplicationDescriptor.fromString('test:android:17.7.0'),
+        PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master')
+      )
+      await cauldronApi(tmpFixture).removeJsApiImplBranchFromContainer(
+        NativeApplicationDescriptor.fromString('test:android:17.7.0'),
+        PackagePath.fromString('https://github.com/foo/JsApiImpl.git')
+      )
+      const jsApiImplBranchesArr = jp.query(
+        tmpFixture,
+        '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].container.jsApiImplsBranches'
+      )[0]
+      expect(jsApiImplBranchesArr).empty
     })
   })
 

--- a/ern-cauldron-api/test/CauldronHelper-test.ts
+++ b/ern-cauldron-api/test/CauldronHelper-test.ts
@@ -141,11 +141,11 @@ describe('CauldronHelper.js', () => {
     })
   })
 
-  describe('addContainerMiniApp', () => {
+  describe('addMiniAppToContainer', () => {
     it('should add the MiniApp to the container miniApps array [registry path]', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.addContainerMiniApp(
+      await cauldronHelper.addMiniAppToContainer(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString('registry-miniapp@1.0.0')
       )
@@ -155,26 +155,11 @@ describe('CauldronHelper.js', () => {
       ).true
     })
 
-    it('should add the MiniApp to the container miniApps array [file path]', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron)
-      const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.addContainerMiniApp(
-        NativeApplicationDescriptor.fromString('test:android:17.8.0'),
-        PackagePath.fromString('file:/Users/foo/test-miniapp')
-      )
-      const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0]
-      expect(
-        nativeAppVersion.container.miniApps.includes(
-          'file:/Users/foo/test-miniapp'
-        )
-      ).true
-    })
-
     it('should add the MiniApp to the container miniApps array [git path - no branch]', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       sandbox.stub(utils, 'isGitBranch').resolves(false)
-      await cauldronHelper.addContainerMiniApp(
+      await cauldronHelper.addMiniAppToContainer(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString('https://github.com/foo/test-miniapp.git#tag')
       )
@@ -190,7 +175,7 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       sandbox.stub(utils, 'isGitBranch').resolves(false)
-      await cauldronHelper.addContainerMiniApp(
+      await cauldronHelper.addMiniAppToContainer(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString('https://github.com/foo/test-miniapp.git#tag')
       )
@@ -209,7 +194,7 @@ describe('CauldronHelper.js', () => {
       sandbox
         .stub(utils, 'getCommitShaOfGitBranchHead')
         .resolves('6319d9ef0c237907c784a8c472b000d5ff83b49a')
-      await cauldronHelper.addContainerMiniApp(
+      await cauldronHelper.addMiniAppToContainer(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString('https://github.com/foo/test-miniapp.git#master')
       )
@@ -229,7 +214,7 @@ describe('CauldronHelper.js', () => {
       sandbox
         .stub(utils, 'getCommitShaOfGitBranchHead')
         .resolves('6319d9ef0c237907c784a8c472b000d5ff83b49a')
-      await cauldronHelper.addContainerMiniApp(
+      await cauldronHelper.addMiniAppToContainer(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString('https://github.com/foo/test-miniapp.git#master')
       )
@@ -242,11 +227,11 @@ describe('CauldronHelper.js', () => {
     })
   })
 
-  describe('updateContainerMiniAppVersion', () => {
+  describe('updateMiniAppVersionInContainer', () => {
     it('should update the MiniApp version in the container miniApps array [registry path]', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.updateContainerMiniAppVersion(
+      await cauldronHelper.updateMiniAppVersionInContainer(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString('@test/react-native-foo@6.0.0')
       )
@@ -262,7 +247,7 @@ describe('CauldronHelper.js', () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       sandbox.stub(utils, 'isGitBranch').resolves(false)
-      await cauldronHelper.updateContainerMiniAppVersion(
+      await cauldronHelper.updateMiniAppVersionInContainer(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString(
           'git+ssh://git@github.com:electrode-io/gitMiniApp.git#0.0.10'
@@ -283,7 +268,7 @@ describe('CauldronHelper.js', () => {
       sandbox
         .stub(utils, 'getCommitShaOfGitBranchHead')
         .resolves('6319d9ef0c237907c784a8c472b000d5ff83b49a')
-      await cauldronHelper.updateContainerMiniAppVersion(
+      await cauldronHelper.updateMiniAppVersionInContainer(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString(
           'git+ssh://git@github.com:electrode-io/gitMiniApp.git#master'
@@ -305,7 +290,7 @@ describe('CauldronHelper.js', () => {
       sandbox
         .stub(utils, 'getCommitShaOfGitBranchHead')
         .resolves('6319d9ef0c237907c784a8c472b000d5ff83b49a')
-      await cauldronHelper.updateContainerMiniAppVersion(
+      await cauldronHelper.updateMiniAppVersionInContainer(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString(
           'git+ssh://git@github.com:electrode-io/gitMiniApp.git#master'
@@ -320,13 +305,13 @@ describe('CauldronHelper.js', () => {
     })
   })
 
-  describe('addContainerNativeDependency', () => {
+  describe('addNativeDependencyToContainer', () => {
     it('should throw if the given native application descriptor is partial', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(
         doesThrow(
-          cauldronHelper.addContainerNativeDependency,
+          cauldronHelper.addNativeDependencyToContainer,
           cauldronHelper,
           NativeApplicationDescriptor.fromString('test:android'),
           PackagePath.fromString('test@1.0.0')
@@ -339,7 +324,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(
         doesThrow(
-          cauldronHelper.addContainerNativeDependency,
+          cauldronHelper.addNativeDependencyToContainer,
           cauldronHelper,
           NativeApplicationDescriptor.fromString('test:android:0.0.0'),
           PackagePath.fromString('test@1.0.0')
@@ -352,7 +337,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(
         doesThrow(
-          cauldronHelper.addContainerNativeDependency,
+          cauldronHelper.addNativeDependencyToContainer,
           cauldronHelper,
           NativeApplicationDescriptor.fromString('test:android:17.7.0'),
           PackagePath.fromString('test@1.0.0')
@@ -363,7 +348,7 @@ describe('CauldronHelper.js', () => {
     it('should add the dependency to the native application version', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.addContainerNativeDependency(
+      await cauldronHelper.addNativeDependencyToContainer(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString('test@1.0.0')
       )
@@ -372,13 +357,13 @@ describe('CauldronHelper.js', () => {
     })
   })
 
-  describe('addContainerJsApiImpl', () => {
+  describe('addJsApiImplToContainer', () => {
     it('should throw if the given native application descriptor is partial', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(
         doesThrow(
-          cauldronHelper.addContainerJsApiImpl,
+          cauldronHelper.addJsApiImplToContainer,
           cauldronHelper,
           NativeApplicationDescriptor.fromString('test:android'),
           PackagePath.fromString('test@1.0.0')
@@ -391,7 +376,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(
         doesThrow(
-          cauldronHelper.addContainerJsApiImpl,
+          cauldronHelper.addJsApiImplToContainer,
           cauldronHelper,
           NativeApplicationDescriptor.fromString('test:android:0.0.0'),
           PackagePath.fromString('test@1.0.0')
@@ -404,7 +389,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(
         doesThrow(
-          cauldronHelper.addContainerJsApiImpl,
+          cauldronHelper.addJsApiImplToContainer,
           cauldronHelper,
           NativeApplicationDescriptor.fromString('test:android:17.7.0'),
           PackagePath.fromString('test@1.0.0')
@@ -415,7 +400,7 @@ describe('CauldronHelper.js', () => {
     it('should add the JS API impl to the native application version', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.addContainerJsApiImpl(
+      await cauldronHelper.addJsApiImplToContainer(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString('test@1.0.0')
       )
@@ -424,13 +409,13 @@ describe('CauldronHelper.js', () => {
     })
   })
 
-  describe('removeContainerNativeDependency', () => {
+  describe('removeNativeDependencyFromContainer', () => {
     it('should throw if the given native application descriptor is partial', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(
         doesThrow(
-          cauldronHelper.removeContainerNativeDependency,
+          cauldronHelper.removeNativeDependencyFromContainer,
           cauldronHelper,
           NativeApplicationDescriptor.fromString('test:android'),
           PackagePath.fromString('test@1.0.0')
@@ -443,7 +428,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(
         doesThrow(
-          cauldronHelper.removeContainerNativeDependency,
+          cauldronHelper.removeNativeDependencyFromContainer,
           cauldronHelper,
           NativeApplicationDescriptor.fromString('test:android:0.0.0'),
           PackagePath.fromString('test@1.0.0')
@@ -456,7 +441,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(
         doesThrow(
-          cauldronHelper.removeContainerNativeDependency,
+          cauldronHelper.removeNativeDependencyFromContainer,
           cauldronHelper,
           NativeApplicationDescriptor.fromString('test:android:17.7.0'),
           PackagePath.fromString('test@1.0.0')
@@ -467,7 +452,7 @@ describe('CauldronHelper.js', () => {
     it('should remove the dependency from the native application version [1]', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.removeContainerNativeDependency(
+      await cauldronHelper.removeNativeDependencyFromContainer(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString('react-native-electrode-bridge@1.4.9')
       )
@@ -482,7 +467,7 @@ describe('CauldronHelper.js', () => {
     it('should remove the dependency from the native application version [2]', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.removeContainerNativeDependency(
+      await cauldronHelper.removeNativeDependencyFromContainer(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString('react-native-electrode-bridge')
       )
@@ -495,14 +480,14 @@ describe('CauldronHelper.js', () => {
     })
   })
 
-  describe('removeContainerMiniApp', () => {
+  describe('removeMiniAppFromContainer', () => {
     it('should throw if the given native application descriptor is partial', async () => {
       sandbox.stub(utils, 'isGitBranch').resolves(false)
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(
         doesThrow(
-          cauldronHelper.removeContainerMiniApp,
+          cauldronHelper.removeMiniAppFromContainer,
           cauldronHelper,
           NativeApplicationDescriptor.fromString('test:android'),
           PackagePath.fromString('@test/react-native-foo@5.0.0')
@@ -516,7 +501,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(
         doesThrow(
-          cauldronHelper.removeContainerMiniApp,
+          cauldronHelper.removeMiniAppFromContainer,
           cauldronHelper,
           NativeApplicationDescriptor.fromString('test:android:0.0.0'),
           PackagePath.fromString('@test/react-native-foo@5.0.0')
@@ -530,7 +515,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(
         doesThrow(
-          cauldronHelper.removeContainerMiniApp,
+          cauldronHelper.removeMiniAppFromContainer,
           cauldronHelper,
           NativeApplicationDescriptor.fromString('test:android:17.7.0'),
           PackagePath.fromString('@test/react-native-foo@5.0.0')
@@ -542,7 +527,7 @@ describe('CauldronHelper.js', () => {
       sandbox.stub(utils, 'isGitBranch').resolves(false)
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.removeContainerMiniApp(
+      await cauldronHelper.removeMiniAppFromContainer(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString('@test/react-native-foo@5.0.0')
       )
@@ -558,7 +543,7 @@ describe('CauldronHelper.js', () => {
       sandbox.stub(utils, 'isGitBranch').resolves(false)
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.removeContainerMiniApp(
+      await cauldronHelper.removeMiniAppFromContainer(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString('@test/react-native-foo')
       )
@@ -571,13 +556,13 @@ describe('CauldronHelper.js', () => {
     })
   })
 
-  describe('removeContainerJsApiImpl', () => {
+  describe('removeJsApiImplFromContainer', () => {
     it('should throw if the given native application descriptor is partial', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(
         doesThrow(
-          cauldronHelper.removeContainerJsApiImpl,
+          cauldronHelper.removeJsApiImplFromContainer,
           cauldronHelper,
           NativeApplicationDescriptor.fromString('test:android'),
           PackagePath.fromString('react-native-my-api-impl@1.0.0')
@@ -590,7 +575,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(
         doesThrow(
-          cauldronHelper.removeContainerJsApiImpl,
+          cauldronHelper.removeJsApiImplFromContainer,
           cauldronHelper,
           NativeApplicationDescriptor.fromString('test:android:0.0.0'),
           PackagePath.fromString('react-native-my-api-impl@1.0.0')
@@ -603,7 +588,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(
         doesThrow(
-          cauldronHelper.removeContainerJsApiImpl,
+          cauldronHelper.removeJsApiImplFromContainer,
           cauldronHelper,
           NativeApplicationDescriptor.fromString('test:android:17.7.0'),
           PackagePath.fromString('react-native-my-api-impl@1.0.0')
@@ -614,7 +599,7 @@ describe('CauldronHelper.js', () => {
     it('should remove the miniapp from the native application version [1]', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.removeContainerJsApiImpl(
+      await cauldronHelper.removeJsApiImplFromContainer(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString('react-native-my-api-impl@1.0.0')
       )
@@ -629,7 +614,7 @@ describe('CauldronHelper.js', () => {
     it('should remove the miniapp from the native application version [2]', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.removeContainerJsApiImpl(
+      await cauldronHelper.removeJsApiImplFromContainer(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString('react-native-my-api-impl')
       )
@@ -1698,17 +1683,16 @@ describe('CauldronHelper.js', () => {
     })
   })
 
-  describe('updateContainerNativeDependencyVersion', () => {
+  describe('updateNativeDependencyVersionInContainer', () => {
     it('should throw if the given native application descriptor is partial', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(
         doesThrow(
-          cauldronHelper.updateContainerNativeDependencyVersion,
+          cauldronHelper.updateNativeDependencyVersionInContainer,
           cauldronHelper,
           NativeApplicationDescriptor.fromString('test:android'),
-          PackagePath.fromString('react-native-electrode-bridge'),
-          '1.5.0'
+          PackagePath.fromString('react-native-electrode-bridge@1.5.0')
         )
       )
     })
@@ -1718,11 +1702,10 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(
         doesThrow(
-          cauldronHelper.updateContainerNativeDependencyVersion,
+          cauldronHelper.updateNativeDependencyVersionInContainer,
           cauldronHelper,
           NativeApplicationDescriptor.fromString('test:android:0.0.0'),
-          PackagePath.fromString('react-native-electrode-bridge'),
-          '1.5.0'
+          PackagePath.fromString('react-native-electrode-bridge@1.5.0')
         )
       )
     })
@@ -1732,11 +1715,10 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(
         doesThrow(
-          cauldronHelper.updateContainerNativeDependencyVersion,
+          cauldronHelper.updateNativeDependencyVersionInContainer,
           cauldronHelper,
           NativeApplicationDescriptor.fromString('test:android:17.7.0'),
-          PackagePath.fromString('react-native-electrode-bridge'),
-          '1.5.0'
+          PackagePath.fromString('react-native-electrode-bridge@1.5.0')
         )
       )
     })
@@ -1744,10 +1726,9 @@ describe('CauldronHelper.js', () => {
     it('should update the native dependency version', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.updateContainerNativeDependencyVersion(
+      await cauldronHelper.updateNativeDependencyVersionInContainer(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
-        'react-native-electrode-bridge',
-        '1.5.0'
+        PackagePath.fromString('react-native-electrode-bridge@1.5.0')
       )
       const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0]
       expect(nativeAppVersion.container.nativeDeps).includes(
@@ -1993,83 +1974,16 @@ describe('CauldronHelper.js', () => {
     })
   })
 
-  describe('syncContainerMiniAppsBranches', () => {
-    it('should update the commit sha of the miniapp to HEAD of branch if newer', async () => {
-      sandbox
-        .stub(utils, 'getCommitShaOfGitBranchHead')
-        .resolves('f20d6bb9c87d4847ce5bf5b7993bd0211a37cdc5')
-      const fixture = cloneFixture(fixtures.defaultCauldron)
-      const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.syncContainerMiniAppsBranches(
-        NativeApplicationDescriptor.fromString('test:android:17.8.0')
-      )
-      const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0]
-      expect(
-        nativeAppVersion.container.miniApps.includes(
-          'https://github.com/foo/foo.git#f20d6bb9c87d4847ce5bf5b7993bd0211a37cdc5'
-        )
-      ).true
-    })
-
-    it('should return updated miniapp package path if it was updated', async () => {
-      sandbox
-        .stub(utils, 'getCommitShaOfGitBranchHead')
-        .resolves('f20d6bb9c87d4847ce5bf5b7993bd0211a37cdc5')
-      const fixture = cloneFixture(fixtures.defaultCauldron)
-      const cauldronHelper = createCauldronHelper(fixture)
-      const result = await cauldronHelper.syncContainerMiniAppsBranches(
-        NativeApplicationDescriptor.fromString('test:android:17.8.0')
-      )
-      expect(
-        result
-          .map(p => p.fullPath)
-          .includes(
-            'https://github.com/foo/foo.git#f20d6bb9c87d4847ce5bf5b7993bd0211a37cdc5'
-          )
-      ).true
-    })
-
-    it('should not update the commit sha of the miniapp if branch HEAD has not changed', async () => {
-      sandbox
-        .stub(utils, 'getCommitShaOfGitBranchHead')
-        .resolves('6319d9ef0c237907c784a8c472b000d5ff83b49a')
-      const fixture = cloneFixture(fixtures.defaultCauldron)
-      const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.syncContainerMiniAppsBranches(
-        NativeApplicationDescriptor.fromString('test:android:17.8.0')
-      )
-      const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0]
-      expect(
-        nativeAppVersion.container.miniApps.includes(
-          'https://github.com/foo/foo.git#6319d9ef0c237907c784a8c472b000d5ff83b49a'
-        )
-      ).true
-    })
-
-    it('should not return miniapp package path if it was notupdated', async () => {
-      sandbox
-        .stub(utils, 'getCommitShaOfGitBranchHead')
-        .resolves('6319d9ef0c237907c784a8c472b000d5ff83b49a')
-      const fixture = cloneFixture(fixtures.defaultCauldron)
-      const cauldronHelper = createCauldronHelper(fixture)
-      const result = await cauldronHelper.syncContainerMiniAppsBranches(
-        NativeApplicationDescriptor.fromString('test:android:17.8.0')
-      )
-      expect(result).empty
-    })
-  })
-
-  describe('updateContainerJsApiImplVersion', () => {
+  describe('updateJsApiImplVersionInContainer', () => {
     it('should throw if the given native application descriptor is partial', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
       assert(
         doesThrow(
-          cauldronHelper.updateContainerJsApiImplVersion,
+          cauldronHelper.updateJsApiImplVersionInContainer,
           cauldronHelper,
           NativeApplicationDescriptor.fromString('test:android'),
-          'react-native-my-api-impl',
-          '1.5.0'
+          PackagePath.fromString('react-native-my-api-impl@1.5.0')
         )
       )
     })
@@ -2079,11 +1993,10 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(
         doesThrow(
-          cauldronHelper.updateContainerJsApiImplVersion,
+          cauldronHelper.updateJsApiImplVersionInContainer,
           cauldronHelper,
           NativeApplicationDescriptor.fromString('test:android:0.0.0'),
-          'react-native-my-api-impl',
-          '1.5.0'
+          PackagePath.fromString('react-native-my-api-impl@1.5.0')
         )
       )
     })
@@ -2093,11 +2006,10 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       assert(
         doesThrow(
-          cauldronHelper.updateContainerJsApiImplVersion,
+          cauldronHelper.updateJsApiImplVersionInContainer,
           cauldronHelper,
           NativeApplicationDescriptor.fromString('test:android:17.7.0'),
-          'react-native-my-api-impl',
-          '1.5.0'
+          PackagePath.fromString('react-native-my-api-impl@1.5.0')
         )
       )
     })
@@ -2105,10 +2017,9 @@ describe('CauldronHelper.js', () => {
     it('should update the native dependency version', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper(fixture)
-      await cauldronHelper.updateContainerJsApiImplVersion(
+      await cauldronHelper.updateJsApiImplVersionInContainer(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
-        'react-native-my-api-impl',
-        '1.5.0'
+        PackagePath.fromString('react-native-my-api-impl@1.5.0')
       )
       const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0]
       expect(nativeAppVersion.container.jsApiImpls).includes(

--- a/ern-local-cli/src/commands/cauldron/add/dependencies.ts
+++ b/ern-local-cli/src/commands/cauldron/add/dependencies.ts
@@ -94,7 +94,7 @@ export const commandHandler = async ({
   await performContainerStateUpdateInCauldron(
     async () => {
       for (const dependency of dependencies) {
-        await cauldron.addContainerNativeDependency(descriptor!, dependency)
+        await cauldron.addNativeDependencyToContainer(descriptor!, dependency)
         cauldronCommitMessage.push(`- Add ${dependency} native dependency`)
       }
     },

--- a/ern-local-cli/src/commands/cauldron/add/jsapiimpls.ts
+++ b/ern-local-cli/src/commands/cauldron/add/jsapiimpls.ts
@@ -57,6 +57,9 @@ export const commandHandler = async ({
             'To avoid conflicts with previous versions, you can only use container version newer than the current one',
         }
       : undefined,
+    isSupportedMiniAppOrJsApiImplVersion: {
+      obj: jsapiimpls,
+    },
     isValidContainerVersion: containerVersion
       ? { containerVersion }
       : undefined,
@@ -79,9 +82,9 @@ export const commandHandler = async ({
   await performContainerStateUpdateInCauldron(
     async () => {
       for (const jsApiImpl of jsapiimpls) {
-        await cauldron.addContainerJsApiImpl(descriptor!, jsApiImpl)
-        cauldronCommitMessage.push(`- Add ${jsApiImpl} JS API implementation`)
+        cauldronCommitMessage.push(`- Add ${jsApiImpl} JS API Implementation`)
       }
+      await cauldron.syncContainerJsApiImpls(descriptor!, jsapiimpls)
     },
     descriptor,
     cauldronCommitMessage,

--- a/ern-local-cli/src/commands/cauldron/add/miniapps.ts
+++ b/ern-local-cli/src/commands/cauldron/add/miniapps.ts
@@ -74,6 +74,9 @@ export const commandHandler = async ({
             'To avoid conflicts with previous versions, you can only use container version newer than the current one',
         }
       : undefined,
+    isSupportedMiniAppOrJsApiImplVersion: {
+      obj: miniapps,
+    },
     isValidContainerVersion: containerVersion
       ? { containerVersion }
       : undefined,

--- a/ern-local-cli/src/commands/cauldron/batch.ts
+++ b/ern-local-cli/src/commands/cauldron/batch.ts
@@ -140,6 +140,9 @@ export const commandHandler = async ({
             'To avoid conflicts with previous versions, you can only use container version newer than the current one',
         }
       : undefined,
+    isSupportedMiniAppOrJsApiImplVersion: {
+      obj: [...updateMiniapps, ...addMiniapps],
+    },
     isValidContainerVersion: containerVersion
       ? { containerVersion }
       : undefined,
@@ -212,7 +215,7 @@ export const commandHandler = async ({
     async () => {
       // Del Dependencies
       for (const delDependency of delDependencies) {
-        await cauldron.removeContainerNativeDependency(
+        await cauldron.removeNativeDependencyFromContainer(
           descriptor!,
           delDependency
         )
@@ -222,15 +225,14 @@ export const commandHandler = async ({
       }
       // Del MiniApps
       for (const delMiniApp of delMiniapps) {
-        await cauldron.removeContainerMiniApp(descriptor!, delMiniApp)
+        await cauldron.removeMiniAppFromContainer(descriptor!, delMiniApp)
         cauldronCommitMessage.push(`- Remove ${delMiniApp} MiniApp`)
       }
       // Update Dependencies
       for (const updateDependency of updateDependencies) {
-        await cauldron.updateContainerNativeDependencyVersion(
+        await cauldron.updateNativeDependencyVersionInContainer(
           descriptor!,
-          updateDependency.basePath,
-          <string>updateDependency.version
+          updateDependency
         )
         cauldronCommitMessage.push(
           `- Update ${
@@ -241,7 +243,10 @@ export const commandHandler = async ({
       // Add Dependencies
       for (const addDependency of addDependencies) {
         // Add the dependency to Cauldron
-        await cauldron.addContainerNativeDependency(descriptor!, addDependency)
+        await cauldron.addNativeDependencyToContainer(
+          descriptor!,
+          addDependency
+        )
         cauldronCommitMessage.push(`-Add ${addDependency} native dependency`)
       }
       // Update MiniApps

--- a/ern-local-cli/src/commands/cauldron/del/dependencies.ts
+++ b/ern-local-cli/src/commands/cauldron/del/dependencies.ts
@@ -94,7 +94,10 @@ export const commandHandler = async ({
   await performContainerStateUpdateInCauldron(
     async () => {
       for (const dependency of dependencies) {
-        await cauldron.removeContainerNativeDependency(descriptor!, dependency)
+        await cauldron.removeNativeDependencyFromContainer(
+          descriptor!,
+          dependency
+        )
         cauldronCommitMessage.push(`- Remove ${dependency} native dependency`)
       }
     },

--- a/ern-local-cli/src/commands/cauldron/del/jsapiimpls.ts
+++ b/ern-local-cli/src/commands/cauldron/del/jsapiimpls.ts
@@ -79,7 +79,7 @@ export const commandHandler = async ({
   await performContainerStateUpdateInCauldron(
     async () => {
       for (const jsApiImpl of jsapiimpls) {
-        await cauldron.removeContainerJsApiImpl(descriptor!, jsApiImpl)
+        await cauldron.removeJsApiImplFromContainer(descriptor!, jsApiImpl)
         cauldronCommitMessage.push(
           `- Remove ${jsApiImpl} JS API implementation`
         )

--- a/ern-local-cli/src/commands/cauldron/del/miniapps.ts
+++ b/ern-local-cli/src/commands/cauldron/del/miniapps.ts
@@ -93,7 +93,7 @@ export const commandHandler = async ({
   await performContainerStateUpdateInCauldron(
     async () => {
       for (const miniapp of miniapps) {
-        await cauldron.removeContainerMiniApp(descriptor!, miniapp)
+        await cauldron.removeMiniAppFromContainer(descriptor!, miniapp)
         cauldronCommitMessage.push(`- Remove ${miniapp} MiniApp`)
       }
     },

--- a/ern-local-cli/src/commands/cauldron/regen-container.ts
+++ b/ern-local-cli/src/commands/cauldron/regen-container.ts
@@ -110,7 +110,7 @@ export const commandHandler = async ({
   await performContainerStateUpdateInCauldron(
     async () => {
       for (const updatedGitMiniApp of updatedGitMiniApps) {
-        await cauldron.updateContainerMiniAppVersion(
+        await cauldron.updateMiniAppVersionInContainer(
           descriptor!,
           updatedGitMiniApp,
           { keepBranch: true }

--- a/ern-local-cli/src/commands/cauldron/update/dependencies.ts
+++ b/ern-local-cli/src/commands/cauldron/update/dependencies.ts
@@ -106,10 +106,9 @@ The following dependencies are missing a version : ${versionLessDependencies.toS
   await performContainerStateUpdateInCauldron(
     async () => {
       for (const dependency of dependencies) {
-        await cauldron.updateContainerNativeDependencyVersion(
+        await cauldron.updateNativeDependencyVersionInContainer(
           descriptor!,
-          dependency.basePath,
-          dependency.version!
+          dependency
         )
         cauldronCommitMessage.push(
           `- Update ${dependency.basePath} native dependency to v${

--- a/ern-local-cli/src/commands/cauldron/update/jsapiimpls.ts
+++ b/ern-local-cli/src/commands/cauldron/update/jsapiimpls.ts
@@ -57,6 +57,9 @@ export const commandHandler = async ({
             'To avoid conflicts with previous versions, you can only use container version newer than the current one',
         }
       : undefined,
+    isSupportedMiniAppOrJsApiImplVersion: {
+      obj: jsapiimpls,
+    },
     isValidContainerVersion: containerVersion
       ? { containerVersion }
       : undefined,
@@ -81,21 +84,11 @@ export const commandHandler = async ({
   await performContainerStateUpdateInCauldron(
     async () => {
       for (const jsapiimpl of jsapiimpls) {
-        if (!jsapiimpl.version) {
-          log.error(
-            `Will not update ${jsapiimpl} as it does not specify a version`
-          )
-          continue
-        }
-        await cauldron.updateContainerJsApiImplVersion(
-          descriptor!,
-          jsapiimpl.basePath,
-          jsapiimpl.version
-        )
         cauldronCommitMessage.push(
           `- Update ${jsapiimpl.basePath} JS API implementation version`
         )
       }
+      await cauldron.syncContainerJsApiImpls(descriptor!, jsapiimpls)
     },
     descriptor,
     cauldronCommitMessage,

--- a/ern-local-cli/src/commands/cauldron/update/miniapps.ts
+++ b/ern-local-cli/src/commands/cauldron/update/miniapps.ts
@@ -76,6 +76,9 @@ export const commandHandler = async ({
             'To avoid conflicts with previous versions, you can only use container version newer than the current one',
         }
       : undefined,
+    isSupportedMiniAppOrJsApiImplVersion: {
+      obj: miniapps,
+    },
     isValidContainerVersion: containerVersion
       ? { containerVersion }
       : undefined,

--- a/ern-local-cli/src/lib/logErrorAndExitIfNotSatisfied.ts
+++ b/ern-local-cli/src/lib/logErrorAndExitIfNotSatisfied.ts
@@ -27,6 +27,7 @@ export async function logErrorAndExitIfNotSatisfied({
   isDirectoryPath,
   pathExist,
   isValidPlatformConfig,
+  isSupportedMiniAppOrJsApiImplVersion,
 }: {
   noGitOrFilesystemPath?: {
     obj: string | PackagePath | Array<string | PackagePath> | void
@@ -134,6 +135,10 @@ export async function logErrorAndExitIfNotSatisfied({
   }
   isValidPlatformConfig?: {
     key: string
+  }
+  isSupportedMiniAppOrJsApiImplVersion?: {
+    obj: string | PackagePath | Array<string | PackagePath> | void
+    extraErrorMessage?: string
   }
 } = {}) {
   let kaxTask
@@ -360,6 +365,14 @@ export async function logErrorAndExitIfNotSatisfied({
     if (isValidPlatformConfig) {
       kaxTask = kax.task('Ensuring that config key is whitelisted')
       Ensure.isValidPlatformConfig(isValidPlatformConfig.key)
+      kaxTask.succeed()
+    }
+    if (isSupportedMiniAppOrJsApiImplVersion) {
+      kaxTask = kax.task('Ensuring that version is fixed')
+      Ensure.isSupportedMiniAppOrJsApiImplVersion(
+        isSupportedMiniAppOrJsApiImplVersion.obj,
+        isSupportedMiniAppOrJsApiImplVersion.extraErrorMessage
+      )
       kaxTask.succeed()
     }
   } catch (e) {

--- a/ern-orchestrator/src/Ensure.ts
+++ b/ern-orchestrator/src/Ensure.ts
@@ -467,4 +467,37 @@ export default class Ensure {
       )
     }
   }
+
+  // Electrode Native currently supports the following versions types
+  // to be added to a Container for MiniApps or JS API Implementations
+  // dependending of the path type :
+  // - File Path      : No intrisic version. Not allowed.
+  // - Git Path       : Branch/Tag/Commit SHA
+  // - Registry Path  : Fixed (and valid) semantic version. No Ranges.
+  public static isSupportedMiniAppOrJsApiImplVersion(
+    obj: string | PackagePath | Array<string | PackagePath> | void,
+    extraErrorMessage?: string
+  ) {
+    if (obj) {
+      const dependencies = coreUtils.coerceToPackagePathArray(obj)
+      for (const dependency of dependencies) {
+        if (dependency.isFilePath) {
+          throw new Error('File Path not supported')
+        } else if (dependency.isRegistryPath) {
+          if (!dependency.version) {
+            throw new Error(`Missing version for ${dependency}`)
+          } else if (!semver.valid(dependency.version)) {
+            throw new Error(
+              `Unsupported version ${dependency.version} for ${
+                dependency.basePath
+              }`
+            )
+          }
+        } else if (!dependency.version) {
+          // git path
+          throw new Error(`Missing version for ${dependency}`)
+        }
+      }
+    }
+  }
 }

--- a/ern-orchestrator/test/Ensure-test.js
+++ b/ern-orchestrator/test/Ensure-test.js
@@ -654,4 +654,27 @@ describe('Ensure.js', () => {
       )
     })
   })
+
+  // ==========================================================
+  // isSupportedMiniAppOrJsApiImplVersion
+  // ==========================================================
+  describe('isSupportedMiniAppOrJsApiImplVersion', () => {
+    fixtures.supportedCauldronMiniAppsVersions.forEach(pkg => {
+      it('shoud not throw if suported version', () => {
+        expect(
+          () => Ensure.isSupportedMiniAppOrJsApiImplVersion(pkg),
+          `throw for ${pkg}`
+        ).to.not.throw()
+      })
+    })
+
+    fixtures.unSupportedCauldronMiniAppsVersions.forEach(pkg => {
+      it('should throw if version is not supported', () => {
+        expect(
+          () => Ensure.isSupportedMiniAppOrJsApiImplVersion(pkg),
+          `does not throw for ${pkg}`
+        ).to.throw()
+      })
+    })
+  })
 })

--- a/ern-orchestrator/test/fixtures/common.js
+++ b/ern-orchestrator/test/fixtures/common.js
@@ -19,6 +19,25 @@ export const withoutFileSystemPath = [
   'package@1.2.3',
 ]
 
+export const supportedCauldronMiniAppsVersions = [
+  'git+ssh://github.com/MiniApp.git#master',
+  'git+ssh://github.com/MiniApp.git#v1.0.0',
+  'git+ssh://github.com/MiniApp.git#ea2e2d248c6af5eb14d76e4108ec922febd096f5',
+  'https://github.com/MiniApp.git#master',
+  'https://github.com/MiniApp.git#v1.0.0',
+  'https://github.com/MiniApp.git#ea2e2d248c6af5eb14d76e4108ec922febd096f5',
+  'MiniApp@1.0.0',
+  'MiniApp@1.0.0-beta',
+]
+
+export const unSupportedCauldronMiniAppsVersions = [
+  'git+ssh://github.com/MiniApp.git',
+  'https://github.com/MiniApp.git',
+  'MiniApp@^1.0.0',
+  'MiniApp@~1.0.0',
+  'file://Users/foo/MiniApp',
+]
+
 export const withFileSystemPath = ['file:/Users/username']
 
 export const completeNapDescriptors = ['myapp:android:17.14.0', 'myapp:ios:1']


### PR DESCRIPTION
Similar work than what was done for MiniApps in https://github.com/electrode-io/electrode-native/pull/945

Also include some refactoring of CauldronApi to clean things up and remove quite some duplication 
and update the following commands ...

- `cauldron add miniapps`
- `cauldron update miniapps`
- `cauldron add jsapiimpls`
- `cauldron update jsapiimpls`
- `cauldron batch`

... to restrict the possible types of paths that can be used, to the ones supported by Electrode Native, in order to make sure that it's not possible to add an unsupported path type that would create issues down the line.
