### PR TITLE
Improve linked MiniApps resolution for start command

### DIFF
--- a/ern-orchestrator/test/start-test.ts
+++ b/ern-orchestrator/test/start-test.ts
@@ -12,6 +12,7 @@ import {
 } from 'ern-cauldron-api'
 import * as cauldronApi from 'ern-cauldron-api'
 import * as containerGen from 'ern-container-gen'
+import fs from 'fs'
 const sandbox = sinon.createSandbox()
 
 function cloneFixture(fixture) {
@@ -68,6 +69,7 @@ describe('start', () => {
       .resolves('/path/to/binary')
     sandbox.stub(core, 'createTmpDir').returns('/tmp/dir')
     sandbox.stub(process.stdin, 'resume')
+    sandbox.stub(fs, 'existsSync').returns(true)
   })
 
   function createStubs({


### PR DESCRIPTION
Skip all MiniApps that have been linked but do not exist on the workstation anymore, to avoid errors when running `ern start` command.