### PR TITLE
Add publishUnmodifiedContainer option to update miniapps command

### DIFF
--- a/docs/cli/cauldron/update/miniapps.md
+++ b/docs/cli/cauldron/update/miniapps.md
@@ -36,6 +36,12 @@ Example: If the current container version is 1.2.3 and a version is not included
 * You can only pass a complete native application descriptor as the MiniApps updated using this command targets only a specific single native application version.  
 **Default**  Lists all non-released native application versions from the Cauldron and prompts you to choose a descriptor.   
 
+`--publishUnmodifiedContainer`
+
+* Publish the Container even if it's identical to the current one. This can be used to perform some sort of Container promotion.  
+For example, if you are generating development Containers using `1000.0.X` versioning convention and want to promote a development Container to a release Container using a different version (`18.0.0` for example), you can use this flag to perform this.
+**Default** False. If Container is identical to the current one, if won't be published again.
+
 `--force/-f`
 
 * Bypass compatibility checks and force-update the MiniApp in the Cauldron.  

--- a/ern-local-cli/src/commands/cauldron/update/miniapps.ts
+++ b/ern-local-cli/src/commands/cauldron/update/miniapps.ts
@@ -44,6 +44,10 @@ export const builder = (argv: Argv) => {
       describe: 'Force',
       type: 'boolean',
     })
+    .option('publishUnmodifiedContainer', {
+      describe: 'Publish Container even if it is identical to the previous one',
+      type: 'boolean',
+    })
     .coerce('miniapps', d => d.map(PackagePath.fromString))
     .epilog(epilog(exports))
 }
@@ -55,11 +59,13 @@ export const commandHandler = async ({
   descriptor,
   force,
   miniapps,
+  publishUnmodifiedContainer,
 }: {
   containerVersion?: string
   descriptor?: NativeApplicationDescriptor
   force?: boolean
   miniapps: PackagePath[]
+  publishUnmodifiedContainer?: boolean
 }) => {
   descriptor =
     descriptor ||
@@ -173,7 +179,10 @@ export const commandHandler = async ({
     },
     descriptor,
     cauldronCommitMessage,
-    { containerVersion }
+    {
+      containerVersion,
+      publishUnmodifiedContainer,
+    }
   )
   log.info(`MiniApp(s) version(s) successfully updated in ${descriptor}`)
 }


### PR DESCRIPTION
Needed for internal CI workflow.

At code freeze, we use `update miniapps` command to update all of the MiniApps branches from `development` to `release/[platform]/[version]` but because the Container will have no changes (it's just a branch cut off) it won't be regenerated nor published by default.
We however want to be able to publish it, because at this point we need to publish the first release version of the Container (promotion).