### PR TITLE
pass android config in runner and local container commands

### DIFF
--- a/docs/cli/create-container.md
+++ b/docs/cli/create-container.md
@@ -50,6 +50,19 @@ You cannot use the Git or file package descriptors for referring to the dependen
 * This flag wil have no effect for a Container generated from a Cauldron as the Container configuration stored in the Cauldron will take precedence.
 * **Default** Do not ignore rnpm assets and package them inside the generated Container.
 
+`--extra/-e`
+* Optional extra configuration specific to creating container
+* Override the android build config during container generation by passing `androidConfig` attributes
+  - **As a json string**  
+  For example `--extra '{"androidConfig": {"androidGradlePlugin": "3.2.1","buildToolsVersion": "28.0.3","compileSdkVersion": "28","gradleDistributionVersion": "4.6","minSdkVersion": "19","supportLibraryVersion": "28.0.0","targetSdkVersion": "28"}}'`    
+  - **As a file path**  
+  For example `--extra /Users/username/my-container-config.json`  
+  In that case, the configuration will be read from the file.  
+  - **As a Cauldron file path**  
+  For example `--extra cauldron://config/container/my-container-config.json`  
+  In that case, the configuration will be read from the file stored in Cauldron.   
+  For this way to work, the file must exist in Cauldron (you can add a file to the cauldron by using the [ern cauldron add file] command).
+
 #### Remarks
 
 * The `ern create-container` command can be used to create a container locally, for development, debugging and experimentation purposes.  

--- a/docs/cli/run-android.md
+++ b/docs/cli/run-android.md
@@ -35,6 +35,19 @@
 `--port`
 * Port on which the local packager should listen on *(default: 8081)*
 
+`--extra/-e`
+* Optional extra configuration specific to local container and runner
+* Override the android build config during local container generation and runner project by passing `androidConfig` attributes
+  - **As a json string**  
+  For example `--extra '{"androidConfig": {"androidGradlePlugin": "3.2.1","buildToolsVersion": "28.0.3","compileSdkVersion": "28","gradleDistributionVersion": "4.6","minSdkVersion": "19","supportLibraryVersion": "28.0.0","targetSdkVersion": "28"}}'`    
+  - **As a file path**  
+  For example `--extra /Users/username/my-container-config.json`  
+  In that case, the configuration will be read from the file.  
+  - **As a Cauldron file path**  
+  For example `--extra cauldron://config/container/my-container-config.json`  
+  In that case, the configuration will be read from the file stored in Cauldron.   
+  For this way to work, the file must exist in Cauldron (you can add a file to the cauldron by using the [ern cauldron add file] command).
+
 #### Remarks
 
 * You can launch the MiniApp located in the current working directory or on a connected Android device or running emulator if available. If a connected Android device is not available, the command prompts you to select an emulator to launch from the list of installed emulator images.  

--- a/ern-local-cli/src/commands/run-android.ts
+++ b/ern-local-cli/src/commands/run-android.ts
@@ -6,12 +6,19 @@ import {
 } from 'ern-core'
 import { runMiniApp } from 'ern-orchestrator'
 import { Argv } from 'yargs'
+import { parseJsonFromStringOrFile } from 'ern-orchestrator'
 
 export const command = 'run-android'
 export const desc = 'Run one or more MiniApps in the Android Runner application'
 
 export const builder = (argv: Argv) => {
   return argv
+    .option('extra', {
+      alias: 'e',
+      describe:
+        'Optional extra run configuration (json string or local/cauldron path to config file)',
+      type: 'string',
+    })
     .option('dependencies', {
       alias: 'deps',
       describe:
@@ -62,6 +69,7 @@ export const builder = (argv: Argv) => {
 }
 
 export const commandHandler = async ({
+  extra,
   dependencies = [],
   descriptor,
   dev,
@@ -71,6 +79,7 @@ export const commandHandler = async ({
   port,
   usePreviousDevice,
 }: {
+  extra?: string
   dependencies: PackagePath[]
   descriptor?: NativeApplicationDescriptor
   dev?: boolean
@@ -82,10 +91,13 @@ export const commandHandler = async ({
 }) => {
   deviceConfig.updateDeviceConfig('android', usePreviousDevice)
 
+  const extraObj = (extra && (await parseJsonFromStringOrFile(extra))) || {}
+
   await runMiniApp('android', {
     dependencies,
     descriptor,
     dev,
+    extra: extraObj,
     host,
     mainMiniAppName,
     miniapps,

--- a/ern-orchestrator/src/container.ts
+++ b/ern-orchestrator/src/container.ts
@@ -36,10 +36,12 @@ export async function runLocalContainerGen(
     outDir = Platform.getContainerGenOutDirectory(platform),
     extraNativeDependencies = [],
     ignoreRnpmAssets = false,
+    extra,
   }: {
     outDir?: string
     extraNativeDependencies: PackagePath[]
     ignoreRnpmAssets?: boolean
+    extra?: any
   }
 ) {
   try {
@@ -108,6 +110,7 @@ export async function runLocalContainerGen(
 
     await kax.task('Generating Container').run(
       generator.generate({
+        androidConfig: (extra && extra.androidConfig) || {},
         compositeMiniAppDir: createTmpDir(),
         ignoreRnpmAssets,
         jsApiImpls: jsApiImplsPackagePaths,

--- a/ern-orchestrator/src/generateContainerForRunner.ts
+++ b/ern-orchestrator/src/generateContainerForRunner.ts
@@ -30,7 +30,7 @@ export async function generateContainerForRunner(
     })
   } else {
     await runLocalContainerGen(miniApps, jsApiImpls, platform, {
-      extra,
+      extra: extra || {},
       extraNativeDependencies: dependencies,
       outDir,
     })

--- a/ern-orchestrator/src/generateContainerForRunner.ts
+++ b/ern-orchestrator/src/generateContainerForRunner.ts
@@ -14,12 +14,14 @@ export async function generateContainerForRunner(
     miniApps = [],
     jsApiImpls = [],
     outDir,
+    extra,
   }: {
     napDescriptor?: NativeApplicationDescriptor
     dependencies?: PackagePath[]
     miniApps?: PackagePath[]
     jsApiImpls?: PackagePath[]
     outDir: string
+    extra?: any
   }
 ) {
   if (napDescriptor) {
@@ -28,6 +30,7 @@ export async function generateContainerForRunner(
     })
   } else {
     await runLocalContainerGen(miniApps, jsApiImpls, platform, {
+      extra,
       extraNativeDependencies: dependencies,
       outDir,
     })

--- a/ern-orchestrator/src/runMiniApp.ts
+++ b/ern-orchestrator/src/runMiniApp.ts
@@ -32,6 +32,7 @@ export async function runMiniApp(
     dev,
     host,
     port,
+    extra,
   }: {
     mainMiniAppName?: string
     miniapps?: PackagePath[]
@@ -41,6 +42,7 @@ export async function runMiniApp(
     dev?: boolean
     host?: string
     port?: string
+    extra?: any
   } = {}
 ) {
   const cwd = process.cwd()
@@ -142,6 +144,7 @@ export async function runMiniApp(
   const outDir = Platform.getContainerGenOutDirectory(platform)
   await generateContainerForRunner(platform, {
     dependencies,
+    extra, // JavaScript object to pass extras e.x. androidConfig
     jsApiImpls,
     miniApps: miniapps,
     napDescriptor: napDescriptor || undefined,
@@ -166,6 +169,7 @@ export async function runMiniApp(
 
   const runnerGeneratorConfig: RunnerGeneratorConfig = {
     extra: {
+      androidConfig: (extra && extra.androidConfig) || {},
       containerGenWorkingDir: Platform.containerGenDirectory,
     },
     mainMiniAppName: entryMiniAppName,

--- a/ern-orchestrator/test/generateContainerForRunner-test.ts
+++ b/ern-orchestrator/test/generateContainerForRunner-test.ts
@@ -47,6 +47,33 @@ describe('generateContainerForRunner', () => {
       jsApiImpls,
       'android',
       {
+        extra: {},
+        extraNativeDependencies: dependencies,
+        outDir,
+      }
+    )
+  })
+
+  it('should call runLocalContainerGen with extra arguments if no descriptor is provided', async () => {
+    const outDir = '/Users/foo/test'
+    const miniApps = [PackagePath.fromString('a@1.0.0')]
+    const jsApiImpls = [PackagePath.fromString('b@1.0.0')]
+    const dependencies = [PackagePath.fromString('c@1.0.0')]
+    const extra = { androidConfig: { compileSdkVersion: '28' } }
+    await generateContainerForRunner('android', {
+      dependencies,
+      extra,
+      jsApiImpls,
+      miniApps,
+      outDir,
+    })
+    sinon.assert.calledWith(
+      containerStub.runLocalContainerGen,
+      miniApps,
+      jsApiImpls,
+      'android',
+      {
+        extra,
         extraNativeDependencies: dependencies,
         outDir,
       }

--- a/ern-orchestrator/test/runMiniApp-test.ts
+++ b/ern-orchestrator/test/runMiniApp-test.ts
@@ -168,6 +168,7 @@ describe('runMiniApp', () => {
     await runMiniApp('android')
     sandbox.assert.calledWith(generateContainerForRunnerStub, 'android', {
       dependencies: undefined,
+      extra: undefined,
       jsApiImpls: undefined,
       miniApps: sinon.match.array,
       napDescriptor: undefined,
@@ -195,7 +196,10 @@ describe('runMiniApp', () => {
     prepareStubs({ existsSyncReturn: false })
     await runMiniApp('android')
     sandbox.assert.calledWith(androidRunnerGenStub.generate, {
-      extra: { containerGenWorkingDir: Platform.containerGenDirectory },
+      extra: {
+        androidConfig: {},
+        containerGenWorkingDir: Platform.containerGenDirectory,
+      },
       mainMiniAppName: 'myMiniApp',
       outDir: sinon.match.string,
       reactNativeDevSupportEnabled: undefined,
@@ -209,7 +213,29 @@ describe('runMiniApp', () => {
     prepareStubs({ existsSyncReturn: true })
     await runMiniApp('android')
     sandbox.assert.calledWith(androidRunnerGenStub.regenerateRunnerConfig, {
-      extra: { containerGenWorkingDir: Platform.containerGenDirectory },
+      extra: {
+        androidConfig: {},
+        containerGenWorkingDir: Platform.containerGenDirectory,
+      },
+      mainMiniAppName: 'myMiniApp',
+      outDir: sinon.match.string,
+      reactNativeDevSupportEnabled: undefined,
+      reactNativePackagerHost: undefined,
+      reactNativePackagerPort: undefined,
+      targetPlatform: 'android',
+    })
+  })
+
+  it('should only regenerate the runner config if runner project already exists [local single miniapp] with android build config', async () => {
+    prepareStubs({ existsSyncReturn: true })
+    await runMiniApp('android', {
+      extra: { androidConfig: { compileSdkVersion: '28' } },
+    })
+    sandbox.assert.calledWith(androidRunnerGenStub.regenerateRunnerConfig, {
+      extra: {
+        androidConfig: { compileSdkVersion: '28' },
+        containerGenWorkingDir: Platform.containerGenDirectory,
+      },
       mainMiniAppName: 'myMiniApp',
       outDir: sinon.match.string,
       reactNativeDevSupportEnabled: undefined,
@@ -232,7 +258,10 @@ describe('runMiniApp', () => {
     })
 
     sandbox.assert.calledWith(androidRunnerGenStub.regenerateRunnerConfig, {
-      extra: { containerGenWorkingDir: Platform.containerGenDirectory },
+      extra: {
+        androidConfig: {},
+        containerGenWorkingDir: Platform.containerGenDirectory,
+      },
       mainMiniAppName: 'myMiniAppA',
       outDir: sinon.match.string,
       reactNativeDevSupportEnabled: false,
@@ -253,7 +282,10 @@ describe('runMiniApp', () => {
     })
 
     sandbox.assert.calledWith(androidRunnerGenStub.regenerateRunnerConfig, {
-      extra: { containerGenWorkingDir: Platform.containerGenDirectory },
+      extra: {
+        androidConfig: {},
+        containerGenWorkingDir: Platform.containerGenDirectory,
+      },
       mainMiniAppName: 'myMiniApp',
       outDir: sinon.match.string,
       reactNativeDevSupportEnabled: undefined,

--- a/ern-runner-gen-android/src/AndroidRunnerGenerator.ts
+++ b/ern-runner-gen-android/src/AndroidRunnerGenerator.ts
@@ -14,23 +14,9 @@ export default class AndroidRunnerGenerator implements RunnerGenerator {
   }
 
   public async generate(config: RunnerGeneratorConfig): Promise<void> {
-    const mustacheView = {
-      androidGradlePlugin: android.DEFAULT_ANDROID_GRADLE_PLUGIN_VERSION,
-      buildToolsVersion: android.DEFAULT_BUILD_TOOLS_VERSION,
-      compileSdkVersion: android.DEFAULT_COMPILE_SDK_VERSION,
-      gradleDistributionVersion: android.DEFAULT_GRADLE_DISTRIBUTION_VERSION,
-      isReactNativeDevSupportEnabled:
-        config.reactNativeDevSupportEnabled === true ? 'true' : 'false',
-      minSdkVersion: android.DEFAULT_MIN_SDK_VERSION,
-      miniAppName: config.mainMiniAppName,
-      packagerHost:
-        config.reactNativePackagerHost || defaultReactNativePackagerHost,
-      packagerPort:
-        config.reactNativePackagerPort || defaultReactNativePackagerPort,
-      pascalCaseMiniAppName: pascalCase(config.mainMiniAppName),
-      supportLibraryVersion: android.DEFAULT_SUPPORT_LIBRARY,
-      targetSdkVersion: android.DEFAULT_TARGET_SDK_VERSION,
-    }
+    const mustacheView: any = {}
+    configureMustacheView(config, mustacheView)
+
     shell.cp('-R', path.join(runnerHullPath, '*'), config.outDir)
     const files = readDir(
       runnerHullPath,
@@ -48,16 +34,9 @@ export default class AndroidRunnerGenerator implements RunnerGenerator {
   public async regenerateRunnerConfig(
     config: RunnerGeneratorConfig
   ): Promise<void> {
-    const mustacheView = {
-      isReactNativeDevSupportEnabled:
-        config.reactNativeDevSupportEnabled === true ? 'true' : 'false',
-      miniAppName: config.mainMiniAppName,
-      packagerHost:
-        config.reactNativePackagerHost || defaultReactNativePackagerHost,
-      packagerPort:
-        config.reactNativePackagerPort || defaultReactNativePackagerPort,
-      pascalCaseMiniAppName: pascalCase(config.mainMiniAppName),
-    }
+    const mustacheView: any = {}
+    configureMustacheView(config, mustacheView)
+
     const subPathToRunnerConfig = path.join(
       'app',
       'src',
@@ -85,4 +64,41 @@ export default class AndroidRunnerGenerator implements RunnerGenerator {
 // Given a string returns the same string with its first letter capitalized
 function pascalCase(str: string) {
   return `${str.charAt(0).toUpperCase()}${str.slice(1)}`
+}
+
+function configureMustacheView(
+  config: RunnerGeneratorConfig,
+  mustacheView: any
+) {
+  const androidBuildOptions =
+    (config && config.extra && config.extra.androidConfig) || {}
+  mustacheView.androidGradlePlugin =
+    (androidBuildOptions && androidBuildOptions.androidGradlePlugin) ||
+    android.DEFAULT_ANDROID_GRADLE_PLUGIN_VERSION
+  mustacheView.buildToolsVersion =
+    (androidBuildOptions && androidBuildOptions.buildToolsVersion) ||
+    android.DEFAULT_BUILD_TOOLS_VERSION
+  mustacheView.compileSdkVersion =
+    (androidBuildOptions && androidBuildOptions.compileSdkVersion) ||
+    android.DEFAULT_COMPILE_SDK_VERSION
+  mustacheView.gradleDistributionVersion =
+    (androidBuildOptions && androidBuildOptions.gradleDistributionVersion) ||
+    android.DEFAULT_GRADLE_DISTRIBUTION_VERSION
+  mustacheView.minSdkVersion =
+    (androidBuildOptions && androidBuildOptions.minSdkVersion) ||
+    android.DEFAULT_MIN_SDK_VERSION
+  mustacheView.supportLibraryVersion =
+    (androidBuildOptions && androidBuildOptions.supportLibraryVersion) ||
+    android.DEFAULT_SUPPORT_LIBRARY
+  mustacheView.targetSdkVersion =
+    (androidBuildOptions && androidBuildOptions.targetSdkVersion) ||
+    android.DEFAULT_TARGET_SDK_VERSION
+  mustacheView.isReactNativeDevSupportEnabled =
+    config.reactNativeDevSupportEnabled === true ? 'true' : 'false'
+  mustacheView.miniAppName = config.mainMiniAppName
+  mustacheView.packagerHost =
+    config.reactNativePackagerHost || defaultReactNativePackagerHost
+  mustacheView.packagerPort =
+    config.reactNativePackagerPort || defaultReactNativePackagerPort
+  mustacheView.pascalCaseMiniAppName = pascalCase(config.mainMiniAppName)
 }


### PR DESCRIPTION
Usage 
`ern create-container -e '{"androidConfig": {"androidGradlePlugin": "3.0.0","buildToolsVersion": "27.0.3","compileSdkVersion": "27","gradleDistributionVersion": "4.1","minSdkVersion": "21","supportLibraryVersion": "27.1.1","targetSdkVersion": "27"}}'`

`ern run-android -e '{"androidConfig": {"androidGradlePlugin": "3.0.0","buildToolsVersion": "27.0.3","compileSdkVersion": "27","gradleDistributionVersion": "4.1","minSdkVersion": "21","supportLibraryVersion": "27.1.1","targetSdkVersion": "27"}}'`

