### PR TITLE
Perform full container generation for new MiniApps

### DIFF
--- a/ern-orchestrator/test/utils-test.js
+++ b/ern-orchestrator/test/utils-test.js
@@ -73,6 +73,10 @@ describe('utils.js', () => {
   // performContainerStateUpdateInCauldron
   // ==========================================================
   describe('performContainerStateUpdateInCauldron', () => {
+    beforeEach(() => {
+      cauldronHelperStub.getContainerMiniApps.resolves([])
+    })
+
     const napDescriptor = NativeApplicationDescriptor.fromString(
       'testapp:android:1.0.0'
     )


### PR DESCRIPTION
Force full container generation in case one or more MiniApps were added to the Container.

This is necessary because Electrode Native needs to regenerate/create some native files in the Container (for example MiniApp activities in the case of Android Container). 
Because Electrode Native was only regenerating the JS bundle in that specific context, the native updates were missing in the Container, leading to issues.

This fix ensure that a full Container generation is performed in case one or more MiniApps was added to the Container.