### PR TITLE
Add detachContainerVersionFromRoot flag to Cauldron nap version

### DIFF
--- a/ern-cauldron-api/src/CauldronHelper.ts
+++ b/ern-cauldron-api/src/CauldronHelper.ts
@@ -1133,19 +1133,25 @@ export class CauldronHelper {
     containerVersion: string
   ): Promise<void> {
     await this.cauldron.updateContainerVersion(napDescriptor, containerVersion)
-    const topLevelContainerVersion = await this.getTopLevelContainerVersion(
+    const nativeApplicationVersion: CauldronNativeAppVersion = await this.getDescriptor(
       napDescriptor
     )
-    if (
-      semver.valid(containerVersion) &&
-      topLevelContainerVersion &&
-      semver.valid(topLevelContainerVersion) &&
-      semver.gt(containerVersion, topLevelContainerVersion)
-    ) {
-      await this.cauldron.updateTopLevelContainerVersion(
-        napDescriptor,
-        containerVersion
+    // Update top level Container version only for non detached container versions
+    if (!nativeApplicationVersion.detachContainerVersionFromRoot) {
+      const topLevelContainerVersion = await this.getTopLevelContainerVersion(
+        napDescriptor
       )
+      if (
+        semver.valid(containerVersion) &&
+        topLevelContainerVersion &&
+        semver.valid(topLevelContainerVersion) &&
+        semver.gt(containerVersion, topLevelContainerVersion)
+      ) {
+        await this.cauldron.updateTopLevelContainerVersion(
+          napDescriptor,
+          containerVersion
+        )
+      }
     }
   }
 

--- a/ern-cauldron-api/src/index.ts
+++ b/ern-cauldron-api/src/index.ts
@@ -13,11 +13,7 @@ export const GitFileStore = _GitFileStore
 export const GitDocumentStore = _GitDocumentStore
 export const getActiveCauldron = _getActiveCauldron
 
-export {
-  CauldronCodePushMetadata,
-  CauldronCodePushEntry,
-  CauldronConfigLevel,
-} from './types'
+export * from './types'
 
 export {
   getSchemaVersionMatchingCauldronApiVersion,

--- a/ern-cauldron-api/src/types/CauldronNativeAppVersion.ts
+++ b/ern-cauldron-api/src/types/CauldronNativeAppVersion.ts
@@ -8,4 +8,5 @@ export interface CauldronNativeAppVersion extends CauldronObject {
   container: CauldronContainer
   codePush: any
   containerVersion: string
+  detachContainerVersionFromRoot?: boolean
 }

--- a/ern-cauldron-api/test/CauldronHelper-test.ts
+++ b/ern-cauldron-api/test/CauldronHelper-test.ts
@@ -3088,6 +3088,25 @@ describe('CauldronHelper.js', () => {
       expect(nativeApplicationVersion.containerVersion).eql('1.0.0')
       expect(topLevelContainerVersion[0]).eql('1.16.44')
     })
+
+    it('should update native app container version only[detachContainerVersionFromRoot=true for target descriptor]', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const napVersion = fixture.nativeApps[0].platforms[0].versions[0]
+      napVersion.detachContainerVersionFromRoot = true
+      const cauldronHelper = createCauldronHelper(fixture)
+
+      await cauldronHelper.updateContainerVersion(
+        NativeApplicationDescriptor.fromString('test:android:17.7.0'),
+        '1000.0.0'
+      )
+      const nativeApplicationVersion = jp.query(fixture, testAndroid1770Path)[0]
+      const topLevelContainerVersion = jp.query(
+        fixture,
+        testTopLevelContainerPath
+      )
+      expect(nativeApplicationVersion.containerVersion).eql('1000.0.0')
+      expect(topLevelContainerVersion[0]).eql('1.16.44')
+    })
   })
 
   describe('getContainerVersion', () => {

--- a/ern-orchestrator/src/performContainerStateUpdateInCauldron.ts
+++ b/ern-orchestrator/src/performContainerStateUpdateInCauldron.ts
@@ -9,7 +9,7 @@ import {
   fileUtils,
 } from 'ern-core'
 import { getContainerMetadataPath } from 'ern-container-gen'
-import { getActiveCauldron } from 'ern-cauldron-api'
+import { getActiveCauldron, CauldronNativeAppVersion } from 'ern-cauldron-api'
 import { runCauldronContainerGen, runCaudronBundleGen } from './container'
 import { runContainerTransformers } from './runContainerTransformers'
 import { runContainerPublishers } from './runContainerPublishers'
@@ -54,9 +54,12 @@ export async function performContainerStateUpdateInCauldron(
     if (containerVersion) {
       cauldronContainerNewVersion = containerVersion
     } else {
-      cauldronContainerNewVersion = await cauldron.getTopLevelContainerVersion(
+      const napVersion: CauldronNativeAppVersion = await cauldron.getDescriptor(
         napDescriptor
       )
+      cauldronContainerNewVersion = napVersion.detachContainerVersionFromRoot
+        ? await cauldron.getContainerVersion(napDescriptor)
+        : await cauldron.getTopLevelContainerVersion(napDescriptor)
       if (cauldronContainerNewVersion) {
         cauldronContainerNewVersion = semver.inc(
           cauldronContainerNewVersion,

--- a/ern-orchestrator/test/utils-test.js
+++ b/ern-orchestrator/test/utils-test.js
@@ -45,6 +45,7 @@ describe('utils.js', () => {
     cauldronHelperStub.getTopLevelContainerVersion.resolves(
       topLevelContainerVersion
     )
+    cauldronHelperStub.getDescriptor.resolves({})
     cauldronHelperStub.getVersionsNames.resolves([
       '1.2.3',
       '1.2.4',


### PR DESCRIPTION
Adds support of a new flag `detachContainerVersionFromRoot` to the `CauldronNativeAppVersion` type.

If this flag is present and set (`"detachContainerVersionFromRoot" : true`) for a given Native Application Version in Cauldron, then, Container versioning will be 'detached' (independent) from top level Container versioning. What this means in practice is that whenever the Container version of the native application is updated, it won't update the top level Container version.

For example, assuming we have a Cauldron with current top level Container version set to `1.0.5` and 3 versions of a native application defined, with only one having the `detachContainerVersionFromRoot ` flag set, as follow :

| Descriptor  | Container Version | detachContainerVersionFromRoot |
| ------------- | ------------- | ------------- |
| test:android:1.0.0  | 1.0.4  | false  |
| test:android:2.0.0 |  1.0.5  | false  |
| test:android:1000.0.0 |  2.0.1  | true  |

If one regenerate a new Container for `test:android:1.0.0`, then the container version associated to `test:android:1.0.0` will be patch bumped to `1.0.5` and the top level Container version will be also set to `1.0.5`.

However, because `detachContainerVersionFromRoot ` flag is set for `test:android:1000.0.0` application, if one was to regenerate a new Container for `test:android:1000.0.0`, the Container version of this descriptor would be bumped to `2.0.2` but the top level container version will remain untouched (thus the container version associated to the native application version is detached from other native application versions).

This is not documented yet as we'll have come up with better flexibility for Container versioning in the future. That being said, this feature is needed for one internal team in relation the CI workflow and will be needed by other internal teams very soon, therefore the need to have a working -temporary- solution in place as of now.