### PR TITLE
Add support for React Native 0.58.0

### DIFF
--- a/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactActivityDelegate.java
+++ b/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactActivityDelegate.java
@@ -304,6 +304,7 @@ public class ElectrodeReactActivityDelegate extends ReactActivityDelegate {
         }
     }
 
+    {{#RN_VERSION_LT_58}} 
     /**
      * NOTE: Duplicate code since the base class has marked this method private.
      *
@@ -321,6 +322,7 @@ public class ElectrodeReactActivityDelegate extends ReactActivityDelegate {
     private Activity getPlainActivity() {
         return ((Activity) getContext());
     }
+    {{/RN_VERSION_LT_58}}
 
      private void unMountReactApplications() {
         List<ReactRootView> list;

--- a/ern-container-gen/src/injectReactNativeVersionKeysInObject.ts
+++ b/ern-container-gen/src/injectReactNativeVersionKeysInObject.ts
@@ -8,6 +8,7 @@ export function injectReactNativeVersionKeysInObject(
     RN_VERSION_GTE_45: semver.gte(reactNativeVersion, '0.45.0'),
     RN_VERSION_GTE_54: semver.gte(reactNativeVersion, '0.54.0'),
     RN_VERSION_LT_54: semver.lt(reactNativeVersion, '0.54.0'),
+    RN_VERSION_LT_58: semver.lt(reactNativeVersion, '0.58.0-rc.2'),
     reactNativeVersion,
   })
 }


### PR DESCRIPTION
[ReactActivityDelegate](https://github.com/facebook/react-native/blob/v0.58.0-rc.2/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java) was updated in RN 0.58. 

Accessibility of `getContext` and `getPlainActivity` methods were changed from `private` to `protected`. 
