### PR TITLE
Watch node_modules when using start command

### DIFF
--- a/ern-orchestrator/src/start.ts
+++ b/ern-orchestrator/src/start.ts
@@ -193,7 +193,7 @@ function startLinkSynchronization(
   const watcher = chokidar.watch(sourceLinkDir, {
     cwd: sourceLinkDir,
     ignoreInitial: true,
-    ignored: ['node_modules/**', 'android/**', 'ios/**'],
+    ignored: ['android/**', 'ios/**'],
     persistent: true,
   })
 

--- a/ern-orchestrator/test/start-test.ts
+++ b/ern-orchestrator/test/start-test.ts
@@ -191,7 +191,7 @@ describe('start', () => {
     sandbox.assert.calledWith(chokidarWatchStub, '/path/to/myMiniApp', {
       cwd: '/path/to/myMiniApp',
       ignoreInitial: true,
-      ignored: ['node_modules/**', 'android/**', 'ios/**'],
+      ignored: ['android/**', 'ios/**'],
       persistent: true,
     })
   })


### PR DESCRIPTION
Remove `node_modules` from the list of ignored watched directories when using `start` command.
This allow users to make modifications to any of the `node_modules` of a linked MiniApp and propagate changes immediately to packager, without having to re-run `ern start` command.