### PR TITLE
Cleanup React Native assets target directory before bundling

### DIFF
--- a/ern-container-gen/src/reactNativeBundleAndroid.ts
+++ b/ern-container-gen/src/reactNativeBundleAndroid.ts
@@ -1,4 +1,5 @@
 import { BundlingResult, reactnative, shell } from 'ern-core'
+import fs from 'fs'
 import path from 'path'
 
 export async function reactNativeBundleAndroid({
@@ -20,6 +21,9 @@ export async function reactNativeBundleAndroid({
     'index.android.bundle'
   )
   const assetsDest = path.join(libSrcMainPath, 'res')
+  if (fs.existsSync(assetsDest)) {
+    shell.rm('-rf', path.join(assetsDest, '{.*,*}'))
+  }
 
   if (workingDir) {
     shell.pushd(workingDir)

--- a/ern-container-gen/src/reactNativeBundleIos.ts
+++ b/ern-container-gen/src/reactNativeBundleIos.ts
@@ -22,6 +22,9 @@ export async function reactNativeBundleIos({
   )
   const bundleOutput = path.join(miniAppOutPath, 'MiniApp.jsbundle')
   const assetsDest = miniAppOutPath
+  if (fs.existsSync(assetsDest)) {
+    shell.rm('-rf', path.join(assetsDest, '{.*,*}'))
+  }
 
   if (!fs.existsSync(miniAppOutPath)) {
     shell.mkdir('-p', miniAppOutPath)


### PR DESCRIPTION
Cleanup Container react native assets target directory of any files, before starting the bundler.

This is needed because when Container is generated with optimization that only regenerates the JS bundle, it will clone an existing Container version from Git, which already contains assets from a previous generation. In that case, it might be that there will be left over assets, that are not used anymore but will remain lingering around, potentially causing issues.