### PR TITLE
Fix MiniApp fromPackagePath function

### DIFF
--- a/ern-core/src/MiniApp.ts
+++ b/ern-core/src/MiniApp.ts
@@ -74,6 +74,7 @@ export class MiniApp {
         fsPackagePath = createTmpDir()
         shell.pushd(fsPackagePath)
         try {
+          await yarn.init()
           await yarn.add(packagePath)
           const packageJson = await readPackageJson('.')
           const packageName = Object.keys(packageJson.dependencies)[0]


### PR DESCRIPTION
To avoid issues if a `package.json` already exist up the directory chain, we need to run `yarn init` before running `yarn add`.