### PR TITLE
Add back headers search paths to iOS Container

### DIFF
--- a/ern-container-gen-ios/src/hull/Config/ElectrodeContainer-Debug.xcconfig
+++ b/ern-container-gen-ios/src/hull/Config/ElectrodeContainer-Debug.xcconfig
@@ -15,6 +15,7 @@ DYLIB_COMPATIBILITY_VERSION = 1
 DYLIB_CURRENT_VERSION = 1
 DYLIB_INSTALL_NAME_BASE = @rpath
 FRAMEWORK_SEARCH_PATHS = $(inherited) $(SRCROOT)/ElectrodeContainer/Frameworks
+HEADER_SEARCH_PATHS = $(inherited) $(SRCROOT)/ElectrodeContainer/Libraries/ReactNative/**
 INFOPLIST_FILE = ElectrodeContainer/Info.plist
 INSTALL_PATH = $(LOCAL_LIBRARY_DIR)/Frameworks
 IPHONEOS_DEPLOYMENT_TARGET = 9.0

--- a/ern-container-gen-ios/src/hull/Config/ElectrodeContainer-QADeployment.xcconfig
+++ b/ern-container-gen-ios/src/hull/Config/ElectrodeContainer-QADeployment.xcconfig
@@ -17,6 +17,7 @@ DYLIB_INSTALL_NAME_BASE = @rpath
 ENABLE_ON_DEMAND_RESOURCES = NO
 ENABLE_TESTABILITY = YES
 FRAMEWORK_SEARCH_PATHS = $(inherited) $(SRCROOT)/ElectrodeContainer/Frameworks
+HEADER_SEARCH_PATHS = $(inherited) $(SRCROOT)/ElectrodeContainer/Libraries/ReactNative/**
 INFOPLIST_FILE = ElectrodeContainer/Info.plist
 INSTALL_PATH = $(LOCAL_LIBRARY_DIR)/Frameworks
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks

--- a/ern-container-gen-ios/src/hull/Config/ElectrodeContainer-Release.xcconfig
+++ b/ern-container-gen-ios/src/hull/Config/ElectrodeContainer-Release.xcconfig
@@ -12,6 +12,7 @@ DYLIB_COMPATIBILITY_VERSION = 1
 DYLIB_CURRENT_VERSION = 1
 DYLIB_INSTALL_NAME_BASE = @rpath
 FRAMEWORK_SEARCH_PATHS = $(inherited) $(SRCROOT)/ElectrodeContainer/Frameworks
+HEADER_SEARCH_PATHS = $(inherited) $(SRCROOT)/ElectrodeContainer/Libraries/ReactNative/**
 INFOPLIST_FILE = ElectrodeContainer/Info.plist
 INSTALL_PATH = $(LOCAL_LIBRARY_DIR)/Frameworks
 IPHONEOS_DEPLOYMENT_TARGET = 9.0

--- a/ern-container-gen-ios/src/hull/Config/ElectrodeContainerTests-Debug.xcconfig
+++ b/ern-container-gen-ios/src/hull/Config/ElectrodeContainerTests-Debug.xcconfig
@@ -5,6 +5,7 @@
 // https://github.com/dempseyatgithub/BuildSettingExtractor
 //
 
+HEADER_SEARCH_PATHS = $(inherited) $(SRCROOT)/ElectrodeContainer/Libraries/ReactNative/**
 INFOPLIST_FILE = ElectrodeContainerTests/Info.plist
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks
 PRODUCT_BUNDLE_IDENTIFIER = com.walmartlabs.ern.ElectrodeContainerTests

--- a/ern-container-gen-ios/src/hull/Config/ElectrodeContainerTests-QADeployment.xcconfig
+++ b/ern-container-gen-ios/src/hull/Config/ElectrodeContainerTests-QADeployment.xcconfig
@@ -5,6 +5,7 @@
 // https://github.com/dempseyatgithub/BuildSettingExtractor
 //
 
+HEADER_SEARCH_PATHS = $(inherited) $(SRCROOT)/ElectrodeContainer/Libraries/ReactNative/**
 FRAMEWORK_SEARCH_PATHS = $(inherited)
 INFOPLIST_FILE = ElectrodeContainerTests/Info.plist
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks

--- a/ern-container-gen-ios/src/hull/Config/ElectrodeContainerTests-Release.xcconfig
+++ b/ern-container-gen-ios/src/hull/Config/ElectrodeContainerTests-Release.xcconfig
@@ -7,6 +7,7 @@
 
 DEVELOPMENT_TEAM = DXZ5VF8836
 FRAMEWORK_SEARCH_PATHS = $(inherited)
+HEADER_SEARCH_PATHS = $(inherited) $(SRCROOT)/ElectrodeContainer/Libraries/ReactNative/**
 INFOPLIST_FILE = ElectrodeContainerTests/Info.plist
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks
 PRODUCT_BUNDLE_IDENTIFIER = com.walmartlabs.ern.ElectrodeContainerTests


### PR DESCRIPTION
Revert removal of `HEADERS_SEARCH_PATHS` from iOS Container that was done in https://github.com/electrode-io/electrode-native/pull/937

Not having this search path was causing issues during Xcode archiving for our native application, not being able to find some header files for some RCT modules.

That being said, having this header search path is causing build issue with latest React Native version (this is a know React Native issue). We will figure out how to properly handle latest React Native version issue prior to next Electrode Native release.