### PR TITLE
Fix binarystore add command for iOS

### DIFF
--- a/ern-local-cli/src/commands/binarystore/add.ts
+++ b/ern-local-cli/src/commands/binarystore/add.ts
@@ -23,8 +23,8 @@ export const commandHandler = async ({
   pathToBinary: string
 }) => {
   await logErrorAndExitIfNotSatisfied({
-    isFilePath: { p: pathToBinary },
     napDescriptorExistInCauldron: { descriptor },
+    pathExist: { p: pathToBinary },
   })
 
   const binaryStore = await getBinaryStoreFromCauldron()


### PR DESCRIPTION
Use `pathExist` check instead of `isFilePath` because what we add to the binary store for iOS is a `.app` directory (which is not a file) v.s `.apk` for Android (which is a file).

So the command was working correctly for Android, but not for iOS.