### PR TITLE
Fix list dependencies command

### DIFF
--- a/ern-local-cli/src/commands/list/dependencies.ts
+++ b/ern-local-cli/src/commands/list/dependencies.ts
@@ -24,6 +24,7 @@ export const commandHandler = async ({ module }: { module?: string }) => {
     pathToModule = createTmpDir()
     shell.pushd(pathToModule)
     try {
+      await yarn.init()
       await yarn.add(PackagePath.fromString(module))
     } finally {
       shell.popd()


### PR DESCRIPTION
Make sure to run `yarn init` prior to `yarn add` to avoid command failure in case a `package.json` already exists up in the directory hierarchy.