### PR TITLE
Fix cauldron repo use command for invalid alias

### DIFF
--- a/ern-cauldron-api/src/CauldronRepositories.ts
+++ b/ern-cauldron-api/src/CauldronRepositories.ts
@@ -81,6 +81,7 @@ https://[token]@[repourl]`)
   }
 
   public activate({ alias }: { alias: string }) {
+    this.throwIfAliasDoesNotExist({ alias })
     this.updateCauldronRepoInUse({ alias })
   }
   public deactivate() {


### PR DESCRIPTION
`cauldron repo use` command was incorrectly working when provided with an invalid alias (alias that does not exist). This PR fixes this issue. `cauldron repo use` command will now properly fail in case it is used with an invalid cauldron alias.

Thanks @gmbharath12 for noticing this issue.