### PR TITLE
Do not cache MiniApps that are referencing a git branch 

### DIFF
--- a/ern-core/src/MiniApp.ts
+++ b/ern-core/src/MiniApp.ts
@@ -56,8 +56,9 @@ export class MiniApp {
   public static async fromPackagePath(packagePath: PackagePath) {
     let fsPackagePath
     if (
+      config.getValue('package-cache-enabled', true) &&
       !packagePath.isFilePath &&
-      config.getValue('package-cache-enabled', true)
+      !(await utils.isGitBranch(packagePath))
     ) {
       if (!(await packageCache.isInCache(packagePath))) {
         fsPackagePath = await packageCache.addToCache(packagePath)

--- a/ern-core/src/utils.ts
+++ b/ern-core/src/utils.ts
@@ -424,21 +424,18 @@ const gitShaLength = 40
 
 export async function isGitBranch(p: PackagePath): Promise<boolean> {
   if (!p.isGitPath) {
-    throw new Error(`${p} is not a git path`)
+    return false
   }
-  if (!p.version) {
-    throw new Error(`${p} does not include the branch to check`)
+  if (p.isGitPath && !p.version) {
+    return true
   }
   const heads = await gitCli().listRemote(['--heads', p.basePath])
-  return heads.includes(gitRefBranch(p.version))
+  return heads.includes(gitRefBranch(p.version!))
 }
 
 export async function isGitTag(p: PackagePath): Promise<boolean> {
-  if (!p.isGitPath) {
-    throw new Error(`${p} is not a git path`)
-  }
-  if (!p.version) {
-    throw new Error(`${p} does not include the tag to check`)
+  if (!p.isGitPath || !p.version) {
+    return false
   }
   const tags = await gitCli().listRemote(['--tags', p.basePath])
   return tags.includes(gitRefTag(p.version))

--- a/ern-core/test/Utils-test.ts
+++ b/ern-core/test/Utils-test.ts
@@ -150,26 +150,20 @@ describe('Core Utils', () => {
 6319d9ef0c237907c784a8c472b000d5ff83b49a        refs/heads/v0.10
 81ac6c5ef280e46a1d643f86f47c66b11aa1f8b4        refs/heads/v0.11`
 
-    it('should throw if the package path is not a git path', async () => {
-      assert(
-        await doesThrow(
-          coreUtils.isGitBranch,
-          null,
-          PackagePath.fromString('registry-package@1.2.3')
-        )
+    it('should return false if the package path is not a git path', async () => {
+      const result = await coreUtils.isGitBranch(
+        PackagePath.fromString('registry-package@1.2.3')
       )
+      expect(result).false
     })
 
-    it('should throw if the package path does not include a branch', async () => {
-      assert(
-        await doesThrow(
-          coreUtils.isGitBranch,
-          null,
-          PackagePath.fromString(
-            'https://github.com/electrode-io/electrode-native.git'
-          )
+    it('should return true if the package path does not include a branch [as it corresponds to default branch]', async () => {
+      const result = await coreUtils.isGitBranch(
+        PackagePath.fromString(
+          'https://github.com/electrode-io/electrode-native.git'
         )
       )
+      expect(result).true
     })
 
     it('shoud return true if the branch exist', async () => {
@@ -207,26 +201,20 @@ c4191b97e0f77f8cd128275977e7f284277131e0        refs/tags/v0.1.0
 4cc7a6f041ebd9a7f4ec267cdc2e57cf0ddc61fa        refs/tags/v0.1.1
 d9fa903349bbb9e7f86535cb69256e064d0fba65        refs/tags/v0.1.2`
 
-    it('should throw if the package path is not a git path', async () => {
-      assert(
-        await doesThrow(
-          coreUtils.isGitTag,
-          null,
-          PackagePath.fromString('registry-package@1.2.3')
-        )
+    it('should return false if the package path is not a git path', async () => {
+      const result = await coreUtils.isGitTag(
+        PackagePath.fromString('registry-package@1.2.3')
       )
+      expect(result).false
     })
 
-    it('should throw if the package path does not include a tag', async () => {
-      assert(
-        await doesThrow(
-          coreUtils.isGitTag,
-          null,
-          PackagePath.fromString(
-            'https://github.com/electrode-io/electrode-native.git'
-          )
+    it('should return false if the package path does not include a tag', async () => {
+      const result = await coreUtils.isGitTag(
+        PackagePath.fromString(
+          'https://github.com/electrode-io/electrode-native.git'
         )
       )
+      expect(result).false
     })
 
     it('shoud return true if the tag exist', async () => {


### PR DESCRIPTION
Electrode Native should not cache MiniApps that are referencing a git branch, otherwise it will reuse the cached MiniApp even if there is new commits available.

Update `isGitTag` and `isGitBranch` method so that they return `false` instead of throwing an exception, if the package path is not git based or if the version is missing (for `isGitTag`).