### PR TITLE
Fix add native app copy over version prompt

### DIFF
--- a/ern-cauldron-api/src/CauldronHelper.ts
+++ b/ern-cauldron-api/src/CauldronHelper.ts
@@ -186,7 +186,10 @@ export class CauldronHelper {
     }
 
     const nativeApp = await this.getDescriptor(partialDescriptor)
-    return _.last(nativeApp.versions) as CauldronNativeAppVersion
+    const sortedNativeAppVersions = nativeApp.versions.sort((a, b) =>
+      semver.rcompare(semver.coerce(b.name)!, semver.coerce(a.name)!)
+    )
+    return _.last(sortedNativeAppVersions) as CauldronNativeAppVersion
   }
 
   public async addNativeDependencyToContainer(

--- a/ern-local-cli/src/commands/cauldron/add/nativeapp.ts
+++ b/ern-local-cli/src/commands/cauldron/add/nativeapp.ts
@@ -59,13 +59,13 @@ export const commandHandler = async ({
   ) {
     const mostRecentVersion = await cauldron.getMostRecentNativeApplicationVersion(
       descriptor
-    ).name
+    )
     if (
       await askUserConfirmation(
-        `Do you want to copy data from version (${mostRecentVersion}) ?`
+        `Do you want to copy data from version (${mostRecentVersion.name}) ?`
       )
     ) {
-      copyFromVersion = mostRecentVersion
+      copyFromVersion = mostRecentVersion.name
     }
   }
 


### PR DESCRIPTION
Fix a bug in `cauldron add nativeapp` command that was leading to `undefined` version to be prompted to the user for copy-over.

```
Do you want to copy data from version (undefined) ?
```

Issue was this invalid `await` call, that was await on `.name` instead of the asynchronous function, thus completing immediately with `undefined`

```js
await cauldron.getMostRecentNativeApplicationVersion(descriptor).name
```

In addition to this fix, this PR also ensure that the version that is listed for copy over is the latest one (by properly sorting versions non alphabetically but rather using semver comparator).
