### PR TITLE
remove skipConfirmation from performCodePushOtaUpdate as unused

### DIFF
--- a/ern-local-cli/src/commands/code-push/release.ts
+++ b/ern-local-cli/src/commands/code-push/release.ts
@@ -193,7 +193,6 @@ export const commandHandler = async ({
         codePushRolloutPercentage: rollout,
         force,
         pathToYarnLock: pathToYarnLock || undefined,
-        skipConfirmation,
         targetBinaryVersion,
       }
     )


### PR DESCRIPTION
``` return new TSError(diagnosticText, diagnosticCodes)
           ^
TSError: ⨯ Unable to compile TypeScript:
ern-local-cli/src/commands/code-push/release.ts(196,9): error TS2345: Argument of type '{ codePushIsMandatoryRelease: boolean | undefined; codePushRolloutPercentage: number | undefined; force: boolean; pathToYarnLock: string | undefined; skipConfirmation: boolean | undefined; targetBinaryVersion: string | undefined; }' is not assignable to parameter of type '{ force?: boolean | undefined; codePushIsMandatoryRelease?: boolean | undefined; codePushRolloutPercentage?: number | undefined; pathToYarnLock?: string | undefined; targetBinaryVersion?: string | undefined; }'.```