### PR TITLE
Extend update miniapps command optimization to git tags

### DIFF
--- a/ern-cauldron-api/src/CauldronHelper.ts
+++ b/ern-cauldron-api/src/CauldronHelper.ts
@@ -646,7 +646,7 @@ export class CauldronHelper {
     } = {}
   ): Promise<void> {
     if (jsApiImpl.isGitPath && (await coreUtils.isGitBranch(jsApiImpl))) {
-      const commitSha = await coreUtils.getCommitShaOfGitBranchHead(jsApiImpl)
+      const commitSha = await coreUtils.getCommitShaOfGitBranchOrTag(jsApiImpl)
       if (
         await this.cauldron.hasJsApiImplBranchInContainer(
           napDescriptor,
@@ -966,7 +966,7 @@ export class CauldronHelper {
     miniApp: PackagePath
   ): Promise<void> {
     if (miniApp.isGitPath && (await coreUtils.isGitBranch(miniApp))) {
-      const commitSha = await coreUtils.getCommitShaOfGitBranchHead(miniApp)
+      const commitSha = await coreUtils.getCommitShaOfGitBranchOrTag(miniApp)
       await this.cauldron.addMiniAppBranchToContainer(napDescriptor, miniApp)
       return this.cauldron.addMiniAppToContainer(
         napDescriptor,
@@ -982,7 +982,7 @@ export class CauldronHelper {
     jsApiImpl: PackagePath
   ): Promise<void> {
     if (jsApiImpl.isGitPath && (await coreUtils.isGitBranch(jsApiImpl))) {
-      const commitSha = await coreUtils.getCommitShaOfGitBranchHead(jsApiImpl)
+      const commitSha = await coreUtils.getCommitShaOfGitBranchOrTag(jsApiImpl)
       await this.cauldron.addJsApiImplBranchToContainer(
         napDescriptor,
         jsApiImpl
@@ -1221,7 +1221,7 @@ export class CauldronHelper {
     } = {}
   ): Promise<void> {
     if (miniApp.isGitPath && (await coreUtils.isGitBranch(miniApp))) {
-      const commitSha = await coreUtils.getCommitShaOfGitBranchHead(miniApp)
+      const commitSha = await coreUtils.getCommitShaOfGitBranchOrTag(miniApp)
       if (
         await this.cauldron.hasMiniAppBranchInContainer(napDescriptor, miniApp)
       ) {
@@ -1270,7 +1270,7 @@ export class CauldronHelper {
       p => PackagePath.fromString(p)
     )
     for (const miniAppBranch of miniAppsBranches) {
-      const latestCommitSha = await coreUtils.getCommitShaOfGitBranchHead(
+      const latestCommitSha = await coreUtils.getCommitShaOfGitBranchOrTag(
         miniAppBranch
       )
       const matchingMiniApp = miniApps.find(
@@ -1297,7 +1297,7 @@ export class CauldronHelper {
       descriptor
     )).map(p => PackagePath.fromString(p))
     for (const jsApiImplBranch of jsApiImplsBranches) {
-      const latestCommitSha = await coreUtils.getCommitShaOfGitBranchHead(
+      const latestCommitSha = await coreUtils.getCommitShaOfGitBranchOrTag(
         jsApiImplBranch
       )
       const matchingJsApiImpl = jsApiImpls.find(

--- a/ern-cauldron-api/test/CauldronHelper-test.ts
+++ b/ern-cauldron-api/test/CauldronHelper-test.ts
@@ -205,7 +205,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       sandbox.stub(utils, 'isGitBranch').resolves(true)
       sandbox
-        .stub(utils, 'getCommitShaOfGitBranchHead')
+        .stub(utils, 'getCommitShaOfGitBranchOrTag')
         .resolves('6319d9ef0c237907c784a8c472b000d5ff83b49a')
       await cauldronHelper.addMiniAppToContainer(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
@@ -225,7 +225,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       sandbox.stub(utils, 'isGitBranch').resolves(true)
       sandbox
-        .stub(utils, 'getCommitShaOfGitBranchHead')
+        .stub(utils, 'getCommitShaOfGitBranchOrTag')
         .resolves('6319d9ef0c237907c784a8c472b000d5ff83b49a')
       await cauldronHelper.addMiniAppToContainer(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
@@ -279,7 +279,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       sandbox.stub(utils, 'isGitBranch').resolves(true)
       sandbox
-        .stub(utils, 'getCommitShaOfGitBranchHead')
+        .stub(utils, 'getCommitShaOfGitBranchOrTag')
         .resolves('6319d9ef0c237907c784a8c472b000d5ff83b49a')
       await cauldronHelper.updateMiniAppVersionInContainer(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),
@@ -301,7 +301,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper(fixture)
       sandbox.stub(utils, 'isGitBranch').resolves(true)
       sandbox
-        .stub(utils, 'getCommitShaOfGitBranchHead')
+        .stub(utils, 'getCommitShaOfGitBranchOrTag')
         .resolves('6319d9ef0c237907c784a8c472b000d5ff83b49a')
       await cauldronHelper.updateMiniAppVersionInContainer(
         NativeApplicationDescriptor.fromString('test:android:17.8.0'),

--- a/ern-core/src/utils.ts
+++ b/ern-core/src/utils.ts
@@ -441,18 +441,18 @@ export async function isGitTag(p: PackagePath): Promise<boolean> {
   return tags.includes(gitRefTag(p.version))
 }
 
-export async function getCommitShaOfGitBranchHead(
+export async function getCommitShaOfGitBranchOrTag(
   p: PackagePath
 ): Promise<string> {
   if (!p.isGitPath) {
     throw new Error(`${p} is not a git path`)
   }
   if (!p.version) {
-    throw new Error(`${p} does not include a branch`)
+    throw new Error(`${p} does not include a branch or tag`)
   }
   const result = await gitCli().listRemote([p.basePath, p.version])
   if (!result || result === '') {
-    throw new Error(`${p.version} branch was not found`)
+    throw new Error(`${p.version} branch or tag not found`)
   }
   return result.substring(0, gitShaLength)
 }

--- a/ern-core/test/Utils-test.ts
+++ b/ern-core/test/Utils-test.ts
@@ -246,13 +246,13 @@ d9fa903349bbb9e7f86535cb69256e064d0fba65        refs/tags/v0.1.2`
     })
   })
 
-  describe('getCommitShaOfGitBranchHead', () => {
+  describe('getCommitShaOfGitBranchOrTag', () => {
     const sampleRef = `31d04959d8786113bfeaee997a1d1eaa8cb6c5f5        refs/heads/master`
 
     it('should throw if the package path is not a git path', async () => {
       assert(
         await doesThrow(
-          coreUtils.getCommitShaOfGitBranchHead,
+          coreUtils.getCommitShaOfGitBranchOrTag,
           null,
           PackagePath.fromString('registry-package@1.2.3')
         )
@@ -262,7 +262,7 @@ d9fa903349bbb9e7f86535cb69256e064d0fba65        refs/tags/v0.1.2`
     it('should throw if the package path does not include a branch', async () => {
       assert(
         await doesThrow(
-          coreUtils.getCommitShaOfGitBranchHead,
+          coreUtils.getCommitShaOfGitBranchOrTag,
           null,
           PackagePath.fromString(
             'https://github.com/electrode-io/electrode-native.git'
@@ -279,7 +279,7 @@ d9fa903349bbb9e7f86535cb69256e064d0fba65        refs/tags/v0.1.2`
       })
       assert(
         await doesThrow(
-          coreUtils.getCommitShaOfGitBranchHead,
+          coreUtils.getCommitShaOfGitBranchOrTag,
           null,
           PackagePath.fromString(
             'https://github.com/electrode-io/electrode-native.git#foo'
@@ -294,7 +294,7 @@ d9fa903349bbb9e7f86535cb69256e064d0fba65        refs/tags/v0.1.2`
           return Promise.resolve(sampleRef)
         },
       })
-      const result = await coreUtils.getCommitShaOfGitBranchHead(
+      const result = await coreUtils.getCommitShaOfGitBranchOrTag(
         PackagePath.fromString(
           'https://github.com/electrode-io/electrode-native.git#master'
         )

--- a/ern-local-cli/src/commands/cauldron/update/miniapps.ts
+++ b/ern-local-cli/src/commands/cauldron/update/miniapps.ts
@@ -114,6 +114,7 @@ export const commandHandler = async ({
   for (const miniapp of miniapps) {
     if (miniapp.isGitPath && (await utils.isGitBranch(miniapp))) {
       const headCommitSha = await utils.getCommitShaOfGitBranchHead(miniapp)
+      const headCommitSha = await utils.getCommitShaOfGitBranchOrTag(miniapp)
       if (
         !containerMiniApps.some(
           m => m.basePath === miniapp.basePath && m.version === headCommitSha

--- a/ern-local-cli/src/commands/cauldron/update/miniapps.ts
+++ b/ern-local-cli/src/commands/cauldron/update/miniapps.ts
@@ -104,16 +104,15 @@ export const commandHandler = async ({
 
   const cauldron = await getActiveCauldron()
 
-  // Special handling for git branch based MiniApps
-  // Indeed, if only the branch of a MiniApp has been updated, but the head commit SHA
+  // Special handling for git based MiniApps
+  // Indeed, if only the branch or tag a MiniApp has been updated, but the head commit SHA
   // is still the same, then we shouldn't consider the MiniApp as an updated MiniApp
   // given that it will not contain any changes at all. We should just update the branch
   // in the Cauldron, but not go through complete handling.
   const updatedMiniApps: PackagePath[] = []
   const containerMiniApps = await cauldron.getContainerMiniApps(descriptor)
   for (const miniapp of miniapps) {
-    if (miniapp.isGitPath && (await utils.isGitBranch(miniapp))) {
-      const headCommitSha = await utils.getCommitShaOfGitBranchHead(miniapp)
+    if ((await utils.isGitBranch(miniapp)) || (await utils.isGitTag(miniapp))) {
       const headCommitSha = await utils.getCommitShaOfGitBranchOrTag(miniapp)
       if (
         !containerMiniApps.some(


### PR DESCRIPTION
A recent optimization was made to the `update miniapps` command, if updating git branches of one or more MiniApp(s). 
Indeed, if a git branch change for a MiniApp is not containing new commits compared to previous branch (i.e identical HEAD commit SHA of both previous and new branch), the command is not checking for new or updated native dependencies in the MiniApp (as it's exactly the same one as before running the command).
This optimization was considering git branches but not git tags. However, the same optimization can be made for git tags (i.e if commit SHA pointed by tag is pointing to same commit SHA as current).
This PR therefore extends the optimization to git tags.