### PR TITLE
Use uuid for yarn lock instead of file shasum

### DIFF
--- a/ern-cauldron-api/src/CauldronApi.ts
+++ b/ern-cauldron-api/src/CauldronApi.ts
@@ -1,6 +1,6 @@
 import * as schemas from './schemas'
 import { NativeApplicationDescriptor, PackagePath } from 'ern-core'
-import { exists, joiValidate, shasum, normalizeCauldronFilePath } from './util'
+import { exists, joiValidate, normalizeCauldronFilePath } from './util'
 import _ from 'lodash'
 import {
   Cauldron,
@@ -1173,7 +1173,7 @@ export default class CauldronApi {
     if (fileName) {
       const pathToOldYarnLock = this.getRelativePathToYarnLock(fileName)
       await this.fileStore.removeFile(pathToOldYarnLock)
-      const newYarnLockFileName = shasum(yarnlock)
+      const newYarnLockFileName = uuidv4()
       const pathToNewYarnLock = this.getRelativePathToYarnLock(
         newYarnLockFileName
       )

--- a/ern-cauldron-api/src/util.ts
+++ b/ern-cauldron-api/src/util.ts
@@ -1,5 +1,4 @@
 import _ from 'lodash'
-import crypto from 'crypto'
 import Joi from 'joi'
 import semver from 'semver'
 import { schemaVersion, cauldronApiVersionBySchemaVersion } from './schemas'
@@ -7,11 +6,6 @@ import { schemaVersion, cauldronApiVersionBySchemaVersion } from './schemas'
 // ====================================
 // Cauldron Helper
 // ====================================
-export const shasum = (payload: string | Buffer) =>
-  crypto
-    .createHash('sha1')
-    .update(payload)
-    .digest('hex')
 
 export function exists(collection: any, name: string, version?: string) {
   if (!version) {


### PR DESCRIPTION
Use uuid instead of file shasum as yarn lock filename (missing from #997).
