### PR TITLE
Favor MiniApp git branches for start command

### DIFF
--- a/ern-cauldron-api/test/CauldronHelper-test.ts
+++ b/ern-cauldron-api/test/CauldronHelper-test.ts
@@ -2577,6 +2577,46 @@ describe('CauldronHelper.js', () => {
         .to.be.an('array')
         .of.length(2)
     })
+
+    it('should return the container MiniApps not favoring git branches by default', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      const result = await cauldronHelper.getContainerMiniApps(
+        NativeApplicationDescriptor.fromString('test:android:17.8.0')
+      )
+      expect(result)
+        .to.be.an('array')
+        .of.length(4)
+    })
+
+    it('should not favor container MiniApps git branches by default', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      const result = await cauldronHelper.getContainerMiniApps(
+        NativeApplicationDescriptor.fromString('test:android:17.8.0')
+      )
+      expect(result)
+        .to.be.an('array')
+        .of.length(4)
+      expect(result.map(m => m.toString())).contains(
+        'https://github.com/foo/foo.git#6319d9ef0c237907c784a8c472b000d5ff83b49a'
+      )
+    })
+
+    it('should favor container MiniApps git branches if favorGitBranches flag is set', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper(fixture)
+      const result = await cauldronHelper.getContainerMiniApps(
+        NativeApplicationDescriptor.fromString('test:android:17.8.0'),
+        { favorGitBranches: true }
+      )
+      expect(result)
+        .to.be.an('array')
+        .of.length(4)
+      expect(result.map(m => m.toString())).contains(
+        'https://github.com/foo/foo.git#master'
+      )
+    })
   })
 
   describe('addCodePushEntry', () => {

--- a/ern-orchestrator/src/start.ts
+++ b/ern-orchestrator/src/start.ts
@@ -35,8 +35,6 @@ export default async function start({
   bundleId?: string
   extraJsDependencies?: PackagePath[]
 } = {}) {
-  let pathToYarnLock
-
   const cauldron = await getActiveCauldron({ throwIfNoActiveCauldron: false })
   if (!cauldron && descriptor) {
     throw new Error(
@@ -49,9 +47,9 @@ export default async function start({
   }
 
   if (descriptor) {
-    const miniAppsObjs = await cauldron.getContainerMiniApps(descriptor)
-    miniapps = _.map(miniAppsObjs, m => PackagePath.fromString(m.toString()))
-    pathToYarnLock = await cauldron.getPathToYarnLock(descriptor, 'container')
+    miniapps = await cauldron.getContainerMiniApps(descriptor, {
+      favorGitBranches: true,
+    })
   }
 
   // Because this command can only be stoped through `CTRL+C` (or killing the process)
@@ -66,7 +64,6 @@ export default async function start({
   await kax.task('Generating MiniApps composite').run(
     generateMiniAppsComposite(miniapps!, compositeDir, {
       extraJsDependencies: extraJsDependencies || undefined,
-      pathToYarnLock: pathToYarnLock || undefined,
     })
   )
 


### PR DESCRIPTION
For MiniApps that are specified as git branches in the Container, the  `start` command was creating a JS composite out of the commit SHAs frozen for the current Container version, rather than from the MiniApps branches. This is not really a desired behavior, as developers expect `start` to pick up the latest changes of all MiniApps (only for MiniApps specified as git branches).

This Pull Request establishes this expected behavior.