### PR TITLE
Downgrade node version to 8 for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '9'
+- '8'
 sudo: enabled
 install:
 - npm install


### PR DESCRIPTION
Due to version 0.57.5 of `react-native init` which depends on some dependency that is not compatible with Node 9, causing system tests runs on Travis CI to fail.

```
– An error occurred: Command failed: /home/travis/build/electrode-io/electrode-native/ern-core/node_modules/.bin/react-native init MiniAppSystemTest --version react-native@0.57.5 --skip-jest
– error sane@3.1.0: The engine "node" is incompatible with this module. Expected version "6.* || 8.* || >= 10.*".
```