### PR TITLE
New Cauldron schema version 2.0.0

### DIFF
--- a/ern-cauldron-api/src/CauldronApi.ts
+++ b/ern-cauldron-api/src/CauldronApi.ts
@@ -51,7 +51,7 @@ export default class CauldronApi {
   // =====================================================================================
 
   public async upgradeCauldronSchema(): Promise<void> {
-    const currentSchemaVersion = await this.getCauldronSchemaVersion()
+    let currentSchemaVersion = await this.getCauldronSchemaVersion()
     if (currentSchemaVersion === schemas.schemaVersion) {
       throw new Error(
         `The Cauldron is already using the proper schema version ${currentSchemaVersion}`
@@ -65,6 +65,7 @@ export default class CauldronApi {
       }
       if (isUpgradeStarted) {
         await upgradeScript.upgrade(this)
+        currentSchemaVersion = upgradeScript.to
       }
     }
   }

--- a/ern-cauldron-api/src/schemas.ts
+++ b/ern-cauldron-api/src/schemas.ts
@@ -38,8 +38,9 @@ export const nativeApplication = Joi.object({
     .default([]),
 })
 
-export const schemaVersion = '1.0.0'
+export const schemaVersion = '2.0.0'
 
 export const cauldronApiVersionBySchemaVersion = {
   '1.0.0': '0.12.x',
+  '2.0.0': '0.25.x',
 }

--- a/ern-cauldron-api/src/upgrade-scripts/1.0.0-2.0.0.ts
+++ b/ern-cauldron-api/src/upgrade-scripts/1.0.0-2.0.0.ts
@@ -1,0 +1,37 @@
+import CauldronApi from '../CauldronApi'
+import { log, PackagePath, utils } from 'ern-core'
+
+export default async function upgrade(cauldronApi: CauldronApi) {
+  try {
+    log.info('Upgrading Cauldron schema from v1.0.0 to v2.0.0')
+    // - Add miniAppsBranches array to container object
+    // - Copy any mini app that is delcared as git branch,
+    //   from the miniApps array to the miniAppsBranches array
+    const cauldron = await cauldronApi.getCauldron()
+    for (const nativeApp of cauldron.nativeApps) {
+      for (const platform of nativeApp.platforms) {
+        for (const version of platform.versions) {
+          version.container.miniAppsBranches = []
+          version.container.jsApiImplsBranches = []
+          for (const miniApp of version.container.miniApps) {
+            const p = PackagePath.fromString(miniApp)
+            if (p.isGitPath && (await utils.isGitBranch(p))) {
+              version.container.miniAppsBranches.push(miniApp)
+            }
+          }
+          for (const jsApiImpl of version.container.jsApiImpls) {
+            const p = PackagePath.fromString(jsApiImpl)
+            if (p.isGitPath && (await utils.isGitBranch(p))) {
+              version.container.jsApiImplsBranches.push(jsApiImpl)
+            }
+          }
+        }
+      }
+    }
+    cauldron.schemaVersion = '2.0.0'
+    await cauldronApi.commit('Upgrade Cauldron schema from v1.0.0 to v2.0.0')
+  } catch (e) {
+    log.error(`Something went wrong : ${e}`)
+    throw e
+  }
+}

--- a/ern-cauldron-api/src/upgrade-scripts/scripts.ts
+++ b/ern-cauldron-api/src/upgrade-scripts/scripts.ts
@@ -1,5 +1,17 @@
 import v000to100 from './0.0.0-1.0.0'
+import v100to200 from './1.0.0-2.0.0'
 
-const scripts = [{ from: '0.0.0', to: '1.0.0', upgrade: v000to100 }]
+const scripts = [
+  {
+    from: '0.0.0',
+    to: '1.0.0',
+    upgrade: v000to100,
+  },
+  {
+    from: '1.0.0',
+    to: '2.0.0',
+    upgrade: v100to200,
+  },
+]
 
 export default scripts

--- a/ern-cauldron-api/test/CauldronApi-test.ts
+++ b/ern-cauldron-api/test/CauldronApi-test.ts
@@ -1,6 +1,6 @@
 import { assert, expect } from 'chai'
 import sinon from 'sinon'
-import { NativeApplicationDescriptor, PackagePath, fileUtils } from 'ern-core'
+import { NativeApplicationDescriptor, PackagePath, utils } from 'ern-core'
 import { doesThrow, doesNotThrow, fixtures } from 'ern-util-dev'
 import { CauldronCodePushEntry } from '../src/types'
 import CauldronApi from '../src/CauldronApi'
@@ -50,7 +50,8 @@ describe('CauldronApi.js', () => {
   // upgradeCauldronSchema
   // ==========================================================
   describe('upgradeCauldronSchema', () => {
-    it('should properly upgrade a cauldron [schema 0.0.0 => 1.0.0]', async () => {
+    it('should properly upgrade a cauldron [schema 0.0.0 => 2.0.0]', async () => {
+      sandbox.stub(utils, 'isGitBranch').resolves(true)
       const fixture = JSON.parse(
         fs
           .readFileSync(path.join(__dirname, 'fixtures', 'cauldron-0.0.0.json'))
@@ -60,7 +61,7 @@ describe('CauldronApi.js', () => {
       await api.upgradeCauldronSchema()
       const expectedCauldronDoc = JSON.parse(
         fs
-          .readFileSync(path.join(__dirname, 'fixtures', 'cauldron-1.0.0.json'))
+          .readFileSync(path.join(__dirname, 'fixtures', 'cauldron-2.0.0.json'))
           .toString()
       )
       const cauldronDoc = await api.getCauldron()

--- a/ern-cauldron-api/test/fixtures/cauldron-0.0.0.json
+++ b/ern-cauldron-api/test/fixtures/cauldron-0.0.0.json
@@ -26,7 +26,8 @@
             "miniApps": {
               "container":[
                 "@test/react-native-foo@4.0.0",
-                "react-native-bar@2.0.0"
+                "react-native-bar@2.0.0",
+                "git+ssh://git@github.com/myminiapp.git#master"
               ]
             },
             "codePush": {

--- a/ern-cauldron-api/test/fixtures/cauldron-2.0.0.json
+++ b/ern-cauldron-api/test/fixtures/cauldron-2.0.0.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "2.0.0",
   "nativeApps": [
   {
     "name": "test",
@@ -24,10 +24,15 @@
                 "react-native@0.42.0",
                 "react-native-code-push@1.17.1-beta"
               ],
+              "miniAppsBranches": [
+                "git+ssh://git@github.com/myminiapp.git#master"
+              ],
               "miniApps": [
                 "@test/react-native-foo@4.0.0",
                 "react-native-bar@2.0.0",
                 "git+ssh://git@github.com/myminiapp.git#master"
+              ],
+              "jsApiImplsBranches": [
               ],
               "jsApiImpls": [
               ]

--- a/ern-cauldron-api/test/upgrade-scripts-test.ts
+++ b/ern-cauldron-api/test/upgrade-scripts-test.ts
@@ -2,11 +2,23 @@ import scripts from '../src/upgrade-scripts/scripts'
 import InMemoryDocumentStore from '../src/InMemoryDocumentStore'
 import EphemeralFileStore from '../src/EphemeralFileStore'
 import CauldronApi from '../src/CauldronApi'
+import { utils } from 'ern-core'
 import fs from 'fs'
 import path from 'path'
 import { expect } from 'chai'
+import sinon from 'sinon'
+
+const sandbox = sinon.createSandbox()
 
 describe('cauldron upgrade scripts', () => {
+  beforeEach(() => {
+    sandbox.stub(utils, 'isGitBranch').resolves(true)
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
   function createCauldronApi(cauldronDocument) {
     return new CauldronApi(
       new InMemoryDocumentStore(cauldronDocument),
@@ -26,6 +38,24 @@ describe('cauldron upgrade scripts', () => {
     const expectedCauldronDoc = JSON.parse(
       fs
         .readFileSync(path.join(__dirname, 'fixtures', 'cauldron-1.0.0.json'))
+        .toString()
+    )
+    const cauldronDoc = await cauldronApi.getCauldron()
+    expect(cauldronDoc).eql(expectedCauldronDoc)
+  })
+
+  it('should correctly upgrade Cauldron structure [1.0.0 => 2.0.0]', async () => {
+    const script = scripts.find(s => s.from === '1.0.0' && s.to === '2.0.0')
+    const fixture = JSON.parse(
+      fs
+        .readFileSync(path.join(__dirname, 'fixtures', 'cauldron-1.0.0.json'))
+        .toString()
+    )
+    const cauldronApi = createCauldronApi(fixture)
+    await script!.upgrade(cauldronApi)
+    const expectedCauldronDoc = JSON.parse(
+      fs
+        .readFileSync(path.join(__dirname, 'fixtures', 'cauldron-2.0.0.json'))
         .toString()
     )
     const cauldronDoc = await cauldronApi.getCauldron()

--- a/ern-cauldron-api/test/util-test.ts
+++ b/ern-cauldron-api/test/util-test.ts
@@ -79,14 +79,19 @@ describe('util.js', () => {
   })
 
   describe('getSchemaVersionMatchingCauldronApiVersion', () => {
-    it('should return 1.0.0 for version 1000.0.0', () => {
+    it('should return 2.0.0 for version 1000.0.0', () => {
       const result = util.getSchemaVersionMatchingCauldronApiVersion('1000.0.0')
-      expect(result).eql('1.0.0')
+      expect(result).eql('2.0.0')
     })
 
     it('should return 1.0.0 for version 0.12.0', () => {
       const result = util.getSchemaVersionMatchingCauldronApiVersion('0.12.0')
       expect(result).eql('1.0.0')
+    })
+
+    it('should return 2.0.0 for version 0.25.0', () => {
+      const result = util.getSchemaVersionMatchingCauldronApiVersion('0.25.0')
+      expect(result).eql('2.0.0')
     })
 
     it('should return 0.0.0 for version 0.50.0', () => {


### PR DESCRIPTION
Associated to Cauldron schema changes introduced in https://github.com/electrode-io/electrode-native/pull/945

Because we added two new arrays `miniAppsBranches` and `jsApiImplsBranches` to the `container` object in Cauldron for git branches features, there is a need to make sure that users that are using git branches for MiniApps or JS API Implementations in the Cauldron won't have to move those to the new arrays by manually edition the Cauldron. Thus the need of new Cauldron schema version along with automated upgrade script.