### PR TITLE
Reformat all ern-api-gen source files with prettier rules

### DIFF
--- a/ern-api-gen/src/CliOption.js
+++ b/ern-api-gen/src/CliOption.js
@@ -81,15 +81,13 @@ export default class CliOption {
   getOptionHelp() {
     let sb = new StringBuilder(this.description)
     if (this.__defaultValue != null) {
-      sb
-        .append(' (Default: ')
+      sb.append(' (Default: ')
         .append(this.__defaultValue)
         .append(')')
     }
     if (this.enumValues != null) {
       for (const [key, value] of this.enumValues) {
-        sb
-          .append('\n    ')
+        sb.append('\n    ')
           .append(key)
           .append(' - ')
           .append(value)

--- a/ern-api-gen/src/ClientOpts.js
+++ b/ern-api-gen/src/ClientOpts.js
@@ -39,12 +39,10 @@ export default class ClientOpts {
   toString() {
     let sb = new StringBuilder()
     sb.append('ClientOpts: {\n')
-    sb
-      .append('  uri: ')
+    sb.append('  uri: ')
       .append(this.uri)
       .append(',')
-    sb
-      .append('  auth: ')
+    sb.append('  auth: ')
       .append(this.auth)
       .append(',')
     sb.append(this.properties)

--- a/ern-api-gen/src/cmd/ConfigHelp.js
+++ b/ern-api-gen/src/cmd/ConfigHelp.js
@@ -1,28 +1,39 @@
-import CodegenConfigLoader from '../CodegenConfigLoader';
-import {Command} from '../java/cli';
+import CodegenConfigLoader from '../CodegenConfigLoader'
+import { Command } from '../java/cli'
 
 export default class ConfigHelp {
-    static Usage = new Command({name: "config-help", description: "Config help for chosen lang"}, [
-        {
-            name: ["-l", "--lang"], title: "language", required: true, hasArg: true,
-            description: "language to get config help for"
-        }
-    ]);
+  static Usage = new Command(
+    { name: 'config-help', description: 'Config help for chosen lang' },
+    [
+      {
+        name: ['-l', '--lang'],
+        title: 'language',
+        required: true,
+        hasArg: true,
+        description: 'language to get config help for',
+      },
+    ]
+  )
 
-    constructor({language}) {
-        this.language = language;
+  constructor({ language }) {
+    this.language = language
+  }
+
+  run() {
+    let config = CodegenConfigLoader.forName(this.language)
+    console.info('CONFIG OPTIONS')
+
+    for (const langCliOption of config.cliOptions()) {
+      {
+        console.info('\t' + langCliOption.getOpt())
+        console.info(
+          '\t    ' +
+            langCliOption
+              .getOptionHelp()
+              .replace(new RegExp('\n', 'g'), '\n\t    ')
+        )
+        console.info()
+      }
     }
-
-    run() {
-        let config = CodegenConfigLoader.forName(this.language);
-        console.info("CONFIG OPTIONS");
-
-        for (const langCliOption of config.cliOptions()) {
-            {
-                console.info("\t" + langCliOption.getOpt());
-                console.info("\t    " + langCliOption.getOptionHelp().replace(new RegExp("\n", 'g'), "\n\t    "));
-                console.info();
-            }
-        }
-    }
+  }
 }

--- a/ern-api-gen/src/cmd/Generate.js
+++ b/ern-api-gen/src/cmd/Generate.js
@@ -1,231 +1,313 @@
-import DefaultGenerator from "../DefaultGenerator";
-import CodegenConfigurator from "../config/CodegenConfigurator";
-import LoggerFactory from "../java/LoggerFactory";
-import {isNotEmpty} from "../java/StringUtils";
+import DefaultGenerator from '../DefaultGenerator'
+import CodegenConfigurator from '../config/CodegenConfigurator'
+import LoggerFactory from '../java/LoggerFactory'
+import { isNotEmpty } from '../java/StringUtils'
 import {
-    applyAdditionalPropertiesKvp,
-    applyImportMappingsKvp,
-    applyInstantiationTypesKvp,
-    applyLanguageSpecificPrimitivesCsv,
-    applySystemPropertiesKvp,
-    applyTypeMappingsKvp
-} from "../config/CodegenConfiguratorUtils";
+  applyAdditionalPropertiesKvp,
+  applyImportMappingsKvp,
+  applyInstantiationTypesKvp,
+  applyLanguageSpecificPrimitivesCsv,
+  applySystemPropertiesKvp,
+  applyTypeMappingsKvp,
+} from '../config/CodegenConfiguratorUtils'
 
-import {Command} from '../java/cli';
-import CodegenConstants from '../CodegenConstants';
-import {apply} from '../java/beanUtils';
+import { Command } from '../java/cli'
+import CodegenConstants from '../CodegenConstants'
+import { apply } from '../java/beanUtils'
 
-const hasArg = true;
+const hasArg = true
 
 export default class Generate {
+  static Usage = new Command(
+    { name: 'generate', description: 'Generate code with chosen lang' },
+    [
+      { name: ['-v', '--verbose'], description: 'verbose mode' },
+      {
+        name: ['-l', '--lang'],
+        title: 'language',
+        required: true,
+        hasArg,
+        property: 'lang',
+        description:
+          'client language to generate ({maybe class name in classpath, required},',
+      },
+      {
+        name: ['-o', '--output'],
+        title: 'output directory',
+        hasArg,
+        description:
+          'where to write the generated files ({current dir by default},',
+        property: 'output',
+      },
+      {
+        name: ['-i', '--input-spec'],
+        title: 'spec file',
+        required: true,
+        hasArg,
+        property: 'spec',
+        description:
+          'location of the swagger spec, as URL or file ({required},',
+      },
+      {
+        name: ['-t', '--template-dir'],
+        title: 'template directory',
+        hasArg,
+        description: 'folder containing the template files',
+      },
+      {
+        name: ['-a', '--auth'],
+        title: 'authorization',
+        hasArg,
+        property: 'auth',
+        description:
+          'adds authorization headers when fetching the swagger definitions remotely. ' +
+          'Pass in a URL-encoded string of name:header with a comma separating multiple values',
+      },
+      {
+        name: ['-D'],
+        title: 'system properties',
+        hasArg,
+        description:
+          'sets specified system properties in ' +
+          'the format of name:value,name:value',
+      },
 
-    static Usage = new Command({name: "generate", description: "Generate code with chosen lang"}, [
-        {name: ["-v", "--verbose"], description: "verbose mode"},
-        {
-            name: ["-l", "--lang"], title: "language", required: true, hasArg,
-            property: 'lang',
-            description: "client language to generate ({maybe class name in classpath, required},"
-        },
-        {
-            name: ["-o", "--output"], title: "output directory", hasArg,
-            description: "where to write the generated files ({current dir by default},",
-            property: 'output'
-        },
-        {
-            name: ["-i", "--input-spec"], title: "spec file", required: true, hasArg,
-            property: 'spec',
-            description: "location of the swagger spec, as URL or file ({required},"
-        },
-        {
-            name: ["-t", "--template-dir"], title: "template directory", hasArg,
-            description: "folder containing the template files"
-        },
-        {
-            name: ["-a", "--auth"], title: "authorization", hasArg,
-            property: 'auth',
-            description: "adds authorization headers when fetching the swagger definitions remotely. " +
-            "Pass in a URL-encoded string of name:header with a comma separating multiple values"
-        },
-        {
-            name: ["-D"], title: "system properties", hasArg, description: "sets specified system properties in " +
-        "the format of name:value,name:value"
-        },
+      {
+        name: ['-c', '--config'],
+        hasArg,
+        title: 'configuration file',
+        property: 'configFile',
+        description:
+          'Path to json configuration file. ' +
+          'File content should be in a json format ["optionKey":"optionValue", "optionKey1":"optionValue1"...] ' +
+          'Supported options can be different for each language. Run config-help -l [lang] command for language specific config options.',
+      },
 
-        {
-            name: ["-c", "--config"], hasArg,
-            title: "configuration file",
-            property: "configFile",
-            description: "Path to json configuration file. " +
-            "File content should be in a json format [\"optionKey\":\"optionValue\", \"optionKey1\":\"optionValue1\"...] " +
-            "Supported options can be different for each language. Run config-help -l [lang] command for language specific config options."
-        },
+      {
+        name: ['-s', '--skip-overwrite'],
+        title: 'skip overwrite',
+        description:
+          'specifies if the existing files should be overwritten during the generation.',
+      },
 
-        {
-            name: ["-s", "--skip-overwrite"],
-            title: "skip overwrite",
-            description: "specifies if the existing files should be overwritten during the generation."
-        },
+      {
+        name: ['--api-package'],
+        title: 'api package',
+        hasArg,
+        description: CodegenConstants.API_PACKAGE_DESC,
+      },
 
-        {name: ["--api-package"], title: "api package", hasArg, description: CodegenConstants.API_PACKAGE_DESC},
+      {
+        name: ['--model-package'],
+        title: 'model package',
+        hasArg,
+        description: CodegenConstants.MODEL_PACKAGE_DESC,
+      },
 
-        {
-            name: ["--model-package"],
-            title: "model package", hasArg,
-            description: CodegenConstants.MODEL_PACKAGE_DESC
-        },
+      {
+        name: ['--model-name-prefix'],
+        title: 'model name prefix',
+        hasArg,
+        description: CodegenConstants.MODEL_NAME_PREFIX_DESC,
+      },
 
-        {
-            name: ["--model-name-prefix"],
-            title: "model name prefix", hasArg,
-            description: CodegenConstants.MODEL_NAME_PREFIX_DESC
-        },
+      {
+        name: ['--model-name-suffix'],
+        title: 'model name suffix',
+        hasArg,
+        description: CodegenConstants.MODEL_NAME_SUFFIX_DESC,
+      },
 
-        {
-            name: ["--model-name-suffix"],
-            title: "model name suffix", hasArg,
-            description: CodegenConstants.MODEL_NAME_SUFFIX_DESC
-        },
+      {
+        name: ['--instantiation-types'],
+        title: 'instantiation types',
+        hasArg,
+        description:
+          'sets instantiation type mappings in the format of type:instantiatedType,type:instantiatedType.' +
+          'For example ({in Java},: array:ArrayList,map:HashMap. In other words array types will get instantiated as ArrayList in generated code.',
+      },
 
+      {
+        name: ['--type-mappings'],
+        title: 'type mappings',
+        hasArg,
+        description:
+          'sets mappings between swagger spec types and generated code types ' +
+          'in the format of swaggerType:generatedType,swaggerType:generatedType. For example: array:List,map:Map,string:String',
+      },
 
-        {
-            name: ["--instantiation-types"],
-            title: "instantiation types", hasArg,
-            description: "sets instantiation type mappings in the format of type:instantiatedType,type:instantiatedType." +
-            "For example ({in Java},: array:ArrayList,map:HashMap. In other words array types will get instantiated as ArrayList in generated code."
-        },
+      {
+        name: ['--additional-properties'],
+        title: 'additional properties',
+        hasArg,
+        description:
+          'sets additional properties that can be referenced by the mustache templates in the format of name:value,name:value',
+      },
 
-        {
-            name: ["--type-mappings"],
-            title: "type mappings", hasArg,
-            description: "sets mappings between swagger spec types and generated code types " +
-            "in the format of swaggerType:generatedType,swaggerType:generatedType. For example: array:List,map:Map,string:String"
-        },
+      {
+        name: ['--language-specific-primitives'],
+        title: 'language specific primitives',
+        hasArg,
+        description:
+          'specifies additional language specific primitive types in the format of type1,type2,type3,type3. For example: String,boolean,Boolean,Double',
+      },
 
-        {
-            name: ["--additional-properties"],
-            title: "additional properties", hasArg,
-            description: "sets additional properties that can be referenced by the mustache templates in the format of name:value,name:value"
-        },
+      {
+        name: ['--import-mappings'],
+        title: 'import mappings',
+        hasArg,
+        description:
+          'specifies mappings between a given class and the import that should be used for that class in the format of type:import,type:import',
+      },
 
-        {
-            name: ["--language-specific-primitives"], title: "language specific primitives", hasArg,
-            description: "specifies additional language specific primitive types in the format of type1,type2,type3,type3. For example: String,boolean,Boolean,Double"
-        },
+      {
+        name: ['--invoker-package'],
+        title: 'invoker package',
+        hasArg,
+        description: CodegenConstants.INVOKER_PACKAGE_DESC,
+      },
 
-        {
-            name: ["--import-mappings"], title: "import mappings", hasArg,
-            description: "specifies mappings between a given class and the import that should be used for that class in the format of type:import,type:import"
-        },
+      {
+        name: ['--group-id'],
+        hasArg,
+        title: 'group id',
+        description: CodegenConstants.GROUP_ID_DESC,
+      },
 
-        {
-            name: ["--invoker-package"],
-            title: "invoker package", hasArg,
-            description: CodegenConstants.INVOKER_PACKAGE_DESC
-        },
+      {
+        name: ['--artifact-id'],
+        hasArg,
+        title: 'artifact id',
+        description: CodegenConstants.ARTIFACT_ID_DESC,
+      },
 
-        {name: ["--group-id"], hasArg, title: "group id", description: CodegenConstants.GROUP_ID_DESC},
+      {
+        name: ['--artifact-version'],
+        title: 'artifact version',
+        hasArg,
+        description: CodegenConstants.ARTIFACT_VERSION_DESC,
+      },
 
-        {name: ["--artifact-id"], hasArg, title: "artifact id", description: CodegenConstants.ARTIFACT_ID_DESC},
+      {
+        name: ['--library'],
+        hasArg,
+        title: 'library',
+        description: CodegenConstants.LIBRARY_DESC,
+      },
 
-        {
-            name: ["--artifact-version"],
-            title: "artifact version", hasArg,
-            description: CodegenConstants.ARTIFACT_VERSION_DESC
-        },
+      {
+        name: ['--git-user-id'],
+        hasArg,
+        title: 'git user id',
+        description: CodegenConstants.GIT_USER_ID_DESC,
+      },
 
-        {name: ["--library"], hasArg, title: "library", description: CodegenConstants.LIBRARY_DESC},
+      {
+        name: ['--git-repo-id'],
+        hasArg,
+        title: 'git repo id',
+        description: CodegenConstants.GIT_REPO_ID_DESC,
+      },
 
-        {name: ["--git-user-id"], hasArg, title: "git user id", description: CodegenConstants.GIT_USER_ID_DESC},
+      {
+        name: ['--release-note'],
+        hasArg,
+        title: 'release note',
+        description: CodegenConstants.RELEASE_NOTE_DESC,
+      },
 
-        {name: ["--git-repo-id"], hasArg, title: "git repo id", description: CodegenConstants.GIT_REPO_ID_DESC},
+      {
+        name: ['--http-user-agent'],
+        hasArg,
+        title: 'http user agent',
+        description: CodegenConstants.HTTP_USER_AGENT_DESC,
+      },
+    ]
+  )
 
-        {name: ["--release-note"], hasArg, title: "release note", description: CodegenConstants.RELEASE_NOTE_DESC},
+  output = ''
 
-        {
-            name: ["--http-user-agent"], hasArg, title: "http user agent",
-            description: CodegenConstants.HTTP_USER_AGENT_DESC
-        }]);
+  constructor(values) {
+    apply(this, values)
+  }
 
-    output = '';
-
-    constructor(values) {
-        apply(this, values);
+  async run() {
+    let configurator = CodegenConfigurator.fromFile(this.configFile)
+    if (configurator == null) {
+      configurator = new CodegenConfigurator()
     }
-
-    async run() {
-        let configurator = CodegenConfigurator.fromFile(this.configFile);
-        if (configurator == null) {
-            configurator = new CodegenConfigurator();
-        }
-        if (this.verbose != null) {
-            configurator.setVerbose(this.verbose);
-        }
-        if (this.skipOverwrite != null) {
-            configurator.setSkipOverwrite(this.skipOverwrite);
-        }
-        if (isNotEmpty(this.spec)) {
-            configurator.setInputSpec(this.spec);
-        }
-        if (isNotEmpty(this.lang)) {
-            configurator.setLang(this.lang);
-        }
-        if (isNotEmpty(this.output)) {
-            configurator.setOutputDir(this.output);
-        }
-        if (isNotEmpty(this.auth)) {
-            configurator.setAuth(this.auth);
-        }
-        if (isNotEmpty(this.templateDir)) {
-            configurator.setTemplateDir(this.templateDir);
-        }
-        if (isNotEmpty(this.apiPackage)) {
-            configurator.setApiPackage(this.apiPackage);
-        }
-        if (isNotEmpty(this.modelPackage)) {
-            configurator.setModelPackage(this.modelPackage);
-        }
-        if (isNotEmpty(this.modelNamePrefix)) {
-            configurator.setModelNamePrefix(this.modelNamePrefix);
-        }
-        if (isNotEmpty(this.modelNameSuffix)) {
-            configurator.setModelNameSuffix(this.modelNameSuffix);
-        }
-        if (isNotEmpty(this.invokerPackage)) {
-            configurator.setInvokerPackage(this.invokerPackage);
-        }
-        if (isNotEmpty(this.groupId)) {
-            configurator.setGroupId(this.groupId);
-        }
-        if (isNotEmpty(this.artifactId)) {
-            configurator.setArtifactId(this.artifactId);
-        }
-        if (isNotEmpty(this.artifactVersion)) {
-            configurator.setArtifactVersion(this.artifactVersion);
-        }
-        if (isNotEmpty(this.library)) {
-            configurator.setLibrary(this.library);
-        }
-        if (isNotEmpty(this.gitUserId)) {
-            configurator.setGitUserId(this.gitUserId);
-        }
-        if (isNotEmpty(this.gitRepoId)) {
-            configurator.setGitRepoId(this.gitRepoId);
-        }
-        if (isNotEmpty(this.releaseNote)) {
-            configurator.setReleaseNote(this.releaseNote);
-        }
-        if (isNotEmpty(this.httpUserAgent)) {
-            configurator.setHttpUserAgent(this.httpUserAgent);
-        }
-        applySystemPropertiesKvp(this.systemProperties, configurator);
-        applyInstantiationTypesKvp(this.instantiationTypes, configurator);
-        applyImportMappingsKvp(this.importMappings, configurator);
-        applyTypeMappingsKvp(this.typeMappings, configurator);
-        applyAdditionalPropertiesKvp(this.additionalProperties, configurator);
-        applyLanguageSpecificPrimitivesCsv(this.languageSpecificPrimitives, configurator);
-        const clientOptInput = await  configurator.toClientOptInput();
-        const dg = new DefaultGenerator().opts(clientOptInput);
-        dg.generate();
+    if (this.verbose != null) {
+      configurator.setVerbose(this.verbose)
     }
+    if (this.skipOverwrite != null) {
+      configurator.setSkipOverwrite(this.skipOverwrite)
+    }
+    if (isNotEmpty(this.spec)) {
+      configurator.setInputSpec(this.spec)
+    }
+    if (isNotEmpty(this.lang)) {
+      configurator.setLang(this.lang)
+    }
+    if (isNotEmpty(this.output)) {
+      configurator.setOutputDir(this.output)
+    }
+    if (isNotEmpty(this.auth)) {
+      configurator.setAuth(this.auth)
+    }
+    if (isNotEmpty(this.templateDir)) {
+      configurator.setTemplateDir(this.templateDir)
+    }
+    if (isNotEmpty(this.apiPackage)) {
+      configurator.setApiPackage(this.apiPackage)
+    }
+    if (isNotEmpty(this.modelPackage)) {
+      configurator.setModelPackage(this.modelPackage)
+    }
+    if (isNotEmpty(this.modelNamePrefix)) {
+      configurator.setModelNamePrefix(this.modelNamePrefix)
+    }
+    if (isNotEmpty(this.modelNameSuffix)) {
+      configurator.setModelNameSuffix(this.modelNameSuffix)
+    }
+    if (isNotEmpty(this.invokerPackage)) {
+      configurator.setInvokerPackage(this.invokerPackage)
+    }
+    if (isNotEmpty(this.groupId)) {
+      configurator.setGroupId(this.groupId)
+    }
+    if (isNotEmpty(this.artifactId)) {
+      configurator.setArtifactId(this.artifactId)
+    }
+    if (isNotEmpty(this.artifactVersion)) {
+      configurator.setArtifactVersion(this.artifactVersion)
+    }
+    if (isNotEmpty(this.library)) {
+      configurator.setLibrary(this.library)
+    }
+    if (isNotEmpty(this.gitUserId)) {
+      configurator.setGitUserId(this.gitUserId)
+    }
+    if (isNotEmpty(this.gitRepoId)) {
+      configurator.setGitRepoId(this.gitRepoId)
+    }
+    if (isNotEmpty(this.releaseNote)) {
+      configurator.setReleaseNote(this.releaseNote)
+    }
+    if (isNotEmpty(this.httpUserAgent)) {
+      configurator.setHttpUserAgent(this.httpUserAgent)
+    }
+    applySystemPropertiesKvp(this.systemProperties, configurator)
+    applyInstantiationTypesKvp(this.instantiationTypes, configurator)
+    applyImportMappingsKvp(this.importMappings, configurator)
+    applyTypeMappingsKvp(this.typeMappings, configurator)
+    applyAdditionalPropertiesKvp(this.additionalProperties, configurator)
+    applyLanguageSpecificPrimitivesCsv(
+      this.languageSpecificPrimitives,
+      configurator
+    )
+    const clientOptInput = await configurator.toClientOptInput()
+    const dg = new DefaultGenerator().opts(clientOptInput)
+    dg.generate()
+  }
 }
-const Log = LoggerFactory.getLogger(Generate);
+const Log = LoggerFactory.getLogger(Generate)

--- a/ern-api-gen/src/cmd/Langs.js
+++ b/ern-api-gen/src/cmd/Langs.js
@@ -1,21 +1,20 @@
-import ServiceLoader from "../java/ServiceLoader";
-import {Command} from '../java/cli';
+import ServiceLoader from '../java/ServiceLoader'
+import { Command } from '../java/cli'
 export default class Langs {
+  static configs() {
+    return ServiceLoader.load('io.swagger.codegen.CodegenConfig')
+  }
 
-    static configs() {
-        return ServiceLoader.load("io.swagger.codegen.CodegenConfig");
-    }
+  static langs() {
+    return Langs.configs().map(v => v.getName())
+  }
 
-    static langs() {
-        return Langs.configs().map(v => v.getName())
-    }
+  static Usage = new Command(
+    { name: 'langs', description: 'Shows available langs' },
+    [{ name: ['-h', '--help'], title: 'help', description: 'verbose mode' }]
+  )
 
-    static Usage = new Command({name: "langs", description: "Shows available langs"}, [
-        {name: ["-h", "--help"], title: "help", description: "verbose mode"}
-    ]);
-
-
-    run() {
-        return "Available languages: " + Langs.langs();
-    }
+  run() {
+    return 'Available languages: ' + Langs.langs()
+  }
 }

--- a/ern-api-gen/src/cmd/Meta.js
+++ b/ern-api-gen/src/cmd/Meta.js
@@ -1,144 +1,193 @@
-import File from "../java/File";
-import Mustache from "../java/Mustache";
-import DefaultGenerator from "../DefaultGenerator";
-import SupportingFile from "../SupportingFile";
-import LoggerFactory from "../java/LoggerFactory";
-import camelCase from "lodash/camelCase";
-import {newHashMap} from "../java/javaUtil";
-import FileUtils from "../java/FileUtils";
-import {Command} from '../java/cli';
-import {apply} from '../java/beanUtils';
+import File from '../java/File'
+import Mustache from '../java/Mustache'
+import DefaultGenerator from '../DefaultGenerator'
+import SupportingFile from '../SupportingFile'
+import LoggerFactory from '../java/LoggerFactory'
+import camelCase from 'lodash/camelCase'
+import { newHashMap } from '../java/javaUtil'
+import FileUtils from '../java/FileUtils'
+import { Command } from '../java/cli'
+import { apply } from '../java/beanUtils'
 
 export default class Meta {
+  static Usage = new Command(
+    {
+      name: 'meta',
+      description:
+        'MetaGenerator. Generator for creating a new template set ' +
+        'and configuration for Codegen.  The output will be based on the language you ' +
+        'specify, and includes default templates to include.',
+    },
+    [
+      {
+        name: ['-o', '--output'],
+        title: 'output directory',
+        hasArg: true,
+        property: 'outputFolder',
+        required: true,
+        description:
+          'where to write the generated files ({current dir by default},',
+      },
 
-    static Usage = new Command({
-        name: "meta", description: "MetaGenerator. Generator for creating a new template set " +
-        "and configuration for Codegen.  The output will be based on the language you " +
-        "specify, and includes default templates to include."
-    }, [
+      {
+        name: ['-n', '--name'],
+        title: 'name',
+        hasArg: true,
+        description: 'the human-readable name of the generator',
+      },
+      {
+        name: ['-s', '--swaggerVersion'],
+        title: 'swagger version',
+        hasArg: true,
+        description: 'the swagger version to use',
+      },
 
-        {
-            name: ["-o", "--output"], title: "output directory", hasArg: true, property: 'outputFolder', required: true,
-            description: "where to write the generated files ({current dir by default},"
-        },
+      {
+        name: ['-p', '--package'],
+        title: 'package',
+        property: 'targetPackage',
+        hasArg: true,
+        description:
+          'the package to put the main class into ({defaults to io.swagger.codegen},',
+      },
+    ]
+  )
 
-        {
-            name: ["-n", "--name"], title: "name", hasArg: true,
-            description: "the human-readable name of the generator"
-        },
-        {
-            name: ["-s", "--swaggerVersion"], title: "swagger version", hasArg: true,
-            description: "the swagger version to use"
-        },
+  static TEMPLATE_DIR_CLASSPATH = 'codegen'
+  static MUSTACHE_EXTENSION = '.mustache'
+  outputFolder = ''
+  name = 'default'
+  targetPackage = 'io.swagger.codegen'
 
-        {
-            name: ["-p", "--package"], title: "package", property: 'targetPackage', hasArg: true,
-            description: "the package to put the main class into ({defaults to io.swagger.codegen},"
-        }
-    ]);
-
-    static TEMPLATE_DIR_CLASSPATH = "codegen";
-    static MUSTACHE_EXTENSION = ".mustache";
-    outputFolder = "";
-    name = "default";
-    targetPackage = "io.swagger.codegen";
-
-    constructor(values) {
-        apply(this, values);
+  constructor(values) {
+    apply(this, values)
+  }
+  getImplementationVersion() {
+    return (this.swaggerVersion = '2.1.3')
+  }
+  run() {
+    const targetDir = new File(this.outputFolder)
+    Log.info('writing to folder [{}]', targetDir.getAbsolutePath())
+    const mainClass = camelCase(this.name) + 'Generator'
+    const supportingFiles = [
+      new SupportingFile('pom.mustache', '', 'pom.xml'),
+      new SupportingFile(
+        'generatorClass.mustache',
+        ['src/main/java', Meta.asPath(this.targetPackage)].join(File.separator),
+        mainClass + '.java'
+      ),
+      new SupportingFile('README.mustache', '', 'README.md'),
+      new SupportingFile(
+        'api.template',
+        'src/main/resources' + File.separator + this.name,
+        'api.mustache'
+      ),
+      new SupportingFile(
+        'model.template',
+        'src/main/resources' + File.separator + this.name,
+        'model.mustache'
+      ),
+      new SupportingFile(
+        'services.mustache',
+        'src/main/resources/META-INF/services',
+        'io.swagger.codegen.CodegenConfig'
+      ),
+    ]
+    let swaggerVersion = this.getImplementationVersion()
+    if (swaggerVersion == null) {
+      swaggerVersion = '2.1.3'
     }
-    getImplementationVersion(){
-        return this.swaggerVersion = '2.1.3'
-    }
-    run() {
-        const targetDir = new File(this.outputFolder);
-        Log.info("writing to folder [{}]", targetDir.getAbsolutePath());
-        const mainClass = camelCase(this.name) + "Generator";
-        const supportingFiles = [
-            new SupportingFile("pom.mustache", "", "pom.xml"),
-            new SupportingFile("generatorClass.mustache", ["src/main/java", Meta.asPath(this.targetPackage)].join(File.separator), mainClass + ".java"),
-            new SupportingFile("README.mustache", "", "README.md"),
-            new SupportingFile("api.template", "src/main/resources" + File.separator + this.name, "api.mustache"),
-            new SupportingFile("model.template", "src/main/resources" + File.separator + this.name, "model.mustache"),
-            new SupportingFile("services.mustache", "src/main/resources/META-INF/services", "io.swagger.codegen.CodegenConfig")
-        ];
-        let swaggerVersion = this.getImplementationVersion();
-        if (swaggerVersion == null) {
-            swaggerVersion = "2.1.3";
-        }
-        const data = newHashMap(["generatorPackage", this.targetPackage], ["generatorClass", mainClass], ["name", this.name], ["fullyQualifiedGeneratorClass", this.targetPackage + "." + mainClass], ["swaggerCodegenVersion", swaggerVersion]);
-        supportingFiles.forEach(Meta.processFiles(targetDir, data).convert);
-    }
+    const data = newHashMap(
+      ['generatorPackage', this.targetPackage],
+      ['generatorClass', mainClass],
+      ['name', this.name],
+      ['fullyQualifiedGeneratorClass', this.targetPackage + '.' + mainClass],
+      ['swaggerCodegenVersion', swaggerVersion]
+    )
+    supportingFiles.forEach(Meta.processFiles(targetDir, data).convert)
+  }
 
-    /**
-     * Converter method to process supporting files: execute with mustache,
-     * or simply copy to destination directory
-     *
-     * @param targetDir - destination directory
-     * @param data      - map with additional params needed to process templates
-     * @return converter object to pass to lambdaj
-     */
-    static processFiles(targetDir, data) {
-        return new Writer(targetDir, data)
-    }
+  /**
+   * Converter method to process supporting files: execute with mustache,
+   * or simply copy to destination directory
+   *
+   * @param targetDir - destination directory
+   * @param data      - map with additional params needed to process templates
+   * @return converter object to pass to lambdaj
+   */
+  static processFiles(targetDir, data) {
+    return new Writer(targetDir, data)
+  }
 
-    /**
-     * Creates mustache loader for template using classpath loader
-     *
-     * @param generator - class with reader getter
-     * @return loader for template
-     */
-    static loader(generator) {
-        return new Reader(generator);
-    }
+  /**
+   * Creates mustache loader for template using classpath loader
+   *
+   * @param generator - class with reader getter
+   * @return loader for template
+   */
+  static loader(generator) {
+    return new Reader(generator)
+  }
 
-    /**
-     * Converts package name to path on file system
-     *
-     * @param packageName - package name to convert
-     * @return relative path
-     */
-    static asPath(packageName) {
-        return packageName.split(".").join(File.separator);
-    }
+  /**
+   * Converts package name to path on file system
+   *
+   * @param packageName - package name to convert
+   * @return relative path
+   */
+  static asPath(packageName) {
+    return packageName.split('.').join(File.separator)
+  }
 }
 
 export class Writer {
-    constructor(targetDir, data) {
-        this.targetDir = targetDir;
-        this.data = data;
-        this.generator = new DefaultGenerator();
-    }
+  constructor(targetDir, data) {
+    this.targetDir = targetDir
+    this.data = data
+    this.generator = new DefaultGenerator()
+  }
 
-    convert = (support) => {
-        try {
-            let destinationFolder = new File(new File(this.targetDir.getAbsolutePath()), support.folder);
-            let outputFile = new File(destinationFolder, support.destinationFilename);
-            let template = this.generator.readTemplate(new File(Meta.TEMPLATE_DIR_CLASSPATH, support.templateFile).getPath());
-            let formatted = template;
-            if (support.templateFile.endsWith(Meta.MUSTACHE_EXTENSION)) {
-                Log.info("writing file to {}", outputFile.getAbsolutePath());
-                formatted = Mustache.compiler().withLoader(Meta.loader(this.generator)).defaultValue("").compile(template).execute(this.data);
-            }
-            else {
-                Log.info("copying file to {}", outputFile.getAbsolutePath());
-            }
-            FileUtils.writeStringToFile(outputFile, formatted);
-            return outputFile;
-        }
-        catch (e) {
-            throw new Error("Can\'t generate project", e);
-        }
-
+  convert = support => {
+    try {
+      let destinationFolder = new File(
+        new File(this.targetDir.getAbsolutePath()),
+        support.folder
+      )
+      let outputFile = new File(destinationFolder, support.destinationFilename)
+      let template = this.generator.readTemplate(
+        new File(Meta.TEMPLATE_DIR_CLASSPATH, support.templateFile).getPath()
+      )
+      let formatted = template
+      if (support.templateFile.endsWith(Meta.MUSTACHE_EXTENSION)) {
+        Log.info('writing file to {}', outputFile.getAbsolutePath())
+        formatted = Mustache.compiler()
+          .withLoader(Meta.loader(this.generator))
+          .defaultValue('')
+          .compile(template)
+          .execute(this.data)
+      } else {
+        Log.info('copying file to {}', outputFile.getAbsolutePath())
+      }
+      FileUtils.writeStringToFile(outputFile, formatted)
+      return outputFile
+    } catch (e) {
+      throw new Error("Can't generate project", e)
     }
+  }
 }
 export class Reader {
-    constructor(generator) {
-        this.generator = generator;
-    }
+  constructor(generator) {
+    this.generator = generator
+  }
 
-    getTemplate(name) {
-        return this.generator.getTemplateReader(Meta.TEMPLATE_DIR_CLASSPATH + File.separator + name + Meta.MUSTACHE_EXTENSION);
-    }
+  getTemplate(name) {
+    return this.generator.getTemplateReader(
+      Meta.TEMPLATE_DIR_CLASSPATH +
+        File.separator +
+        name +
+        Meta.MUSTACHE_EXTENSION
+    )
+  }
 }
 
-const Log = LoggerFactory.getLogger(Meta);
+const Log = LoggerFactory.getLogger(Meta)

--- a/ern-api-gen/src/config/CodegenConfigurator.js
+++ b/ern-api-gen/src/config/CodegenConfigurator.js
@@ -1,22 +1,22 @@
-import ClientOptInput from "../ClientOptInput";
-import ClientOpts from "../ClientOpts";
-import CodegenConfigLoader from "../CodegenConfigLoader";
-import CodegenConstants from "../CodegenConstants";
-import AuthParser from "../auth/AuthParser";
-import File from "../java/File";
-import LoggerFactory from "../java/LoggerFactory";
-import {isNotEmpty, isEmpty} from "../java/StringUtils";
-import {apply, applyStrict} from "../java/beanUtils";
-import System from "../java/System";
-import fs from "fs";
-import {newHashMap, newHashSet, asMap} from "../java/javaUtil";
-import Swagger from '../java/Swagger';
+import ClientOptInput from '../ClientOptInput'
+import ClientOpts from '../ClientOpts'
+import CodegenConfigLoader from '../CodegenConfigLoader'
+import CodegenConstants from '../CodegenConstants'
+import AuthParser from '../auth/AuthParser'
+import File from '../java/File'
+import LoggerFactory from '../java/LoggerFactory'
+import { isNotEmpty, isEmpty } from '../java/StringUtils'
+import { apply, applyStrict } from '../java/beanUtils'
+import System from '../java/System'
+import fs from 'fs'
+import { newHashMap, newHashSet, asMap } from '../java/javaUtil'
+import Swagger from '../java/Swagger'
 
 const Validate = {
-    notEmpty(value, message){
-        if (isEmpty(value)) throw new Error(message);
-    }
-};
+  notEmpty(value, message) {
+    if (isEmpty(value)) throw new Error(message)
+  },
+}
 /**
  * A class that contains all codegen configuration properties a user would want to manipulate.
  * An instance could be created by deserializing a JSON file or being populated from CLI or Maven plugin parameters.
@@ -24,414 +24,453 @@ const Validate = {
  * to generate code.
  */
 export default class CodegenConfigurator {
-    systemProperties = newHashMap();
-    instantiationTypes = newHashMap();
-    typeMappings = newHashMap();
-    additionalProperties = newHashMap();
-    importMappings = newHashMap();
-    languageSpecificPrimitives = newHashSet();
-    dynamicProperties = newHashMap();
-
-    gitUserId = "GIT_USER_ID";
-    gitRepoId = "GIT_REPO_ID";
-    releaseNote = "Minor update";
-    verbose = false;
-    skipOverwrite = false;
-
-    constructor(opts = {outputDir: '.'}) {
-        apply(this, opts);
-    }
-
-    setBridgeVersion(version) {
-        this.bridgeVersion = version;
-    }
-
-    getBridgeVersion() {
-        return this.bridgeVersion;
-    }
-
-    setLang(lang) {
-        this.lang = lang;
-        return this;
-    }
-
-    setInputSpec(inputSpec) {
-        this.inputSpec = inputSpec;
-        return this;
-    }
-
-    getInputSpec() {
-        return this.inputSpec;
-    }
-
-    getOutputDir() {
-        return this.outputDir;
-    }
-
-    setOutputDir(outputDir) {
-        this.outputDir = CodegenConfigurator.toAbsolutePathStr(outputDir);
-        return this;
-    }
-
-    getModelPackage() {
-        return this.modelPackage;
-    }
-
-    setModelPackage(modelPackage) {
-        this.modelPackage = modelPackage;
-        return this;
-    }
-
-    getModelNamePrefix() {
-        return this.modelNamePrefix;
-    }
-
-    setModelNamePrefix(prefix) {
-        this.modelNamePrefix = prefix;
-        return this;
-    }
-
-    getModelNameSuffix() {
-        return this.modelNameSuffix;
-    }
-
-    setModelNameSuffix(suffix) {
-        this.modelNameSuffix = suffix;
-        return this;
-    }
-
-    isVerbose() {
-        return this.verbose;
-    }
-
-    setVerbose(verbose) {
-        this.verbose = verbose;
-        return this;
-    }
-
-    isSkipOverwrite() {
-        return this.skipOverwrite;
-    }
-
-    setSkipOverwrite(skipOverwrite) {
-        this.skipOverwrite = skipOverwrite;
-        return this;
-    }
-
-    getLang() {
-        return this.lang;
-    }
-
-    getTemplateDir() {
-        return this.templateDir;
-    }
-
-    setTemplateDir(templateDir) {
-        let f = new File(templateDir);
-        if (!(f != null && f.exists() && f.isDirectory())) {
-            throw new Error("Template directory " + templateDir + " does not exist.");
-        }
-        this.templateDir = f.getAbsolutePath();
-        return this;
-    }
-
-    getAuth() {
-        return this.auth;
-    }
-
-    setAuth(auth) {
-        this.auth = auth;
-        return this;
-    }
-
-    getApiPackage() {
-        return this.apiPackage;
-    }
-
-    setApiPackage(apiPackage) {
-        this.apiPackage = apiPackage;
-        return this;
-    }
-
-    getInvokerPackage() {
-        return this.invokerPackage;
-    }
-
-    setInvokerPackage(invokerPackage) {
-        this.invokerPackage = invokerPackage;
-        return this;
-    }
-
-    getGroupId() {
-        return this.groupId;
-    }
-
-    setGroupId(groupId) {
-        this.groupId = groupId;
-        return this;
-    }
-
-    getArtifactId() {
-        return this.artifactId;
-    }
-
-    setArtifactId(artifactId) {
-        this.artifactId = artifactId;
-        return this;
-    }
-
-    getArtifactVersion() {
-        return this.artifactVersion;
-    }
-
-    setArtifactVersion(artifactVersion) {
-        this.artifactVersion = artifactVersion;
-        return this;
-    }
-
-    getSystemProperties() {
-        return this.systemProperties;
-    }
-
-    setSystemProperties(systemProperties) {
-        if (arguments.length) {
-            this.systemProperties = systemProperties;
-        } else {
-            for (const [key, value] of this.systemProperties) {
-                System.setProperty(key, value);
-            }
-        }
-    }
-
-    addSystemProperty(key, value) {
-
-        this.systemProperties.put(key, value);
-        return this;
-    }
-
-    getInstantiationTypes() {
-        return this.instantiationTypes;
-    }
-
-    setInstantiationTypes(instantiationTypes) {
-        this.instantiationTypes = instantiationTypes;
-        return this;
-    }
-
-    addInstantiationType(key, value) {
-        this.instantiationTypes.put(key, value);
-        return this;
-    }
-
-    getTypeMappings() {
-        return this.typeMappings;
-    }
-
-    setTypeMappings(typeMappings) {
-        this.typeMappings = asMap(typeMappings);
-        return this;
-    }
-
-    addTypeMapping(key, value) {
-        this.typeMappings.put(key, value);
-        return this;
-    }
-
-    getAdditionalProperties() {
-        return this.additionalProperties;
-    }
-
-    setAdditionalProperties(additionalProperties) {
-        this.additionalProperties = asMap(additionalProperties);
-        return this;
-    }
-
-    addAdditionalProperty(key, value) {
-        this.additionalProperties.put(key, value);
-        return this;
-    }
-
-    getImportMappings() {
-        return this.importMappings;
-    }
-
-    setImportMappings(importMappings) {
-        this.importMappings = asMap(importMappings);
-        return this;
-    }
-
-    addImportMapping(key, value) {
-        this.importMappings.put(key, value);
-        return this;
-    }
-
-    setDynamicProperties(properties) {
-        properties = asMap(properties);
-        this.dynamicProperties.clear();
-        this.dynamicProperties.putAll(properties);
-    }
-
-    getLanguageSpecificPrimitives() {
-        return this.languageSpecificPrimitives;
-    }
-
-    setLanguageSpecificPrimitives(languageSpecificPrimitives) {
-        this.languageSpecificPrimitives = languageSpecificPrimitives;
-        return this;
-    }
-
-    addLanguageSpecificPrimitive(value) {
-        this.languageSpecificPrimitives.add(value);
-        return this;
-    }
-
-    getLibrary() {
-        return this.library;
-    }
-
-    setLibrary(library) {
-        this.library = library;
-        return this;
-    }
-
-    getGitUserId() {
-        return this.gitUserId;
-    }
-
-    setGitUserId(gitUserId) {
-        this.gitUserId = gitUserId;
-        return this;
-    }
-
-    getGitRepoId() {
-        return this.gitRepoId;
-    }
-
-    setGitRepoId(gitRepoId) {
-        this.gitRepoId = gitRepoId;
-        return this;
-    }
-
-    getReleaseNote() {
-        return this.releaseNote;
-    }
-
-    setReleaseNote(releaseNote) {
-        this.releaseNote = releaseNote;
-        return this;
-    }
-
-    getHttpUserAgent() {
-        return this.httpUserAgent;
-    }
-
-    setHttpUserAgent(httpUserAgent) {
-        this.httpUserAgent = httpUserAgent;
-        return this;
-    }
-
-    async toClientOptInput() {
-
-        Validate.notEmpty(this.lang, "language must be specified");
-        Validate.notEmpty(this.inputSpec, "input spec must be specified");
-        this.setVerboseFlags();
-        this.setSystemProperties();
-        let config = CodegenConfigLoader.forName(this.lang);
-        applyStrict(config, this);
-        config.setOutputDir(this.outputDir);
-        config.setSkipOverwrite(this.skipOverwrite);
-        config.instantiationTypes().putAll(this.instantiationTypes);
-        config.typeMapping().putAll(this.typeMappings);
-        config.importMapping().putAll(this.importMappings);
-        config.languageSpecificPrimitives().addAll(this.languageSpecificPrimitives);
-        this.checkAndSetAdditionalProperty(this.apiPackage, CodegenConstants.API_PACKAGE);
-        this.checkAndSetAdditionalProperty(this.modelPackage, CodegenConstants.MODEL_PACKAGE);
-        this.checkAndSetAdditionalProperty(this.invokerPackage, CodegenConstants.INVOKER_PACKAGE);
-        this.checkAndSetAdditionalProperty(this.bridgeVersion, "bridgeVersion");
-        this.checkAndSetAdditionalProperty(this.groupId, CodegenConstants.GROUP_ID);
-        this.checkAndSetAdditionalProperty(this.artifactId, CodegenConstants.ARTIFACT_ID);
-        this.checkAndSetAdditionalProperty(this.artifactVersion, CodegenConstants.ARTIFACT_VERSION);
-        this.checkAndSetAdditionalProperty(this.templateDir, CodegenConfigurator.toAbsolutePathStr(this.templateDir), CodegenConstants.TEMPLATE_DIR);
-        this.checkAndSetAdditionalProperty(this.modelNamePrefix, CodegenConstants.MODEL_NAME_PREFIX);
-        this.checkAndSetAdditionalProperty(this.modelNameSuffix, CodegenConstants.MODEL_NAME_SUFFIX);
-        this.checkAndSetAdditionalProperty(this.gitUserId, CodegenConstants.GIT_USER_ID);
-        this.checkAndSetAdditionalProperty(this.gitRepoId, CodegenConstants.GIT_REPO_ID);
-        this.checkAndSetAdditionalProperty(this.releaseNote, CodegenConstants.RELEASE_NOTE);
-        this.checkAndSetAdditionalProperty(this.httpUserAgent, CodegenConstants.HTTP_USER_AGENT);
-        this.handleDynamicProperties(config);
-        if (isNotEmpty(this.library)) {
-            config.setLibrary(this.library);
-        }
-        config.additionalProperties().putAll(this.additionalProperties);
-        let input = new ClientOptInput().config(config);
-        let authorizationValues = AuthParser.parse(this.auth);
-        const swagger = await Swagger.create({definition: this.inputSpec});
-        return input.opts(new ClientOpts()).swagger(swagger);
-    }
-
-    addDynamicProperty(name, value) {
-        this.dynamicProperties.put(name, value.toString());
-        return this;
-    }
-
-    getDynamicProperties() {
-        return this.dynamicProperties;
-    }
-
-    handleDynamicProperties(codegenConfig) {
-        for (const langCliOption of codegenConfig.cliOptions()) {
-            let opt = langCliOption.getOpt();
-            if (this.dynamicProperties.containsKey(opt)) {
-                codegenConfig.additionalProperties().put(opt, this.dynamicProperties.get(opt));
-            }
-            else if (this.systemProperties.containsKey(opt)) {
-                codegenConfig.additionalProperties().put(opt, this.systemProperties.get(opt).toString());
-            }
-        }
-    }
-
-    setVerboseFlags() {
-        if (!this.verbose) {
-            return;
-        }
-        Log.info("\nVERBOSE MODE: ON. Additional debug options are injected\n - [debugSwagger] prints the swagger specification as interpreted by the codegen\n - [debugModels] prints models passed to the template engine\n - [debugOperations] prints operations passed to the template engine\n - [debugSupportingFiles] prints additional data passed to the template engine");
-        System.setProperty("debugSwagger", "");
-        System.setProperty("debugModels", "");
-        System.setProperty("debugOperations", "");
-        System.setProperty("debugSupportingFiles", "");
-    }
-
-
-    static toAbsolutePathStr(path) {
-        if (isNotEmpty(path)) {
-            return new File(path).toAbsolutePath();
-        }
-        return path;
-    }
-
-    checkAndSetAdditionalProperty(property, valueToSet, propertyKey) {
-        if (arguments.length > 2) {
-            if (isNotEmpty(property)) {
-                this.additionalProperties.put(propertyKey, valueToSet);
-            }
-        } else {
-            this.checkAndSetAdditionalProperty(property, property, valueToSet);
-        }
-    }
-
-    static  fromFile(configFile) {
-        if (isNotEmpty(configFile)) {
-            try {
-                const conf = JSON.parse(fs.readFileSync(new File(configFile).getAbsolutePath(), 'utf-8'));
-                return apply(new CodegenConfigurator(), conf);
-            }
-            catch (e) {
-                Log.error("Unable to deserialize config file: " + configFile, e);
-            }
-
-        }
-        return null;
-    }
+  systemProperties = newHashMap()
+  instantiationTypes = newHashMap()
+  typeMappings = newHashMap()
+  additionalProperties = newHashMap()
+  importMappings = newHashMap()
+  languageSpecificPrimitives = newHashSet()
+  dynamicProperties = newHashMap()
+
+  gitUserId = 'GIT_USER_ID'
+  gitRepoId = 'GIT_REPO_ID'
+  releaseNote = 'Minor update'
+  verbose = false
+  skipOverwrite = false
+
+  constructor(opts = { outputDir: '.' }) {
+    apply(this, opts)
+  }
+
+  setBridgeVersion(version) {
+    this.bridgeVersion = version
+  }
+
+  getBridgeVersion() {
+    return this.bridgeVersion
+  }
+
+  setLang(lang) {
+    this.lang = lang
+    return this
+  }
+
+  setInputSpec(inputSpec) {
+    this.inputSpec = inputSpec
+    return this
+  }
+
+  getInputSpec() {
+    return this.inputSpec
+  }
+
+  getOutputDir() {
+    return this.outputDir
+  }
+
+  setOutputDir(outputDir) {
+    this.outputDir = CodegenConfigurator.toAbsolutePathStr(outputDir)
+    return this
+  }
+
+  getModelPackage() {
+    return this.modelPackage
+  }
+
+  setModelPackage(modelPackage) {
+    this.modelPackage = modelPackage
+    return this
+  }
+
+  getModelNamePrefix() {
+    return this.modelNamePrefix
+  }
+
+  setModelNamePrefix(prefix) {
+    this.modelNamePrefix = prefix
+    return this
+  }
+
+  getModelNameSuffix() {
+    return this.modelNameSuffix
+  }
+
+  setModelNameSuffix(suffix) {
+    this.modelNameSuffix = suffix
+    return this
+  }
+
+  isVerbose() {
+    return this.verbose
+  }
+
+  setVerbose(verbose) {
+    this.verbose = verbose
+    return this
+  }
+
+  isSkipOverwrite() {
+    return this.skipOverwrite
+  }
+
+  setSkipOverwrite(skipOverwrite) {
+    this.skipOverwrite = skipOverwrite
+    return this
+  }
+
+  getLang() {
+    return this.lang
+  }
+
+  getTemplateDir() {
+    return this.templateDir
+  }
+
+  setTemplateDir(templateDir) {
+    let f = new File(templateDir)
+    if (!(f != null && f.exists() && f.isDirectory())) {
+      throw new Error('Template directory ' + templateDir + ' does not exist.')
+    }
+    this.templateDir = f.getAbsolutePath()
+    return this
+  }
+
+  getAuth() {
+    return this.auth
+  }
+
+  setAuth(auth) {
+    this.auth = auth
+    return this
+  }
+
+  getApiPackage() {
+    return this.apiPackage
+  }
+
+  setApiPackage(apiPackage) {
+    this.apiPackage = apiPackage
+    return this
+  }
+
+  getInvokerPackage() {
+    return this.invokerPackage
+  }
+
+  setInvokerPackage(invokerPackage) {
+    this.invokerPackage = invokerPackage
+    return this
+  }
+
+  getGroupId() {
+    return this.groupId
+  }
+
+  setGroupId(groupId) {
+    this.groupId = groupId
+    return this
+  }
+
+  getArtifactId() {
+    return this.artifactId
+  }
+
+  setArtifactId(artifactId) {
+    this.artifactId = artifactId
+    return this
+  }
+
+  getArtifactVersion() {
+    return this.artifactVersion
+  }
+
+  setArtifactVersion(artifactVersion) {
+    this.artifactVersion = artifactVersion
+    return this
+  }
+
+  getSystemProperties() {
+    return this.systemProperties
+  }
+
+  setSystemProperties(systemProperties) {
+    if (arguments.length) {
+      this.systemProperties = systemProperties
+    } else {
+      for (const [key, value] of this.systemProperties) {
+        System.setProperty(key, value)
+      }
+    }
+  }
+
+  addSystemProperty(key, value) {
+    this.systemProperties.put(key, value)
+    return this
+  }
+
+  getInstantiationTypes() {
+    return this.instantiationTypes
+  }
+
+  setInstantiationTypes(instantiationTypes) {
+    this.instantiationTypes = instantiationTypes
+    return this
+  }
+
+  addInstantiationType(key, value) {
+    this.instantiationTypes.put(key, value)
+    return this
+  }
+
+  getTypeMappings() {
+    return this.typeMappings
+  }
+
+  setTypeMappings(typeMappings) {
+    this.typeMappings = asMap(typeMappings)
+    return this
+  }
+
+  addTypeMapping(key, value) {
+    this.typeMappings.put(key, value)
+    return this
+  }
+
+  getAdditionalProperties() {
+    return this.additionalProperties
+  }
+
+  setAdditionalProperties(additionalProperties) {
+    this.additionalProperties = asMap(additionalProperties)
+    return this
+  }
+
+  addAdditionalProperty(key, value) {
+    this.additionalProperties.put(key, value)
+    return this
+  }
+
+  getImportMappings() {
+    return this.importMappings
+  }
+
+  setImportMappings(importMappings) {
+    this.importMappings = asMap(importMappings)
+    return this
+  }
+
+  addImportMapping(key, value) {
+    this.importMappings.put(key, value)
+    return this
+  }
+
+  setDynamicProperties(properties) {
+    properties = asMap(properties)
+    this.dynamicProperties.clear()
+    this.dynamicProperties.putAll(properties)
+  }
+
+  getLanguageSpecificPrimitives() {
+    return this.languageSpecificPrimitives
+  }
+
+  setLanguageSpecificPrimitives(languageSpecificPrimitives) {
+    this.languageSpecificPrimitives = languageSpecificPrimitives
+    return this
+  }
+
+  addLanguageSpecificPrimitive(value) {
+    this.languageSpecificPrimitives.add(value)
+    return this
+  }
+
+  getLibrary() {
+    return this.library
+  }
+
+  setLibrary(library) {
+    this.library = library
+    return this
+  }
+
+  getGitUserId() {
+    return this.gitUserId
+  }
+
+  setGitUserId(gitUserId) {
+    this.gitUserId = gitUserId
+    return this
+  }
+
+  getGitRepoId() {
+    return this.gitRepoId
+  }
+
+  setGitRepoId(gitRepoId) {
+    this.gitRepoId = gitRepoId
+    return this
+  }
+
+  getReleaseNote() {
+    return this.releaseNote
+  }
+
+  setReleaseNote(releaseNote) {
+    this.releaseNote = releaseNote
+    return this
+  }
+
+  getHttpUserAgent() {
+    return this.httpUserAgent
+  }
+
+  setHttpUserAgent(httpUserAgent) {
+    this.httpUserAgent = httpUserAgent
+    return this
+  }
+
+  async toClientOptInput() {
+    Validate.notEmpty(this.lang, 'language must be specified')
+    Validate.notEmpty(this.inputSpec, 'input spec must be specified')
+    this.setVerboseFlags()
+    this.setSystemProperties()
+    let config = CodegenConfigLoader.forName(this.lang)
+    applyStrict(config, this)
+    config.setOutputDir(this.outputDir)
+    config.setSkipOverwrite(this.skipOverwrite)
+    config.instantiationTypes().putAll(this.instantiationTypes)
+    config.typeMapping().putAll(this.typeMappings)
+    config.importMapping().putAll(this.importMappings)
+    config.languageSpecificPrimitives().addAll(this.languageSpecificPrimitives)
+    this.checkAndSetAdditionalProperty(
+      this.apiPackage,
+      CodegenConstants.API_PACKAGE
+    )
+    this.checkAndSetAdditionalProperty(
+      this.modelPackage,
+      CodegenConstants.MODEL_PACKAGE
+    )
+    this.checkAndSetAdditionalProperty(
+      this.invokerPackage,
+      CodegenConstants.INVOKER_PACKAGE
+    )
+    this.checkAndSetAdditionalProperty(this.bridgeVersion, 'bridgeVersion')
+    this.checkAndSetAdditionalProperty(this.groupId, CodegenConstants.GROUP_ID)
+    this.checkAndSetAdditionalProperty(
+      this.artifactId,
+      CodegenConstants.ARTIFACT_ID
+    )
+    this.checkAndSetAdditionalProperty(
+      this.artifactVersion,
+      CodegenConstants.ARTIFACT_VERSION
+    )
+    this.checkAndSetAdditionalProperty(
+      this.templateDir,
+      CodegenConfigurator.toAbsolutePathStr(this.templateDir),
+      CodegenConstants.TEMPLATE_DIR
+    )
+    this.checkAndSetAdditionalProperty(
+      this.modelNamePrefix,
+      CodegenConstants.MODEL_NAME_PREFIX
+    )
+    this.checkAndSetAdditionalProperty(
+      this.modelNameSuffix,
+      CodegenConstants.MODEL_NAME_SUFFIX
+    )
+    this.checkAndSetAdditionalProperty(
+      this.gitUserId,
+      CodegenConstants.GIT_USER_ID
+    )
+    this.checkAndSetAdditionalProperty(
+      this.gitRepoId,
+      CodegenConstants.GIT_REPO_ID
+    )
+    this.checkAndSetAdditionalProperty(
+      this.releaseNote,
+      CodegenConstants.RELEASE_NOTE
+    )
+    this.checkAndSetAdditionalProperty(
+      this.httpUserAgent,
+      CodegenConstants.HTTP_USER_AGENT
+    )
+    this.handleDynamicProperties(config)
+    if (isNotEmpty(this.library)) {
+      config.setLibrary(this.library)
+    }
+    config.additionalProperties().putAll(this.additionalProperties)
+    let input = new ClientOptInput().config(config)
+    let authorizationValues = AuthParser.parse(this.auth)
+    const swagger = await Swagger.create({ definition: this.inputSpec })
+    return input.opts(new ClientOpts()).swagger(swagger)
+  }
+
+  addDynamicProperty(name, value) {
+    this.dynamicProperties.put(name, value.toString())
+    return this
+  }
+
+  getDynamicProperties() {
+    return this.dynamicProperties
+  }
+
+  handleDynamicProperties(codegenConfig) {
+    for (const langCliOption of codegenConfig.cliOptions()) {
+      let opt = langCliOption.getOpt()
+      if (this.dynamicProperties.containsKey(opt)) {
+        codegenConfig
+          .additionalProperties()
+          .put(opt, this.dynamicProperties.get(opt))
+      } else if (this.systemProperties.containsKey(opt)) {
+        codegenConfig
+          .additionalProperties()
+          .put(opt, this.systemProperties.get(opt).toString())
+      }
+    }
+  }
+
+  setVerboseFlags() {
+    if (!this.verbose) {
+      return
+    }
+    Log.info(
+      '\nVERBOSE MODE: ON. Additional debug options are injected\n - [debugSwagger] prints the swagger specification as interpreted by the codegen\n - [debugModels] prints models passed to the template engine\n - [debugOperations] prints operations passed to the template engine\n - [debugSupportingFiles] prints additional data passed to the template engine'
+    )
+    System.setProperty('debugSwagger', '')
+    System.setProperty('debugModels', '')
+    System.setProperty('debugOperations', '')
+    System.setProperty('debugSupportingFiles', '')
+  }
+
+  static toAbsolutePathStr(path) {
+    if (isNotEmpty(path)) {
+      return new File(path).toAbsolutePath()
+    }
+    return path
+  }
+
+  checkAndSetAdditionalProperty(property, valueToSet, propertyKey) {
+    if (arguments.length > 2) {
+      if (isNotEmpty(property)) {
+        this.additionalProperties.put(propertyKey, valueToSet)
+      }
+    } else {
+      this.checkAndSetAdditionalProperty(property, property, valueToSet)
+    }
+  }
+
+  static fromFile(configFile) {
+    if (isNotEmpty(configFile)) {
+      try {
+        const conf = JSON.parse(
+          fs.readFileSync(new File(configFile).getAbsolutePath(), 'utf-8')
+        )
+        return apply(new CodegenConfigurator(), conf)
+      } catch (e) {
+        Log.error('Unable to deserialize config file: ' + configFile, e)
+      }
+    }
+    return null
+  }
 }
 
-const Log = LoggerFactory.getLogger(CodegenConfigurator);
+const Log = LoggerFactory.getLogger(CodegenConfigurator)

--- a/ern-api-gen/src/config/CodegenConfiguratorUtils.js
+++ b/ern-api-gen/src/config/CodegenConfiguratorUtils.js
@@ -1,17 +1,19 @@
-import {newHashMap, newHashSet} from '../java/javaUtil'
-import {isNotEmpty} from '../java/StringUtils'
+import { newHashMap, newHashSet } from '../java/javaUtil'
+import { isNotEmpty } from '../java/StringUtils'
 
-export function splitCommaSeparatedList (input) {
+export function splitCommaSeparatedList(input) {
   const results = []
   if (isNotEmpty(input)) {
     for (const value of input.split(',')) {
-      if (isNotEmpty(value)) { results.push(value) }
+      if (isNotEmpty(value)) {
+        results.push(value)
+      }
     }
   }
   return results
 }
 
-export function parseCommaSeparatedTuples (input) {
+export function parseCommaSeparatedTuples(input) {
   let results = []
   for (const tuple of splitCommaSeparatedList(input)) {
     const [name, value] = tuple.split('=', 2)
@@ -31,51 +33,57 @@ export function parseCommaSeparatedTuples (input) {
  * to CodegenConfigurator, but this complicates things when mocking CodegenConfigurator.
  * </p>
  */
-export function applySystemPropertiesKvp (systemProperties, configurator) {
+export function applySystemPropertiesKvp(systemProperties, configurator) {
   for (const [key, value] of createMapFromKeyValuePairs(systemProperties)) {
     configurator.addSystemProperty(key, value)
   }
 }
 
-export function applyInstantiationTypesKvp (instantiationTypes, configurator) {
+export function applyInstantiationTypesKvp(instantiationTypes, configurator) {
   for (const [key, value] of createMapFromKeyValuePairs(instantiationTypes)) {
     configurator.addInstantiationType(key, value)
   }
 }
 
-export function applyImportMappingsKvp (importMappings, configurator) {
+export function applyImportMappingsKvp(importMappings, configurator) {
   for (const [key, value] of createMapFromKeyValuePairs(importMappings)) {
     configurator.addImportMapping(key, value)
   }
 }
 
-export function applyTypeMappingsKvp (typeMappings, configurator) {
+export function applyTypeMappingsKvp(typeMappings, configurator) {
   for (const [key, value] of createMapFromKeyValuePairs(typeMappings)) {
     configurator.addTypeMapping(key, value)
   }
 }
 
-export function applyAdditionalPropertiesKvp (additionalProperties, configurator) {
+export function applyAdditionalPropertiesKvp(
+  additionalProperties,
+  configurator
+) {
   for (let [key, value] of createMapFromKeyValuePairs(additionalProperties)) {
     configurator.addAdditionalProperty(key, value)
   }
 }
 
-export function applyLanguageSpecificPrimitivesCsv (languageSpecificPrimitives, configurator) {
+export function applyLanguageSpecificPrimitivesCsv(
+  languageSpecificPrimitives,
+  configurator
+) {
   for (const item of createSetFromCsvList(languageSpecificPrimitives)) {
     configurator.addLanguageSpecificPrimitive(item)
   }
 }
 
-export function createSetFromCsvList (csvProperty) {
+export function createSetFromCsvList(csvProperty) {
   return newHashSet(...splitCommaSeparatedList(csvProperty))
 }
 
-export function createMapFromKeyValuePairs (commaSeparatedKVPairs) {
+export function createMapFromKeyValuePairs(commaSeparatedKVPairs) {
   return newHashMap(...parseCommaSeparatedTuples(commaSeparatedKVPairs))
 }
 
-export default ({
+export default {
   applySystemPropertiesKvp,
   applyInstantiationTypesKvp,
   applyImportMappingsKvp,
@@ -83,5 +91,5 @@ export default ({
   applyAdditionalPropertiesKvp,
   applyLanguageSpecificPrimitivesCsv,
   createSetFromCsvList,
-  createMapFromKeyValuePairs
-})
+  createMapFromKeyValuePairs,
+}

--- a/ern-api-gen/src/examples/ExampleGenerator.js
+++ b/ern-api-gen/src/examples/ExampleGenerator.js
@@ -1,30 +1,30 @@
 import XmlExampleGenerator from './XmlExampleGenerator'
 import {
-    ArrayProperty,
-    BooleanProperty,
-    DateProperty,
-    DateTimeProperty,
-    DecimalProperty,
-    DoubleProperty,
-    FileProperty,
-    FloatProperty,
-    IntegerProperty,
-    LongProperty,
-    MapProperty,
-    ObjectProperty,
-    RefProperty,
-    StringProperty,
-    UUIDProperty
+  ArrayProperty,
+  BooleanProperty,
+  DateProperty,
+  DateTimeProperty,
+  DecimalProperty,
+  DoubleProperty,
+  FileProperty,
+  FloatProperty,
+  IntegerProperty,
+  LongProperty,
+  MapProperty,
+  ObjectProperty,
+  RefProperty,
+  StringProperty,
+  UUIDProperty,
 } from '../models/properties'
 import Json from '../java/Json'
-import {HashMap, newHashMap, newHashSet, asMap} from '../java/javaUtil'
+import { HashMap, newHashMap, newHashSet, asMap } from '../java/javaUtil'
 
 export default class ExampleGenerator {
-  constructor (examples) {
+  constructor(examples) {
     this.examples = examples
   }
 
-  generate (examples, mediaTypes, property) {
+  generate(examples, mediaTypes, property) {
     const output = []
     const processedModels = newHashSet()
     if (examples == null) {
@@ -34,13 +34,20 @@ export default class ExampleGenerator {
       for (const mediaType of mediaTypes) {
         const kv = newHashMap(['contentType', mediaType])
         if (property != null && mediaType.startsWith('application/json')) {
-          const rexample = this.resolvePropertyToExample(mediaType, property, processedModels)
+          const rexample = this.resolvePropertyToExample(
+            mediaType,
+            property,
+            processedModels
+          )
           let example = JSON.stringify(rexample, null, 2)
           if (example != null) {
             kv.put('example', example)
             output.push(kv)
           }
-        } else if (property != null && mediaType.startsWith('application/xml')) {
+        } else if (
+          property != null &&
+          mediaType.startsWith('application/xml')
+        ) {
           const example = new XmlExampleGenerator(this.examples).toXml(property)
           if (example != null) {
             kv.put('example', example)
@@ -50,7 +57,12 @@ export default class ExampleGenerator {
       }
     } else {
       for (const [contentType, example] of asMap(examples)) {
-        output.push(newHashMap(['contentType', contentType], ['example', Json.pretty(example)]))
+        output.push(
+          newHashMap(
+            ['contentType', contentType],
+            ['example', Json.pretty(example)]
+          )
+        )
       }
     }
     if (output.length == 0) {
@@ -59,7 +71,7 @@ export default class ExampleGenerator {
     return JSON.stringify(output)
   }
 
-  resolvePropertyToExample (mediaType, property, processedModels) {
+  resolvePropertyToExample(mediaType, property, processedModels) {
     if (property.getExample() != null) {
       return property.getExample()
     } else if (property instanceof BooleanProperty) {
@@ -67,7 +79,9 @@ export default class ExampleGenerator {
     } else if (property instanceof ArrayProperty) {
       let innerType = property.getItems()
       if (innerType != null) {
-        return [this.resolvePropertyToExample(mediaType, innerType, processedModels)]
+        return [
+          this.resolvePropertyToExample(mediaType, innerType, processedModels),
+        ]
       }
     } else if (property instanceof DateProperty) {
       return '2000-01-23T04:56:07.000+00:00'
@@ -80,36 +94,55 @@ export default class ExampleGenerator {
     } else if (property instanceof FileProperty) {
       return ''
     } else if (property instanceof FloatProperty) {
-        return Number(1.23).toPrecision(2)
-      } else if (property instanceof IntegerProperty) {
-          return Number(123).toPrecision(1)
-        } else if (property instanceof LongProperty) {
-          return Number(123456789).toPrecision(9)
-        } else if (property instanceof MapProperty) {
-          let mp = newHashMap()
-          if (property.getName() != null) {
-            mp.put(property.getName(), this.resolvePropertyToExample(mediaType, property.getAdditionalProperties(), processedModels))
-          } else {
-            mp.put('key', this.resolvePropertyToExample(mediaType, property.getAdditionalProperties(), processedModels))
-          }
-          return mp
-        } else if (property instanceof ObjectProperty) {
-          return '{}'
-        } else if (property instanceof RefProperty) {
-          let simpleName = property.getSimpleRef()
-          let model = this.examples.get(simpleName)
-          if (model != null) {
-          return this.resolveModelToExample(simpleName, mediaType, model, processedModels)
-        }
-        } else if (property instanceof UUIDProperty) {
-        return '046b6c7f-0b8a-43b9-b35d-6489e6daee91'
-      } else if (property instanceof StringProperty) {
-          return 'aeiou'
-        }
+      return Number(1.23).toPrecision(2)
+    } else if (property instanceof IntegerProperty) {
+      return Number(123).toPrecision(1)
+    } else if (property instanceof LongProperty) {
+      return Number(123456789).toPrecision(9)
+    } else if (property instanceof MapProperty) {
+      let mp = newHashMap()
+      if (property.getName() != null) {
+        mp.put(
+          property.getName(),
+          this.resolvePropertyToExample(
+            mediaType,
+            property.getAdditionalProperties(),
+            processedModels
+          )
+        )
+      } else {
+        mp.put(
+          'key',
+          this.resolvePropertyToExample(
+            mediaType,
+            property.getAdditionalProperties(),
+            processedModels
+          )
+        )
+      }
+      return mp
+    } else if (property instanceof ObjectProperty) {
+      return '{}'
+    } else if (property instanceof RefProperty) {
+      let simpleName = property.getSimpleRef()
+      let model = this.examples.get(simpleName)
+      if (model != null) {
+        return this.resolveModelToExample(
+          simpleName,
+          mediaType,
+          model,
+          processedModels
+        )
+      }
+    } else if (property instanceof UUIDProperty) {
+      return '046b6c7f-0b8a-43b9-b35d-6489e6daee91'
+    } else if (property instanceof StringProperty) {
+      return 'aeiou'
+    }
     return ''
   }
 
-  resolveModelToExample (name, mediaType, model, processedModels) {
+  resolveModelToExample(name, mediaType, model, processedModels) {
     if (processedModels.contains(name)) {
       return ''
     }
@@ -118,7 +151,10 @@ export default class ExampleGenerator {
       let values = newHashMap()
       if (model.getProperties() != null) {
         for (const [propertyName, property] of model.getProperties()) {
-          values.put(propertyName, this.resolvePropertyToExample(mediaType, property, processedModels))
+          values.put(
+            propertyName,
+            this.resolvePropertyToExample(mediaType, property, processedModels)
+          )
         }
       }
       return values

--- a/ern-api-gen/src/examples/XmlExampleGenerator.js
+++ b/ern-api-gen/src/examples/XmlExampleGenerator.js
@@ -1,30 +1,31 @@
 import ModelImpl from '../models/ModelImpl'
 import RefModel from '../models/RefModel'
 import {
-    Property, ArrayProperty,
-    BooleanProperty,
-    DateProperty,
-    DateTimeProperty,
-    IntegerProperty,
-    LongProperty,
-    RefProperty,
-    StringProperty
+  Property,
+  ArrayProperty,
+  BooleanProperty,
+  DateProperty,
+  DateTimeProperty,
+  IntegerProperty,
+  LongProperty,
+  RefProperty,
+  StringProperty,
 } from '../models/properties'
 
 import StringUtils from '../java/StringUtils'
-import {Collections, newHashMap, newHashSet} from '../java/javaUtil'
+import { Collections, newHashMap, newHashSet } from '../java/javaUtil'
 import AbstractModel from '../models/AbstractModel'
 import StringBuilder from '../java/StringBuilder'
 
 export default class XmlExampleGenerator {
-  constructor (examples) {
+  constructor(examples) {
     this.examples = examples
     if (examples == null) {
       this.examples = newHashMap()
     }
   }
 
-  modelImplToXml (model, indent, path) {
+  modelImplToXml(model, indent, path) {
     const modelName = model.getName()
     if (path.contains(modelName)) {
       return XmlExampleGenerator.EMPTY
@@ -43,7 +44,12 @@ export default class XmlExampleGenerator {
     }
     if (model.getProperties() != null) {
       for (const [pName, p] of model.getProperties()) {
-        if (p != null && p.getXml() != null && p.getXml().getAttribute() != null && p.getXml().getAttribute()) {
+        if (
+          p != null &&
+          p.getXml() != null &&
+          p.getXml().getAttribute() != null &&
+          p.getXml().getAttribute()
+        ) {
           attributes.put(pName, p)
         } else {
           elements.put(pName, p)
@@ -53,7 +59,10 @@ export default class XmlExampleGenerator {
     sb.append(this.indent(indent)).append(XmlExampleGenerator.TAG_START)
     sb.append(name)
     for (const [p, pName] of attributes) {
-      sb.append(' ').append(pName).append('=').append(this.quote(this.toXml(null, p, 0, selfPath)))
+      sb.append(' ')
+        .append(pName)
+        .append('=')
+        .append(this.quote(this.toXml(null, p, 0, selfPath)))
     }
     sb.append(XmlExampleGenerator.CLOSE_TAG)
     sb.append(XmlExampleGenerator.NEWLINE)
@@ -65,16 +74,24 @@ export default class XmlExampleGenerator {
       sb.append(asXml)
       sb.append(XmlExampleGenerator.NEWLINE)
     }
-    sb.append(this.indent(indent)).append(XmlExampleGenerator.TAG_END).append(name).append(XmlExampleGenerator.CLOSE_TAG)
+    sb.append(this.indent(indent))
+      .append(XmlExampleGenerator.TAG_END)
+      .append(name)
+      .append(XmlExampleGenerator.CLOSE_TAG)
     return sb.toString()
   }
 
-  quote (string) {
+  quote(string) {
     return '"' + string + '"'
   }
 
-  toXml (name, property, indent, path) {
-    if ((typeof name === 'string' || name === null) && (property instanceof Property || property === null) && ((typeof indent === 'number') || indent === null) && (path === null || 'size' in path)) {
+  toXml(name, property, indent, path) {
+    if (
+      (typeof name === 'string' || name === null) &&
+      (property instanceof Property || property === null) &&
+      (typeof indent === 'number' || indent === null) &&
+      (path === null || 'size' in path)
+    ) {
       if (property == null) {
         return ''
       }
@@ -83,7 +100,11 @@ export default class XmlExampleGenerator {
         let p = property
         let inner = p.getItems()
         let wrapped = false
-        if (property.getXml() != null && property.getXml().getWrapped() != null && property.getXml().getWrapped()) {
+        if (
+          property.getXml() != null &&
+          property.getXml().getWrapped() != null &&
+          property.getXml().getWrapped()
+        ) {
           wrapped = true
         }
         if (wrapped) {
@@ -138,7 +159,7 @@ export default class XmlExampleGenerator {
     throw new Error(`unknown overload`)
   }
 
-  getExample (property) {
+  getExample(property) {
     if (property instanceof DateTimeProperty) {
       if (property.getExample() != null) {
         return property.getExample().toString()
@@ -179,15 +200,15 @@ export default class XmlExampleGenerator {
     return 'not implemented ' + property
   }
 
-  openTag (name) {
+  openTag(name) {
     return '<' + name + '>'
   }
 
-  closeTag (name) {
+  closeTag(name) {
     return '</' + name + '>'
   }
 
-  indent (indent) {
+  indent(indent) {
     let sb = new StringBuilder()
     for (let i = 0; i < indent; i++) {
       sb.append('  ')

--- a/ern-api-gen/src/ignore/CodegenIgnoreProcessor.js
+++ b/ern-api-gen/src/ignore/CodegenIgnoreProcessor.js
@@ -1,97 +1,101 @@
-import {DirectoryRule} from "./rules/DirectoryRule";
-import ruleCreate from "./rules/create";
-import File from "../java/File";
-import LoggerFactory from "../java/LoggerFactory";
-import {Rule} from "./rules/Rule";
-import fs from "fs";
-const {Operation} = Rule;
+import { DirectoryRule } from './rules/DirectoryRule'
+import ruleCreate from './rules/create'
+import File from '../java/File'
+import LoggerFactory from '../java/LoggerFactory'
+import { Rule } from './rules/Rule'
+import fs from 'fs'
+const { Operation } = Rule
 export default class CodegenIgnoreProcessor {
-    static IGNORE_FILE = ".swagger-codegen-ignore";
-    exclusionRules = [];
-    inclusionRules = [];
+  static IGNORE_FILE = '.swagger-codegen-ignore'
+  exclusionRules = []
+  inclusionRules = []
 
-    constructor(outputPath) {
-        this.outputPath = outputPath;
-        let directory = new File(outputPath);
-        if (directory.exists() && directory.isDirectory()) {
-            const codegenIgnore = new File(directory, CodegenIgnoreProcessor.IGNORE_FILE);
-            if (codegenIgnore.exists() && codegenIgnore.isFile()) {
-                try {
-                    this.loadCodegenRules(codegenIgnore.getAbsolutePath());
-                } catch (e) {
-                    Log.error("Could not process .swagger-codegen-ignore.", e.message);
-                }
-            }
-            else {
-                Log.info("No .swagger-codegen-ignore file found.");
-            }
+  constructor(outputPath) {
+    this.outputPath = outputPath
+    let directory = new File(outputPath)
+    if (directory.exists() && directory.isDirectory()) {
+      const codegenIgnore = new File(
+        directory,
+        CodegenIgnoreProcessor.IGNORE_FILE
+      )
+      if (codegenIgnore.exists() && codegenIgnore.isFile()) {
+        try {
+          this.loadCodegenRules(codegenIgnore.getAbsolutePath())
+        } catch (e) {
+          Log.error('Could not process .swagger-codegen-ignore.', e.message)
         }
+      } else {
+        Log.info('No .swagger-codegen-ignore file found.')
+      }
     }
+  }
 
-
-    loadCodegenRules(codegenIgnore) {
-        const lines = fs.readFileSync(codegenIgnore, 'utf8').split('\n');
-        for (const line of lines) {
-            if (line.trim().length === 0)
-                continue;
-            const rule = ruleCreate(line);
-            if (rule != null) {
-                if (rule.getNegated()) {
-                    this.inclusionRules.push(rule);
-                }
-                else {
-                    this.exclusionRules.push(rule);
-                }
-            }
+  loadCodegenRules(codegenIgnore) {
+    const lines = fs.readFileSync(codegenIgnore, 'utf8').split('\n')
+    for (const line of lines) {
+      if (line.trim().length === 0) continue
+      const rule = ruleCreate(line)
+      if (rule != null) {
+        if (rule.getNegated()) {
+          this.inclusionRules.push(rule)
+        } else {
+          this.exclusionRules.push(rule)
         }
+      }
     }
+  }
 
-    allowsFile(targetFile) {
-        if (this.exclusionRules.length === 0 && this.inclusionRules.length === 0) {
-            return true;
-        }
-        const file = new File(this.outputPath, targetFile).relativeTo(this.outputPath);
-        let directoryExcluded = false;
-        let exclude = false;
-        EXCLUDE: for (const current of this.exclusionRules) {
-            const op = current.evaluate(file.getPath());
-            switch (op) {
-                case Operation.EXCLUDE:
-                    exclude = true;
-                    if (current != null && current instanceof DirectoryRule) {
-                        directoryExcluded = true;
-                    }
-                    break;
-                case Operation.INCLUDE:
-                    break;
-                case Operation.NOOP:
-                    break;
-                case Operation.EXCLUDE_AND_TERMINATE:
-                    break EXCLUDE;
-            }
-        }
-        if (exclude) {
-            for (const current of this.inclusionRules) {
-                const op = current.evaluate(file.getPath());
-                if (op === Rule.Operation.INCLUDE) {
-                    if ((current != null && current instanceof DirectoryRule) && directoryExcluded) {
-                        exclude = false;
-                    }
-                    else if (!directoryExcluded) {
-                        exclude = false;
-                    }
-                }
-            }
-        }
-        return !exclude;
+  allowsFile(targetFile) {
+    if (this.exclusionRules.length === 0 && this.inclusionRules.length === 0) {
+      return true
     }
+    const file = new File(this.outputPath, targetFile).relativeTo(
+      this.outputPath
+    )
+    let directoryExcluded = false
+    let exclude = false
+    EXCLUDE: for (const current of this.exclusionRules) {
+      const op = current.evaluate(file.getPath())
+      switch (op) {
+        case Operation.EXCLUDE:
+          exclude = true
+          if (current != null && current instanceof DirectoryRule) {
+            directoryExcluded = true
+          }
+          break
+        case Operation.INCLUDE:
+          break
+        case Operation.NOOP:
+          break
+        case Operation.EXCLUDE_AND_TERMINATE:
+          break EXCLUDE
+      }
+    }
+    if (exclude) {
+      for (const current of this.inclusionRules) {
+        const op = current.evaluate(file.getPath())
+        if (op === Rule.Operation.INCLUDE) {
+          if (
+            current != null &&
+            current instanceof DirectoryRule &&
+            directoryExcluded
+          ) {
+            exclude = false
+          } else if (!directoryExcluded) {
+            exclude = false
+          }
+        }
+      }
+    }
+    return !exclude
+  }
 
-    getInclusionRules() {
-        return this.inclusionRules.concat();
-    }
+  getInclusionRules() {
+    return this.inclusionRules.concat()
+  }
 
-    getExclusionRules() {
-        return this.exclusionRules.concat();
-    }
+  getExclusionRules() {
+    return this.exclusionRules.concat()
+  }
 }
-const Log = LoggerFactory.getLogger(CodegenIgnoreProcessor);
+const Log = LoggerFactory.getLogger(CodegenIgnoreProcessor)

--- a/ern-api-gen/src/ignore/rules/DirectoryRule.js
+++ b/ern-api-gen/src/ignore/rules/DirectoryRule.js
@@ -1,18 +1,25 @@
-import {FileRule} from './FileRule'
+import { FileRule } from './FileRule'
 import FileSystems from '../../java/FileSystems'
 import StringBuilder from '../../java/StringBuilder'
 
 export class DirectoryRule extends FileRule {
-  constructor (syntax, definition) {
+  constructor(syntax, definition) {
     super(syntax, definition)
     const pattern = this.getPattern()
     const sb = new StringBuilder('glob:', pattern)
     if (!pattern.endsWith('/')) sb.append('/')
-    this.directoryMatcher = FileSystems.getDefault().getPathMatcher(sb.toString())
-    this.contentsMatcher = FileSystems.getDefault().getPathMatcher(sb.append('**').toString())
+    this.directoryMatcher = FileSystems.getDefault().getPathMatcher(
+      sb.toString()
+    )
+    this.contentsMatcher = FileSystems.getDefault().getPathMatcher(
+      sb.append('**').toString()
+    )
   }
 
-  matches (relativePath) {
-    return this.contentsMatcher.matches(relativePath) || this.directoryMatcher.matches(relativePath)
+  matches(relativePath) {
+    return (
+      this.contentsMatcher.matches(relativePath) ||
+      this.directoryMatcher.matches(relativePath)
+    )
   }
 }

--- a/ern-api-gen/src/ignore/rules/EverythingRule.js
+++ b/ern-api-gen/src/ignore/rules/EverythingRule.js
@@ -3,15 +3,15 @@ import Rule from './Rule'
  * An ignore rule which matches everything.
  */
 export class EverythingRule extends Rule {
-  constructor (syntax, definition) {
+  constructor(syntax, definition) {
     super(syntax, definition)
   }
 
-  matches (relativePath) {
+  matches(relativePath) {
     return true
   }
 
-  getExcludeOperation () {
+  getExcludeOperation() {
     return Rule.Operation.EXCLUDE_AND_TERMINATE
   }
 }

--- a/ern-api-gen/src/ignore/rules/FileRule.js
+++ b/ern-api-gen/src/ignore/rules/FileRule.js
@@ -1,13 +1,15 @@
-import {Rule} from './Rule'
+import { Rule } from './Rule'
 import FileSystems from '../../java/FileSystems'
 
 export class FileRule extends Rule {
-  constructor (syntax, definition, root) {
+  constructor(syntax, definition, root) {
     super(syntax, definition)
-    this.matcher = FileSystems.getDefault().getPathMatcher('glob:' + this.getPattern())
+    this.matcher = FileSystems.getDefault().getPathMatcher(
+      'glob:' + this.getPattern()
+    )
   }
 
-  matches (relativePath) {
+  matches(relativePath) {
     return this.matcher.matches(relativePath)
   }
 }

--- a/ern-api-gen/src/ignore/rules/IgnoreLineParser.js
+++ b/ern-api-gen/src/ignore/rules/IgnoreLineParser.js
@@ -1,10 +1,10 @@
 import Part from './Part'
 import ParserException from './ParserException'
-import {IgnoreToken} from './IgnoreToken'
+import { IgnoreToken } from './IgnoreToken'
 import StringBuilder from '../../java/StringBuilder'
 
 export class IgnoreLineParser {
-  static parse (text) {
+  static parse(text) {
     const parts = []
     const sb = new StringBuilder()
     const characters = text.split('')
@@ -14,7 +14,7 @@ export class IgnoreLineParser {
       let current = characters[i]
       next = i < totalLength - 1 ? characters[i + 1] : null
       if (i === 0) {
-        if ((current === '#')) {
+        if (current === '#') {
           parts.push(new Part(IgnoreToken.COMMENT, text))
           i = totalLength
           continue
@@ -25,7 +25,7 @@ export class IgnoreLineParser {
             parts.push(new Part(IgnoreToken.NEGATE))
             continue
           }
-        } else if ((current === '\\') && (next === '#')) {
+        } else if (current === '\\' && next === '#') {
           current = next
           next = null
           i++
@@ -33,8 +33,8 @@ export class IgnoreLineParser {
       }
       const any = IgnoreToken.MATCH_ANY.getPattern()
       if (any === current) {
-        if ((any === next)) {
-          if ((i + 3 < totalLength) && (characters[i + 2] === any)) {
+        if (any === next) {
+          if (i + 3 < totalLength && characters[i + 2] === any) {
             throw new ParserException('The pattern *** is invalid.')
           }
           parts.push(new Part(IgnoreToken.MATCH_ALL))
@@ -49,15 +49,15 @@ export class IgnoreLineParser {
           continue
         }
       }
-      if (i === 0 && (IgnoreToken.ROOTED_MARKER.getPattern() === current)) {
+      if (i === 0 && IgnoreToken.ROOTED_MARKER.getPattern() === current) {
         parts.push(new Part(IgnoreToken.ROOTED_MARKER))
         continue
       }
-      if ((current === '\\') && (next === ' ')) {
+      if (current === '\\' && next === ' ') {
         parts.push(new Part(IgnoreToken.ESCAPED_SPACE))
         i++
         continue
-      } else if ((current === '\\') && (next === '!')) {
+      } else if (current === '\\' && next === '!') {
         parts.push(new Part(IgnoreToken.ESCAPED_EXCLAMATION))
         i++
         continue

--- a/ern-api-gen/src/ignore/rules/IgnoreToken.js
+++ b/ern-api-gen/src/ignore/rules/IgnoreToken.js
@@ -2,55 +2,54 @@
  * Created by jspear1 on 3/6/17.
  */
 export class IgnoreToken {
-    constructor(name, pattern) {
-        this.name = name;
-        this.pattern = pattern;
-        IgnoreToken[name] = this;
-    }
+  constructor(name, pattern) {
+    this.name = name
+    this.pattern = pattern
+    IgnoreToken[name] = this
+  }
 
-    getPattern() {
-        return this.pattern;
-    }
+  getPattern() {
+    return this.pattern
+  }
 
-    ordinal() {
-        return ENUMS.indexOf(this);
-    }
+  ordinal() {
+    return ENUMS.indexOf(this)
+  }
 
-    toString() {
-        return this.name;
-    }
+  toString() {
+    return this.name
+  }
 
-    equals(that) {
-        if (that == null) return false;
-        if (this === that) return true;
-        if (typeof that === 'string')
-            return this.name === that;
-        return this.name === that.name;
-    }
+  equals(that) {
+    if (that == null) return false
+    if (this === that) return true
+    if (typeof that === 'string') return this.name === that
+    return this.name === that.name
+  }
 
-    static values = () => ENUMS;
+  static values = () => ENUMS
 }
 const ENUMS = [
-    new IgnoreToken("MATCH_ALL", "**"),
-    new IgnoreToken("MATCH_ANY", "*"),
-    new IgnoreToken("ESCAPED_EXCLAMATION", "\\!"),
-    new IgnoreToken("ESCAPED_SPACE", "\\ "),
-    new IgnoreToken("PATH_DELIM", "/"),
-    new IgnoreToken("NEGATE", "!"),
-    new IgnoreToken("TEXT", null),
-    new IgnoreToken("DIRECTORY_MARKER", "/"),
-    new IgnoreToken("ROOTED_MARKER", "/"),
-    new IgnoreToken("COMMENT", null)
-];
-export default ({
-    MATCH_ALL: ENUMS[0],
-    MATCH_ANY: ENUMS[1],
-    ESCAPED_EXCLAMATION: ENUMS[2],
-    ESCAPED_SPACE: ENUMS[3],
-    PATH_DELIM: ENUMS[4],
-    NEGATE: ENUMS[5],
-    TEXT: ENUMS[6],
-    DIRECTORY_MARKER: ENUMS[7],
-    ROOTED_MARKER: ENUMS[8],
-    COMMENT: ENUMS[9]
-})
+  new IgnoreToken('MATCH_ALL', '**'),
+  new IgnoreToken('MATCH_ANY', '*'),
+  new IgnoreToken('ESCAPED_EXCLAMATION', '\\!'),
+  new IgnoreToken('ESCAPED_SPACE', '\\ '),
+  new IgnoreToken('PATH_DELIM', '/'),
+  new IgnoreToken('NEGATE', '!'),
+  new IgnoreToken('TEXT', null),
+  new IgnoreToken('DIRECTORY_MARKER', '/'),
+  new IgnoreToken('ROOTED_MARKER', '/'),
+  new IgnoreToken('COMMENT', null),
+]
+export default {
+  MATCH_ALL: ENUMS[0],
+  MATCH_ANY: ENUMS[1],
+  ESCAPED_EXCLAMATION: ENUMS[2],
+  ESCAPED_SPACE: ENUMS[3],
+  PATH_DELIM: ENUMS[4],
+  NEGATE: ENUMS[5],
+  TEXT: ENUMS[6],
+  DIRECTORY_MARKER: ENUMS[7],
+  ROOTED_MARKER: ENUMS[8],
+  COMMENT: ENUMS[9],
+}

--- a/ern-api-gen/src/ignore/rules/InvalidRule.js
+++ b/ern-api-gen/src/ignore/rules/InvalidRule.js
@@ -1,19 +1,19 @@
-import {Rule} from './Rule'
+import { Rule } from './Rule'
 export class InvalidRule extends Rule {
-  constructor (syntax, definition, reason) {
+  constructor(syntax, definition, reason) {
     super(syntax, definition)
     this.reason = reason
   }
 
-  matches (relativePath) {
+  matches(relativePath) {
     return null
   }
 
-  evaluate (relativePath) {
+  evaluate(relativePath) {
     return Rule.Operation.NOOP
   }
 
-  getReason () {
+  getReason() {
     return this.reason
   }
 }

--- a/ern-api-gen/src/ignore/rules/ParserException.js
+++ b/ern-api-gen/src/ignore/rules/ParserException.js
@@ -1,13 +1,13 @@
 export default class ParserException extends Error {
-    /**
-     * Constructs a new exception with the specified detail message.  The
-     * cause is not initialized, and may subsequently be initialized by
-     * a call to {@link #initCause}.
-     *
-     * @param message the detail message. The detail message is saved for
-     * later retrieval by the {@link #getMessage()} method.
-     */
-  constructor (message) {
+  /**
+   * Constructs a new exception with the specified detail message.  The
+   * cause is not initialized, and may subsequently be initialized by
+   * a call to {@link #initCause}.
+   *
+   * @param message the detail message. The detail message is saved for
+   * later retrieval by the {@link #getMessage()} method.
+   */
+  constructor(message) {
     super(message)
     this.message = message
   }

--- a/ern-api-gen/src/ignore/rules/Part.js
+++ b/ern-api-gen/src/ignore/rules/Part.js
@@ -1,14 +1,14 @@
 export default class Part {
-  constructor (token, value) {
+  constructor(token, value) {
     this.token = token
     this.value = arguments.length < 2 ? token.getPattern() : value
   }
 
-  getToken () {
+  getToken() {
     return this.token
   }
 
-  getValue () {
+  getValue() {
     return this.value
   }
 }

--- a/ern-api-gen/src/ignore/rules/RootedFileRule.js
+++ b/ern-api-gen/src/ignore/rules/RootedFileRule.js
@@ -1,4 +1,4 @@
-import {Rule} from './Rule'
+import { Rule } from './Rule'
 import IgnoreToken from './IgnoreToken'
 import Pattern from '../../java/Pattern'
 
@@ -7,7 +7,7 @@ import Pattern from '../../java/Pattern'
  * in the same directory as the .swagger-codegen-ignore file.
  */
 export class RootedFileRule extends Rule {
-  constructor (syntax, definition) {
+  constructor(syntax, definition) {
     super(syntax, definition)
     this.definedFilename = null
     this.definedExtension = null
@@ -16,26 +16,41 @@ export class RootedFileRule extends Rule {
     this.definedExtension = this.getExtensionPart(definition, separatorIndex)
   }
 
-  getFilenamePart (input, stopIndex) {
-    return input.substring(input.charAt(0) === '/' ? 1 : 0, stopIndex > 0 ? stopIndex : input.length)
+  getFilenamePart(input, stopIndex) {
+    return input.substring(
+      input.charAt(0) === '/' ? 1 : 0,
+      stopIndex > 0 ? stopIndex : input.length
+    )
   }
 
-  getExtensionPart (input, stopIndex) {
-    return input.substring(stopIndex > 0 ? stopIndex + 1 : input.length, input.length)
+  getExtensionPart(input, stopIndex) {
+    return input.substring(
+      stopIndex > 0 ? stopIndex + 1 : input.length,
+      input.length
+    )
   }
 
-  matches (relativePath) {
+  matches(relativePath) {
     let isSingleFile = relativePath.lastIndexOf('/') <= 0
     if (isSingleFile) {
       let separatorIndex = relativePath.lastIndexOf('.')
       let filename = this.getFilenamePart(relativePath, separatorIndex)
       let extension = this.getExtensionPart(relativePath, separatorIndex)
-      let extensionMatches = (this.definedExtension === extension) || (this.definedExtension === IgnoreToken.MATCH_ANY.getPattern())
-      if (extensionMatches && this.definedFilename.indexOf(IgnoreToken.MATCH_ANY.getPattern()) != -1) {
-        let regex = Pattern.compile(/* replaceAll */ /* replaceAll */ this.definedFilename.replace(new RegExp(Pattern.quote('.'), 'g'), '\\\\Q.\\\\E').replace(new RegExp(Pattern.quote('*'), 'g'), '.*?'))
+      let extensionMatches =
+        this.definedExtension === extension ||
+        this.definedExtension === IgnoreToken.MATCH_ANY.getPattern()
+      if (
+        extensionMatches &&
+        this.definedFilename.indexOf(IgnoreToken.MATCH_ANY.getPattern()) != -1
+      ) {
+        let regex = Pattern.compile(
+          /* replaceAll */ /* replaceAll */ this.definedFilename
+            .replace(new RegExp(Pattern.quote('.'), 'g'), '\\\\Q.\\\\E')
+            .replace(new RegExp(Pattern.quote('*'), 'g'), '.*?')
+        )
         return regex.matcher(filename).matches()
       }
-      return extensionMatches && (this.definedFilename === filename)
+      return extensionMatches && this.definedFilename === filename
     }
     return false
   }

--- a/ern-api-gen/src/ignore/rules/Rule.js
+++ b/ern-api-gen/src/ignore/rules/Rule.js
@@ -1,80 +1,81 @@
-import IgnoreToken from "./IgnoreToken";
-import StringBuilder from "../../java/StringBuilder";
-import LoggerFactory from '../../java/LoggerFactory';
+import IgnoreToken from './IgnoreToken'
+import StringBuilder from '../../java/StringBuilder'
+import LoggerFactory from '../../java/LoggerFactory'
 
 export class Rule {
-    static Operation = {
-        EXCLUDE: 0,
-        INCLUDE: 1,
-        NOOP: 2,
-        EXCLUDE_AND_TERMINATE: 3
-    };
+  static Operation = {
+    EXCLUDE: 0,
+    INCLUDE: 1,
+    NOOP: 2,
+    EXCLUDE_AND_TERMINATE: 3,
+  }
 
-    constructor(syntax, definition) {
-        this.syntax = syntax;
-        this.definition = definition;
+  constructor(syntax, definition) {
+    this.syntax = syntax
+    this.definition = definition
+  }
+
+  getDefinition() {
+    return this.definition
+  }
+
+  getPattern() {
+    if (this.syntax == null) return this.definition
+    const sb = new StringBuilder()
+    for (const current of this.syntax) {
+      const token = current.getToken()
+
+      switch (token) {
+        case IgnoreToken.MATCH_ALL:
+        case IgnoreToken.MATCH_ANY:
+        case IgnoreToken.ESCAPED_EXCLAMATION:
+        case IgnoreToken.ESCAPED_SPACE:
+        case IgnoreToken.PATH_DELIM:
+        case IgnoreToken.TEXT:
+        case IgnoreToken.DIRECTORY_MARKER:
+          sb.append(current.getValue())
+          break
+        case IgnoreToken.NEGATE:
+        case IgnoreToken.ROOTED_MARKER:
+        case IgnoreToken.COMMENT:
+          break
+        default:
+          Log.warn('unknown token')
+      }
     }
+    return sb.toString()
+  }
 
-    getDefinition() {
-        return this.definition;
+  /**
+   * Whether or not the rule should be negated. !foo means foo should be removed from previous matches.
+   * Example: **\/*.bak excludes all backup. Adding !/test.bak will include test.bak in the project root.
+   * <p>
+   * NOTE: It is not possible to re-include a file if a parent directory of that file is excluded.
+   */
+  getNegated() {
+    const negated =
+      this.syntax &&
+      this.syntax[0] &&
+      this.syntax[0].getToken().equals(IgnoreToken.NEGATE)
+    return negated
+  }
+
+  evaluate(relativePath) {
+    if (this.matches(relativePath)) {
+      if (this.getNegated()) {
+        return this.getIncludeOperation()
+      }
+      return this.getExcludeOperation()
     }
+    return Rule.Operation.NOOP
+  }
 
-    getPattern() {
-        if (this.syntax == null)
-            return this.definition;
-        const sb = new StringBuilder();
-        for (const current of this.syntax) {
+  getIncludeOperation() {
+    return Rule.Operation.INCLUDE
+  }
 
-            const token = current.getToken();
-
-            switch (token) {
-                case IgnoreToken.MATCH_ALL:
-                case IgnoreToken.MATCH_ANY:
-                case IgnoreToken.ESCAPED_EXCLAMATION:
-                case IgnoreToken.ESCAPED_SPACE:
-                case IgnoreToken.PATH_DELIM:
-                case IgnoreToken.TEXT:
-                case IgnoreToken.DIRECTORY_MARKER:
-                    sb.append(current.getValue());
-                    break;
-                case IgnoreToken.NEGATE:
-                case IgnoreToken.ROOTED_MARKER:
-                case IgnoreToken.COMMENT:
-                    break;
-                default:
-                    Log.warn('unknown token');
-            }
-        }
-        return sb.toString();
-    }
-
-    /**
-     * Whether or not the rule should be negated. !foo means foo should be removed from previous matches.
-     * Example: **\/*.bak excludes all backup. Adding !/test.bak will include test.bak in the project root.
-     * <p>
-     * NOTE: It is not possible to re-include a file if a parent directory of that file is excluded.
-     */
-    getNegated() {
-        const negated = this.syntax && this.syntax[0] && this.syntax[0].getToken().equals(IgnoreToken.NEGATE);
-        return negated;
-    }
-
-    evaluate(relativePath) {
-        if (this.matches(relativePath)) {
-            if (this.getNegated()) {
-                return this.getIncludeOperation();
-            }
-            return this.getExcludeOperation();
-        }
-        return Rule.Operation.NOOP;
-    }
-
-    getIncludeOperation() {
-        return Rule.Operation.INCLUDE;
-    }
-
-    getExcludeOperation() {
-        return Rule.Operation.EXCLUDE;
-    }
+  getExcludeOperation() {
+    return Rule.Operation.EXCLUDE
+  }
 }
-const Log = LoggerFactory.getLogger(Rule);
+const Log = LoggerFactory.getLogger(Rule)

--- a/ern-api-gen/src/ignore/rules/create.js
+++ b/ern-api-gen/src/ignore/rules/create.js
@@ -1,18 +1,18 @@
 import IgnoreToken from './IgnoreToken'
-import {InvalidRule} from './InvalidRule'
-import {DirectoryRule} from './DirectoryRule'
-import {RootedFileRule} from './RootedFileRule'
-import {FileRule} from './FileRule'
-import {IgnoreLineParser} from './IgnoreLineParser'
+import { InvalidRule } from './InvalidRule'
+import { DirectoryRule } from './DirectoryRule'
+import { RootedFileRule } from './RootedFileRule'
+import { FileRule } from './FileRule'
+import { IgnoreLineParser } from './IgnoreLineParser'
 
-export default function create (definition) {
+export default function create(definition) {
   let rule = null
-  if ((definition === '.')) {
-    return new InvalidRule(null, definition, "Pattern \'.\' is invalid.")
-  } else if ((definition === '!.')) {
-    return new InvalidRule(null, definition, "Pattern \'!.\' is invalid.")
+  if (definition === '.') {
+    return new InvalidRule(null, definition, "Pattern '.' is invalid.")
+  } else if (definition === '!.') {
+    return new InvalidRule(null, definition, "Pattern '!.' is invalid.")
   } else if (definition.startsWith('..')) {
-    return new InvalidRule(null, definition, "Pattern \'..\' is invalid.")
+    return new InvalidRule(null, definition, "Pattern '..' is invalid.")
   }
   try {
     let result = IgnoreLineParser.parse(definition)
@@ -28,7 +28,9 @@ export default function create (definition) {
       }
     } else {
       const head = result[0].getToken()
-      directoryOnly = IgnoreToken.DIRECTORY_MARKER.equals(result[result.length - 1].getToken())
+      directoryOnly = IgnoreToken.DIRECTORY_MARKER.equals(
+        result[result.length - 1].getToken()
+      )
       if (directoryOnly) {
         rule = new DirectoryRule(result, definition)
       } else if (IgnoreToken.PATH_DELIM.equals(head)) {

--- a/ern-api-gen/src/java/BooleanHelper.js
+++ b/ern-api-gen/src/java/BooleanHelper.js
@@ -1,4 +1,4 @@
-export function parseBoolean (str) {
+export function parseBoolean(str) {
   if (str == null) return false
   if (str === true || str === false) return str
   const cstr = ('' + str).toLowerCase()
@@ -6,6 +6,6 @@ export function parseBoolean (str) {
   if (cstr === 'false') return false
   return !!str
 }
-export default ({
-  parseBoolean
-})
+export default {
+  parseBoolean,
+}

--- a/ern-api-gen/src/java/File.js
+++ b/ern-api-gen/src/java/File.js
@@ -1,109 +1,109 @@
-import fs from "fs";
-import path from "path";
-import {sync as mkdirsSync} from "mkdirp";
+import fs from 'fs'
+import path from 'path'
+import { sync as mkdirsSync } from 'mkdirp'
 function canAccess(file) {
-    try {
-        fs.accessSync(file);
-        return true;
-    } catch (e) {
-    }
-    return false;
+  try {
+    fs.accessSync(file)
+    return true
+  } catch (e) {}
+  return false
 }
-const toString = String.valueOf();
+const toString = String.valueOf()
 
 export default class File {
-    static separator = path.sep;
-    static separatorChar = path.sep;
+  static separator = path.sep
+  static separatorChar = path.sep
 
-    constructor(file, ...args) {
-        if (!file) {
-            throw new Error(`File needs an argument`);
-        }
-        if (file instanceof File && args.length === 0) {
-            return file;
-        }
-        this._filename = args.length ? path.join(toString(file), ...args.map(toString)) : toString(file);
+  constructor(file, ...args) {
+    if (!file) {
+      throw new Error(`File needs an argument`)
     }
-
-    relativeTo(file) {
-
-        if (file instanceof File) {
-            file = file._filename;
-        }
-        const relPath = path.relative(file, this._filename);
-        return new File(relPath);
+    if (file instanceof File && args.length === 0) {
+      return file
     }
+    this._filename = args.length
+      ? path.join(toString(file), ...args.map(toString))
+      : toString(file)
+  }
 
-    toAbsolutePath() {
-        return this.getAbsoluteFile().getPath();
+  relativeTo(file) {
+    if (file instanceof File) {
+      file = file._filename
     }
+    const relPath = path.relative(file, this._filename)
+    return new File(relPath)
+  }
 
-    getAbsolutePath() {
-        return this.toAbsolutePath();
-    }
+  toAbsolutePath() {
+    return this.getAbsoluteFile().getPath()
+  }
 
-    isAbsolute() {
-        return this._filename.startsWith("/");
-    }
+  getAbsolutePath() {
+    return this.toAbsolutePath()
+  }
 
-    toAbsolute() {
-        return this.getAbsoluteFile();
-    }
+  isAbsolute() {
+    return this._filename.startsWith('/')
+  }
 
-    getAbsoluteFile() {
-        if (this.isAbsolute()) {
-            return this;
-        }
-        return new File(path.join(process.cwd(), this._filename));
-    }
+  toAbsolute() {
+    return this.getAbsoluteFile()
+  }
 
-    canRead() {
-        return this.exists() && canAccess(this._filename);
+  getAbsoluteFile() {
+    if (this.isAbsolute()) {
+      return this
     }
+    return new File(path.join(process.cwd(), this._filename))
+  }
 
-    exists() {
-        return fs.existsSync(this._filename);
-    }
+  canRead() {
+    return this.exists() && canAccess(this._filename)
+  }
 
-    getName() {
-        return this._filename;
-    }
+  exists() {
+    return fs.existsSync(this._filename)
+  }
 
-    getParentFile() {
-        if (this._parent) {
-            return this._parent;
-        }
-        this._parent = new File(path.resolve(this._filename, '..'));
-        return this._parent;
-    }
+  getName() {
+    return this._filename
+  }
 
-    getPath() {
-        return this._filename;
+  getParentFile() {
+    if (this._parent) {
+      return this._parent
     }
+    this._parent = new File(path.resolve(this._filename, '..'))
+    return this._parent
+  }
 
-    _() {
-        if (!this._stat) {
-            if (!this.exists()) return false;
-            this._stat = fs.statSync(this._filename);
-        }
-        return this._stat;
-    }
+  getPath() {
+    return this._filename
+  }
 
-    isDirectory() {
-        const s = this._();
-        return s && s.isDirectory();
+  _() {
+    if (!this._stat) {
+      if (!this.exists()) return false
+      this._stat = fs.statSync(this._filename)
     }
+    return this._stat
+  }
 
-    isFile() {
-        const s = this._();
-        return s && s.isFile();
-    }
+  isDirectory() {
+    const s = this._()
+    return s && s.isDirectory()
+  }
 
-    mkdirs() {
-        return mkdirsSync(this._filename);
-    }
+  isFile() {
+    const s = this._()
+    return s && s.isFile()
+  }
 
-    toString() {
-        return this._filename
-    }
+  mkdirs() {
+    return mkdirsSync(this._filename)
+  }
+
+  toString() {
+    return this._filename
+  }
 }

--- a/ern-api-gen/src/java/FileSystems.js
+++ b/ern-api-gen/src/java/FileSystems.js
@@ -1,45 +1,47 @@
 import File from './File'
-import {Minimatch} from 'minimatch'
+import { Minimatch } from 'minimatch'
 
 const GLOB = 'glob:'
-const glob = (str) => {
+const glob = str => {
   str = str || '**'
-  const mm = new Minimatch(str, {empty: false})
-  return (to) => {
+  const mm = new Minimatch(str, { empty: false })
+  return to => {
     const ret = mm.match(to)
     return ret
   }
 }
-const match = (str) => {
+const match = str => {
   const f = new File(str).getAbsolutePath()
-  return (to) => {
+  return to => {
     return new File(to).getAbsolutePath() === f
   }
 }
 
 const EmptyMatcher = {
-  matches () {
+  matches() {
     return false
-  }
+  },
 }
 
 const FileSystems = {
-  getDefault () {
+  getDefault() {
     return {
-      getPathMatcher (str) {
+      getPathMatcher(str) {
         if (str == GLOB) {
           return EmptyMatcher
         }
-        const matches = str.startsWith(GLOB) ? glob(str.substring(GLOB.length)) : match(str)
+        const matches = str.startsWith(GLOB)
+          ? glob(str.substring(GLOB.length))
+          : match(str)
         return {
-          matches
+          matches,
         }
       },
-      getPath (file) {
+      getPath(file) {
         return new File(file).getAbsolutePath()
-      }
+      },
     }
-  }
+  },
 }
 
 export default FileSystems

--- a/ern-api-gen/src/java/FileUtils.js
+++ b/ern-api-gen/src/java/FileUtils.js
@@ -1,7 +1,7 @@
 import fs from 'fs'
-export default ({
-  writeStringToFile (file, content) {
+export default {
+  writeStringToFile(file, content) {
     file.getParentFile().mkdirs()
     fs.writeFileSync(file.getPath(), content, 'utf-8')
-  }
-})
+  },
+}

--- a/ern-api-gen/src/java/IOUtils.js
+++ b/ern-api-gen/src/java/IOUtils.js
@@ -1,13 +1,11 @@
-import {
-  shell
-} from 'ern-core'
+import { shell } from 'ern-core'
 import File from './File'
 
-export default ({
-
-  copy (src, out) {
-    const fsrc = new File(src), fout = new File(out)
+export default {
+  copy(src, out) {
+    const fsrc = new File(src),
+      fout = new File(out)
     fout.getParentFile().mkdirs()
     shell.cp('-f', fsrc.getPath(), fout.getPath())
-  }
-})
+  },
+}

--- a/ern-api-gen/src/java/Json.js
+++ b/ern-api-gen/src/java/Json.js
@@ -1,8 +1,8 @@
 import stringify from 'json-stable-stringify'
 
 export const pretty = obj => stringify(obj, null, 2)
-export const prettyPrint = (obj) => console.log(pretty(obj))
-export default ({
+export const prettyPrint = obj => console.log(pretty(obj))
+export default {
   pretty,
-  prettyPrint
-})
+  prettyPrint,
+}

--- a/ern-api-gen/src/java/Logger.js
+++ b/ern-api-gen/src/java/Logger.js
@@ -6,47 +6,63 @@ export const LEVELS = {
   WARN: 4,
   NOTICE: 5,
   INFO: 6,
-  DEBUG: 7
+  DEBUG: 7,
 }
 
 export const CONFIG = {
   LEVEL: LEVELS.DEBUG,
-  console
+  console,
 }
-export function makeLogger (pre = '') {
+export function makeLogger(pre = '') {
   const prefix = pre ? `${pre}:` : ''
   return {
-    trace (e) {
+    trace(e) {
       CONFIG.console.log(prefix, 'tracing')
       CONFIG.console.trace(e)
     },
-    log (...args) {
+    log(...args) {
       CONFIG.console.log(prefix, ...args)
     },
-    emergency (...args) {
-      if (CONFIG.LEVEL <= LEVELS.ALERT) { CONFIG.console.error(prefix, ...args) }
+    emergency(...args) {
+      if (CONFIG.LEVEL <= LEVELS.ALERT) {
+        CONFIG.console.error(prefix, ...args)
+      }
     },
-    alert (...args) {
-      if (CONFIG.LEVEL <= LEVELS.ALERT) { CONFIG.console.error(prefix, ...args) }
+    alert(...args) {
+      if (CONFIG.LEVEL <= LEVELS.ALERT) {
+        CONFIG.console.error(prefix, ...args)
+      }
     },
-    critical (...args) {
-      if (CONFIG.LEVEL <= LEVELS.CRITICAL) { CONFIG.console.error(prefix, ...args) }
+    critical(...args) {
+      if (CONFIG.LEVEL <= LEVELS.CRITICAL) {
+        CONFIG.console.error(prefix, ...args)
+      }
     },
-    error (...args) {
-      if (CONFIG.LEVEL <= LEVELS.ERROR) { CONFIG.console.error(prefix, ...args) }
+    error(...args) {
+      if (CONFIG.LEVEL <= LEVELS.ERROR) {
+        CONFIG.console.error(prefix, ...args)
+      }
     },
-    warn (...args) {
-      if (CONFIG.LEVEL <= LEVELS.WARN) { CONFIG.console.error(prefix, ...args) }
+    warn(...args) {
+      if (CONFIG.LEVEL <= LEVELS.WARN) {
+        CONFIG.console.error(prefix, ...args)
+      }
     },
-    notice (...args) {
-      if (CONFIG.LEVEL <= LEVELS.NOTICE) { CONFIG.console.log(prefix, ...args) }
+    notice(...args) {
+      if (CONFIG.LEVEL <= LEVELS.NOTICE) {
+        CONFIG.console.log(prefix, ...args)
+      }
     },
-    info (...args) {
-      if (CONFIG.LEVEL <= LEVELS.INFO) { CONFIG.console.log(prefix, ...args) }
+    info(...args) {
+      if (CONFIG.LEVEL <= LEVELS.INFO) {
+        CONFIG.console.log(prefix, ...args)
+      }
     },
-    debug (...args) {
-      if (CONFIG.LEVEL <= LEVELS.DEBUG) { CONFIG.console.log(prefix, ...args) }
-    }
+    debug(...args) {
+      if (CONFIG.LEVEL <= LEVELS.DEBUG) {
+        CONFIG.console.log(prefix, ...args)
+      }
+    },
   }
 }
 

--- a/ern-api-gen/src/java/LoggerFactory.js
+++ b/ern-api-gen/src/java/LoggerFactory.js
@@ -1,12 +1,12 @@
-import {makeLogger} from './Logger'
+import { makeLogger } from './Logger'
 const LOGGER_CACHE = {}
-export default ({
-  getLogger (clz) {
+export default {
+  getLogger(clz) {
     if (!clz) {
       clz = ''
     } else {
       clz = clz.displayName || clz.name || clz
     }
-    return (LOGGER_CACHE[clz] || (LOGGER_CACHE[clz] = makeLogger(clz)))
-  }
-})
+    return LOGGER_CACHE[clz] || (LOGGER_CACHE[clz] = makeLogger(clz))
+  },
+}

--- a/ern-api-gen/src/java/Mustache.js
+++ b/ern-api-gen/src/java/Mustache.js
@@ -1,47 +1,55 @@
 import Mustache from 'mustache'
 import Json from './Json'
 import LoggerFactory from './LoggerFactory'
-function truthy (val) {
-  if (val == null || val.length === 0 || val === false) { return false }
+function truthy(val) {
+  if (val == null || val.length === 0 || val === false) {
+    return false
+  }
   return true
 }
-function isInt (val) {
+function isInt(val) {
   return /^\d+?$/.test(val)
 }
 class MyContext extends Mustache.Context {
-  constructor (value, parent, first, last) {
+  constructor(value, parent, first, last) {
     super(value, parent)
     this._first = first
     this._last = last
   }
 
-  lookup (name) {
+  lookup(name) {
     if (/-?last/.test(name)) {
       return this._last
     }
     if (/-?first/.test(name)) {
       return this._first
     }
-        // match the dot, unless it is followed only by a number, than we guess its an array and
-        // we will let the natural path happen.
+    // match the dot, unless it is followed only by a number, than we guess its an array and
+    // we will let the natural path happen.
     if (/.+?\.(?!\d+?$).+?$/.test(name)) {
       const filters = name.split(/(\-|\+|\.)/)
       let arr = super.lookup(filters.shift())
       if (!isIterable(arr)) {
         return arr
       }
-            // Using a Set to prevent duplicates, this may be a mistake.
+      // Using a Set to prevent duplicates, this may be a mistake.
       const ret = new Set()
       FILTER: for (let v of arr) {
         for (let i = 0, l = filters.length; i < l; i += 2) {
           const pm = filters[i]
           const prop = filters[i + 1]
           if (pm == '+') {
-            if (!truthy(v[prop])) { continue FILTER }
+            if (!truthy(v[prop])) {
+              continue FILTER
+            }
           } else if (pm === '-') {
-            if (truthy(v[prop])) { continue FILTER }
+            if (truthy(v[prop])) {
+              continue FILTER
+            }
           } else if (pm === '.' && prop) {
-            if (v != null) { v = v[prop] }
+            if (v != null) {
+              v = v[prop]
+            }
           }
         }
         ret.add(v)
@@ -51,17 +59,17 @@ class MyContext extends Mustache.Context {
     return super.lookup(name)
   }
 
-  push (view, first, last) {
+  push(view, first, last) {
     return new MyContext(view, this, first, last)
-  };
+  }
 }
 
-function isIterable (obj) {
-    // checks for null and undefined
+function isIterable(obj) {
+  // checks for null and undefined
   if (obj == null) {
     return false
   }
-    // Don't consider a string iterable.
+  // Don't consider a string iterable.
   if (typeof obj === 'string') {
     return false
   }
@@ -69,7 +77,7 @@ function isIterable (obj) {
 }
 
 class MustacheWriter extends Mustache.Writer {
-  renderSection (token, context, partials, originalTemplate) {
+  renderSection(token, context, partials, originalTemplate) {
     let buffer = ''
     let value = context.lookup(token[1])
 
@@ -89,51 +97,69 @@ class MustacheWriter extends Mustache.Writer {
         first = next
       }
       return buffer
-    } else if (typeof value === 'object' || typeof value === 'string' || typeof value === 'number') {
-      buffer += this.renderTokens(token[4], context.push(value), partials, originalTemplate)
+    } else if (
+      typeof value === 'object' ||
+      typeof value === 'string' ||
+      typeof value === 'number'
+    ) {
+      buffer += this.renderTokens(
+        token[4],
+        context.push(value),
+        partials,
+        originalTemplate
+      )
     } else if (typeof value === 'function') {
-      if (typeof originalTemplate !== 'string') { throw new Error('Cannot use higher-order sections without the original template') }
+      if (typeof originalTemplate !== 'string') {
+        throw new Error(
+          'Cannot use higher-order sections without the original template'
+        )
+      }
 
-            // Extract the portion of the original template that the section contains.
-      value = value.call(context.view, originalTemplate.slice(token[3], token[5]), (template) => this.render(template, context, partials))
+      // Extract the portion of the original template that the section contains.
+      value = value.call(
+        context.view,
+        originalTemplate.slice(token[3], token[5]),
+        template => this.render(template, context, partials)
+      )
 
-      if (value != null) { buffer += value }
+      if (value != null) {
+        buffer += value
+      }
     } else {
       buffer += this.renderTokens(token[4], context, partials, originalTemplate)
     }
     return buffer
-  };
+  }
 }
 
 const Log = LoggerFactory.getLogger('Mustache')
-export default ({
-  compiler () {
+export default {
+  compiler() {
     let defValue
     const partials = {}
     let partialProxy
     const cret = {
-
-      withLoader (_loader) {
+      withLoader(_loader) {
         const handler = {
-          get (target, name) {
+          get(target, name) {
             if (name in target) return target[name]
             return (target[name] = _loader.getTemplate(name))
-          }
+          },
         }
-        partialProxy = function (name) {
+        partialProxy = function(name) {
           return _loader.getTemplate(name)
         }
         return cret
       },
-      defaultValue (def) {
+      defaultValue(def) {
         defValue = def
         return cret
       },
-      compile (template, file) {
+      compile(template, file) {
         const writer = new MustacheWriter()
 
         return {
-          execute (data) {
+          execute(data) {
             try {
               data = JSON.parse(Json.pretty(data))
               return writer.render(template, new MyContext(data), partialProxy)
@@ -141,10 +167,10 @@ export default ({
               Log.trace(e)
               throw new Error(`Error invoking template ${file}`)
             }
-          }
+          },
         }
-      }
+      },
     }
     return cret
-  }
-})
+  },
+}

--- a/ern-api-gen/src/java/ObjectUtils.js
+++ b/ern-api-gen/src/java/ObjectUtils.js
@@ -5,6 +5,6 @@ export const compare = (a, b) => {
   return a < b
 }
 
-export default ({
-  compare
-})
+export default {
+  compare,
+}

--- a/ern-api-gen/src/java/Pattern.js
+++ b/ern-api-gen/src/java/Pattern.js
@@ -3,55 +3,57 @@ const Pattern = {
   LITERAL: 'q',
   UNICODE_CHARACTER_CLASS: 'u',
   MULTILINE: 'm',
-  matches (regex, str) {
-    return Pattern.compile(regex).matcher(str).find()
+  matches(regex, str) {
+    return Pattern.compile(regex)
+      .matcher(str)
+      .find()
   },
-  split (regex, str) {
+  split(regex, str) {
     return Pattern.compile(regex).split(str)
   },
-  quote (str) {
+  quote(str) {
     return (str + '').replace(/[.?*+^$[\]\\(){}|-]/g, '\\$&')
   },
-  compile (pattern, opts = '') {
+  compile(pattern, opts = '') {
     let re = new RegExp(pattern, 'g' + opts)
 
     const p = {
-      matcher (str) {
+      matcher(str) {
         let found
         return {
-          find () {
+          find() {
             found = re.exec(str)
             return found != null
           },
-          start () {
+          start() {
             return found.index
           },
-          groupCount () {
+          groupCount() {
             return found.length
           },
-          group (idx = 0) {
+          group(idx = 0) {
             return found[idx]
           },
-          end () {
+          end() {
             return re.lastIndex
           },
-          replaceAll (replaceWith) {
+          replaceAll(replaceWith) {
             return str.replace(re, replaceWith)
           },
-          reset () {
+          reset() {
             found = null
             re = new RegExp(pattern, 'g' + opts)
-          }
+          },
         }
       },
-      split (str, count) {
+      split(str, count) {
         return re[Symbol.split](str, count)
       },
-      pattern () {
+      pattern() {
         return p
-      }
+      },
     }
     return p
-  }
+  },
 }
 export default Pattern

--- a/ern-api-gen/src/java/ServiceLoader.js
+++ b/ern-api-gen/src/java/ServiceLoader.js
@@ -2,11 +2,11 @@ import fs from 'fs'
 import path from 'path'
 import LoggerFactory from './LoggerFactory'
 import File from './File'
-import {isEmpty} from './StringUtils'
+import { isEmpty } from './StringUtils'
 
 const Log = LoggerFactory.getLogger('ServiceLoader')
 
-const tryNewRequire = (mod) => {
+const tryNewRequire = mod => {
   try {
     const Clz = require(mod).default
     return new Clz()
@@ -16,8 +16,8 @@ const tryNewRequire = (mod) => {
 }
 export const SEARCH_PATH = [path.join(__dirname, '..', '..', 'resources')]
 
-export default ({
-  load (className) {
+export default {
+  load(className) {
     const ret = []
     const lines = []
     for (const searchPath of SEARCH_PATH) {
@@ -44,5 +44,5 @@ export default ({
     }
 
     return ret
-  }
-})
+  },
+}

--- a/ern-api-gen/src/java/StringBuilder.js
+++ b/ern-api-gen/src/java/StringBuilder.js
@@ -1,40 +1,40 @@
-export default function StringBuilder (...strs) {
+export default function StringBuilder(...strs) {
   let _str = ''
   const ret = {
-    append (...strs) {
+    append(...strs) {
       for (const str of strs) {
         _str += str
       }
       return ret
     },
-    toString () {
+    toString() {
       return _str
     },
-    length () {
+    length() {
       return _str.length
     },
-    charAt (idx) {
+    charAt(idx) {
       return _str[idx]
     },
-    setCharAt (idx, ch) {
+    setCharAt(idx, ch) {
       _str[idx] = ch
       return ret
     },
-    replace (start, end, str) {
+    replace(start, end, str) {
       const before = str.substring(0, start)
       const after = str.substring(end)
       _str = before + str + after
       return ret
     },
-    codePointAt (at) {
+    codePointAt(at) {
       return _str.codePointAt(at)
     },
-    'delete' (from, to) {
+    delete(from, to) {
       const left = _str.substring(0, from)
       const right = _str.substring(to)
       _str = left + right
       return this
-    }
+    },
   }
 
   ret.append(...strs)

--- a/ern-api-gen/src/java/StringEscapeUtils.js
+++ b/ern-api-gen/src/java/StringEscapeUtils.js
@@ -3,14 +3,14 @@ const CHARS = {
   '<': '&lt;',
   '>': '&gt;',
   '"': '&quot;',
-  '\'': '&#39;',
+  "'": '&#39;',
   '`': '&#96;',
-  '=': '&#61;'
+  '=': '&#61;',
 }
-export default ({
-  escapeJava (str) {
+export default {
+  escapeJava(str) {
     if (!str) return str
-        /*
+    /*
 
          char[] AMP = "&amp;".toCharArray();
          char[] LT = "&lt;".toCharArray();
@@ -25,7 +25,7 @@ export default ({
     })
     return ret
 
-        /*                '&lt;')
+    /*                '&lt;')
          .replace(/>/g, '&gt;')
          .replace(/"/g, '&quot;')
          .replace(/'/g, '&#39;')
@@ -34,7 +34,7 @@ export default ({
          .replace(/&(?!amp|lt|gt|quot|#39|#96|#61);/g, '&amp;')
          ; */
   },
-  unescapeJava (str) {
+  unescapeJava(str) {
     return str
-  }
-})
+  },
+}

--- a/ern-api-gen/src/java/StringUtils.js
+++ b/ern-api-gen/src/java/StringUtils.js
@@ -2,7 +2,7 @@ import _snakeCase from 'lodash/snakeCase'
 const EMPTY = ''
 const INDEX_NOT_FOUND = -1
 
-function indexOfDifference (cs1, cs2) {
+function indexOfDifference(cs1, cs2) {
   if (cs1 == cs2) {
     return INDEX_NOT_FOUND
   }
@@ -11,7 +11,9 @@ function indexOfDifference (cs1, cs2) {
   }
   let i = 0
   for (; i < cs1.length && i < cs2.length; ++i) {
-    if (cs1[i] != cs2[i]) { break }
+    if (cs1[i] != cs2[i]) {
+      break
+    }
   }
 
   if (i < cs2.length || i < cs1.length) return i
@@ -20,11 +22,15 @@ function indexOfDifference (cs1, cs2) {
 }
 const smallWords = /^(a|an|and|as|at|but|by|en|for|if|in|nor|of|on|or|per|the|to|vs?\.?|via)$/i
 
-const capitalizeFully$inner = function (match, index, title) {
-  if (index > 0 && index + match.length !== title.length &&
-        match.match(smallWords) && title[index - 2] !== ':' &&
-        (title[index + match.length] !== '-' || title[index - 1] === '-') &&
-        !title[index - 1].match(/[^\s-]/)) {
+const capitalizeFully$inner = function(match, index, title) {
+  if (
+    index > 0 &&
+    index + match.length !== title.length &&
+    match.match(smallWords) &&
+    title[index - 2] !== ':' &&
+    (title[index + match.length] !== '-' || title[index - 1] === '-') &&
+    !title[index - 1].match(/[^\s-]/)
+  ) {
     return match.toLowerCase()
   }
 
@@ -35,58 +41,65 @@ const capitalizeFully$inner = function (match, index, title) {
   return match[0].toUpperCase() + match.substr(1)
 }
 
-export const capitalizeFully = (str) => str.replace(/[A-Za-z0-9\u00C0-\u00FF]+[^\s-]*/g, capitalizeFully$inner)
+export const capitalizeFully = str =>
+  str.replace(/[A-Za-z0-9\u00C0-\u00FF]+[^\s-]*/g, capitalizeFully$inner)
 
-export function getCommonPrefix (...strs) {
+export function getCommonPrefix(...strs) {
   if (strs.length == 0) {
     return EMPTY
   }
   const smallestIndexOfDiff = indexOfDifference(strs)
   if (smallestIndexOfDiff == INDEX_NOT_FOUND) {
-        // all strings were identical
+    // all strings were identical
     if (strs[0] == null) {
       return EMPTY
     }
     return strs[0]
   } else if (smallestIndexOfDiff == 0) {
-        // there were no common initial characters
+    // there were no common initial characters
     return EMPTY
   } else {
-        // we found a common initial character sequence
+    // we found a common initial character sequence
     return strs[0].substring(0, smallestIndexOfDiff)
   }
 }
 
-export function isEmpty (str) {
-  return (str == null || str === '' || str.length == 0)
+export function isEmpty(str) {
+  return str == null || str === '' || str.length == 0
 }
-export function isNotEmpty (str) {
+export function isNotEmpty(str) {
   return !isEmpty(str)
 }
-export function capitalize (str) {
+export function capitalize(str) {
   if (isEmpty(str)) {
     return ''
   }
   return str[0].toUpperCase() + str.substring(1)
 }
-export function isBlank (str) {
+export function isBlank(str) {
   return isEmpty(str) || str.trim().length === 0
 }
-export function isNotBlank (str) {
+export function isNotBlank(str) {
   return !isBlank(str)
 }
-export function join (arr, char) {
+export function join(arr, char) {
   return char ? arr.join(char) : arr.join()
 }
 
-export function lowerFirst (word) {
+export function lowerFirst(word) {
   if (isBlank(word)) return word
   return word[0].toLowerCase() + word.substring(1)
 }
-export function camelize (word, lowerFirst) {
+export function camelize(word, lowerFirst) {
   if (isBlank(word)) return word
 
-  const ret = word.replace(/(?:^\w|[A-Z]|\b\w)/g, (letter, i) => lowerFirst && i == 0 ? letter.toLowerCase() : letter.toUpperCase()).replace(/\s+/g, '')
+  const ret = word
+    .replace(
+      /(?:^\w|[A-Z]|\b\w)/g,
+      (letter, i) =>
+        lowerFirst && i == 0 ? letter.toLowerCase() : letter.toUpperCase()
+    )
+    .replace(/\s+/g, '')
   return ret
 }
 export const snakeCase = _snakeCase
@@ -98,7 +111,11 @@ export const compareTo = (value, anotherString) => {
   const len1 = value.length
   const len2 = anotherString.length
 
-  for (let k = 0, lim = Math.min(value.length, anotherString.length); k < lim; k++) {
+  for (
+    let k = 0, lim = Math.min(value.length, anotherString.length);
+    k < lim;
+    k++
+  ) {
     const c1 = value[k]
     const c2 = anotherString[k]
     if (c1 != c2) {
@@ -107,13 +124,13 @@ export const compareTo = (value, anotherString) => {
   }
   return len1 - len2
 }
-export const upperFirst = (word) => {
+export const upperFirst = word => {
   if (isBlank(word)) return word
   word = word.trim()
   return word[0].toUpperCase() + word.substring(1)
 }
 
-export default ({
+export default {
   capitalizeFully,
   compareTo,
   join,
@@ -127,5 +144,5 @@ export default ({
   capitalize,
   isBlank,
   isNotBlank,
-  indexOfDifference
-})
+  indexOfDifference,
+}

--- a/ern-api-gen/src/java/Swagger.js
+++ b/ern-api-gen/src/java/Swagger.js
@@ -1,133 +1,169 @@
-import {newHashMap, HashMap} from './javaUtil'
+import { newHashMap, HashMap } from './javaUtil'
 import factory from '../models/factory'
 import Response from 'sway/lib/types/response'
 import SwaggerApi from 'sway/lib/types/api'
 import Path from 'sway/lib/types/path'
 import Operation from 'sway/lib/types/operation'
 import parameterFactory from '../models/parameters'
-import {beanify, apply} from './beanUtils'
-import {Property} from '../models/properties'
-import {toModel} from '../models/PropertyBuilder'
+import { beanify, apply } from './beanUtils'
+import { Property } from '../models/properties'
+import { toModel } from '../models/PropertyBuilder'
 import authFactory from '../models/auth'
 import Sway from 'sway'
-import {upperFirst} from './StringUtils'
+import { upperFirst } from './StringUtils'
 import supportedHttpMethods from 'swagger-methods'
 supportedHttpMethods.push('event')
 /**
  * This class fixes up Sway so that it can work as the model for swagger-codegen.
  *
  */
-supportedHttpMethods.map(function method (name) {
-  this[`get${upperFirst(name)}`] = function () {
+supportedHttpMethods.map(function method(name) {
+  this[`get${upperFirst(name)}`] = function() {
     return this.getOperation(name)
   }
 }, Path.prototype)
 
-Path.prototype.toJSON = function () {
+Path.prototype.toJSON = function() {
   return this.definition
 }
-const _asResponse = (r) => [(r.statusCode || 'default') + '', r]
+const _asResponse = r => [(r.statusCode || 'default') + '', r]
 
-function asParameter (p) {
+function asParameter(p) {
   if (p.definition && '$ref' in p.definition) {
     return parameterFactory(p.definitionFullyResolved)
   }
   return parameterFactory(p.definition)
 }
-beanify(Object.assign(Operation.prototype, {
-  getVendorExtensions () {
-    if (!this._vendorExtensions) {
-      this._vendorExtensions = newHashMap()
-    }
-    return this._vendorExtensions
-  },
-  getParameters () {
-    if (!this._parameters) {
-      if (this.parameterObjects) {
-        this._parameters = this.parameterObjects.map(asParameter)
-      } else if (this.parameters) {
-        this._parameters = this.parameters.map(parameterFactory)
+beanify(
+  Object.assign(Operation.prototype, {
+    getVendorExtensions() {
+      if (!this._vendorExtensions) {
+        this._vendorExtensions = newHashMap()
       }
-    }
-    return this._parameters
-  },
-  getResponses () {
-    if (!this._responses) {
-      this._responses = newHashMap(...this.responseObjects.map(_asResponse))
-    }
-    return this._responses
-  },
-  getSchema () {
-    if (this._schema === void (0)) {
-      this._schema = this.schema ? factory(this.schema) : null
-    }
-    return this._schema
-  },
-  setParameters (parameters) {
-    this._parameters = parameters ? parameters.map(parameterFactory) : []
-  }
-}), ['produces', 'summary', 'tags', 'operationId', 'description', 'externalDocs', 'consumes', 'schemes', 'method', 'securityDefinitions'])
+      return this._vendorExtensions
+    },
+    getParameters() {
+      if (!this._parameters) {
+        if (this.parameterObjects) {
+          this._parameters = this.parameterObjects.map(asParameter)
+        } else if (this.parameters) {
+          this._parameters = this.parameters.map(parameterFactory)
+        }
+      }
+      return this._parameters
+    },
+    getResponses() {
+      if (!this._responses) {
+        this._responses = newHashMap(...this.responseObjects.map(_asResponse))
+      }
+      return this._responses
+    },
+    getSchema() {
+      if (this._schema === void 0) {
+        this._schema = this.schema ? factory(this.schema) : null
+      }
+      return this._schema
+    },
+    setParameters(parameters) {
+      this._parameters = parameters ? parameters.map(parameterFactory) : []
+    },
+  }),
+  [
+    'produces',
+    'summary',
+    'tags',
+    'operationId',
+    'description',
+    'externalDocs',
+    'consumes',
+    'schemes',
+    'method',
+    'securityDefinitions',
+  ]
+)
 
-beanify(Object.assign(Response.prototype, {
-  getSchema () {
-    if (this._schema === void (0)) {
-      if (!this.definition.schema) {
-        this._schema = null
-      } else {
-        this._schema = factory(Object.assign({description: this.definition.description}, this.definition.schema))
+beanify(
+  Object.assign(Response.prototype, {
+    getSchema() {
+      if (this._schema === void 0) {
+        if (!this.definition.schema) {
+          this._schema = null
+        } else {
+          this._schema = factory(
+            Object.assign(
+              { description: this.definition.description },
+              this.definition.schema
+            )
+          )
+        }
       }
-    }
-    return this._schema
-  },
-  setSchema (schema) {
-    if (schema instanceof Property) { this._schema = schema } else { this.schema = schema }
-  },
-  getCode () {
-    return this.statusCode
-  },
-  getHeaders () {
-    return this.headers && newHashMap(...Object.keys(this.headers).map(key => [key, this.headers[key]]))
-  },
-  toJSON () {
-    return this.definition
-  }
-}), ['description', 'statusCode', 'examples'])
+      return this._schema
+    },
+    setSchema(schema) {
+      if (schema instanceof Property) {
+        this._schema = schema
+      } else {
+        this.schema = schema
+      }
+    },
+    getCode() {
+      return this.statusCode
+    },
+    getHeaders() {
+      return (
+        this.headers &&
+        newHashMap(
+          ...Object.keys(this.headers).map(key => [key, this.headers[key]])
+        )
+      )
+    },
+    toJSON() {
+      return this.definition
+    },
+  }),
+  ['description', 'statusCode', 'examples']
+)
 
 class VendorExtensions {
-  setVendorExtensions (extensions) {
+  setVendorExtensions(extensions) {
     this.vendorExtensions = extensions
   }
 
-  getVendorExtensions () {
-    if (!this.vendorExtensions) { this.setVendorExtensions(newHashMap()) }
+  getVendorExtensions() {
+    if (!this.vendorExtensions) {
+      this.setVendorExtensions(newHashMap())
+    }
     return this.vendorExtensions
   }
 }
-class Contact extends VendorExtensions {
-}
+class Contact extends VendorExtensions {}
 
 beanify(Contact.prototype, ['name', 'url', 'email'])
 
-class License extends VendorExtensions {
-
-}
+class License extends VendorExtensions {}
 
 beanify(License.prototype, ['name', 'url'])
 
 class Info {
-  getContact () {
+  getContact() {
     return apply(new Contact(), this.contact)
   }
 
-  getLicense () {
+  getLicense() {
     return apply(new License(), this.license)
   }
 }
 
-beanify(Info.prototype, ['title', 'description', 'version', 'title', 'termsOfService'])
+beanify(Info.prototype, [
+  'title',
+  'description',
+  'version',
+  'title',
+  'termsOfService',
+])
 
 Object.assign(SwaggerApi.prototype, {
-  addDefinition (name, definition) {
+  addDefinition(name, definition) {
     let definitions = this.getDefinitions()
     if (definitions == null) {
       definitions = this._definitions = newHashMap()
@@ -135,14 +171,24 @@ Object.assign(SwaggerApi.prototype, {
     definitions.put(name, definition)
     return this
   },
-  getDefinitions () {
-    if (this._definitions === void (0)) {
+  getDefinitions() {
+    if (this._definitions === void 0) {
       if (this.definitions == null) {
         this._definitions = null
       } else {
-        const defs = Object.keys(this.definitions).map(key => [key, toModel(factory(Object.assign({
-          name: key
-        }, this.definitions[key])))])
+        const defs = Object.keys(this.definitions).map(key => [
+          key,
+          toModel(
+            factory(
+              Object.assign(
+                {
+                  name: key,
+                },
+                this.definitions[key]
+              )
+            )
+          ),
+        ])
 
         this._definitions = newHashMap(...defs)
       }
@@ -150,24 +196,42 @@ Object.assign(SwaggerApi.prototype, {
     return this._definitions
   },
 
-  getInfo () {
+  getInfo() {
     if (!this._info) {
       this._info = apply(new Info(), this.info)
     }
     return this._info
   },
-  getSecurityDefinitions () {
+  getSecurityDefinitions() {
     if (!this._securityDefinitions) {
-      const securityDefinitions = this.definitionFullyResolved.securityDefinitions || {}
-      const defs = Object.keys(securityDefinitions).map(key => [key, authFactory(securityDefinitions[key])])
+      const securityDefinitions =
+        this.definitionFullyResolved.securityDefinitions || {}
+      const defs = Object.keys(securityDefinitions).map(key => [
+        key,
+        authFactory(securityDefinitions[key]),
+      ])
       this._securityDefinitions = newHashMap(...defs)
     }
     return this._securityDefinitions
-  }
+  },
 })
 
-beanify(SwaggerApi.prototype, ['info', 'host', 'basePath', 'tags', 'schemes', 'produces', 'consumes', 'security', 'paths',
-  'securityDefinitions', 'definitions', 'parameters', 'responses', 'externalDocs', ['vendorExtensions', newHashMap]
+beanify(SwaggerApi.prototype, [
+  'info',
+  'host',
+  'basePath',
+  'tags',
+  'schemes',
+  'produces',
+  'consumes',
+  'security',
+  'paths',
+  'securityDefinitions',
+  'definitions',
+  'parameters',
+  'responses',
+  'externalDocs',
+  ['vendorExtensions', newHashMap],
 ])
 
 export default Sway

--- a/ern-api-gen/src/java/System.js
+++ b/ern-api-gen/src/java/System.js
@@ -1,33 +1,31 @@
-
-
 export default class System {
-    static  properties = {};
-    /**
-     * Handle -Daasdasd=astasdsad
-     * and process.env;
-     * arguments take precidence?
-     * @param key
-     * @returns {*}
-     */
-    static getProperty(key) {
-        const {properties} = System;
-        if (key in properties) return properties[key];
-        const starts = `-D${key}`;
-        const args = process.argv.slice(2);
-        for (let i = 0, l = args.length; i < l; i++) {
-            const arg = args[i];
-            if (arg == starts) {
-                return (properties[key] = args[++i]);
-            }
-            if (arg.startsWith(starts + '=')) {
-                return (properties[key] = arg.substring(starts.length + 1));
-            }
-        }
-        return process.env[key];
+  static properties = {}
+  /**
+   * Handle -Daasdasd=astasdsad
+   * and process.env;
+   * arguments take precidence?
+   * @param key
+   * @returns {*}
+   */
+  static getProperty(key) {
+    const { properties } = System
+    if (key in properties) return properties[key]
+    const starts = `-D${key}`
+    const args = process.argv.slice(2)
+    for (let i = 0, l = args.length; i < l; i++) {
+      const arg = args[i]
+      if (arg == starts) {
+        return (properties[key] = args[++i])
+      }
+      if (arg.startsWith(starts + '=')) {
+        return (properties[key] = arg.substring(starts.length + 1))
+      }
     }
+    return process.env[key]
+  }
 
-    static setProperty(key, value) {
-        const {properties} = System;
-        properties[key] = value;
-    }
+  static setProperty(key, value) {
+    const { properties } = System
+    properties[key] = value
+  }
 }

--- a/ern-api-gen/src/java/beanUtils.js
+++ b/ern-api-gen/src/java/beanUtils.js
@@ -1,4 +1,4 @@
-import {lowerFirst as lcFirst, upperFirst as ucFirst} from './StringUtils'
+import { lowerFirst as lcFirst, upperFirst as ucFirst } from './StringUtils'
 
 /**
  * Takes a prototype and a list of property names and creates getters and
@@ -16,21 +16,29 @@ export const beanify = (prototype, p, prefix = '') => {
     let defValue
     if (Array.isArray(p)) {
       op = p[0]
-      if (p.length > 1) { defValue = p[1] }
-      if (p.length > 2) { pre = p[2] }
+      if (p.length > 1) {
+        defValue = p[1]
+      }
+      if (p.length > 2) {
+        pre = p[2]
+      }
     }
     const prop = `${pre}${op}`
     const uProp = ucFirst(op)
     const set = `set${uProp}`
     const get = `get${uProp}`
     if (!has(prototype, set)) {
-      prototype[set] = function (value) {
+      prototype[set] = function(value) {
         this[prop] = value
       }
     }
     if (!has(prototype, get)) {
-      prototype[get] = function () {
-        return has(this, prop) ? this[prop] : typeof defValue === 'function' ? defValue() : defValue
+      prototype[get] = function() {
+        return has(this, prop)
+          ? this[prop]
+          : typeof defValue === 'function'
+            ? defValue()
+            : defValue
       }
     }
   }
@@ -42,14 +50,14 @@ export const beanify = (prototype, p, prefix = '') => {
  * Takes a bean and applies the values where the values have
  * setters the setters are called.
  */
-function resolve (obj, path) {
+function resolve(obj, path) {
   if (obj == null) return
   if (path == null) return obj
   if (typeof obj[path] === 'function') return obj[path]()
   if (path in obj) return obj[path]
   if (obj instanceof Map) return obj.get(path)
 }
-function canResolve (obj, path) {
+function canResolve(obj, path) {
   return true
   if (obj == null) return false
   if (path == null) return false
@@ -57,7 +65,7 @@ function canResolve (obj, path) {
   if (obj instanceof Map) return obj.has(path)
   return Object.hasOwnProperty.call(obj, path)
 }
-function each (obj, keys, fn, scope) {
+function each(obj, keys, fn, scope) {
   if (obj == null) return obj
   if (typeof obj[Symbol.iterator] === 'function') {
     for (const [k, v] of obj) {
@@ -80,7 +88,9 @@ export const applyStrict = (bean, obj) => {
   return apply(bean, obj, null, true)
 }
 export const canResolveNoFunc = (obj, prop) => {
-  if (!canResolve(obj, prop)) { return false }
+  if (!canResolve(obj, prop)) {
+    return false
+  }
   return typeof obj[prop] !== 'function'
 }
 
@@ -88,22 +98,35 @@ export const apply = (bean, obj, properties, strict = false) => {
   if (obj == null) return bean
   if (bean == null) throw new Error(`Bean can not be null`)
   const prefix = ''
-  each(obj, properties, function (v, p) {
+  each(obj, properties, function(v, p) {
     let op = p
     let pre = prefix
     let defValue
     if (Array.isArray(p)) {
       op = p[0]
-      if (p.length > 1) { defValue = p[1] }
-      if (p.length > 2) { pre = p[2] }
+      if (p.length > 1) {
+        defValue = p[1]
+      }
+      if (p.length > 2) {
+        pre = p[2]
+      }
     }
     const prop = `${pre}${op}`
     const uProp = ucFirst(op)
     const set = `set${uProp}`
     const is = `is${uProp}`
     const get = `get${uProp}`
-    if (canResolve(obj, prop) || typeof obj[get] === 'function' || typeof obj[is] === 'function') {
-      const value = typeof obj[get] === 'function' ? obj[get]() : typeof obj[is] === 'function' ? obj[is]() : resolve(obj, prop)
+    if (
+      canResolve(obj, prop) ||
+      typeof obj[get] === 'function' ||
+      typeof obj[is] === 'function'
+    ) {
+      const value =
+        typeof obj[get] === 'function'
+          ? obj[get]()
+          : typeof obj[is] === 'function'
+            ? obj[is]()
+            : resolve(obj, prop)
       if (typeof bean[set] === 'function') {
         bean[set](value)
       } else if (!strict || canResolveNoFunc(bean, prop)) {
@@ -124,4 +147,4 @@ export const has = (obj, ...properties) => {
   return true
 }
 
-export default({beanify, apply, has})
+export default { beanify, apply, has }

--- a/ern-api-gen/src/java/cli.js
+++ b/ern-api-gen/src/java/cli.js
@@ -1,187 +1,213 @@
-import pad from 'lodash/padEnd';
-import camelCase from 'lodash/camelCase';
-const SORT_CMDS = (a, b) => a.Usage.name.localeCompare(b.Usage.name);
+import pad from 'lodash/padEnd'
+import camelCase from 'lodash/camelCase'
+const SORT_CMDS = (a, b) => a.Usage.name.localeCompare(b.Usage.name)
 const SORT_OPTS = (b, a) => {
-    if (a.required && !b.required) {
-        return 1;
-    }
-    if (b.required && !a.required) {
-        return -1;
-    }
-    let ret = a.name[0].replace(PREFIX, '').localeCompare(b.name[0].replace(PREFIX, ''));
-    if (ret == 0 && a.name.length > 1) {
-        if (b.name.length < 2)return 1;
-        ret = a.name[1].repalce(PREFIX, '').localeCompare(b.name[1].replace(PREFIX, ''));
-    }
-    return ret;
-};
+  if (a.required && !b.required) {
+    return 1
+  }
+  if (b.required && !a.required) {
+    return -1
+  }
+  let ret = a.name[0]
+    .replace(PREFIX, '')
+    .localeCompare(b.name[0].replace(PREFIX, ''))
+  if (ret == 0 && a.name.length > 1) {
+    if (b.name.length < 2) return 1
+    ret = a.name[1]
+      .repalce(PREFIX, '')
+      .localeCompare(b.name[1].replace(PREFIX, ''))
+  }
+  return ret
+}
 
-const PREFIX = /^-+?/;
+const PREFIX = /^-+?/
 export class Command {
-    constructor({name, description}, options = []) {
-        this.name = name;
-        this.description = description;
-        this.options = options;
-    }
+  constructor({ name, description }, options = []) {
+    this.name = name
+    this.description = description
+    this.options = options
+  }
 }
 export class CommandUsage {
-    constructor(values, meta, cmd) {
-        this.values = values;
-        this.cmd = cmd;
-        this.meta = meta;
-    }
+  constructor(values, meta, cmd) {
+    this.values = values
+    this.cmd = cmd
+    this.meta = meta
+  }
 
-    run() {
-        const Usage = this.cmd.Usage;
-        const name = Usage.name;
-        const options = Usage.options;
-        const description = Usage.description;
-        const {values} = this;
-        let str = `Command ${name} has the following options:\n${description}`;
-        for (const opt of options.sort(SORT_OPTS)) {
-            const property = opt.property || camelCase(values[opt.title]);
-            const value = (values[property] || opt.title);
-            const short = opt.name.length > 1 ? opt.name[0] : '';
-            const long = opt.name.length > 1 ? opt.name[1] : opt.name[0];
-            str = `${str}
-\t${pad(opt.required ? '* ' : '', 2)}${pad(short, 5)} ${pad(long, 25)} ${pad(opt.hasArg ? `[${value}]` : '', 20)}\v${opt.description}`
-        }
-        return str;
+  run() {
+    const Usage = this.cmd.Usage
+    const name = Usage.name
+    const options = Usage.options
+    const description = Usage.description
+    const { values } = this
+    let str = `Command ${name} has the following options:\n${description}`
+    for (const opt of options.sort(SORT_OPTS)) {
+      const property = opt.property || camelCase(values[opt.title])
+      const value = values[property] || opt.title
+      const short = opt.name.length > 1 ? opt.name[0] : ''
+      const long = opt.name.length > 1 ? opt.name[1] : opt.name[0]
+      str = `${str}
+\t${pad(opt.required ? '* ' : '', 2)}${pad(short, 5)} ${pad(long, 25)} ${pad(
+        opt.hasArg ? `[${value}]` : '',
+        20
+      )}\v${opt.description}`
     }
+    return str
+  }
 }
 
 export class Help {
-    static Usage = new Command({name: "help", description: "This helpful message."}, []);
+  static Usage = new Command(
+    { name: 'help', description: 'This helpful message.' },
+    []
+  )
 
-    constructor(values, opts) {
-        this.values = values;
-        this.opts = opts;
-    }
+  constructor(values, opts) {
+    this.values = values
+    this.opts = opts
+  }
 
-    run() {
-        const {name, description, commands = []} = this.opts;
-        console.log(`${name}\n${description}`);
-        for (const cmd of commands.sort(SORT_CMDS)) {
-            console.log(`\t${pad(cmd.Usage.name, 20)} - ${cmd.Usage.description}`);
-        }
+  run() {
+    const { name, description, commands = [] } = this.opts
+    console.log(`${name}\n${description}`)
+    for (const cmd of commands.sort(SORT_CMDS)) {
+      console.log(`\t${pad(cmd.Usage.name, 20)} - ${cmd.Usage.description}`)
     }
+  }
 }
 class CliError extends Error {
-    constructor(message, cmd, opt) {
-        super(message);
-        this.cmd = cmd;
-        this.opt = opt;
-    }
+  constructor(message, cmd, opt) {
+    super(message)
+    this.cmd = cmd
+    this.opt = opt
+  }
 }
 class CommandErrorHandler {
-    constructor(values, opts, cmd) {
-        this.values = values;
-        this.opts = opts;
-        this.cmd = cmd;
-    }
+  constructor(values, opts, cmd) {
+    this.values = values
+    this.opts = opts
+    this.cmd = cmd
+  }
 
-    handle(message) {
-        if (this.opts.commandUsage && this.opts && this.cmd) {
-            const help = new this.opts.commandUsage(this.values, this.opts, this.cmd);
-            const helpMesg = help.run();
-            throw new CliError(`${message}\n${helpMesg}`);
-        }
-        throw new CliError(message);
+  handle(message) {
+    if (this.opts.commandUsage && this.opts && this.cmd) {
+      const help = new this.opts.commandUsage(this.values, this.opts, this.cmd)
+      const helpMesg = help.run()
+      throw new CliError(`${message}\n${helpMesg}`)
     }
+    throw new CliError(message)
+  }
 }
 export class Cli {
-    static builder(name) {
-        const opts = {name, commandHelp: Help, commandUsage: CommandUsage, commandErrorHandler: CommandErrorHandler};
-        const w = {
-            withDescription(description){
-                opts.description = description;
-                return w;
-            },
-            withDefaultCommand(command){
-                opts.defaultCommand = command;
-                return w;
-            },
-            withCommands(...commands){
-                opts.commands = commands;
-                return w;
-            },
-            withCommandsHelp(commandHelp){
-                opts.commandHelp = commandHelp;
-                return w;
-            },
-            withCommandUsage(commandUsage){
-                opts.commandUsage = commandUsage;
-                return w;
-            },
-            withCommandErrorHandler(errorHandler){
-                opts.commandErrorHandler = errorHandler;
-                return w;
-            },
-            build(){
-                return {
-                    parse(args = []){
-                        const isHelp = args.indexOf('-h') > -1 || args.indexOf('--help') > -1;
-
-                        const values = {};
-                        let Command = opts.defaultCommand;
-                        for (const c of opts.commands) {
-                            if (c.Usage.name === args[0]) {
-                                Command = c;
-                                break;
-                            }
-                        }
-                        if (!Command) {
-                            new opts.commandErrorHandler(values, opts, Command).handle(args.length ? `Unknown Command  ${args[0]}` : 'No Command given');
-                        }
-                        if (isHelp && Command == opts.defaultCommand) {
-                            return new opts.commandHelp(values, opts).run();
-                        }
-                        for (const opt of Command.Usage.options) {
-                            let value;
-                            let current;
-                            NAMES: for (const name of opt.name) {
-                                for (let i = 0, l = args.length; i < l; i++) {
-                                    if (args[i] === name) {
-                                        value = args[++i];
-                                        current = opt;
-                                        break NAMES;
-                                    }
-                                    const eqStr = `${name}=`;
-                                    if (args[i].startsWith(eqStr)) {
-                                        value = args[i].substring(eqStr.length);
-                                        current = opt;
-                                        break NAMES;
-                                    }
-
-                                }
-                            }
-                            if (current) {
-                                const property = opt.property || camelCase(opt.title);
-                                if (current.hasArg) {
-                                    if (value == null) {
-                                        return new opts.commandErrorHandler(values, opts, Command).handle(`${_check.name} requires a value`);
-
-                                    }
-                                    values[property] = value;
-                                } else {
-                                    values[property] = true;
-                                }
-                            } else {
-                                if (opt.required) {
-                                    return new opts.commandErrorHandler(values, opts, Command).handle(`${args[0]} requires a option for ${opt.description}`);
-                                }
-                            }
-                        }
-                        if (isHelp) {
-                            return new opts.commandUsage(values, opts, Command).run();
-                        }
-
-                        return new Command(values, opts).run();
-                    }
-                }
-            }
-        };
-
-        return w;
+  static builder(name) {
+    const opts = {
+      name,
+      commandHelp: Help,
+      commandUsage: CommandUsage,
+      commandErrorHandler: CommandErrorHandler,
     }
+    const w = {
+      withDescription(description) {
+        opts.description = description
+        return w
+      },
+      withDefaultCommand(command) {
+        opts.defaultCommand = command
+        return w
+      },
+      withCommands(...commands) {
+        opts.commands = commands
+        return w
+      },
+      withCommandsHelp(commandHelp) {
+        opts.commandHelp = commandHelp
+        return w
+      },
+      withCommandUsage(commandUsage) {
+        opts.commandUsage = commandUsage
+        return w
+      },
+      withCommandErrorHandler(errorHandler) {
+        opts.commandErrorHandler = errorHandler
+        return w
+      },
+      build() {
+        return {
+          parse(args = []) {
+            const isHelp =
+              args.indexOf('-h') > -1 || args.indexOf('--help') > -1
+
+            const values = {}
+            let Command = opts.defaultCommand
+            for (const c of opts.commands) {
+              if (c.Usage.name === args[0]) {
+                Command = c
+                break
+              }
+            }
+            if (!Command) {
+              new opts.commandErrorHandler(values, opts, Command).handle(
+                args.length ? `Unknown Command  ${args[0]}` : 'No Command given'
+              )
+            }
+            if (isHelp && Command == opts.defaultCommand) {
+              return new opts.commandHelp(values, opts).run()
+            }
+            for (const opt of Command.Usage.options) {
+              let value
+              let current
+              NAMES: for (const name of opt.name) {
+                for (let i = 0, l = args.length; i < l; i++) {
+                  if (args[i] === name) {
+                    value = args[++i]
+                    current = opt
+                    break NAMES
+                  }
+                  const eqStr = `${name}=`
+                  if (args[i].startsWith(eqStr)) {
+                    value = args[i].substring(eqStr.length)
+                    current = opt
+                    break NAMES
+                  }
+                }
+              }
+              if (current) {
+                const property = opt.property || camelCase(opt.title)
+                if (current.hasArg) {
+                  if (value == null) {
+                    return new opts.commandErrorHandler(
+                      values,
+                      opts,
+                      Command
+                    ).handle(`${_check.name} requires a value`)
+                  }
+                  values[property] = value
+                } else {
+                  values[property] = true
+                }
+              } else {
+                if (opt.required) {
+                  return new opts.commandErrorHandler(
+                    values,
+                    opts,
+                    Command
+                  ).handle(
+                    `${args[0]} requires a option for ${opt.description}`
+                  )
+                }
+              }
+            }
+            if (isHelp) {
+              return new opts.commandUsage(values, opts, Command).run()
+            }
+
+            return new Command(values, opts).run()
+          },
+        }
+      },
+    }
+
+    return w
+  }
 }

--- a/ern-api-gen/src/java/encoders.js
+++ b/ern-api-gen/src/java/encoders.js
@@ -1,6 +1,6 @@
-export const URLDecoder = {decode: decodeURIComponent}
-export const URLEncoder = {encode: encodeURIComponent}
-export default ({
+export const URLDecoder = { decode: decodeURIComponent }
+export const URLEncoder = { encode: encodeURIComponent }
+export default {
   URLDecoder,
-  URLEncoder
-})
+  URLEncoder,
+}

--- a/ern-api-gen/src/java/fakeMap.js
+++ b/ern-api-gen/src/java/fakeMap.js
@@ -1,200 +1,194 @@
 class FakeHashSet {
-    value = [];
+  value = []
 
-    constructor(...arr) {
-        this.addAll(arr);
-    }
+  constructor(...arr) {
+    this.addAll(arr)
+  }
 
-    add(v) {
-        if (this.contains(v)) return false;
-        this.value.push(v);
-        return true;
-    }
+  add(v) {
+    if (this.contains(v)) return false
+    this.value.push(v)
+    return true
+  }
 
-    addAll(all) {
-        let ret = false;
-        for (const v of all) {
-            ret |= this.add(v);
-        }
-        return !!ret;
+  addAll(all) {
+    let ret = false
+    for (const v of all) {
+      ret |= this.add(v)
     }
+    return !!ret
+  }
 
-    clear() {
-        this.value = [];
-    }
+  clear() {
+    this.value = []
+  }
 
-    remove(v) {
-        const idx = this.value.indexOf(v);
-        if (idx > -1) {
-            this.value.splice(idx, 1);
-            return true;
-        }
-        return false;
+  remove(v) {
+    const idx = this.value.indexOf(v)
+    if (idx > -1) {
+      this.value.splice(idx, 1)
+      return true
     }
+    return false
+  }
 
-    removeAll(c) {
-        let ret = false;
-        for (const v of c) {
-            ret |= this.remove(v);
-        }
-        return !!ret;
+  removeAll(c) {
+    let ret = false
+    for (const v of c) {
+      ret |= this.remove(v)
     }
+    return !!ret
+  }
 
-    contains(v) {
-        return this.value.indexOf(v) > -1;
-    }
+  contains(v) {
+    return this.value.indexOf(v) > -1
+  }
 
-    get size() {
-        return this.value.length;
-    }
+  get size() {
+    return this.value.length
+  }
 
-    //So Array.from will work.
-    get length() {
-        return this.value.length;
-    }
+  //So Array.from will work.
+  get length() {
+    return this.value.length
+  }
 
-    isEmpty() {
-        return this.value.length === 0;
-    }
+  isEmpty() {
+    return this.value.length === 0
+  }
 
-    [Symbol.iterator]() {
-        return this.value[Symbol.iterator]();
-    }
+  [Symbol.iterator]() {
+    return this.value[Symbol.iterator]()
+  }
 
-    //Java Like iterator different than Symbol.iterator.
-    iterator() {
-        const itr = this.value[Symbol.iterator]();
-        let c = itr.next();
-        return {
-            next(){
-                const value = c.value;
-                c = itr.next();
-                return value;
-            },
-            hasNext(){
-                return !c.done;
-            }
-        };
+  //Java Like iterator different than Symbol.iterator.
+  iterator() {
+    const itr = this.value[Symbol.iterator]()
+    let c = itr.next()
+    return {
+      next() {
+        const value = c.value
+        c = itr.next()
+        return value
+      },
+      hasNext() {
+        return !c.done
+      },
     }
+  }
 
-    toArray() {
-        return this.value;
-    }
+  toArray() {
+    return this.value
+  }
 
-    toJSON() {
-        return this.value;
-    }
+  toJSON() {
+    return this.value
+  }
 }
 
-export const fakeSet = (...arr) => new FakeHashSet(...arr);
-
+export const fakeSet = (...arr) => new FakeHashSet(...arr)
 
 export class FakeHashMap {
+  static toEntry(key) {
+    const self = this
+    return {
+      getValue() {
+        return self[key]
+      },
+      getKey() {
+        return key
+      },
+    }
+  }
 
-    static toEntry(key) {
-        const self = this;
-        return {
-            getValue(){
-                return self[key];
-            },
-            getKey(){
-                return key
-            }
+  value = {}
+
+  constructor(...args) {
+    for (const [k, v] of args) this.value[k] = v
+  }
+
+  put(key, value) {
+    return (this.value[key] = value)
+  }
+
+  putAll(all) {
+    if (Symbol.iterator in all)
+      for (const [key, value] of all) this.value[key] = value
+    else {
+      for (const key of Object.keys(all)) {
+        this.value[key] = all[key]
+      }
+    }
+  }
+
+  entrySet() {
+    return new FakeHashSet(
+      ...Object.keys(this.value).map(FakeHashMap.toEntry, this.value)
+    )
+  }
+
+  keySet() {
+    return new FakeHashSet(...Object.keys(this.value))
+  }
+
+  isEmpty() {
+    return this.size === 0
+  }
+
+  remove(key) {
+    return delete this.value[key]
+  }
+
+  clear() {
+    this.value = {}
+  }
+
+  values() {
+    const values = []
+    for (const [k, v] of this) {
+      values.push(v)
+    }
+    return values
+  }
+
+  containsValue(value) {
+    for (const key of Object.keys(this.value)) {
+      if (this.value[key] === value) return true
+    }
+    return false
+  }
+
+  containsKey(value) {
+    return value in this.value
+  }
+
+  [Symbol.iterator]() {
+    const { value } = this
+    const it = Object.keys(value)[Symbol.iterator]()
+    return {
+      next() {
+        const n = it.next()
+        if (!n.done) {
+          n.value = [n.value, value[n.value]]
         }
-    };
-
-
-    value = {};
-
-    constructor(...args) {
-        for (const [k, v] of args)
-            this.value[k] = v;
+        return n
+      },
     }
+  }
 
-    put(key, value) {
-        return (this.value[key] = value);
-    }
+  get(key) {
+    return this.value[key]
+  }
 
-    putAll(all) {
-        if (Symbol.iterator in all)
-            for (const [key, value] of all)
-                this.value[key] = value;
-        else {
-            for (const key of Object.keys(all)) {
-                this.value[key] = all[key];
-            }
-        }
-    }
+  get size() {
+    return Object.keys(this.value).length
+  }
 
-
-    entrySet() {
-        return new FakeHashSet(...Object.keys(this.value).map(FakeHashMap.toEntry, this.value));
-    }
-
-    keySet() {
-        return new FakeHashSet(...Object.keys(this.value));
-    }
-
-    isEmpty() {
-        return this.size === 0;
-    }
-
-    remove(key) {
-        return delete this.value[key];
-    }
-
-    clear() {
-        this.value = {};
-    }
-
-    values() {
-        const values = [];
-        for (const [k, v] of this) {
-            values.push(v);
-        }
-        return values;
-    }
-
-    containsValue(value) {
-        for (const key of Object.keys(this.value)) {
-            if (this.value[key] === value) return true;
-        }
-        return false;
-    }
-
-    containsKey(value) {
-        return value in this.value;
-    }
-
-    [Symbol.iterator]() {
-        const {value} = this;
-        const it = Object.keys(value)[Symbol.iterator]();
-        return {
-            next() {
-                const n = it.next();
-                if (!n.done) {
-                    n.value = [n.value, value[n.value]]
-                }
-                return n;
-            }
-        }
-    }
-
-    get(key) {
-        return this.value[key];
-    }
-
-    get size() {
-        return Object.keys(this.value).length;
-    }
-
-    toJSON() {
-        return this.value;
-    }
-
-
+  toJSON() {
+    return this.value
+  }
 }
 
 export default function newHashMap(...args) {
-    return new FakeHashMap(...args);
+  return new FakeHashMap(...args)
 }

--- a/ern-api-gen/src/languages/ES6Codegen.js
+++ b/ern-api-gen/src/languages/ES6Codegen.js
@@ -1,34 +1,43 @@
-import JavascriptClientCodegen from "./JavascriptClientCodegen";
-import SupportingFile from '../SupportingFile';
+import JavascriptClientCodegen from './JavascriptClientCodegen'
+import SupportingFile from '../SupportingFile'
 
 export default class ES6Codegen extends JavascriptClientCodegen {
-    __templateDir = 'es6';
-    invokerPackage = "";
+  __templateDir = 'es6'
+  invokerPackage = ''
 
+  constructor() {
+    super()
+    this.__supportingFiles = this.__supportingFiles.filter(
+      v => v.templateFile != 'mocha.opts'
+    )
+    this.__supportingFiles.push(
+      new SupportingFile('babelrc.mustache', '', '.babelrc')
+    )
+    this.__supportingFiles.push(
+      new SupportingFile('npmignore.mustache', '', '.npmignore')
+    )
+    this.__supportingFiles.push(
+      new SupportingFile('gitignore.mustache', '', '.gitignore')
+    )
 
-    constructor() {
-        super();
-        this.__supportingFiles = this.__supportingFiles.filter(v => v.templateFile != 'mocha.opts');
-        this.__supportingFiles.push(new SupportingFile("babelrc.mustache", "", ".babelrc"));
-        this.__supportingFiles.push(new SupportingFile("npmignore.mustache", "", ".npmignore"));
-        this.__supportingFiles.push(new SupportingFile("gitignore.mustache", "", ".gitignore"));
+    this.usePromises = true
+  }
 
-        this.usePromises = true;
-    }
+  processOpts() {
+    super.processOpts()
+    const f = this[
+      `addSupportingFilesFor${JavascriptClientCodegen.camelize(
+        this.getLibrary()
+      )}`
+    ]
+    f && f.call(this)
+  }
 
-    processOpts() {
-        super.processOpts();
-        const f = this[`addSupportingFilesFor${JavascriptClientCodegen.camelize(this.getLibrary())}`];
-        f && f.call(this);
-    }
+  getName() {
+    return 'ES6'
+  }
 
-    getName() {
-        return 'ES6';
-    }
-
-    apiFileFolder(templateName, tag) {
-        return this.__outputFolder + "/src/api";
-    }
-
+  apiFileFolder(templateName, tag) {
+    return this.__outputFolder + '/src/api'
+  }
 }
-

--- a/ern-api-gen/src/languages/ErnAndroidApiCodegen.js
+++ b/ern-api-gen/src/languages/ErnAndroidApiCodegen.js
@@ -1,24 +1,25 @@
-import AndroidClientCodegen from "../languages/AndroidClientCodegen";
-import ernify from './ERNMixin';
-import {newHashMap} from '../java/javaUtil';
+import AndroidClientCodegen from '../languages/AndroidClientCodegen'
+import ernify from './ERNMixin'
+import { newHashMap } from '../java/javaUtil'
 
 export default class ErnAndroidApiCodegen extends AndroidClientCodegen {
+  sourceFolder = 'lib/src/main/java'
+  platformVersion = '1.3.0'
+  library = 'ern'
+  __supportedLibraries = newHashMap([
+    'ern',
+    'ERN plugin makes this platform work',
+  ])
 
-    sourceFolder = "lib/src/main/java";
-    platformVersion = "1.3.0";
-    library = "ern";
-    __supportedLibraries = newHashMap(["ern", "ERN plugin makes this platform work"]);
+  addSupportingFilesForErn() {
+    this.__apiTemplateFiles.put('apirequests.mustache', '.java')
+    this.__apiTemplateFiles.put('apievents.mustache', '.java')
+    this.__apiDataTemplateFile.put('apidatamodel.mustache', '.java')
+  }
 
-    addSupportingFilesForErn() {
-
-        this.__apiTemplateFiles.put("apirequests.mustache", ".java");
-        this.__apiTemplateFiles.put("apievents.mustache", ".java");
-        this.__apiDataTemplateFile.put("apidatamodel.mustache", ".java");
-    }
-
-    getName() {
-        return "ERNAndroid";
-    }
+  getName() {
+    return 'ERNAndroid'
+  }
 }
 
-ernify(ErnAndroidApiCodegen);
+ernify(ErnAndroidApiCodegen)

--- a/ern-api-gen/src/languages/ErnES6ApiCodegen.js
+++ b/ern-api-gen/src/languages/ErnES6ApiCodegen.js
@@ -1,70 +1,75 @@
-import ES6Codegen from "../languages/ES6Codegen";
-import ernify from './ERNMixin';
-import {newHashMap} from '../java/javaUtil';
-const {postProcessOperations} = ES6Codegen.prototype;
-export const ERN_SUPPORTING = ['index.mustache', 'package.mustache', 'README.mustache'];
-export const ERN_REMOVING = ['ApiClient.mustache'];
+import ES6Codegen from '../languages/ES6Codegen'
+import ernify from './ERNMixin'
+import { newHashMap } from '../java/javaUtil'
+const { postProcessOperations } = ES6Codegen.prototype
+export const ERN_SUPPORTING = [
+  'index.mustache',
+  'package.mustache',
+  'README.mustache',
+]
+export const ERN_REMOVING = ['ApiClient.mustache']
 const contains = (arr, val) => {
-    if (arr == null) return false;
-    return arr.indexOf(val) > -1;
-};
+  if (arr == null) return false
+  return arr.indexOf(val) > -1
+}
 
 export default class ErnES6ApiCodegen extends ES6Codegen {
-    library = "ern";
-    classy = false;
-    __supportedLibraries = newHashMap(
-        ["ern", "ERN plugin makes this platform work"]
-    );
+  library = 'ern'
+  classy = false
+  __supportedLibraries = newHashMap([
+    'ern',
+    'ERN plugin makes this platform work',
+  ])
 
-    addSupportingFilesForErn() {
-        this.__modelTemplateFiles.clear();
-        this.__modelTestTemplateFiles.clear();
-        this.__modelDocTemplateFiles.clear();
-        this.__apiTestTemplateFiles.clear();
-        this.__apiDocTemplateFiles.clear();
-        //add our special sauce.
-        this.__apiTemplateFiles.put("api.mustache", ".js");
-        this.__apiTemplateFiles.put("apirequests.mustache", ".js");
-        this.__apiTemplateFiles.put("apievents.mustache", ".js");
-        this.__apiTestTemplateFiles.put("api_test.mustache", ".js");
-        // this.__apiDocTemplateFiles.put("api_doc.mustache", ".md");
-        if (this.classy) {
-            this.__additionalProperties.put("isClassy", this.classy);
-            this.__modelTemplateFiles.put("model.mustache", ".js");
-            // this.__modelDocTemplateFiles.put("model_doc.mustache", ".md");
-        }
+  addSupportingFilesForErn() {
+    this.__modelTemplateFiles.clear()
+    this.__modelTestTemplateFiles.clear()
+    this.__modelDocTemplateFiles.clear()
+    this.__apiTestTemplateFiles.clear()
+    this.__apiDocTemplateFiles.clear()
+    //add our special sauce.
+    this.__apiTemplateFiles.put('api.mustache', '.js')
+    this.__apiTemplateFiles.put('apirequests.mustache', '.js')
+    this.__apiTemplateFiles.put('apievents.mustache', '.js')
+    this.__apiTestTemplateFiles.put('api_test.mustache', '.js')
+    // this.__apiDocTemplateFiles.put("api_doc.mustache", ".md");
+    if (this.classy) {
+      this.__additionalProperties.put('isClassy', this.classy)
+      this.__modelTemplateFiles.put('model.mustache', '.js')
+      // this.__modelDocTemplateFiles.put("model_doc.mustache", ".md");
     }
+  }
 
-    preprocessSwagger(swagger) {
-        super.preprocessSwagger(swagger);
-        if (!this.classy) {
-            this.__supportingFiles = this.__supportingFiles.filter(v => !contains(ERN_REMOVING, v.templateFile));
-        }
+  preprocessSwagger(swagger) {
+    super.preprocessSwagger(swagger)
+    if (!this.classy) {
+      this.__supportingFiles = this.__supportingFiles.filter(
+        v => !contains(ERN_REMOVING, v.templateFile)
+      )
     }
+  }
 
-    getName() {
-        return "ERNES6";
-    }
+  getName() {
+    return 'ERNES6'
+  }
 }
 ernify(ErnES6ApiCodegen, {
-    postProcessOperations(objs){
-        objs = postProcessOperations.call(this, objs);
-        const operations = objs.get("operations");
-        const ops = operations && operations.get("operation");
-        if (ops == null)
-            return objs;
+  postProcessOperations(objs) {
+    objs = postProcessOperations.call(this, objs)
+    const operations = objs.get('operations')
+    const ops = operations && operations.get('operation')
+    if (ops == null) return objs
 
-
-        for (const op of ops) {
-            op.hasSingleParam = op.allParams.length == 1;
-            if (op.httpMethod !== 'EVENT') {
-                objs.put("hasRequest", true);
-                continue;
-            }
-            op.isEvent = true;
-            objs.put("hasEvent", true);
-        }
-        objs.put("isClassy", this.classy);
-        return objs;
+    for (const op of ops) {
+      op.hasSingleParam = op.allParams.length == 1
+      if (op.httpMethod !== 'EVENT') {
+        objs.put('hasRequest', true)
+        continue
+      }
+      op.isEvent = true
+      objs.put('hasEvent', true)
     }
-});
+    objs.put('isClassy', this.classy)
+    return objs
+  },
+})

--- a/ern-api-gen/src/languages/ErnSwiftCodegen.js
+++ b/ern-api-gen/src/languages/ErnSwiftCodegen.js
@@ -1,48 +1,50 @@
-import SwiftCodegen from './SwiftCodegen';
-import ernify from './ERNMixin';
-import {newHashMap} from '../java/javaUtil';
-import File from '../java/File';
+import SwiftCodegen from './SwiftCodegen'
+import ernify from './ERNMixin'
+import { newHashMap } from '../java/javaUtil'
+import File from '../java/File'
 
 export default class ErnSwiftCodegen extends SwiftCodegen {
-    library = "ern";
-    __apiPackage = "io.swagger.client.api";
-    __supportedLibraries = newHashMap(
-        ["ern", "ERN plugin makes this platform work"]
-    );
-    unwrapRequired = true;
+  library = 'ern'
+  __apiPackage = 'io.swagger.client.api'
+  __supportedLibraries = newHashMap([
+    'ern',
+    'ERN plugin makes this platform work',
+  ])
+  unwrapRequired = true
 
-    constructor() {
-        super();
-        this.__typeMapping.put("int", "Int");
-        this.__typeMapping.put("integer", "Int");
-        this.sourceFolder = ""
-    }
+  constructor() {
+    super()
+    this.__typeMapping.put('int', 'Int')
+    this.__typeMapping.put('integer', 'Int')
+    this.sourceFolder = ''
+  }
 
-    modelFileFolder() {
-        return this.__outputFolder
-    }
+  modelFileFolder() {
+    return this.__outputFolder
+  }
 
-    apiFileFolder() {
-        return this.__outputFolder
-    }
+  apiFileFolder() {
+    return this.__outputFolder
+  }
 
-    processOpts() {
-        super.processOpts();
-        //Events and Requests files.
-        const f = this[`addSupportingFilesFor${SwiftCodegen.camelize(this.getLibrary())}`];
-        f && f.call(this);
-    }
+  processOpts() {
+    super.processOpts()
+    //Events and Requests files.
+    const f = this[
+      `addSupportingFilesFor${SwiftCodegen.camelize(this.getLibrary())}`
+    ]
+    f && f.call(this)
+  }
 
-    addSupportingFilesForErn() {
-        this.__apiTemplateFiles.put("apirequests.mustache", ".swift");
-        this.__apiTemplateFiles.put("apievents.mustache", ".swift");
-        this.__apiDataTemplateFile.put("apidatamodel.mustache", ".swift");
-    }
+  addSupportingFilesForErn() {
+    this.__apiTemplateFiles.put('apirequests.mustache', '.swift')
+    this.__apiTemplateFiles.put('apievents.mustache', '.swift')
+    this.__apiDataTemplateFile.put('apidatamodel.mustache', '.swift')
+  }
 
-    getName() {
-        return "ERNSwift";
-    }
+  getName() {
+    return 'ERNSwift'
+  }
 }
 
-ernify(ErnSwiftCodegen);
-
+ernify(ErnSwiftCodegen)

--- a/ern-api-gen/src/models/AbstractModel.js
+++ b/ern-api-gen/src/models/AbstractModel.js
@@ -1,44 +1,43 @@
-import {newHashMap} from "../java/javaUtil";
+import { newHashMap } from '../java/javaUtil'
 
 export default class AbstractModel {
-    vendorExtensions = newHashMap();
+  vendorExtensions = newHashMap()
 
-    getExternalDocs() {
-        return this.externalDocs;
-    };
+  getExternalDocs() {
+    return this.externalDocs
+  }
 
-    setExternalDocs(value) {
-        this.externalDocs = value;
-    };
+  setExternalDocs(value) {
+    this.externalDocs = value
+  }
 
-    getTitle() {
-        return this.title;
-    };
+  getTitle() {
+    return this.title
+  }
 
-    setTitle(title) {
-        this.title = title;
-    };
+  setTitle(title) {
+    this.title = title
+  }
 
-    getVendorExtensions() {
-        return this.vendorExtensions;
-    };
+  getVendorExtensions() {
+    return this.vendorExtensions
+  }
 
-    setVendorExtension(name, value) {
-        if (typeof name === 'string' && name.startsWith("x-")) {
-            this.vendorExtensions.put(name, value);
-        }
-    };
+  setVendorExtension(name, value) {
+    if (typeof name === 'string' && name.startsWith('x-')) {
+      this.vendorExtensions.put(name, value)
+    }
+  }
 
-    setVendorExtensions(vendorExtensions) {
-        this.vendorExtensions = vendorExtensions;
-    };
+  setVendorExtensions(vendorExtensions) {
+    this.vendorExtensions = vendorExtensions
+  }
 
+  getReference() {
+    return this.reference
+  }
 
-    getReference() {
-        return this.reference;
-    };
-
-    setReference(reference) {
-        this.reference = reference;
-    };
+  setReference(reference) {
+    this.reference = reference
+  }
 }

--- a/ern-api-gen/src/models/ArrayModel.js
+++ b/ern-api-gen/src/models/ArrayModel.js
@@ -1,90 +1,88 @@
-import AbstractModel from './AbstractModel';
-import factory from './factory';
-import {asMap} from '../java/javaUtil';
-import {apply} from '../java/beanUtils';
+import AbstractModel from './AbstractModel'
+import factory from './factory'
+import { asMap } from '../java/javaUtil'
+import { apply } from '../java/beanUtils'
 
 export default class ArrayModel extends AbstractModel {
-    type = "array";
+  type = 'array'
 
-    description(description) {
-        this.setDescription(description);
-        return this;
-    };
+  description(description) {
+    this.setDescription(description)
+    return this
+  }
 
-    items(items) {
-        this.setItems(items);
-        return this;
-    };
+  items(items) {
+    this.setItems(items)
+    return this
+  }
 
-    minItems(minItems) {
-        this.setMinItems(minItems);
-        return this;
-    };
+  minItems(minItems) {
+    this.setMinItems(minItems)
+    return this
+  }
 
-    maxItems(maxItems) {
-        this.setMaxItems(maxItems);
-        return this;
-    };
+  maxItems(maxItems) {
+    this.setMaxItems(maxItems)
+    return this
+  }
 
-    getType() {
-        return this.type;
-    };
+  getType() {
+    return this.type
+  }
 
-    setType(type) {
-        this.type = type;
-    };
+  setType(type) {
+    this.type = type
+  }
 
-    getDescription() {
-        return this.__description;
-    };
+  getDescription() {
+    return this.__description
+  }
 
-    setDescription(description) {
-        this.__description = description;
-    };
+  setDescription(description) {
+    this.__description = description
+  }
 
-    getItems() {
-        return this.__items;
-    };
+  getItems() {
+    return this.__items
+  }
 
-    setItems(items) {
-        this.__items = factory(items);
-    };
+  setItems(items) {
+    this.__items = factory(items)
+  }
 
-    getProperties() {
-        return this.properties;
-    };
+  getProperties() {
+    return this.properties
+  }
 
-    setProperties(properties) {
-        this.properties = asMap(properties);
-    };
+  setProperties(properties) {
+    this.properties = asMap(properties)
+  }
 
-    getExample() {
-        return this.example;
-    };
+  getExample() {
+    return this.example
+  }
 
-    setExample(example) {
-        this.example = example;
-    };
+  setExample(example) {
+    this.example = example
+  }
 
-    getMinItems() {
-        return this.__minItems;
-    };
+  getMinItems() {
+    return this.__minItems
+  }
 
-    setMinItems(minItems) {
-        this.__minItems = minItems;
-    };
+  setMinItems(minItems) {
+    this.__minItems = minItems
+  }
 
-    getMaxItems() {
-        return this.__maxItems;
-    };
+  getMaxItems() {
+    return this.__maxItems
+  }
 
-    setMaxItems(maxItems) {
-        this.__maxItems = maxItems;
-    };
+  setMaxItems(maxItems) {
+    this.__maxItems = maxItems
+  }
 
-
-    clone() {
-        return apply(new this.constructor(), this);
-    };
-
+  clone() {
+    return apply(new this.constructor(), this)
+  }
 }

--- a/ern-api-gen/src/models/ComposedModel.js
+++ b/ern-api-gen/src/models/ComposedModel.js
@@ -1,91 +1,90 @@
-import AbstractModel from './AbstractModel';
-import {apply} from '../java/javaUtil';
+import AbstractModel from './AbstractModel'
+import { apply } from '../java/javaUtil'
 
 export default class ComposedModel extends AbstractModel {
-    allOf = [];
+  allOf = []
 
-    parent(model) {
-        this.setParent(model);
-        return this;
-    };
+  parent(model) {
+    this.setParent(model)
+    return this
+  }
 
-    child(model) {
-        this.setChild(model);
-        return this;
-    };
+  child(model) {
+    this.setChild(model)
+    return this
+  }
 
-    interfaces(interfaces) {
-        this.setInterfaces(interfaces);
-        return this;
-    };
+  interfaces(interfaces) {
+    this.setInterfaces(interfaces)
+    return this
+  }
 
-    getDescription() {
-        return this.description;
-    };
+  getDescription() {
+    return this.description
+  }
 
-    setDescription(description) {
-        this.description = description;
-    };
+  setDescription(description) {
+    this.description = description
+  }
 
-    getProperties() {
-        return null;
-    };
+  getProperties() {
+    return null
+  }
 
-    setProperties(properties) {
-    };
+  setProperties(properties) {}
 
-    getExample() {
-        return this.example;
-    };
+  getExample() {
+    return this.example
+  }
 
-    setExample(example) {
-        this.example = example;
-    };
+  setExample(example) {
+    this.example = example
+  }
 
-    getAllOf() {
-        return this.allOf;
-    };
+  getAllOf() {
+    return this.allOf
+  }
 
-    setAllOf(allOf) {
-        this.allOf = allOf;
-    };
+  setAllOf(allOf) {
+    this.allOf = allOf
+  }
 
-    getParent() {
-        return this.__parent;
-    };
+  getParent() {
+    return this.__parent
+  }
 
-    setParent(model) {
-        this.__parent = model;
-        if (this.allOf.indexOf(model) === -1) {
-            this.allOf.push(model);
-        }
-    };
-
-    getChild() {
-        return this.__child;
-    };
-
-    setChild(model) {
-        this.__child = model;
-        if (this.allOf.indexOf(model) === -1) {
-            this.allOf.push(model);
-        }
-    };
-
-    getInterfaces() {
-        return this.__interfaces;
-    };
-
-    setInterfaces(interfaces) {
-        this.__interfaces = interfaces;
-        for (const model of interfaces) {
-            if (this.allOf.indexOf(model) === -1) {
-                this.allOf.push(model);
-            }
-        }
-    };
-
-    clone() {
-        return apply(new this.constructor, this);
+  setParent(model) {
+    this.__parent = model
+    if (this.allOf.indexOf(model) === -1) {
+      this.allOf.push(model)
     }
+  }
+
+  getChild() {
+    return this.__child
+  }
+
+  setChild(model) {
+    this.__child = model
+    if (this.allOf.indexOf(model) === -1) {
+      this.allOf.push(model)
+    }
+  }
+
+  getInterfaces() {
+    return this.__interfaces
+  }
+
+  setInterfaces(interfaces) {
+    this.__interfaces = interfaces
+    for (const model of interfaces) {
+      if (this.allOf.indexOf(model) === -1) {
+        this.allOf.push(model)
+      }
+    }
+  }
+
+  clone() {
+    return apply(new this.constructor(), this)
+  }
 }

--- a/ern-api-gen/src/models/ModelImpl.js
+++ b/ern-api-gen/src/models/ModelImpl.js
@@ -1,305 +1,304 @@
-import {Collections, newHashMap, HashMap, asMap} from "../java/javaUtil";
-import AbstractModel from "./AbstractModel";
-import {apply} from '../java/beanUtils';
-import factory from './factory';
+import { Collections, newHashMap, HashMap, asMap } from '../java/javaUtil'
+import AbstractModel from './AbstractModel'
+import { apply } from '../java/beanUtils'
+import factory from './factory'
 
 export default class ModelImpl extends AbstractModel {
-    static OBJECT = "object";
+  static OBJECT = 'object'
 
-    __isSimple = false;
+  __isSimple = false
 
-    _enum(value) {
-        var _this = this;
-        if (Array.isArray(value)) {
-            this.__enum = value;
-        } else if (value != null) {
-            this.__enum = [value];
+  _enum(value) {
+    var _this = this
+    if (Array.isArray(value)) {
+      this.__enum = value
+    } else if (value != null) {
+      this.__enum = [value]
+    }
+    return this
+  }
+
+  getEnum() {
+    return this.___enum
+  }
+
+  setEnum(_enum) {
+    this.___enum = _enum
+  }
+
+  discriminator(discriminator) {
+    this.setDiscriminator(discriminator)
+    return this
+  }
+
+  type(type) {
+    this.setType(type)
+    return this
+  }
+
+  format(format) {
+    this.setFormat(format)
+    return this
+  }
+
+  name(name) {
+    this.setName(name)
+    return this
+  }
+
+  uniqueItems(uniqueItems) {
+    this.setUniqueItems(uniqueItems)
+    return this
+  }
+
+  allowEmptyValue(allowEmptyValue) {
+    this.setAllowEmptyValue(allowEmptyValue)
+    return this
+  }
+
+  description(description) {
+    this.setDescription(description)
+    return this
+  }
+
+  property(key, property) {
+    this.addProperty(key, property)
+    return this
+  }
+
+  example(example) {
+    this.setExample(example)
+    return this
+  }
+
+  additionalProperties(additionalProperties) {
+    this.setAdditionalProperties(additionalProperties)
+    return this
+  }
+
+  required(name) {
+    this.addRequired(name)
+    return this
+  }
+
+  xml(xml) {
+    this.setXml(xml)
+    return this
+  }
+
+  minimum(minimum) {
+    this.__minimum = minimum
+    return this
+  }
+
+  maximum(maximum) {
+    this.__maximum = maximum
+    return this
+  }
+
+  getDiscriminator() {
+    return this.__discriminator
+  }
+
+  setDiscriminator(discriminator) {
+    this.__discriminator = discriminator
+  }
+
+  getName() {
+    return this.__name
+  }
+
+  setName(name) {
+    this.__name = name
+  }
+
+  getDescription() {
+    return this.__description
+  }
+
+  setDescription(description) {
+    this.__description = description
+  }
+
+  isSimple() {
+    return this.__isSimple
+  }
+
+  setSimple(isSimple) {
+    this.__isSimple = isSimple
+  }
+
+  getAdditionalProperties() {
+    return this.__additionalProperties
+  }
+
+  setAdditionalProperties(additionalProperties) {
+    this.type(ModelImpl.OBJECT)
+    this.__additionalProperties = additionalProperties
+  }
+
+  getAllowEmptyValue() {
+    return this.__allowEmptyValue
+  }
+
+  setAllowEmptyValue(allowEmptyValue) {
+    if (allowEmptyValue != null) {
+      this.__allowEmptyValue = allowEmptyValue
+    }
+  }
+
+  getType() {
+    return this.__type
+  }
+
+  setType(type) {
+    this.__type = type
+  }
+
+  getFormat() {
+    return this.__format
+  }
+
+  setFormat(format) {
+    this.__format = format
+  }
+
+  addRequired(name) {
+    if (this.__required == null) {
+      this.__required = []
+    }
+    this.__required.push(name)
+    const p = this.properties.get(name)
+    if (p != null) {
+      p.setRequired(true)
+    }
+  }
+
+  getRequired() {
+    const output = []
+    if (this.properties != null) {
+      for (const [key, prop] of this.properties) {
+        if (prop != null && prop.getRequired()) {
+          output.push(key)
         }
-        return this;
-    };
+      }
+    }
+    if (output.length == 0) return null
+    Collections.sort(output)
+    return output
+  }
 
-    getEnum() {
-        return this.___enum;
-    };
-
-    setEnum(_enum) {
-        this.___enum = _enum;
-    };
-
-    discriminator(discriminator) {
-        this.setDiscriminator(discriminator);
-        return this;
-    };
-
-    type(type) {
-        this.setType(type);
-        return this;
-    };
-
-    format(format) {
-        this.setFormat(format);
-        return this;
-    };
-
-    name(name) {
-        this.setName(name);
-        return this;
-    };
-
-    uniqueItems(uniqueItems) {
-        this.setUniqueItems(uniqueItems);
-        return this;
-    };
-
-    allowEmptyValue(allowEmptyValue) {
-        this.setAllowEmptyValue(allowEmptyValue);
-        return this;
-    };
-
-    description(description) {
-        this.setDescription(description);
-        return this;
-    };
-
-    property(key, property) {
-        this.addProperty(key, property);
-        return this;
-    };
-
-    example(example) {
-        this.setExample(example);
-        return this;
-    };
-
-    additionalProperties(additionalProperties) {
-        this.setAdditionalProperties(additionalProperties);
-        return this;
-    };
-
-    required(name) {
-        this.addRequired(name);
-        return this;
-    };
-
-    xml(xml) {
-        this.setXml(xml);
-        return this;
-    };
-
-    minimum(minimum) {
-        this.__minimum = minimum;
-        return this;
-    };
-
-    maximum(maximum) {
-        this.__maximum = maximum;
-        return this;
-    };
-
-    getDiscriminator() {
-        return this.__discriminator;
-    };
-
-    setDiscriminator(discriminator) {
-        this.__discriminator = discriminator;
-    };
-
-    getName() {
-        return this.__name;
-    };
-
-    setName(name) {
-        this.__name = name;
-    };
-
-    getDescription() {
-        return this.__description;
-    };
-
-    setDescription(description) {
-        this.__description = description;
-    };
-
-    isSimple() {
-        return this.__isSimple;
-    };
-
-    setSimple(isSimple) {
-        this.__isSimple = isSimple;
-    };
-
-    getAdditionalProperties() {
-        return this.__additionalProperties;
-    };
-
-    setAdditionalProperties(additionalProperties) {
-        this.type(ModelImpl.OBJECT);
-        this.__additionalProperties = additionalProperties;
-    };
-
-    getAllowEmptyValue() {
-        return this.__allowEmptyValue;
-    };
-
-    setAllowEmptyValue(allowEmptyValue) {
-        if (allowEmptyValue != null) {
-            this.__allowEmptyValue = allowEmptyValue;
-        }
-    };
-
-    getType() {
-        return this.__type;
-    };
-
-    setType(type) {
-        this.__type = type;
-    };
-
-    getFormat() {
-        return this.__format;
-    };
-
-    setFormat(format) {
-        this.__format = format;
-    };
-
-    addRequired(name) {
-        if (this.__required == null) {
-            this.__required = []
-        }
-        this.__required.push(name);
-        const p = this.properties.get(name);
+  setRequired(required) {
+    this.__required = required
+    if (this.properties != null) {
+      for (const s of required) {
+        const p = this.properties.get(s)
         if (p != null) {
-            p.setRequired(true);
+          p.setRequired(true)
         }
-    };
-
-    getRequired() {
-        const output = [];
-        if (this.properties != null) {
-            for (const [key, prop] of this.properties) {
-                if (prop != null && prop.getRequired()) {
-                    output.push(key);
-                }
-            }
-        }
-        if (output.length == 0)  return null;
-        Collections.sort(output);
-        return output;
-    };
-
-    setRequired(required) {
-        this.__required = required;
-        if (this.properties != null) {
-            for (const s of required) {
-                const p = this.properties.get(s);
-                if (p != null) {
-                    p.setRequired(true);
-                }
-            }
-        }
-    };
-
-    addProperty(key, property) {
-        if (property == null) {
-            return;
-        }
-        if (this.properties == null) {
-            this.properties = newHashMap();
-        }
-        if (this.__required != null) {
-            if (this.__required.indexOf(key) > -1) {
-                property.setRequired(true);
-            }
-        }
-        this.properties.put(key, factory(property));
-    };
-
-    getProperties() {
-        return this.properties;
-    };
-
-    setProperties(properties) {
-        if (properties != null) {
-            for (const [key, property] of asMap(properties)) {
-                this.addProperty(key, property);
-            }
-        }
-    };
-
-    getExample() {
-        if (this.__example == null) {
-        }
-        return this.__example;
-    };
-
-    setExample(example) {
-        this.__example = example;
-    };
-
-    getXml() {
-        return this.__xml;
-    };
-
-    setXml(xml) {
-        this.__xml = xml;
-    };
-
-    getDefaultValue() {
-        if (this.defaultValue == null) {
-            return null;
-        }
-        try {
-            if (("integer" === this.__type)) {
-                return parseInt(this.defaultValue, 10);
-            }
-            if (("number" === this.__type)) {
-                return parseFloat(this.defaultValue);
-            }
-        }
-        catch (e) {
-            return null;
-        }
-        return this.defaultValue;
-    };
-
-    setDefaultValue(defaultValue) {
-        this.defaultValue = defaultValue;
-    };
-
-    getMinimum() {
-        return this.__minimum;
-    };
-
-    setMinimum(minimum) {
-        this.__minimum = minimum;
-    };
-
-    getMaximum() {
-        return this.__maximum;
-    };
-
-    setMaximum(maximum) {
-        this.__maximum = maximum;
-    };
-
-    getUniqueItems() {
-        return this.__uniqueItems;
-    };
-
-    getReadOnly() {
-        return this.__readOnly;
+      }
     }
+  }
 
-    setReadOnly(ro) {
-        this.__readOnly = ro;
+  addProperty(key, property) {
+    if (property == null) {
+      return
     }
+    if (this.properties == null) {
+      this.properties = newHashMap()
+    }
+    if (this.__required != null) {
+      if (this.__required.indexOf(key) > -1) {
+        property.setRequired(true)
+      }
+    }
+    this.properties.put(key, factory(property))
+  }
 
-    setUniqueItems(uniqueItems) {
-        this.__uniqueItems = uniqueItems;
-    };
+  getProperties() {
+    return this.properties
+  }
 
-    clone() {
-        return apply(new this.constructor, this);
-    };
+  setProperties(properties) {
+    if (properties != null) {
+      for (const [key, property] of asMap(properties)) {
+        this.addProperty(key, property)
+      }
+    }
+  }
+
+  getExample() {
+    if (this.__example == null) {
+    }
+    return this.__example
+  }
+
+  setExample(example) {
+    this.__example = example
+  }
+
+  getXml() {
+    return this.__xml
+  }
+
+  setXml(xml) {
+    this.__xml = xml
+  }
+
+  getDefaultValue() {
+    if (this.defaultValue == null) {
+      return null
+    }
+    try {
+      if ('integer' === this.__type) {
+        return parseInt(this.defaultValue, 10)
+      }
+      if ('number' === this.__type) {
+        return parseFloat(this.defaultValue)
+      }
+    } catch (e) {
+      return null
+    }
+    return this.defaultValue
+  }
+
+  setDefaultValue(defaultValue) {
+    this.defaultValue = defaultValue
+  }
+
+  getMinimum() {
+    return this.__minimum
+  }
+
+  setMinimum(minimum) {
+    this.__minimum = minimum
+  }
+
+  getMaximum() {
+    return this.__maximum
+  }
+
+  setMaximum(maximum) {
+    this.__maximum = maximum
+  }
+
+  getUniqueItems() {
+    return this.__uniqueItems
+  }
+
+  getReadOnly() {
+    return this.__readOnly
+  }
+
+  setReadOnly(ro) {
+    this.__readOnly = ro
+  }
+
+  setUniqueItems(uniqueItems) {
+    this.__uniqueItems = uniqueItems
+  }
+
+  clone() {
+    return apply(new this.constructor(), this)
+  }
 }

--- a/ern-api-gen/src/models/PropertyBuilder.js
+++ b/ern-api-gen/src/models/PropertyBuilder.js
@@ -1,15 +1,15 @@
-import {resolve, factory} from './factory'
+import { resolve, factory } from './factory'
 import ModelImpl from './ModelImpl'
 import ArrayModel from './ArrayModel'
 import RefModel from './RefModel'
 import ComposedModel from './ComposedModel'
-import {apply} from '../java/beanUtils'
-import {ArrayProperty, RefProperty} from './properties'
+import { apply } from '../java/beanUtils'
+import { ArrayProperty, RefProperty } from './properties'
 import LoggerFactory from '../java/LoggerFactory'
 const Log = LoggerFactory.getLogger(`PropertyBuilder`)
 
-export function build (type, format, args) {
-  const prop = {type, format}
+export function build(type, format, args) {
+  const prop = { type, format }
   if (args) {
     for (const [k, v] of args) {
       prop[k] = v
@@ -22,13 +22,18 @@ export function build (type, format, args) {
   return property
 }
 
-export function toModel (property, parent) {
-  if (property == null || property instanceof ArrayModel || property instanceof RefModel || property instanceof ModelImpl) {
+export function toModel(property, parent) {
+  if (
+    property == null ||
+    property instanceof ArrayModel ||
+    property instanceof RefModel ||
+    property instanceof ModelImpl
+  ) {
     return property
   }
   property = factory(property)
 
-  const {allowedProps} = property.constructor
+  const { allowedProps } = property.constructor
   let model
   if (property.allOf) {
     model = new ComposedModel()
@@ -36,9 +41,11 @@ export function toModel (property, parent) {
     const child = property.allOf.filter(withOutRef)
 
     model.parent(parent).child(toModel(child.shift(), model))
-    model.setInterfaces(interfaces.map((c) => toModel(c, model)))
+    model.setInterfaces(interfaces.map(c => toModel(c, model)))
     if (child.length) {
-      Log.warn(`An allOf can only have 1 implementation, it can have multiple $ref types`)
+      Log.warn(
+        `An allOf can only have 1 implementation, it can have multiple $ref types`
+      )
     }
   } else if (property instanceof ArrayProperty) {
     model = new ArrayModel()
@@ -52,9 +59,9 @@ export function toModel (property, parent) {
 
   return model
 }
-const withOutRef = ({$ref}) => !$ref
-const withRef = ({$ref}) => $ref
-export default ({
+const withOutRef = ({ $ref }) => !$ref
+const withRef = ({ $ref }) => $ref
+export default {
   build,
-  toModel
-})
+  toModel,
+}

--- a/ern-api-gen/src/models/RefModel.js
+++ b/ern-api-gen/src/models/RefModel.js
@@ -1,90 +1,90 @@
 import AbstractModel from './AbstractModel'
-import {DEFINITION} from './refs/RefType'
+import { DEFINITION } from './refs/RefType'
 import GenericRef from './refs/GenericRef'
-import {apply} from '../java/beanUtils'
+import { apply } from '../java/beanUtils'
 
 export default class RefModel extends AbstractModel {
-  constructor (ref) {
+  constructor(ref) {
     super()
     if (typeof ref === 'string') {
       this.set$ref(ref)
     }
   }
 
-  asDefault (ref) {
+  asDefault(ref) {
     this.setReference(DEFINITION.getInternalPrefix() + ref)
     return this
-  };
+  }
 
-  getTitle () {
+  getTitle() {
     return this.title
-  };
+  }
 
-  setTitle (title) {
+  setTitle(title) {
     this.title = title
-  };
+  }
 
-  getDescription () {
+  getDescription() {
     return this.description
-  };
+  }
 
-  setDescription (description) {
+  setDescription(description) {
     this.description = description
-  };
+  }
 
-  getProperties () {
+  getProperties() {
     return this.properties
-  };
+  }
 
-  setProperties (properties) {
+  setProperties(properties) {
     this.properties = properties
-  };
+  }
 
-  getSimpleRef () {
+  getSimpleRef() {
     return this.genericRef.getSimpleRef()
-  };
+  }
 
-  get$ref () {
+  get$ref() {
     return this.genericRef.getRef()
-  };
+  }
 
-  set$ref (ref) {
+  set$ref(ref) {
     this.genericRef = new GenericRef(DEFINITION, ref)
-  };
+  }
 
-  getRefFormat () {
+  getRefFormat() {
     return this.genericRef.getFormat()
-  };
+  }
 
-  getExample () {
+  getExample() {
     return this.example
-  };
+  }
 
-  setExample (example) {
+  setExample(example) {
     this.example = example
-  };
+  }
 
-  getExternalDocs () {
+  getExternalDocs() {
     return this.externalDocs
-  };
+  }
 
-  setExternalDocs (value) {
+  setExternalDocs(value) {
     this.externalDocs = value
-  };
+  }
 
-  clone () {
+  clone() {
     return apply(new this.constructor(), this)
-  };
+  }
 
-  getVendorExtensions () {
+  getVendorExtensions() {
     return null
-  };
+  }
 
-  getReference () {
+  getReference() {
     return this.genericRef.getRef()
-  };
+  }
 
-  setReference (reference) {
+  setReference(reference) {
     this.set$ref(reference)
-  };
+  }
 }

--- a/ern-api-gen/src/models/Xml.js
+++ b/ern-api-gen/src/models/Xml.js
@@ -1,72 +1,72 @@
-import {apply} from '../java/beanUtils'
+import { apply } from '../java/beanUtils'
 
 export default class Xml {
-  constructor (obj) {
+  constructor(obj) {
     obj && apply(this, obj)
   }
 
-  name (name) {
+  name(name) {
     this.setName(name)
     return this
   }
 
-  namespace (namespace) {
+  namespace(namespace) {
     this.setNamespace(namespace)
     return this
   }
 
-  prefix (prefix) {
+  prefix(prefix) {
     this.setPrefix(prefix)
     return this
   }
 
-  attribute (attribute) {
+  attribute(attribute) {
     this.setAttribute(attribute)
     return this
   }
 
-  wrapped (wrapped) {
+  wrapped(wrapped) {
     this.setWrapped(wrapped)
     return this
   }
 
-  getName () {
+  getName() {
     return this.__name
   }
 
-  setName (name) {
+  setName(name) {
     this.__name = name
   }
 
-  getNamespace () {
+  getNamespace() {
     return this.__namespace
   }
 
-  setNamespace (namespace) {
+  setNamespace(namespace) {
     this.__namespace = namespace
   }
 
-  getPrefix () {
+  getPrefix() {
     return this.__prefix
   }
 
-  setPrefix (prefix) {
+  setPrefix(prefix) {
     this.__prefix = prefix
   }
 
-  getAttribute () {
+  getAttribute() {
     return this.__attribute
   }
 
-  setAttribute (attribute) {
+  setAttribute(attribute) {
     this.__attribute = attribute
   }
 
-  getWrapped () {
+  getWrapped() {
     return this.__wrapped
   }
 
-  setWrapped (wrapped) {
+  setWrapped(wrapped) {
     this.__wrapped = wrapped
   }
 }

--- a/ern-api-gen/src/models/auth.js
+++ b/ern-api-gen/src/models/auth.js
@@ -1,11 +1,15 @@
 import ApiKeyAuthDefinition from './auth/ApiKeyAuthDefinition'
 import BasicAuthDefinition from './auth/BasicAuthDefinition'
 import OAuth2Definition from './auth/OAuth2Definition'
-import {apply} from '../java/beanUtils'
+import { apply } from '../java/beanUtils'
 
-export const AUTHS = [ApiKeyAuthDefinition, BasicAuthDefinition, OAuth2Definition]
+export const AUTHS = [
+  ApiKeyAuthDefinition,
+  BasicAuthDefinition,
+  OAuth2Definition,
+]
 
-const resolve = (def) => {
+const resolve = def => {
   if (def == null || def.type == null) return null
   for (const o of AUTHS) {
     if (o.TYPE === def.type) {
@@ -14,7 +18,7 @@ const resolve = (def) => {
   }
 }
 
-export default function authFactory (definition) {
+export default function authFactory(definition) {
   const Type = resolve(definition)
   if (Type == null) {
     throw new Error(`Unknown Auth Type for :${JSON.stringify(definition)}`)

--- a/ern-api-gen/src/models/auth/AbstractSecuritySchemeDefinition.js
+++ b/ern-api-gen/src/models/auth/AbstractSecuritySchemeDefinition.js
@@ -1,40 +1,40 @@
-import {newHashMap} from "../../java/javaUtil";
+import { newHashMap } from '../../java/javaUtil'
 
 export default class AbstractSecuritySchemeDefinition {
-    vendorExtensions = newHashMap();
+  vendorExtensions = newHashMap()
 
-    getVendorExtensions() {
-        return this.vendorExtensions;
-    };
-    getType() {
-        return this.type;
-    };
+  getVendorExtensions() {
+    return this.vendorExtensions
+  }
+  getType() {
+    return this.type
+  }
 
-    setType(type) {
-        this.type = type;
-    };
-    setVendorExtension(name, value) {
-        if (name.startsWith("x-")) {
-            this.vendorExtensions.put(name, value);
-        }
-    };
-
-    setVendorExtensions(vendorExtensions) {
-        this.vendorExtensions = vendorExtensions;
-    };
-
-    getDescription() {
-        return this.description;
-    };
-
-    setDescription(description) {
-        this.description = description;
+  setType(type) {
+    this.type = type
+  }
+  setVendorExtension(name, value) {
+    if (name.startsWith('x-')) {
+      this.vendorExtensions.put(name, value)
     }
+  }
 
-    toJSON() {
-        return {
-            description: this.description,
-            vendorExtensions: this.vendorExtensions,
-        }
+  setVendorExtensions(vendorExtensions) {
+    this.vendorExtensions = vendorExtensions
+  }
+
+  getDescription() {
+    return this.description
+  }
+
+  setDescription(description) {
+    this.description = description
+  }
+
+  toJSON() {
+    return {
+      description: this.description,
+      vendorExtensions: this.vendorExtensions,
     }
+  }
 }

--- a/ern-api-gen/src/models/auth/ApiKeyAuthDefinition.js
+++ b/ern-api-gen/src/models/auth/ApiKeyAuthDefinition.js
@@ -1,43 +1,41 @@
-import AbstractSecuritySchemeDefinition from "./AbstractSecuritySchemeDefinition";
-import In from './In';
+import AbstractSecuritySchemeDefinition from './AbstractSecuritySchemeDefinition'
+import In from './In'
 
 export default class ApiKeyAuthDefinition extends AbstractSecuritySchemeDefinition {
+  static TYPE = 'apiKey'
+  type = ApiKeyAuthDefinition.TYPE
 
-    static TYPE = "apiKey";
-    type = ApiKeyAuthDefinition.TYPE;
+  name(name) {
+    this.setName(name)
+    return this
+  }
 
+  in(__in) {
+    this.setIn(__in)
+    return this
+  }
 
-    name(name) {
-        this.setName(name);
-        return this;
-    };
+  getName() {
+    return this.__name
+  }
 
-    in(__in) {
-        this.setIn(__in);
-        return this;
-    };
+  setName(name) {
+    this.__name = name
+  }
 
-    getName() {
-        return this.__name;
-    };
+  getIn() {
+    return this.__in
+  }
 
-    setName(name) {
-        this.__name = name;
-    };
+  setIn(__in) {
+    this.__in = In(__in)
+  }
 
-    getIn() {
-        return this.__in;
-    };
-
-    setIn(__in) {
-        this.__in = In(__in);
-    };
-
-    toJSON() {
-        return {
-            type: this.type,
-            name: this.__name,
-            in: this.__in + ''
-        }
+  toJSON() {
+    return {
+      type: this.type,
+      name: this.__name,
+      in: this.__in + '',
     }
+  }
 }

--- a/ern-api-gen/src/models/auth/AuthorizationValue.js
+++ b/ern-api-gen/src/models/auth/AuthorizationValue.js
@@ -1,46 +1,48 @@
 /* Generated from Java with JSweet 1.2.0 - http://www.jsweet.org */
 
 export default class AuthorizationValue {
-  constructor (keyName, value, type) {
-    this.keyName(keyName).value(value).type(type)
+  constructor(keyName, value, type) {
+    this.keyName(keyName)
+      .value(value)
+      .type(type)
   }
 
-  value (value) {
+  value(value) {
     this.setValue(value)
     return this
-  };
+  }
 
-  type (type) {
+  type(type) {
     this.setType(type)
     return this
-  };
+  }
 
-  keyName (keyName) {
+  keyName(keyName) {
     this.setKeyName(keyName)
     return this
-  };
+  }
 
-  getValue () {
+  getValue() {
     return this.__value
-  };
+  }
 
-  setValue (value) {
+  setValue(value) {
     this.__value = value
-  };
+  }
 
-  getType () {
+  getType() {
     return this.__type
-  };
+  }
 
-  setType (type) {
+  setType(type) {
     this.__type = type
-  };
+  }
 
-  getKeyName () {
+  getKeyName() {
     return this.__keyName
-  };
+  }
 
-  setKeyName (keyName) {
+  setKeyName(keyName) {
     this.__keyName = keyName
-  };
+  }
 }

--- a/ern-api-gen/src/models/auth/BasicAuthDefinition.js
+++ b/ern-api-gen/src/models/auth/BasicAuthDefinition.js
@@ -1,9 +1,9 @@
-import AbstractSecuritySchemeDefinition from "./AbstractSecuritySchemeDefinition";
+import AbstractSecuritySchemeDefinition from './AbstractSecuritySchemeDefinition'
 export default class BasicAuthDefinition extends AbstractSecuritySchemeDefinition {
-    static TYPE = "basic";
-    type = BasicAuthDefinition.TYPE;
+  static TYPE = 'basic'
+  type = BasicAuthDefinition.TYPE
 
-    toJSON() {
-        return Object.assign(super.toJSON(), {type: this.type});
-    }
+  toJSON() {
+    return Object.assign(super.toJSON(), { type: this.type })
+  }
 }

--- a/ern-api-gen/src/models/auth/In.js
+++ b/ern-api-gen/src/models/auth/In.js
@@ -1,21 +1,21 @@
 class In {
-  constructor (key) {
+  constructor(key) {
     this.key = key
   }
 
-  toValue () {
+  toValue() {
     return this.key
   }
 
-  toJSON () {
+  toJSON() {
     return this.key
   }
-  toString () {
+  toString() {
     return this.key
   }
 }
 
-export default function forValue (value) {
+export default function forValue(value) {
   if (value == null || value instanceof In) return value
   value = value.toLowerCase()
   if (value == HEADER.key) return HEADER

--- a/ern-api-gen/src/models/auth/OAuth2Definition.js
+++ b/ern-api-gen/src/models/auth/OAuth2Definition.js
@@ -1,90 +1,86 @@
-import AbstractSecuritySchemeDefinition from "./AbstractSecuritySchemeDefinition";
-import {newHashMap, asMap} from "../../java/javaUtil";
+import AbstractSecuritySchemeDefinition from './AbstractSecuritySchemeDefinition'
+import { newHashMap, asMap } from '../../java/javaUtil'
 
 export default class OAuth2Definition extends AbstractSecuritySchemeDefinition {
-    static TYPE = "oauth2";
-    type = OAuth2Definition.TYPE;
+  static TYPE = 'oauth2'
+  type = OAuth2Definition.TYPE
 
+  implicit(authorizationUrl) {
+    this.setAuthorizationUrl(authorizationUrl)
+    this.setFlow('implicit')
+    return this
+  }
 
-    implicit(authorizationUrl) {
-        this.setAuthorizationUrl(authorizationUrl);
-        this.setFlow("implicit");
-        return this;
-    };
+  password(tokenUrl) {
+    this.setTokenUrl(tokenUrl)
+    this.setFlow('password')
+    return this
+  }
 
-    password(tokenUrl) {
-        this.setTokenUrl(tokenUrl);
-        this.setFlow("password");
-        return this;
-    };
+  application(tokenUrl) {
+    this.setTokenUrl(tokenUrl)
+    this.setFlow('application')
+    return this
+  }
 
-    application(tokenUrl) {
-        this.setTokenUrl(tokenUrl);
-        this.setFlow("application");
-        return this;
-    };
+  accessCode(authorizationUrl, tokenUrl) {
+    this.setTokenUrl(tokenUrl)
+    this.setAuthorizationUrl(authorizationUrl)
+    this.setFlow('accessCode')
+    return this
+  }
 
-    accessCode(authorizationUrl, tokenUrl) {
-        this.setTokenUrl(tokenUrl);
-        this.setAuthorizationUrl(authorizationUrl);
-        this.setFlow("accessCode");
-        return this;
-    };
+  scope(name, description) {
+    this.addScope(name, description)
+    return this
+  }
 
-    scope(name, description) {
-        this.addScope(name, description);
-        return this;
-    };
+  getAuthorizationUrl() {
+    return this.authorizationUrl
+  }
 
-    getAuthorizationUrl() {
-        return this.authorizationUrl;
-    };
+  setAuthorizationUrl(authorizationUrl) {
+    this.authorizationUrl = authorizationUrl
+  }
 
-    setAuthorizationUrl(authorizationUrl) {
-        this.authorizationUrl = authorizationUrl;
-    };
+  getTokenUrl() {
+    return this.tokenUrl
+  }
 
-    getTokenUrl() {
-        return this.tokenUrl;
-    };
+  setTokenUrl(tokenUrl) {
+    this.tokenUrl = tokenUrl
+  }
 
-    setTokenUrl(tokenUrl) {
-        this.tokenUrl = tokenUrl;
-    };
+  getFlow() {
+    return this.flow
+  }
 
-    getFlow() {
-        return this.flow;
-    };
+  setFlow(flow) {
+    this.flow = flow
+  }
 
-    setFlow(flow) {
-        this.flow = flow;
-    };
+  getScopes() {
+    return this.scopes
+  }
 
-    getScopes() {
-        return this.scopes;
-    };
+  setScopes(scopes) {
+    this.scopes = asMap(scopes)
+  }
 
-    setScopes(scopes) {
-        this.scopes = asMap(scopes);
-    };
-
-    addScope(name, description) {
-        if (this.scopes == null) {
-            this.scopes = newHashMap();
-        }
-        this.scopes.put(name, description);
-    };
-
-
-
-    toJSON() {
-        return Object.assign(super.toJSON(), {
-            type: this.type,
-            scopes: this.scopes,
-            flow: this.flow,
-            tokenUrl: this.tokenUrl,
-            authorizationUrl: this.authorizationUrl
-        })
+  addScope(name, description) {
+    if (this.scopes == null) {
+      this.scopes = newHashMap()
     }
+    this.scopes.put(name, description)
+  }
 
+  toJSON() {
+    return Object.assign(super.toJSON(), {
+      type: this.type,
+      scopes: this.scopes,
+      flow: this.flow,
+      tokenUrl: this.tokenUrl,
+      authorizationUrl: this.authorizationUrl,
+    })
+  }
 }

--- a/ern-api-gen/src/models/factory.js
+++ b/ern-api-gen/src/models/factory.js
@@ -1,10 +1,11 @@
 import * as properties from './properties'
-import {beanify, apply} from '../java/beanUtils'
+import { beanify, apply } from '../java/beanUtils'
 import ComposedModel from './ComposedModel'
 
-const values = (obj) => Object.keys(obj).map(key => {
-  return obj[key]
-})
+const values = obj =>
+  Object.keys(obj).map(key => {
+    return obj[key]
+  })
 
 /**
  * Best guess here. It is possible for json schema to refer
@@ -14,17 +15,21 @@ const values = (obj) => Object.keys(obj).map(key => {
  */
 let TYPES
 let STR_TYPES
-export function resolve (prop = {}) {
+export function resolve(prop = {}) {
   TYPES = TYPES || values(properties)
-  STR_TYPES = STR_TYPES || TYPES.filter(function (t) {
-    return t && t.TYPE === 'string'
-  })
+  STR_TYPES =
+    STR_TYPES ||
+    TYPES.filter(function(t) {
+      return t && t.TYPE === 'string'
+    })
   if (prop == null) {
     return properties.NullProperty
   }
   if (prop.format && prop.type === 'string') {
     for (const clz of STR_TYPES) {
-      if (prop.format === clz.FORMAT) { return clz }
+      if (prop.format === clz.FORMAT) {
+        return clz
+      }
     }
   }
 
@@ -45,7 +50,13 @@ export function resolve (prop = {}) {
       if ('$ref' in prop) {
         return properties.RefProperty
       }
-      if (prop.minimum || prop.maximum || prop.exclusiveMinimum || prop.exclusiveMaximum || prop.multipleOf) {
+      if (
+        prop.minimum ||
+        prop.maximum ||
+        prop.exclusiveMinimum ||
+        prop.exclusiveMaximum ||
+        prop.multipleOf
+      ) {
         return properties.NumberProperty
       }
       if (prop.minLength || prop.maxLength || prop.pattern) {
@@ -53,15 +64,21 @@ export function resolve (prop = {}) {
       }
       if (prop.format) {
         for (const strClz of STR_TYPES) {
-          if (strClz.FORMAT === prop.format) { return strClz }
+          if (strClz.FORMAT === prop.format) {
+            return strClz
+          }
         }
       }
     } else if (clz.TYPE === prop.type) {
       if (prop.type === 'object') {
-        return prop.additionalProperties ? properties.MapProperty : properties.ObjectProperty
+        return prop.additionalProperties
+          ? properties.MapProperty
+          : properties.ObjectProperty
       }
       if (prop.format) {
-        if (clz.FORMAT === prop.format) { return clz }
+        if (clz.FORMAT === prop.format) {
+          return clz
+        }
       } else {
         return clz
       }
@@ -73,14 +90,14 @@ export function resolve (prop = {}) {
   throw new Error(`Could not resolve type ${prop.type} ${prop.format}`)
 }
 
-function setup () {
-  for (const {prototype, allowedProps} of values(properties)) {
+function setup() {
+  for (const { prototype, allowedProps } of values(properties)) {
     beanify(prototype, allowedProps)
   }
 }
 
 let hasSetup = false
-export function factory (prop, parent) {
+export function factory(prop, parent) {
   const TYPES = values(properties)
 
   if (!hasSetup) {

--- a/ern-api-gen/src/models/parameters.js
+++ b/ern-api-gen/src/models/parameters.js
@@ -1,164 +1,186 @@
-import {newHashMap} from '../java/javaUtil';
-import RefType from './refs/RefType';
-import GenericRef from './refs/GenericRef';
-import {apply, beanify} from '../java/beanUtils';
-import {toModel} from './PropertyBuilder';
+import { newHashMap } from '../java/javaUtil'
+import RefType from './refs/RefType'
+import GenericRef from './refs/GenericRef'
+import { apply, beanify } from '../java/beanUtils'
+import { toModel } from './PropertyBuilder'
 
 export class Parameter {
-    required = false;
-    vendorExtensions = newHashMap();
+  required = false
+  vendorExtensions = newHashMap()
 
-    isUniqueItems() {
-        return this.uniqueItems
+  isUniqueItems() {
+    return this.uniqueItems
+  }
+
+  isExclusiveMinimum() {
+    return this.exclusiveMinimum != null
+  }
+
+  isExclusiveMaximum() {
+    return this.exclusiveMaximum != null
+  }
+
+  setFormat(format) {
+    this.format = format
+  }
+
+  getFormat() {
+    return this.format
+  }
+
+  getIn() {
+    return this.in
+  }
+
+  isReadOnly() {
+    return this.readOnly
+  }
+
+  setVendorExtension(name, value) {
+    if (name.startsWith('-x')) {
+      this.vendorExtensions.put(name, value)
+    }
+  }
+
+  getVendorExtensions() {
+    return this.vendorExtensions
+  }
+
+  getDefaultValue() {
+    return this.defaultValue
+  }
+
+  setDefaultValue(defaultValue) {
+    this.defaultValue = defaultValue
+  }
+
+  getDefault() {
+    if (this.defaultValue == null || this.defaultValue.length == 0) {
+      return null
     }
 
-    isExclusiveMinimum() {
-        return this.exclusiveMinimum != null;
-    }
+    return this.defaultValue
+  }
 
-    isExclusiveMaximum() {
-        return this.exclusiveMaximum != null;
-    }
+  setDefault(defaultValue) {
+    this.defaultValue = defaultValue == null ? null : defaultValue.toString()
+  }
 
-    setFormat(format) {
-        this.format = format
-    }
-
-    getFormat() {
-        return this.format
-    }
-
-    getIn() {
-        return this.in;
-    };
-
-
-    isReadOnly() {
-        return this.readOnly;
-    };
-
-    setVendorExtension(name, value) {
-        if (name.startsWith("-x")) {
-            this.vendorExtensions.put(name, value);
-        }
-    };
-
-    getVendorExtensions() {
-        return this.vendorExtensions;
-    }
-
-    getDefaultValue() {
-        return this.defaultValue;
-    }
-
-
-    setDefaultValue(defaultValue) {
-        this.defaultValue = defaultValue;
-    }
-
-    getDefault() {
-        if (this.defaultValue == null || this.defaultValue.length == 0) {
-            return null;
-        }
-
-        return this.defaultValue;
-    }
-
-    setDefault(defaultValue) {
-        this.defaultValue = defaultValue == null ? null : defaultValue.toString();
-    }
-
-    copy() {
-        return apply(new this.constructor, this);
-    }
+  copy() {
+    return apply(new this.constructor(), this)
+  }
 }
-export class SerializableParameter extends Parameter {
-
-}
-
+export class SerializableParameter extends Parameter {}
 
 export class BodyParameter extends Parameter {
-    static TYPE = "body";
+  static TYPE = 'body'
 
-    getSchema() {
-        return this.schema;
-    }
+  getSchema() {
+    return this.schema
+  }
 
-    setSchema(schema) {
-        this.schema = toModel(schema);
-    }
+  setSchema(schema) {
+    this.schema = toModel(schema)
+  }
 }
 export class CookieParameter extends SerializableParameter {
-    static TYPE = "cookie";
+  static TYPE = 'cookie'
 }
 export class FormParameter extends SerializableParameter {
-    static TYPE = "formData";
+  static TYPE = 'formData'
 
-    getDefaultCollectionFormat() {
-        return "multi";
-    }
+  getDefaultCollectionFormat() {
+    return 'multi'
+  }
 }
 export class HeaderParameter extends SerializableParameter {
-    static TYPE = "header";
+  static TYPE = 'header'
 }
 export class PathParameter extends SerializableParameter {
-    static TYPE = "path";
-    required = true;
+  static TYPE = 'path'
+  required = true
 }
 export class QueryParameter extends SerializableParameter {
-    static TYPE = "query";
+  static TYPE = 'query'
 
-    getDefaultCollectionFormat() {
-        return "multi";
-    }
+  getDefaultCollectionFormat() {
+    return 'multi'
+  }
 }
 
 export class RefParameter extends Parameter {
-    static TYPE = "ref";
+  static TYPE = 'ref'
 
-    constructor({$ref}={}) {
-        super();
-        this.set$ref($ref);
-    }
+  constructor({ $ref } = {}) {
+    super()
+    this.set$ref($ref)
+  }
 
-    asDefault(ref) {
-        this.set$ref(RefType.PARAMETER.getInternalPrefix() + ref);
-        return this;
-    }
+  asDefault(ref) {
+    this.set$ref(RefType.PARAMETER.getInternalPrefix() + ref)
+    return this
+  }
 
-    set$ref(ref) {
-        this.genericRef = new GenericRef(RefType.PARAMETER, ref);
-    }
+  set$ref(ref) {
+    this.genericRef = new GenericRef(RefType.PARAMETER, ref)
+  }
 
-    getRefFormat() {
-        return this.genericRef.getFormat();
-    }
+  getRefFormat() {
+    return this.genericRef.getFormat()
+  }
 
-    getSimpleRef() {
-        return this.genericRef.getSimpleRef();
-    }
+  getSimpleRef() {
+    return this.genericRef.getSimpleRef()
+  }
 }
 
-beanify(Parameter.prototype, ["name", "enum", "in", "description", "required", "type", "items", "collectionFormat", "default", "maximum",
-    "exclusiveMaximum", "minimum", "exclusiveMinimum", "maxLength", "minLength", "pattern", "maxItems", "minItems",
-    "uniqueItems", "multipleOf", "format"]);
+beanify(Parameter.prototype, [
+  'name',
+  'enum',
+  'in',
+  'description',
+  'required',
+  'type',
+  'items',
+  'collectionFormat',
+  'default',
+  'maximum',
+  'exclusiveMaximum',
+  'minimum',
+  'exclusiveMinimum',
+  'maxLength',
+  'minLength',
+  'pattern',
+  'maxItems',
+  'minItems',
+  'uniqueItems',
+  'multipleOf',
+  'format',
+])
 
-const TYPES = [BodyParameter, CookieParameter, FormParameter, HeaderParameter, PathParameter, QueryParameter, RefParameter];
+const TYPES = [
+  BodyParameter,
+  CookieParameter,
+  FormParameter,
+  HeaderParameter,
+  PathParameter,
+  QueryParameter,
+  RefParameter,
+]
 
-export default function (val) {
+export default function(val) {
+  if (val instanceof Parameter) return val
 
-    if (val instanceof Parameter) return val;
-
-    for (const ParameterType of TYPES) {
-        if (ParameterType.TYPE == val.in) {
-            const ret = apply(new ParameterType(val), val);
-            return ret;
-        }
+  for (const ParameterType of TYPES) {
+    if (ParameterType.TYPE == val.in) {
+      const ret = apply(new ParameterType(val), val)
+      return ret
     }
-    if ('$ref' in val) {
-        const rp = new RefParameter(val);
+  }
+  if ('$ref' in val) {
+    const rp = new RefParameter(val)
 
-        return apply(rp, val);
-    }
-    throw new Error(`Could not resolve parameter type: ${val.in}`)
+    return apply(rp, val)
+  }
+  throw new Error(`Could not resolve parameter type: ${val.in}`)
 }

--- a/ern-api-gen/src/models/properties.js
+++ b/ern-api-gen/src/models/properties.js
@@ -1,246 +1,283 @@
-import {newHashMap} from "../java/javaUtil";
-import factory from "./factory";
-import {has} from "../java/beanUtils";
-import GenericRef from './refs/GenericRef';
-import RefType from './refs/RefType';
-import Xml from './Xml';
+import { newHashMap } from '../java/javaUtil'
+import factory from './factory'
+import { has } from '../java/beanUtils'
+import GenericRef from './refs/GenericRef'
+import RefType from './refs/RefType'
+import Xml from './Xml'
 
 export class Property {
-    static allowedProps = ["title", "type", "format", "description", "name", "readOnly", "position", "access", "enum", "example", "externalDocs", "required", "xml", ["default", null, "_"]];
+  static allowedProps = [
+    'title',
+    'type',
+    'format',
+    'description',
+    'name',
+    'readOnly',
+    'position',
+    'access',
+    'enum',
+    'example',
+    'externalDocs',
+    'required',
+    'xml',
+    ['default', null, '_'],
+  ]
 
-    constructor(obj, parent) {
-        if (parent) {
-            this.getParent = () => parent;
-        }
+  constructor(obj, parent) {
+    if (parent) {
+      this.getParent = () => parent
     }
+  }
 
-    getType() {
-        return this.type || this.constructor.TYPE;
+  getType() {
+    return this.type || this.constructor.TYPE
+  }
+
+  getFormat() {
+    return this.format || this.constructor.FORMAT
+  }
+
+  setXml(xml) {
+    if (xml instanceof Xml) {
+      this.xml = xml
     }
+    this.xml = new Xml(xml)
+  }
 
-    getFormat() {
-        return this.format || this.constructor.FORMAT;
+  getVendorExtensions() {
+    if (!this.vendorExtensions) {
+      return newHashMap()
     }
+    return this.vendorExtensions
+  }
 
-    setXml(xml) {
-        if (xml instanceof Xml) {
-            this.xml = xml;
-        }
-        this.xml = new Xml(xml);
-    }
+  toString() {
+    return `[${this.constructor.name}]${JSON.stringify(this, null, 2)}`
+  }
 
-    getVendorExtensions() {
-        if (!this.vendorExtensions) {
-            return newHashMap();
-        }
-        return this.vendorExtensions
-    }
-
-    toString() {
-        return `[${this.constructor.name}]${JSON.stringify(this, null, 2)}`;
-    }
-
-    toXml() {
-
-    }
+  toXml() {}
 }
 export class AbstractNumericProperty extends Property {
-    static allowedProps = [...Property.allowedProps, "minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "multipleOf"];
-
+  static allowedProps = [
+    ...Property.allowedProps,
+    'minimum',
+    'maximum',
+    'exclusiveMinimum',
+    'exclusiveMaximum',
+    'multipleOf',
+  ]
 }
 
 function objectToPropertyMap(obj) {
-    return newHashMap(...Object.keys(obj).map(key => [key, factory(obj[key], this)]));
+  return newHashMap(
+    ...Object.keys(obj).map(key => [key, factory(obj[key], this)])
+  )
 }
 class _ObjectProperty extends Property {
-    static allowedProps = [...Property.allowedProps, "additionalProperties", "required",
-        "minProperties", "maxProperties", "anyOf", "allOf", "readOnly", "vendorExtensions", "xml"];
+  static allowedProps = [
+    ...Property.allowedProps,
+    'additionalProperties',
+    'required',
+    'minProperties',
+    'maxProperties',
+    'anyOf',
+    'allOf',
+    'readOnly',
+    'vendorExtensions',
+    'xml',
+  ]
 
-    constructor(obj, parent) {
-        super(obj, parent);
-        // this.setRequiredProperties(obj.required);
+  constructor(obj, parent) {
+    super(obj, parent)
+    // this.setRequiredProperties(obj.required);
+  }
+
+  getAdditionalProperties() {
+    return this._additionalProperties
+  }
+
+  setAdditionalProperties(properties) {
+    if (!properties) {
+      this._additionalProperties = null
     }
-
-    getAdditionalProperties() {
-        return this._additionalProperties;
+    if (properties.type) {
+      this._additionalProperties = factory(properties)
+    } else {
+      this._additionalProperties = objectToPropertyMap(properties)
     }
+  }
 
-    setAdditionalProperties(properties) {
-        if (!properties) {
-            this._additionalProperties = null;
-        }
-        if (properties.type) {
-            this._additionalProperties = factory(properties);
-        } else {
-            this._additionalProperties = objectToPropertyMap(properties);
-        }
+  setProperties(properties) {
+    this.properties = objectToPropertyMap(properties)
+  }
+
+  getRequiredProperties() {
+    const required = []
+    for (const [key, prop] of this.properties) {
+      if (prop.required) required.push(key)
     }
+    return required
+  }
 
-    setProperties(properties) {
-        this.properties = objectToPropertyMap(properties);
-
+  setRequiredProperties(required) {
+    for (const [key, prop] of this.properties) {
+      const isRequired = required ? required.indexOf(key) != -1 : false
+      if (has(prop, 'required') || isRequired) {
+        prop.required = isRequired
+      }
     }
-
-    getRequiredProperties() {
-        const required = [];
-        for (const [key, prop] of this.properties) {
-            if (prop.required) required.push(key);
-        }
-        return required;
-    }
-
-    setRequiredProperties(required) {
-        for (const [key, prop] of this.properties) {
-            const isRequired = required ? required.indexOf(key) != -1 : false;
-            if (has(prop, 'required') || isRequired) {
-                prop.required = isRequired;
-            }
-        }
-    }
+  }
 }
 
 export class ObjectProperty extends _ObjectProperty {
-    static TYPE = "object";
-    static allowedProps = [..._ObjectProperty.allowedProps, 'properties']
+  static TYPE = 'object'
+  static allowedProps = [..._ObjectProperty.allowedProps, 'properties']
 }
 export class MapProperty extends _ObjectProperty {
-    static TYPE = "object";
+  static TYPE = 'object'
 }
 export class RefProperty extends Property {
-    static TYPE = "ref";
-    static allowedProps = [...Property.allowedProps, '$ref'];
+  static TYPE = 'ref'
+  static allowedProps = [...Property.allowedProps, '$ref']
 
-    constructor(ref) {
-        super();
-        if (ref && ref.$ref) this.set$ref(ref.$ref);
-        else if (typeof ref === 'string')
-            this.set$ref(ref);
+  constructor(ref) {
+    super()
+    if (ref && ref.$ref) this.set$ref(ref.$ref)
+    else if (typeof ref === 'string') this.set$ref(ref)
+  }
 
+  set$ref(ref) {
+    this.genericRef = new GenericRef(RefType.DEFINITION, ref)
+  }
+
+  get$ref() {
+    return this.genericRef.getRef()
+  }
+
+  asDefault(ref) {
+    this.set$ref(RefType.DEFINITION.getInternalPrefix() + ref)
+    return this
+  }
+
+  getSimpleRef() {
+    if (this.genericRef != null) {
+      const simp = this.genericRef.getSimpleRef()
+      return simp
     }
+  }
 
-    set$ref(ref) {
-        this.genericRef = new GenericRef(RefType.DEFINITION, ref);
+  getRefFormat() {
+    if (this.genericRef != null) {
+      return this.genericRef.getFormat()
     }
-
-    get$ref() {
-        return this.genericRef.getRef();
-    }
-
-    asDefault(ref) {
-        this.set$ref(RefType.DEFINITION.getInternalPrefix() + ref);
-        return this;
-    }
-
-    getSimpleRef() {
-        if (this.genericRef != null) {
-            const simp = this.genericRef.getSimpleRef();
-            return simp;
-        }
-    }
-
-    getRefFormat() {
-        if (this.genericRef != null) {
-            return this.genericRef.getFormat();
-        }
-
-    }
+  }
 }
 export class ArrayProperty extends Property {
-    static TYPE = "array";
-    static allowedProps = [...Property.allowedProps, "uniqueItems", "items", "maxItems", "minItems"];
+  static TYPE = 'array'
+  static allowedProps = [
+    ...Property.allowedProps,
+    'uniqueItems',
+    'items',
+    'maxItems',
+    'minItems',
+  ]
 
-    items(items) {
-        this.setItems(items);
-        return this;
-    }
+  items(items) {
+    this.setItems(items)
+    return this
+  }
 
-    getItems() {
-        return this._items;
-    }
+  getItems() {
+    return this._items
+  }
 
-    setItems(items) {
-        this._items = factory(items, this);
-    }
+  setItems(items) {
+    this._items = factory(items, this)
+  }
 }
 export class BooleanProperty extends Property {
-    static TYPE = "boolean";
+  static TYPE = 'boolean'
 }
 
 export class StringProperty extends Property {
-    static TYPE = "string";
-    static allowedProps = [...Property.allowedProps, "minLength", "maxLength", "pattern"];
-
+  static TYPE = 'string'
+  static allowedProps = [
+    ...Property.allowedProps,
+    'minLength',
+    'maxLength',
+    'pattern',
+  ]
 }
 
 export class NumberProperty extends AbstractNumericProperty {
-    static TYPE = "number";
+  static TYPE = 'number'
 }
 export class BaseIntegerProperty extends AbstractNumericProperty {
-    static TYPE = "integer";
+  static TYPE = 'integer'
 }
 export class IntegerProperty extends BaseIntegerProperty {
-    static FORMAT = "integer";
+  static FORMAT = 'integer'
 }
 export class LongProperty extends NumberProperty {
-    static FORMAT = "long";
+  static FORMAT = 'long'
 }
 export class Int64Property extends LongProperty {
-    static FORMAT = "int64";
-    static TYPE = "integer";
+  static FORMAT = 'int64'
+  static TYPE = 'integer'
 }
 export class Int32Property extends BaseIntegerProperty {
-    static FORMAT = "int32";
-    static TYPE = "integer";
+  static FORMAT = 'int32'
+  static TYPE = 'integer'
 }
 export class DoubleProperty extends NumberProperty {
-    static FORMAT = "double";
+  static FORMAT = 'double'
 }
 
 export class DecimalProperty extends NumberProperty {
-    static FORMAT = "decimal";
+  static FORMAT = 'decimal'
 }
 
 export class FloatProperty extends NumberProperty {
-    static FORMAT = "float";
+  static FORMAT = 'float'
 }
 
 export class ByteArrayProperty extends StringProperty {
-    static FORMAT = "byte-array";
+  static FORMAT = 'byte-array'
 }
 
 export class ByteProperty extends StringProperty {
-    static FORMAT = "byte";
+  static FORMAT = 'byte'
 }
 export class BinaryProperty extends StringProperty {
-    static FORMAT = "binary";
+  static FORMAT = 'binary'
 }
 export class EmailProperty extends StringProperty {
-    static FORMAT = "email";
+  static FORMAT = 'email'
 }
 export class DateProperty extends StringProperty {
-    static FORMAT = "date";
+  static FORMAT = 'date'
 }
 
 export class DateTimeProperty extends StringProperty {
-    static FORMAT = "date-time";
+  static FORMAT = 'date-time'
 }
 
 export class UriProperty extends StringProperty {
-    static FORMAT = "uri";
+  static FORMAT = 'uri'
 }
 
 export class UrlProperty extends UriProperty {
-    static FORMAT = "url";
+  static FORMAT = 'url'
 }
 
 export class UUIDProperty extends Property {
-    static FORMAT = "uuid";
-    static TYPE = "string";
+  static FORMAT = 'uuid'
+  static TYPE = 'string'
 }
 
 export class NullProperty extends Property {
-    static TYPE = "null";
+  static TYPE = 'null'
 }
 export class FileProperty extends StringProperty {
-    static TYPE = "file";
+  static TYPE = 'file'
 }

--- a/ern-api-gen/src/models/refs/GenericRef.js
+++ b/ern-api-gen/src/models/refs/GenericRef.js
@@ -1,58 +1,53 @@
-import RefFormat from "./RefFormat";
+import RefFormat from './RefFormat'
 /**
  * A class the encapsulates logic that is common to RefModel, RefParameter, and RefProperty.
  */
 export default class GenericRef {
+  constructor(type, ref) {
+    if (type != null && typeof ref === 'string') {
+      this.format = GenericRef.computeRefFormat(ref)
+      this.type = type
+      if (this.format === RefFormat.INTERNAL && !ref.startsWith('#/')) {
+        this.ref = type.getInternalPrefix() + ref
+      } else {
+        this.ref = ref
+      }
+      this.simpleRef = GenericRef.computeSimpleRef(this.ref, this.format, type)
+    }
+  }
 
-    constructor(type, ref) {
-        if (type != null && typeof ref === 'string') {
-            this.format = GenericRef.computeRefFormat(ref);
-            this.type = type;
-            if (this.format === RefFormat.INTERNAL && !ref.startsWith("#/")) {
-                this.ref = type.getInternalPrefix() + ref;
-            }
-            else {
-                this.ref = ref;
-            }
-            this.simpleRef = GenericRef.computeSimpleRef(this.ref, this.format, type);
-        }
+  getFormat() {
+    return this.format
+  }
 
+  getType() {
+    return this.type
+  }
+
+  getRef() {
+    return this.ref
+  }
+
+  getSimpleRef() {
+    return this.simpleRef
+  }
+
+  static computeSimpleRef = function(ref, format, type) {
+    if (format === RefFormat.INTERNAL) {
+      return ref.substring(type.getInternalPrefix().length)
+    }
+    return ref
+  }
+
+  static computeRefFormat = function(ref) {
+    if (ref.startsWith('http:') || ref.startsWith('https:')) {
+      return RefFormat.URL
+    } else if (ref.startsWith('#/')) {
+      return RefFormat.INTERNAL
+    } else if (ref.startsWith('.') || ref.startsWith('/')) {
+      return RefFormat.RELATIVE
     }
 
-    getFormat() {
-        return this.format;
-    };
-
-    getType() {
-        return this.type;
-    };
-
-    getRef() {
-        return this.ref;
-    };
-
-    getSimpleRef() {
-        return this.simpleRef;
-    };
-
-
-    static computeSimpleRef = function (ref, format, type) {
-        if (format === RefFormat.INTERNAL) {
-            return ref.substring(type.getInternalPrefix().length);
-        }
-        return ref;
-    };
-
-    static computeRefFormat = function (ref) {
-
-        if (ref.startsWith("http:") || ref.startsWith("https:")) {
-            return RefFormat.URL;
-        } else if (ref.startsWith("#/")) {
-            return RefFormat.INTERNAL;
-        } else if (ref.startsWith(".") || ref.startsWith("/")) {
-            return RefFormat.RELATIVE;
-        }
-
-        return RefFormat.INTERNAL;
-    }
+    return RefFormat.INTERNAL
+  }
 }

--- a/ern-api-gen/src/models/refs/RefFormat.js
+++ b/ern-api-gen/src/models/refs/RefFormat.js
@@ -1,4 +1,4 @@
 export const URL = 0
 export const RELATIVE = 1
 export const INTERNAL = 2
-export default ({URL, RELATIVE, INTERNAL})
+export default { URL, RELATIVE, INTERNAL }

--- a/ern-api-gen/src/models/refs/RefType.js
+++ b/ern-api-gen/src/models/refs/RefType.js
@@ -1,37 +1,34 @@
 export function forValue(str) {
-    str = str.toUpperCase();
-    if (str in ALL)
-        return ALL[str];
+  str = str.toUpperCase()
+  if (str in ALL) return ALL[str]
 }
-
 
 class RefType {
-    constructor(internalPrefix) {
-        this.internalPrefix = internalPrefix;
-    }
+  constructor(internalPrefix) {
+    this.internalPrefix = internalPrefix
+  }
 
-    getInternalPrefix() {
-        return this.internalPrefix;
-    }
+  getInternalPrefix() {
+    return this.internalPrefix
+  }
 
-    ordinal() {
-        return ENUMS.indexOf(this);
-    }
+  ordinal() {
+    return ENUMS.indexOf(this)
+  }
 
-    static values() {
-        return ENUMS;
-    }
+  static values() {
+    return ENUMS
+  }
 
-    static forValue = forValue;
+  static forValue = forValue
 }
 
+export const DEFINITION = new RefType('#/definitions/')
+export const PARAMETER = new RefType('#/parameters/')
+export const PATH = new RefType('#/paths/')
+export const RESPONSE = new RefType('#/responses/')
 
-export const DEFINITION = new RefType("#/definitions/");
-export const PARAMETER = new RefType("#/parameters/");
-export const PATH = new RefType("#/paths/");
-export const RESPONSE = new RefType("#/responses/");
+const ALL = { DEFINITION, PARAMETER, PATH, RESPONSE }
+const ENUMS = Object.freeze(Object.keys(ALL).map(v => ALL[v]))
 
-const ALL = {DEFINITION, PARAMETER, PATH, RESPONSE};
-const ENUMS = Object.freeze(Object.keys(ALL).map(v => ALL[v]));
-
-export default ({...ALL, forValue});
+export default { ...ALL, forValue }


### PR DESCRIPTION
No code changes, only cosmetic changes with prettier so that future code changes to any of these files will not show the whole file as modified (because of the auto-format on save) and make code review easier.