### PR TITLE
Maintain sort order of Cauldron entries

### DIFF
--- a/ern-cauldron-api/src/CauldronApi.ts
+++ b/ern-cauldron-api/src/CauldronApi.ts
@@ -16,6 +16,7 @@ import {
 import upgradeScripts from './upgrade-scripts/scripts'
 import path from 'path'
 import uuidv4 from 'uuid/v4'
+import semver from 'semver'
 
 const yarnLocksStoreDirectory = 'yarnlocks'
 const bundlesStoreDirectory = 'bundles'
@@ -439,6 +440,7 @@ export default class CauldronApi {
       schemas.nativeApplication
     )
     cauldron.nativeApps.push(validatedNativeApplication)
+    cauldron.nativeApps.sort((a, b) => a.name.localeCompare(b.name))
     return this.commit(`Create ${nativeApplication.name} native application`)
   }
 
@@ -469,6 +471,7 @@ export default class CauldronApi {
       schemas.nativeApplicationPlatform
     )
     nativeApplication.platforms.push(validatedPlatform)
+    nativeApplication.platforms.sort((a, b) => a.name.localeCompare(b.name))
     return this.commit(
       `Create ${platformName} platform for ${descriptor.toString()}`
     )
@@ -509,6 +512,7 @@ export default class CauldronApi {
       schemas.nativeApplicationVersion
     )
     platform.versions.push(validatedVersion)
+    platform.versions.sort((a, b) => semver.compare(a.name, b.name))
     return this.commit(
       `Create version ${versionName} for ${descriptor.toString()}`
     )


### PR DESCRIPTION
Keep native application names/platforms/versions in sorted ascending order in Cauldron.