### PR TITLE
Allow Cauldron to require an ern version

### DIFF
--- a/docs/cli/platform/config/set.md
+++ b/docs/cli/platform/config/set.md
@@ -49,6 +49,11 @@ Indicates whether the package cache should be enabled.
 Enabling the package cache will lead to faster Containers generation, given that all packages versions used for a Container generation, will be retrieved from the cache if available rather than being downloaded upon every generation.
 **default** : true  
 
+- `ignore-required-ern-version` [boolean]
+Indicates whether any Cauldron ern version requirement should be ignored.
+This is mostly used for Electrode Native development and should not be set to true otherwise.
+**default** : false
+
 #### Remarks
  
 * In case a value already exists in the configuration for a given key, this command will not fail and will overwrite the existing value.

--- a/docs/platform-parts/cauldron/structure.md
+++ b/docs/platform-parts/cauldron/structure.md
@@ -30,6 +30,7 @@ The following is an example of a `cauldron.json` document.
      "codePush": {
       "entriesLimit": 10
     },
+    "requiredErnVersion": ">=0.26.0"
   },
   "nativeApps": [
     {

--- a/ern-cauldron-api/src/types/Cauldron.ts
+++ b/ern-cauldron-api/src/types/Cauldron.ts
@@ -1,7 +1,6 @@
 import { CauldronNativeApp } from './CauldronNativeApp'
 import { CauldronObject } from './CauldronObject'
 export interface Cauldron extends CauldronObject {
-  ernVersion?: string
   schemaVersion: string
   nativeApps: CauldronNativeApp[]
 }

--- a/ern-local-cli/src/commands/cauldron/config/del.ts
+++ b/ern-local-cli/src/commands/cauldron/config/del.ts
@@ -29,7 +29,9 @@ export const commandHandler = async ({
   descriptor?: NativeApplicationDescriptor
   key?: string
 }) => {
-  const cauldron = await getActiveCauldron()
+  const cauldron = await getActiveCauldron({
+    ignoreRequiredErnVersionMismatch: true,
+  })
   await cauldron.delConfig({
     descriptor,
     key,

--- a/ern-local-cli/src/commands/cauldron/config/get.ts
+++ b/ern-local-cli/src/commands/cauldron/config/get.ts
@@ -36,7 +36,9 @@ export const commandHandler = async ({
   key?: string
   strict: boolean
 }) => {
-  const cauldron = await getActiveCauldron()
+  const cauldron = await getActiveCauldron({
+    ignoreRequiredErnVersionMismatch: true,
+  })
   let result: any
   if (key && strict) {
     result = await cauldron.getConfigForKeyStrict(key, descriptor)

--- a/ern-local-cli/src/commands/cauldron/config/set.ts
+++ b/ern-local-cli/src/commands/cauldron/config/set.ts
@@ -36,7 +36,9 @@ export const commandHandler = async ({
   key?: string
   value: any
 }) => {
-  const cauldron = await getActiveCauldron()
+  const cauldron = await getActiveCauldron({
+    ignoreRequiredErnVersionMismatch: true,
+  })
   await cauldron.setConfig({
     descriptor,
     key,

--- a/ern-local-cli/src/commands/cauldron/upgrade.ts
+++ b/ern-local-cli/src/commands/cauldron/upgrade.ts
@@ -10,6 +10,7 @@ export const builder = (argv: Argv) => {
 }
 export const commandHandler = async () => {
   const cauldron = await getActiveCauldron({
+    ignoreRequiredErnVersionMismatch: true,
     ignoreSchemaVersionMismatch: true,
   })
   await cauldron.upgradeCauldronSchema()

--- a/ern-orchestrator/src/constants.ts
+++ b/ern-orchestrator/src/constants.ts
@@ -41,4 +41,9 @@ export const availableUserConfigKeys = [
     name: 'overrideManifestUrlModifier',
     values: ['string'],
   },
+  {
+    desc: 'Indicates whether to ignore any Cauldron required ern version',
+    name: 'ignore-required-ern-version',
+    values: [true, false],
+  },
 ]


### PR DESCRIPTION
- Add support of new Cauldron top level config key `requiredErnVersion`
- Value for this key can be a fixed version (for example `0.26.0`) or a valid version range as defined in the [semver](https://www.npmjs.com/package/semver) library (for example `0.26.x` or `>=0.26` or `0.26.0 - 0.28.0` ...)
- If this key is present in a Cauldron, it enforces a specific Electrode Native version (or range) to be used by the client connected to the Cauldron.
- If the user is not using a version satisfying the Cauldron requirement, any command that involves access to the Cauldron will fail and let the user know of the specific Cauldron requirement.
- Not enforced for `ern cauldron upgrade` and `ern cauldron config` commands.
- Version requirement can be bypassed in two ways :
  - By setting the new local platform config key `ignore-required-ern-version` to `true` **OR**
  - By setting the env variable `ERN_IGNORE_REQUIRED_ERN_VERSION` to `true`