### PR TITLE
Ensure that apk in zip file is properly named after extraction

### DIFF
--- a/ern-core/src/ErnBinaryStore.ts
+++ b/ern-core/src/ErnBinaryStore.ts
@@ -121,9 +121,14 @@ export class ErnBinaryStore implements BinaryStore {
       )
       const unzipper = new DecompressZip(zippedBinaryPath)
       unzipper.on('error', err => reject(err))
-      unzipper.on('extract', () => resolve(pathToOutputBinary))
+      unzipper.on('extract', () => {
+        if (descriptor.platform === 'android') {
+          shell.mv(path.join(outputDirectory, '*.apk'), pathToOutputBinary)
+        }
+        resolve(pathToOutputBinary)
+      })
       if (descriptor.platform === 'android') {
-        unzipper.extract({ path: path.dirname(pathToOutputBinary) })
+        unzipper.extract({ path: outputDirectory })
       } else {
         unzipper.extract({ path: pathToOutputBinary })
       }


### PR DESCRIPTION
Binary Store improvement

If APK that is inside the zip file is not conventionally named, installation on emulator/device will fail.
This PR just make sure that the APK is conventionally named, by renaming it to follow convention after extraction.