### PR TITLE
Fix cauldron object removal in specific context

### DIFF
--- a/ern-cauldron-api/src/CauldronApi.ts
+++ b/ern-cauldron-api/src/CauldronApi.ts
@@ -1262,6 +1262,22 @@ If you want to modify this publisher configuration you need to edit it manually 
     }
   }
 
+  /**
+   * Empty the Container of a given native application version
+   * Removes all MiniApps/JsApiImpls and native dependencies from
+   * the target Container and Container yarn lock
+   * @param descriptor Target native application version descriptor
+   */
+  public async emptyContainer(descriptor: NativeApplicationDescriptor) {
+    this.throwIfPartialNapDescriptor(descriptor)
+    const version = await this.getVersion(descriptor)
+    version.container.jsApiImpls = []
+    version.container.miniApps = []
+    version.container.nativeDeps = []
+    delete version.yarnLocks.container
+    await this.commit(`Empty Container of ${descriptor}`)
+  }
+
   public throwIfPartialNapDescriptor(
     napDescriptor: NativeApplicationDescriptor
   ) {

--- a/ern-cauldron-api/src/CauldronHelper.ts
+++ b/ern-cauldron-api/src/CauldronHelper.ts
@@ -1271,6 +1271,10 @@ export class CauldronHelper {
     return result
   }
 
+  public async emptyContainer(descriptor: NativeApplicationDescriptor) {
+    return this.cauldron.emptyContainer(descriptor)
+  }
+
   //
   // Retrieves all native applications versions from the Cauldron, optionaly
   // filtered by platform/and or release status and returns them as an array

--- a/ern-cauldron-api/test/CauldronApi-test.ts
+++ b/ern-cauldron-api/test/CauldronApi-test.ts
@@ -2877,6 +2877,74 @@ describe('CauldronApi.js', () => {
   })
 
   // ==========================================================
+  // emptyContainer
+  // ==========================================================
+  describe('emptyContainer', () => {
+    it('should throw if provided a partial native application desscriptor', async () => {
+      const cauldron = cauldronApi()
+      assert(
+        await doesThrow(
+          cauldron.emptyContainer,
+          cauldron,
+          NativeApplicationDescriptor.fromString('test:android')
+        )
+      )
+    })
+
+    it('should remove all MiniApps from Container of target native application version', async () => {
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      const cauldron = cauldronApi(tmpFixture)
+      await cauldron.emptyContainer(
+        NativeApplicationDescriptor.fromString('test:android:17.7.0')
+      )
+      const version = jp.query(
+        tmpFixture,
+        '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")]'
+      )[0]
+      expect(version.container.miniApps).empty
+    })
+
+    it('should remove all JS API Implementations from Container of target native application version', async () => {
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      const cauldron = cauldronApi(tmpFixture)
+      await cauldron.emptyContainer(
+        NativeApplicationDescriptor.fromString('test:android:17.7.0')
+      )
+      const version = jp.query(
+        tmpFixture,
+        '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")]'
+      )[0]
+      expect(version.container.jsApiImpls).empty
+    })
+
+    it('should remove all native dependencies from Container of target native application version', async () => {
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      const cauldron = cauldronApi(tmpFixture)
+      await cauldron.emptyContainer(
+        NativeApplicationDescriptor.fromString('test:android:17.7.0')
+      )
+      const version = jp.query(
+        tmpFixture,
+        '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")]'
+      )[0]
+      expect(version.container.nativeDeps).empty
+    })
+
+    it('should remove the Container yarn lock of target native application version', async () => {
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      const cauldron = cauldronApi(tmpFixture)
+      await cauldron.emptyContainer(
+        NativeApplicationDescriptor.fromString('test:android:17.7.0')
+      )
+      const version = jp.query(
+        tmpFixture,
+        '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")]'
+      )[0]
+      expect(version.yarnLocks.container).undefined
+    })
+  })
+
+  // ==========================================================
   // throwIfPartialNapDescriptor
   // ==========================================================
   describe('throwIfPartialNapDescriptor', () => {

--- a/ern-local-cli/src/commands/cauldron/batch.ts
+++ b/ern-local-cli/src/commands/cauldron/batch.ts
@@ -13,6 +13,7 @@ import {
   askUserToChooseANapDescriptorFromCauldron,
   logNativeDependenciesConflicts,
   tryCatchWrap,
+  emptyContainerIfSingleMiniAppOrJsApiImpl,
 } from '../../lib'
 import _ from 'lodash'
 import { Argv } from 'yargs'
@@ -225,7 +226,9 @@ export const commandHandler = async ({
       }
       // Del MiniApps
       for (const delMiniApp of delMiniapps) {
-        await cauldron.removeMiniAppFromContainer(descriptor!, delMiniApp)
+        if (!(await emptyContainerIfSingleMiniAppOrJsApiImpl(descriptor!))) {
+          await cauldron.removeMiniAppFromContainer(descriptor!, delMiniApp)
+        }
         cauldronCommitMessage.push(`- Remove ${delMiniApp} MiniApp`)
       }
       // Update Dependencies

--- a/ern-local-cli/src/commands/cauldron/del/jsapiimpls.ts
+++ b/ern-local-cli/src/commands/cauldron/del/jsapiimpls.ts
@@ -6,6 +6,7 @@ import {
   logErrorAndExitIfNotSatisfied,
   askUserToChooseANapDescriptorFromCauldron,
   tryCatchWrap,
+  emptyContainerIfSingleMiniAppOrJsApiImpl,
 } from '../../../lib'
 import { Argv } from 'yargs'
 
@@ -75,20 +76,22 @@ export const commandHandler = async ({
     }`,
   ]
 
-  const cauldron = await getActiveCauldron()
-  await performContainerStateUpdateInCauldron(
-    async () => {
-      for (const jsApiImpl of jsapiimpls) {
-        await cauldron.removeJsApiImplFromContainer(descriptor!, jsApiImpl)
-        cauldronCommitMessage.push(
-          `- Remove ${jsApiImpl} JS API implementation`
-        )
-      }
-    },
-    descriptor,
-    cauldronCommitMessage,
-    { containerVersion }
-  )
+  if (!(await emptyContainerIfSingleMiniAppOrJsApiImpl(descriptor))) {
+    const cauldron = await getActiveCauldron()
+    await performContainerStateUpdateInCauldron(
+      async () => {
+        for (const jsApiImpl of jsapiimpls) {
+          await cauldron.removeJsApiImplFromContainer(descriptor!, jsApiImpl)
+          cauldronCommitMessage.push(
+            `- Remove ${jsApiImpl} JS API implementation`
+          )
+        }
+      },
+      descriptor,
+      cauldronCommitMessage,
+      { containerVersion }
+    )
+  }
   log.info(`JS API implementation(s) successfully removed from ${descriptor}`)
 }
 

--- a/ern-local-cli/src/commands/cauldron/del/miniapps.ts
+++ b/ern-local-cli/src/commands/cauldron/del/miniapps.ts
@@ -6,6 +6,7 @@ import {
   logErrorAndExitIfNotSatisfied,
   askUserToChooseANapDescriptorFromCauldron,
   tryCatchWrap,
+  emptyContainerIfSingleMiniAppOrJsApiImpl,
 } from '../../../lib'
 import _ from 'lodash'
 import { Argv } from 'yargs'
@@ -89,18 +90,21 @@ export const commandHandler = async ({
     }`,
   ]
 
-  const cauldron = await getActiveCauldron()
-  await performContainerStateUpdateInCauldron(
-    async () => {
-      for (const miniapp of miniapps) {
-        await cauldron.removeMiniAppFromContainer(descriptor!, miniapp)
-        cauldronCommitMessage.push(`- Remove ${miniapp} MiniApp`)
-      }
-    },
-    descriptor,
-    cauldronCommitMessage,
-    { containerVersion }
-  )
+  if (!(await emptyContainerIfSingleMiniAppOrJsApiImpl(descriptor))) {
+    const cauldron = await getActiveCauldron()
+    await performContainerStateUpdateInCauldron(
+      async () => {
+        for (const miniapp of miniapps) {
+          await cauldron.removeMiniAppFromContainer(descriptor!, miniapp)
+          cauldronCommitMessage.push(`- Remove ${miniapp} MiniApp`)
+        }
+      },
+      descriptor,
+      cauldronCommitMessage,
+      { containerVersion }
+    )
+  }
+
   log.info(`MiniApp(s) successfully removed from ${descriptor}`)
 }
 

--- a/ern-local-cli/src/lib/emptyContainerIfSingleMiniAppOrJsApiImpl.ts
+++ b/ern-local-cli/src/lib/emptyContainerIfSingleMiniAppOrJsApiImpl.ts
@@ -1,0 +1,19 @@
+import { getActiveCauldron } from 'ern-cauldron-api'
+import { NativeApplicationDescriptor } from 'ern-core'
+
+export async function emptyContainerIfSingleMiniAppOrJsApiImpl(
+  descriptor: NativeApplicationDescriptor
+): Promise<boolean> {
+  const cauldron = await getActiveCauldron()
+  const containerMiniApps = await cauldron.getContainerMiniApps(descriptor)
+  const containerJsApiImpls = await cauldron.getContainerJsApiImpls(descriptor)
+  const containerMiniAppsAndJsApiImpls = [
+    ...containerJsApiImpls,
+    ...containerMiniApps,
+  ]
+  if (containerMiniAppsAndJsApiImpls.length === 1) {
+    await cauldron.emptyContainer(descriptor)
+    return true
+  }
+  return false
+}

--- a/ern-local-cli/src/lib/index.ts
+++ b/ern-local-cli/src/lib/index.ts
@@ -26,3 +26,6 @@ export { askUserToInputPackageName } from './askUserToInputPackageName'
 export { askUserToSelectAnEnvironment } from './askUserToSelectAnEnvironment'
 export { askUserConfirmation } from './askUserConfirmation'
 export { askUserForCodePushLabel } from './askUserForCodePushLabel'
+export {
+  emptyContainerIfSingleMiniAppOrJsApiImpl,
+} from './emptyContainerIfSingleMiniAppOrJsApiImpl'

--- a/ern-local-cli/test/emptyContainerIfSingleMiniAppOrJsApiImpl-test.ts
+++ b/ern-local-cli/test/emptyContainerIfSingleMiniAppOrJsApiImpl-test.ts
@@ -1,0 +1,157 @@
+import { emptyContainerIfSingleMiniAppOrJsApiImpl } from '../src/lib'
+import {
+  CauldronApi,
+  CauldronHelper,
+  EphemeralFileStore,
+  InMemoryDocumentStore,
+} from 'ern-cauldron-api'
+import { fixtures } from 'ern-util-dev'
+import { NativeApplicationDescriptor } from 'ern-core'
+import * as cauldronApi from 'ern-cauldron-api'
+import { expect } from 'chai'
+import sinon from 'sinon'
+import jp from 'jsonpath'
+
+const sandbox = sinon.createSandbox()
+
+const singleMiniAppCauldron = {
+  nativeApps: [
+    {
+      name: 'test',
+      platforms: [
+        {
+          name: 'android',
+          versions: [
+            {
+              container: {
+                jsApiImpls: [],
+                miniApps: ['react-native-bar@2.0.0'],
+                nativeDeps: [
+                  'react-native@0.42.0',
+                  'react-native-code-push@1.17.1-beta',
+                ],
+              },
+              containerVersion: '1.0.0',
+              ernPlatformVersion: '1000.0.0',
+              isReleased: false,
+              name: '1.0.0',
+
+              yarnLocks: {
+                container: '2110ae042d2bf337973c7b60615ba19fe7fb120c',
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  schemaVersion: '1.0.0',
+}
+
+const singleJsApiImplCauldron = {
+  nativeApps: [
+    {
+      name: 'test',
+      platforms: [
+        {
+          name: 'android',
+          versions: [
+            {
+              container: {
+                jsApiImpls: [],
+                miniApps: ['react-native-bar@2.0.0'],
+                nativeDeps: [
+                  'react-native@0.42.0',
+                  'react-native-code-push@1.17.1-beta',
+                ],
+              },
+              containerVersion: '1.0.0',
+              ernPlatformVersion: '1000.0.0',
+              isReleased: false,
+              name: '1.0.0',
+
+              yarnLocks: {
+                container: '2110ae042d2bf337973c7b60615ba19fe7fb120c',
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  schemaVersion: '1.0.0',
+}
+
+const testAndroid100Path =
+  '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="1.0.0")]'
+
+function cloneFixture(fixture) {
+  return JSON.parse(JSON.stringify(fixture))
+}
+
+function createCauldronApi(cauldronDocument) {
+  return new CauldronApi(
+    new InMemoryDocumentStore(cauldronDocument),
+    new EphemeralFileStore()
+  )
+}
+
+function createCauldronHelper(cauldronDocument) {
+  return new CauldronHelper(createCauldronApi(cauldronDocument))
+}
+
+describe('emptyContainerIfSingleMiniAppOrJsApiImpl', () => {
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it('should return true if it emptied the Container', async () => {
+    const fixture = cloneFixture(singleMiniAppCauldron)
+    sandbox
+      .stub(cauldronApi, 'getActiveCauldron')
+      .resolves(createCauldronHelper(fixture))
+    const result = await emptyContainerIfSingleMiniAppOrJsApiImpl(
+      NativeApplicationDescriptor.fromString('test:android:1.0.0')
+    )
+    expect(result).true
+  })
+
+  it('should return false if it did not emptied the Container', async () => {
+    const fixture = cloneFixture(fixtures.defaultCauldron)
+    sandbox
+      .stub(cauldronApi, 'getActiveCauldron')
+      .resolves(createCauldronHelper(fixture))
+    const result = await emptyContainerIfSingleMiniAppOrJsApiImpl(
+      NativeApplicationDescriptor.fromString('test:android:17.7.0')
+    )
+    expect(result).false
+  })
+
+  it('should empty the Container if there is a single MiniApp', async () => {
+    const fixture = cloneFixture(singleMiniAppCauldron)
+    sandbox
+      .stub(cauldronApi, 'getActiveCauldron')
+      .resolves(createCauldronHelper(fixture))
+    await emptyContainerIfSingleMiniAppOrJsApiImpl(
+      NativeApplicationDescriptor.fromString('test:android:1.0.0')
+    )
+    const version = jp.query(fixture, testAndroid100Path)[0]
+    expect(version.container.miniApps).empty
+    expect(version.container.nativeDeps).empty
+    expect(version.yarnLocks.container).undefined
+  })
+
+  it('should empty the Container if there is a single JS API Impl', async () => {
+    const fixture = cloneFixture(singleJsApiImplCauldron)
+    sandbox
+      .stub(cauldronApi, 'getActiveCauldron')
+      .resolves(createCauldronHelper(fixture))
+    await emptyContainerIfSingleMiniAppOrJsApiImpl(
+      NativeApplicationDescriptor.fromString('test:android:1.0.0')
+    )
+    const version = jp.query(fixture, testAndroid100Path)[0]
+    expect(version.container.jsApiImpls).empty
+    expect(version.container.nativeDeps).empty
+    expect(version.yarnLocks.container).undefined
+  })
+})


### PR DESCRIPTION
Fix the following commands:

- `cauldron del miniapps`
- `cauldron del jsapiimpls`
- `cauldron batch` *(when removing miniapps or jsapiimpls)*

That were failing if ever the MiniApp or JS API Implementation to remove from the Container was the only one remaining in the Container. 
Problem was that Electrode Native wasn't properly handling this scenario. It was just removing the MiniApp or JS API Implementation and then was regenerating a new Container. However because there was no MiniApps or JS Api Implementations left in the Container, it was failing to properly regenerate a Container.

This PR fixes this specific fringe scenario. If the MiniApp or JS API Implementation to remove is the only one left in the Container, Electrode Native will just empty the target Container in Cauldron (reset the miniApps, jsApiImpls and nativeDeps array to empty arrays and clear the container yarn lock). 
