### PR TITLE
Add json option flag to some commands

### DIFF
--- a/docs/cli/cauldron/config/get.md
+++ b/docs/cli/cauldron/config/get.md
@@ -20,6 +20,10 @@ Echoes configuration stored in Cauldron.
 * The target descriptor which to retrieve configuration from  
 **Default**  Returns the top level / global configuration, not associated to a specific descriptor
 
+`--json`
+
+* Output config as a single line JSON record.
+
 `--strict`
 
 * Echoes the configuration strictly associated to the descriptor  

--- a/docs/cli/cauldron/get/dependency.md
+++ b/docs/cli/cauldron/get/dependency.md
@@ -9,6 +9,12 @@
 
 `ern cauldron get dependency <descriptor>`  
 
+**Options**
+
+`--json`
+
+* Output dependencies as a single line JSON array.
+
 **Arguments**
 
 `<descriptor>`

--- a/docs/cli/cauldron/get/nativeapp.md
+++ b/docs/cli/cauldron/get/nativeapp.md
@@ -11,10 +11,14 @@
 
 **Options**
 
-`descriptor`
+`--descriptor`
 
 * A partial or complete application descriptor representing which native application object to get
 * If not provided, the command will log the list of all complete native application descriptors stored in the Cauldron
+
+`--json`
+
+* Output result as a single line JSON record.
 
 **Examples**
 e

--- a/docs/cli/list/dependencies.md
+++ b/docs/cli/list/dependencies.md
@@ -8,6 +8,12 @@
 
 `ern list dependencies [module]`
 
+**Options**
+
+`--json`
+
+* Output dependencies as a single line JSON record.
+
 **Arguments**
 
 `[module]`

--- a/ern-core/src/coloredLog.ts
+++ b/ern-core/src/coloredLog.ts
@@ -14,9 +14,11 @@ export default class ColoredLog {
 
   public setLogLevel(level: string) {
     this.pLevel = level
-    this.log = require('console-log-level')({
-      level,
-    })
+    if (level !== 'off') {
+      this.log = require('console-log-level')({
+        level,
+      })
+    }
   }
 
   get level(): string {
@@ -24,22 +26,32 @@ export default class ColoredLog {
   }
 
   public trace(msg: string) {
-    this.log.trace(chalk.gray(msg))
+    if (this.pLevel !== 'off') {
+      this.log.trace(chalk.gray(msg))
+    }
   }
 
   public debug(msg: string) {
-    this.log.debug(chalk.green(msg))
+    if (this.pLevel !== 'off') {
+      this.log.debug(chalk.green(msg))
+    }
   }
 
   public info(msg: string) {
-    kax.info(msg)
+    if (this.pLevel !== 'off') {
+      kax.info(msg)
+    }
   }
 
   public warn(msg: string) {
-    kax.warn(msg)
+    if (this.pLevel !== 'off') {
+      kax.warn(msg)
+    }
   }
 
   public error(msg: string) {
-    kax.error(msg)
+    if (this.pLevel !== 'off') {
+      kax.error(msg)
+    }
   }
 }

--- a/ern-local-cli/src/commands/cauldron/config/get.ts
+++ b/ern-local-cli/src/commands/cauldron/config/get.ts
@@ -14,6 +14,10 @@ export const builder = (argv: Argv) => {
       type: 'string',
     })
     .coerce('descriptor', NativeApplicationDescriptor.fromString)
+    .option('json', {
+      describe: 'Output config as a single line JSON record',
+      type: 'boolean',
+    })
     .option('key', {
       describe:
         'The config key (echoes the whole config object if not specified)',
@@ -29,10 +33,12 @@ export const builder = (argv: Argv) => {
 
 export const commandHandler = async ({
   descriptor,
+  json,
   key,
   strict,
 }: {
   descriptor?: NativeApplicationDescriptor
+  json?: boolean
   key?: string
   strict: boolean
 }) => {
@@ -49,8 +55,10 @@ export const commandHandler = async ({
   } else if (!key && !strict) {
     result = await cauldron.getConfig(descriptor)
   }
-  const jsonConfig = JSON.stringify(result, null, 2)
-  console.log(jsonConfig)
+
+  process.stdout.write(
+    json ? JSON.stringify(result) : JSON.stringify(result, null, 2)
+  )
 }
 
 export const handler = tryCatchWrap(commandHandler)

--- a/ern-local-cli/src/commands/cauldron/get/dependency.ts
+++ b/ern-local-cli/src/commands/cauldron/get/dependency.ts
@@ -16,13 +16,19 @@ export const builder = (argv: Argv) => {
     .coerce('descriptor', d =>
       NativeApplicationDescriptor.fromString(d, { throwIfNotComplete: true })
     )
+    .option('json', {
+      describe: 'Output dependencies as a single line JSON array',
+      type: 'boolean',
+    })
     .epilog(epilog(exports))
 }
 
 export const commandHandler = async ({
   descriptor,
+  json,
 }: {
   descriptor: NativeApplicationDescriptor
+  json?: boolean
 }) => {
   await logErrorAndExitIfNotSatisfied({
     napDescriptorExistInCauldron: {
@@ -34,9 +40,9 @@ export const commandHandler = async ({
 
   const cauldron = await getActiveCauldron()
   const dependencies = await cauldron.getNativeDependencies(descriptor)
-  for (const dependency of dependencies) {
-    log.info(dependency.toString())
-  }
+  json
+    ? process.stdout.write(JSON.stringify(dependencies))
+    : dependencies.forEach(d => log.info(d.toString()))
 }
 
 export const handler = tryCatchWrap(commandHandler)

--- a/ern-local-cli/src/commands/cauldron/get/nativeapp.ts
+++ b/ern-local-cli/src/commands/cauldron/get/nativeapp.ts
@@ -9,21 +9,31 @@ export const desc = 'Get a native application from the cauldron'
 export const builder = (argv: Argv) => {
   return argv
     .coerce('descriptor', NativeApplicationDescriptor.fromString)
+    .option('json', {
+      describe: 'Output result as a single line JSON record',
+      type: 'boolean',
+    })
     .epilog(epilog(exports))
 }
 
 export const commandHandler = async ({
   descriptor,
+  json,
 }: {
   descriptor?: NativeApplicationDescriptor
+  json?: boolean
 }) => {
   const cauldron = await getActiveCauldron()
   if (!descriptor) {
     const napDescriptors = await cauldron.getNapDescriptorStrings()
-    napDescriptors.forEach(n => log.info(n))
+    json
+      ? process.stdout.write(JSON.stringify(napDescriptors))
+      : napDescriptors.forEach(n => log.info(n))
   } else {
     const nativeApp = await cauldron.getDescriptor(descriptor)
-    console.log(JSON.stringify(nativeApp, null, 1))
+    process.stdout.write(
+      json ? JSON.stringify(nativeApp) : JSON.stringify(nativeApp, null, 1)
+    )
   }
 }
 

--- a/ern-local-cli/src/commands/list/dependencies.ts
+++ b/ern-local-cli/src/commands/list/dependencies.ts
@@ -15,10 +15,21 @@ export const command = 'dependencies [module]'
 export const desc = 'List the native dependencies of an Electrode Native module'
 
 export const builder = (argv: Argv) => {
-  return argv.epilog(epilog(exports))
+  return argv
+    .option('json', {
+      describe: 'Output dependencies as a single line JSON record',
+      type: 'boolean',
+    })
+    .epilog(epilog(exports))
 }
 
-export const commandHandler = async ({ module }: { module?: string }) => {
+export const commandHandler = async ({
+  module,
+  json,
+}: {
+  module?: string
+  json?: boolean
+}) => {
   let pathToModule = process.cwd()
   if (module) {
     pathToModule = createTmpDir()
@@ -34,17 +45,21 @@ export const commandHandler = async ({ module }: { module?: string }) => {
     path.join(pathToModule, 'node_modules')
   )
 
-  console.log(chalk.bold.yellow('Native dependencies :'))
-  logDependencies(dependencies.apis, 'APIs')
-  logDependencies(dependencies.nativeApisImpl, 'Native API Implementations')
-  logDependencies(
-    dependencies.thirdPartyInManifest,
-    'Third party declared in Manifest'
-  )
-  logDependencies(
-    dependencies.thirdPartyNotInManifest,
-    'Third party not declared in Manifest'
-  )
+  if (json) {
+    process.stdout.write(JSON.stringify(dependencies))
+  } else {
+    console.log(chalk.bold.yellow('Native dependencies :'))
+    logDependencies(dependencies.apis, 'APIs')
+    logDependencies(dependencies.nativeApisImpl, 'Native API Implementations')
+    logDependencies(
+      dependencies.thirdPartyInManifest,
+      'Third party declared in Manifest'
+    )
+    logDependencies(
+      dependencies.thirdPartyNotInManifest,
+      'Third party not declared in Manifest'
+    )
+  }
 }
 
 function logDependencies(dependencies: PackagePath[], type: string) {


### PR DESCRIPTION
Add `--json` option flag to the following commands :

- `cauldron config get`
- `cauldron get dependency`
- `cauldron get nativeapp`
- `list dependencies`

There is some special handling in the top level CLI implementation to disable all other console output in case this flag is set (no banner / no header and no logs what so ever), so that only the resulting formatted JSON output is written to the console. 

This is done because common use of the `--json` flag in CLI commands is to feed the result of the command to some other program. Having some banner / logs before the formatted JSON makes it more difficult to be parsed for consuming app.