### PR TITLE
Fix a bug in MiniApps delta computation for git miniapps

### DIFF
--- a/ern-container-gen/src/yarnLockUtils.ts
+++ b/ern-container-gen/src/yarnLockUtils.ts
@@ -1,4 +1,5 @@
 import { PackagePath } from 'ern-core'
+import _ from 'lodash'
 
 /**
  * Builds a regular expression matching a top level registry
@@ -16,7 +17,7 @@ import { PackagePath } from 'ern-core'
 export function getYarnLockTopLevelRegistryDependencyRe(
   dep: PackagePath
 ): RegExp {
-  return new RegExp(`\n(${dep.basePath})@(.+):`)
+  return new RegExp(`\n(${_.escapeRegExp(dep.basePath)})@(.+):`)
 }
 
 /**
@@ -33,7 +34,7 @@ export function getYarnLockTopLevelRegistryDependencyRe(
  * @param dep The dependency to build a Regular Expression for
  */
 export function getYarnLockTopLevelGitDependencyRe(dep: PackagePath): RegExp {
-  return new RegExp(`\n"(.+)@${dep.basePath}#(.+)":`)
+  return new RegExp(`\n"(.+)@${_.escapeRegExp(dep.basePath)}#(.+)":`)
 }
 
 export function getYarnLockTopLevelDependencyRe(dep: PackagePath): RegExp {


### PR DESCRIPTION
Fix a bug that was impacting MiniApps deltas computation for git based MiniApps, leading to MiniApps versions being misclassified as `new` instead of `same` or `upgraded`.

Issue was due to the direct use of the base path of the MiniApp (for example 
`git+ssh://git@github.com/foo/bar.git`) in the regular expression that was used to check for matches in the `yarn.lock` file.

However, this kind of string contains some characters that are reserved for regex (for example `+`, `.`) and therefore needed to be escaped properly.

This PR fixes this issue by making use of [the `escapeRegExp` utility function offered by lodash](
https://lodash.com/docs/4.17.11#escapeRegExp).