### PR TITLE
Throw instead of returning false if package does not exist

### DIFF
--- a/ern-core/src/utils.ts
+++ b/ern-core/src/utils.ts
@@ -152,21 +152,16 @@ export async function isDependencyApi(
   if (/^.*react-native-.+-api$/.test(dependencyName)) {
     return true
   }
-  let result
-  try {
-    const depInfo = await yarn.info(PackagePath.fromString(dependencyName), {
-      field: 'ern 2> /dev/null',
-      json: true,
-    })
-    result =
-      depInfo && depInfo.type === 'error'
-        ? false
-        : depInfo.data && ModuleType.API === depInfo.data.moduleType
-  } catch (e) {
-    log.debug(e)
-    return false
+
+  const depInfo = await yarn.info(PackagePath.fromString(dependencyName), {
+    field: 'ern 2> /dev/null',
+    json: true,
+  })
+  if (depInfo && depInfo.type === 'error') {
+    throw new Error(`Cannot find ${dependencyName} in npm registry`)
   }
-  return result
+
+  return depInfo.data && ModuleType.API === depInfo.data.moduleType
 }
 
 /**
@@ -196,22 +191,16 @@ export async function isDependencyApiImpl(
   const modulesTypes = type
     ? [type]
     : [ModuleType.NATIVE_API_IMPL, ModuleType.JS_API_IMPL]
-  let result
-  try {
-    const depInfo = await yarn.info(PackagePath.fromString(dependencyName), {
-      field: 'ern 2> /dev/null',
-      json: true,
-    })
-    result =
-      depInfo && depInfo.type === 'error'
-        ? false
-        : depInfo.data && modulesTypes.indexOf(depInfo.data.moduleType) > -1
-  } catch (e) {
-    log.debug(e)
-    return false
+
+  const depInfo = await yarn.info(PackagePath.fromString(dependencyName), {
+    field: 'ern 2> /dev/null',
+    json: true,
+  })
+  if (depInfo && depInfo.type === 'error') {
+    throw new Error(`Cannot find ${dependencyName} in npm registry`)
   }
 
-  return result
+  return depInfo.data && modulesTypes.indexOf(depInfo.data.moduleType) > -1
 }
 
 export async function isDependencyJsApiImpl(

--- a/ern-core/test/coreutils-test.ts
+++ b/ern-core/test/coreutils-test.ts
@@ -2,8 +2,13 @@ import { assert, expect } from 'chai'
 import { yarn } from '../src/clients'
 import sinon from 'sinon'
 import * as utils from '../src/utils'
+import {
+  isDependencyApiImpl,
+  isDependencyApi,
+  isDependencyApiOrApiImpl,
+} from '../src/utils'
 import { PackagePath } from '../src/PackagePath'
-import { beforeTest, afterTest } from 'ern-util-dev'
+import { beforeTest, afterTest, doesThrow } from 'ern-util-dev'
 import * as fixtures from './fixtures/common'
 import * as ModuleTypes from '../src/ModuleTypes'
 import path from 'path'
@@ -501,10 +506,10 @@ describe('utils.js', () => {
       yarnStub.restore()
     })
 
-    it('return false if yarn info error', async () => {
+    it('throw if yarn info errors', async () => {
       const yarnStub = sinon.stub(yarn, 'info')
       yarnStub.resolves(yarnInfoError)
-      expect(await utils.isDependencyApiImpl('react-header')).to.eql(false)
+      assert(await doesThrow(isDependencyApiImpl, null, 'react-header'))
       yarnStub.restore()
     })
   })
@@ -526,10 +531,10 @@ describe('utils.js', () => {
       yarnStub.restore()
     })
 
-    it('return false if yarn info error', async () => {
+    it('throw if yarn info errors', async () => {
       const yarnStub = sinon.stub(yarn, 'info')
       yarnStub.resolves(yarnInfoError)
-      expect(await utils.isDependencyApi('react-header')).to.eql(false)
+      assert(await doesThrow(isDependencyApi, null, 'react-header'))
       yarnStub.restore()
     })
   })
@@ -551,10 +556,10 @@ describe('utils.js', () => {
       yarnStub.restore()
     })
 
-    it('return false if yarn info error', async () => {
+    it('throw if yarn info errors', async () => {
       const yarnStub = sinon.stub(yarn, 'info')
       yarnStub.resolves(yarnInfoError)
-      expect(await utils.isDependencyApiOrApiImpl('react-header')).to.eql(false)
+      assert(await doesThrow(isDependencyApiOrApiImpl, null, 'react-header'))
       yarnStub.restore()
     })
 
@@ -581,10 +586,10 @@ describe('utils.js', () => {
       yarnStub.restore()
     })
 
-    it('return false if yarn info error', async () => {
+    it('throw if yarn info errors', async () => {
       const yarnStub = sinon.stub(yarn, 'info')
       yarnStub.resolves(yarnInfoError)
-      expect(await utils.isDependencyApiOrApiImpl('react-header')).to.eql(false)
+      assert(await doesThrow(isDependencyApiOrApiImpl, null, 'react-header'))
       yarnStub.restore()
     })
   })


### PR DESCRIPTION
Update `isDependencyApi` and `isDependencyApiImpl` functions to throw a clear error instead of returning false in case the target api or api-impl is not found in the npm registry.

Returning false was leading to the following misleading error to be thrown and logged  :

`Error: Unsupported plugin. No configuration found in manifest for foo-api`

Now the error will instead  be`Cannot find foo-api in npm registry` which is exactly what the problem is.

