### PR TITLE
Update organization name

### DIFF
--- a/ern-runner-gen-ios/src/hull/ErnRunner.xcodeproj/project.pbxproj
+++ b/ern-runner-gen-ios/src/hull/ErnRunner.xcodeproj/project.pbxproj
@@ -173,7 +173,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0830;
-				ORGANIZATIONNAME = "Claire Weijie Li";
+				ORGANIZATIONNAME = "Walmart";
 				TargetAttributes = {
 					304F3E941EEF455C00F1E36B = {
 						CreatedOnToolsVersion = 8.3.2;

--- a/ern-runner-gen-ios/test/fixtures/simple-ios-runner/ErnRunner.xcodeproj/project.pbxproj
+++ b/ern-runner-gen-ios/test/fixtures/simple-ios-runner/ErnRunner.xcodeproj/project.pbxproj
@@ -173,7 +173,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0830;
-				ORGANIZATIONNAME = "Claire Weijie Li";
+				ORGANIZATIONNAME = "Walmart";
 				TargetAttributes = {
 					304F3E941EEF455C00F1E36B = {
 						CreatedOnToolsVersion = 8.3.2;


### PR DESCRIPTION
- when a new file is generated in `ErnRunner` project copyright is assigned to a person's name instead of organization name. 
- This PR fixes ^ issue
- Generate fixtures ?! 