### PR TITLE
Fix manifest plugin config lookup

### DIFF
--- a/ern-core/src/GitManifest.ts
+++ b/ern-core/src/GitManifest.ts
@@ -186,6 +186,7 @@ export default class GitManifest {
     await this.syncIfNeeded()
     const versionRe = /_v(.+)\+/
     const scopeNameRe = /^(@.+)\/(.+)$/
+    const packageNameRe = /(.+)_v\d+\.\d+\.\d+\+/
 
     // Top level plugin configuration directories ordered by descending
     // Electrode Native version
@@ -219,7 +220,10 @@ export default class GitManifest {
 
       const pluginConfigDirectories = fs
         .readdirSync(basePluginPath)
-        .filter(f => f.startsWith(pluginName))
+        .filter(f => {
+          const p = packageNameRe.exec(f)
+          return p ? p![1] === pluginName : false
+        })
 
       const pluginVersions = _.map(
         pluginConfigDirectories,


### PR DESCRIPTION
Fix a bug that was causing plugin config lookup failure in case a plugin name was starting with same prefix (for example `appcenter` / `appcenter-crashes`)

```
Error: Unsupported plugin. No configuration found in manifest for [plugin]
```