### PR TITLE
Add disableBinaryStore option to ern start

### DIFF
--- a/docs/cli/start.md
+++ b/docs/cli/start.md
@@ -35,6 +35,11 @@ If you do not pass an argument to this command, you are prompted to select a nat
 `--extraJsDependencies/-e <jsdependencies>`
 * Additional JavaScript dependencies to add to the composite JavaScript bundle.
 
+`--disableBinaryStore`
+
+* Setting this option will bypass retrieval and installation of the binary from the Binary Store.  
+* It can be useful in case you want to use `ern start` command in conjunction with your own mobile application native binary, build locally on your workstation or retrieved from a specific location.
+
 **Platform Specific Options**
 
 `Android`

--- a/ern-local-cli/src/commands/start.ts
+++ b/ern-local-cli/src/commands/start.ts
@@ -60,6 +60,11 @@ export const builder = (argv: Argv) => {
         'A list of one or more directory name from node_modules that should be watched for changes',
       type: 'array',
     })
+    .option('disableBinaryStore', {
+      describe:
+        'Disable automatic retrieval of the binary from the Binary Store',
+      type: 'boolean',
+    })
     .group(['packageName', 'activityName'], 'Android binary specific options:')
     .group(['bundleId'], 'iOS binary specific options:')
     .epilog(epilog(exports))
@@ -74,6 +79,7 @@ export const commandHandler = async ({
   miniapps,
   packageName,
   watchNodeModules,
+  disableBinaryStore,
 }: {
   activityName?: string
   bundleId?: string
@@ -83,6 +89,7 @@ export const commandHandler = async ({
   miniapps?: PackagePath[]
   packageName?: string
   watchNodeModules?: string[]
+  disableBinaryStore?: boolean
 } = {}) => {
   if (!miniapps && !descriptor) {
     descriptor = await askUserToChooseANapDescriptorFromCauldron()
@@ -92,6 +99,7 @@ export const commandHandler = async ({
     activityName,
     bundleId,
     descriptor,
+    disableBinaryStore,
     extraJsDependencies,
     jsApiImpls,
     miniapps,

--- a/ern-orchestrator/src/start.ts
+++ b/ern-orchestrator/src/start.ts
@@ -27,6 +27,7 @@ export default async function start({
   activityName,
   bundleId,
   extraJsDependencies,
+  disableBinaryStore,
 }: {
   jsApiImpls?: PackagePath[]
   miniapps?: PackagePath[]
@@ -36,6 +37,7 @@ export default async function start({
   activityName?: string
   bundleId?: string
   extraJsDependencies?: PackagePath[]
+  disableBinaryStore?: boolean
 } = {}) {
   const cauldron = await getActiveCauldron({ throwIfNoActiveCauldron: false })
   if (!cauldron && descriptor) {
@@ -103,7 +105,7 @@ export default async function start({
       .join(',')}`,
   ])
 
-  if (descriptor) {
+  if (descriptor && !disableBinaryStore) {
     const binaryStoreConfig = await cauldron.getBinaryStoreConfig()
     if (binaryStoreConfig) {
       const cauldronStartCommandConfig = await cauldron.getStartCommandConfig(


### PR DESCRIPTION
Add a new option flag `--disableBinaryStore` to `ern start` command, to allow bypassing retrieval and install of binary from the binary store.