### PR TITLE
Publish raw Containers to git

### DIFF
--- a/ern-cauldron-api/src/CauldronHelper.ts
+++ b/ern-cauldron-api/src/CauldronHelper.ts
@@ -305,6 +305,19 @@ export class CauldronHelper {
     )
   }
 
+  public async getPublishers(descriptor: NativeApplicationDescriptor) {
+    const conf = await this.getContainerGeneratorConfig(descriptor)
+    return conf && conf.publishers
+  }
+
+  public async getPublisher(
+    descriptor: NativeApplicationDescriptor,
+    name: string
+  ) {
+    const publishers = await this.getPublishers(descriptor)
+    return publishers && publishers.find(p => p.name === name)
+  }
+
   public async getNativeAppsForPlatform(
     platformName: string
   ): Promise<string[]> {

--- a/ern-local-cli/src/commands/publish-container.ts
+++ b/ern-local-cli/src/commands/publish-container.ts
@@ -68,7 +68,6 @@ export const commandHandler = async ({
       extraErrorMessage: `Make sure that ${containerPath} is the root of a Container project`,
       p: containerPath!,
     },
-    isValidContainerVersion: { containerVersion: version },
   })
 
   const extraObj = extra && (await parseJsonFromStringOrFile(extra))

--- a/ern-orchestrator/src/runContainerPublishers.ts
+++ b/ern-orchestrator/src/runContainerPublishers.ts
@@ -23,12 +23,8 @@ export async function runContainerPublishers({
 
   const cauldron = await getActiveCauldron()
 
-  const containerGenConfig = await cauldron.getContainerGeneratorConfig(
-    napDescriptor
-  )
+  const publishersFromCauldron = await cauldron.getPublishers(napDescriptor)
 
-  const publishersFromCauldron =
-    containerGenConfig && containerGenConfig.publishers
   if (publishersFromCauldron) {
     for (const publisherFromCauldron of publishersFromCauldron || []) {
       let extra = publisherFromCauldron.extra


### PR DESCRIPTION
This PR updates the `performContainerStateUpdateInCauldron` function workflow, to publish raw Containers to git and work out of raw Containers instead of working out of regular Containers.

A raw Container is just a regular Container before any transformers have been applied to it. It is basically the pure untransformed output of the Container Generator.

Raw containers are published to a specific git branch `raw`. Also they are git tagged with the Container version suffixed by `-raw`. For example if Container version to be published is `1.2.3`, then two tags will be created : `1.2.3` for the regular/post-transform Container, and `1.2.3-raw` for the raw/pre-transform Container.

Storing pre-transformed Containers in addition to post-transformed Containers has two uses :

1. When working on, setting up, or debugging transformers it can be useful to have access to the pre-transformed version of a Container in git, alongside the transformed version, to do git comparisons.
2. `performContainerStateUpdateInCauldron` has an optimization where it only regenerates the JS bundle if no native dependencies changes have been detected. To do this, it clones the current Container version from git and only regenerates the JS bundle on top of it. Because it was cloning the post-transformed Container, it was not running transformers (makes no sense to apply transformers on an already transformed Container, and could lead surely to issues in some cases). However, some transformers actually needs to be run for each Container generation (for example our internal fat-binary transformer). Therefore, this function need to have access to a pre-transformed Container version so that it can run transformers properly.

This latter use case is the main reason why this work has been done. First use case is just a by-product.
