### PR TITLE
Update publish/transform container commands with container path validity check

### DIFF
--- a/ern-local-cli/src/commands/publish-container.ts
+++ b/ern-local-cli/src/commands/publish-container.ts
@@ -60,15 +60,21 @@ export const commandHandler = async ({
   url: string
   version: string
 }) => {
+  containerPath =
+    containerPath || Platform.getContainerGenOutDirectory(platform)
+
   await logErrorAndExitIfNotSatisfied({
+    isContainerPath: {
+      extraErrorMessage: `Make sure that ${containerPath} is the root of a Container project`,
+      p: containerPath!,
+    },
     isValidContainerVersion: { containerVersion: version },
   })
 
   const extraObj = extra && (await parseJsonFromStringOrFile(extra))
 
   await publishContainer({
-    containerPath:
-      containerPath || Platform.getContainerGenOutDirectory(platform),
+    containerPath,
     containerVersion: version,
     extra: extraObj,
     platform,

--- a/ern-local-cli/src/commands/transform-container.ts
+++ b/ern-local-cli/src/commands/transform-container.ts
@@ -1,7 +1,7 @@
 import { Platform, NativePlatform, log } from 'ern-core'
 import { transformContainer } from 'ern-container-transformer'
 import { parseJsonFromStringOrFile } from 'ern-orchestrator'
-import { epilog, tryCatchWrap } from '../lib'
+import { epilog, logErrorAndExitIfNotSatisfied, tryCatchWrap } from '../lib'
 import { Argv } from 'yargs'
 
 export const command = 'transform-container'
@@ -46,11 +46,20 @@ export const commandHandler = async ({
   platform: NativePlatform
   transformer: string
 }) => {
+  containerPath =
+    containerPath || Platform.getContainerGenOutDirectory(platform)
+
+  await logErrorAndExitIfNotSatisfied({
+    isContainerPath: {
+      extraErrorMessage: `Make sure that ${containerPath} is the root of a Container project`,
+      p: containerPath!,
+    },
+  })
+
   const extraObj = extra && (await parseJsonFromStringOrFile(extra))
 
   await transformContainer({
-    containerPath:
-      containerPath || Platform.getContainerGenOutDirectory(platform),
+    containerPath,
     extra: extraObj,
     platform,
     transformer,

--- a/ern-local-cli/src/lib/logErrorAndExitIfNotSatisfied.ts
+++ b/ern-local-cli/src/lib/logErrorAndExitIfNotSatisfied.ts
@@ -28,6 +28,7 @@ export async function logErrorAndExitIfNotSatisfied({
   pathExist,
   isValidPlatformConfig,
   isSupportedMiniAppOrJsApiImplVersion,
+  isContainerPath,
 }: {
   noGitOrFilesystemPath?: {
     obj: string | PackagePath | Array<string | PackagePath> | void
@@ -138,6 +139,9 @@ export async function logErrorAndExitIfNotSatisfied({
   }
   isSupportedMiniAppOrJsApiImplVersion?: {
     obj: string | PackagePath | Array<string | PackagePath> | void
+  }
+  isContainerPath?: {
+    p: string
     extraErrorMessage?: string
   }
 } = {}) {
@@ -370,8 +374,15 @@ export async function logErrorAndExitIfNotSatisfied({
     if (isSupportedMiniAppOrJsApiImplVersion) {
       kaxTask = kax.task('Ensuring that version is fixed')
       Ensure.isSupportedMiniAppOrJsApiImplVersion(
-        isSupportedMiniAppOrJsApiImplVersion.obj,
-        isSupportedMiniAppOrJsApiImplVersion.extraErrorMessage
+        isSupportedMiniAppOrJsApiImplVersion.obj
+      )
+      kaxTask.succeed()
+    }
+    if (isContainerPath) {
+      kaxTask = kax.task('Ensuring that path is a container path')
+      Ensure.isContainerPath(
+        isContainerPath.p,
+        isContainerPath.extraErrorMessage
       )
       kaxTask.succeed()
     }

--- a/ern-orchestrator/src/Ensure.ts
+++ b/ern-orchestrator/src/Ensure.ts
@@ -5,6 +5,7 @@ import {
   dependencyLookup,
 } from 'ern-core'
 import { getActiveCauldron } from 'ern-cauldron-api'
+import { getContainerMetadataPath } from 'ern-container-gen'
 import _ from 'lodash'
 import semver from 'semver'
 import validateNpmPackageName from 'validate-npm-package-name'
@@ -498,6 +499,14 @@ export default class Ensure {
           throw new Error(`Missing version for ${dependency}`)
         }
       }
+    }
+  }
+
+  public static isContainerPath(path: string, extraErrorMessage: string = '') {
+    if (!fs.existsSync(getContainerMetadataPath(path))) {
+      throw new Error(
+        `${path} is not a path to a Container\n${extraErrorMessage}`
+      )
     }
   }
 }

--- a/ern-orchestrator/test/Ensure-test.js
+++ b/ern-orchestrator/test/Ensure-test.js
@@ -1,6 +1,7 @@
 import { assert, expect } from 'chai'
 import * as cauldron from 'ern-cauldron-api'
 import { utils, createTmpDir, PackagePath } from 'ern-core'
+import { getContainerMetadataPath } from 'ern-container-gen'
 import { doesThrow, doesNotThrow } from 'ern-util-dev'
 import sinon from 'sinon'
 import Ensure from '../src/Ensure'
@@ -675,6 +676,25 @@ describe('Ensure.js', () => {
           `does not throw for ${pkg}`
         ).to.throw()
       })
+    })
+  })
+
+  // ==========================================================
+  // isContainerPath
+  // ==========================================================
+  describe('isContainerPath', () => {
+    it('should not throw if path points to a container', async () => {
+      const tmpDirPath = createTmpDir()
+      fs.writeFileSync(
+        getContainerMetadataPath(tmpDirPath),
+        JSON.stringify('{}')
+      )
+      assert(await doesNotThrow(Ensure.isContainerPath, Ensure, tmpDirPath))
+    })
+
+    it('should throw if path does not points to a container', async () => {
+      const tmpDirPath = createTmpDir()
+      assert(await doesThrow(Ensure.isContainerPath, Ensure, tmpDirPath))
     })
   })
 })


### PR DESCRIPTION
To have a clear error message rather than an obscure one, if user provided `--containerPath` does not point to a directory that holds a Container project.