### PR TITLE
Add support for JSX source files

### DIFF
--- a/ern-container-gen/src/generateMiniAppsComposite.ts
+++ b/ern-container-gen/src/generateMiniAppsComposite.ts
@@ -236,6 +236,17 @@ export async function generateMiniAppsComposite(
 
     await writeFile('.babelrc', JSON.stringify(compositeBabelRc, null, 2))
 
+    // Add support for JSX source files
+    let sourceExts
+    if (semver.gte(compositeReactNativeVersion, '0.57.0')) {
+      sourceExts =
+        "module.exports = { resolver: { sourceExts: ['jsx', 'mjs', 'js'] } };"
+    } else {
+      sourceExts =
+        "module.exports = { getSourceExts: () => [ 'jsx', 'mjs', 'js' ] }"
+    }
+    await writeFile('rn-cli.config.js', sourceExts)
+
     // If code push plugin is present we need to do some additional work
     if (fs.existsSync(pathToCodePushNodeModuleDir)) {
       //


### PR DESCRIPTION
We need support for JSX source files for an internal team.

This is not the final solution, just a temporary workaround while waiting on a more proper design to allow custom `rn-cli.config.js` files to be used for the composite JS project.