### PR TITLE
Typescript file support

### DIFF
--- a/ern-container-gen/src/generateMiniAppsComposite.ts
+++ b/ern-container-gen/src/generateMiniAppsComposite.ts
@@ -240,10 +240,10 @@ export async function generateMiniAppsComposite(
     let sourceExts
     if (semver.gte(compositeReactNativeVersion, '0.57.0')) {
       sourceExts =
-        "module.exports = { resolver: { sourceExts: ['jsx', 'mjs', 'js'] } };"
+        "module.exports = { resolver: { sourceExts: ['jsx', 'mjs', 'js', 'ts', 'tsx'] } };"
     } else {
       sourceExts =
-        "module.exports = { getSourceExts: () => [ 'jsx', 'mjs', 'js' ] }"
+        "module.exports = { getSourceExts: () => ['jsx', 'mjs', 'js', 'ts', 'tsx'] }"
     }
     await writeFile('rn-cli.config.js', sourceExts)
 


### PR DESCRIPTION
Recent versions of react-native support typescript source files (`.ts`, `.tsx`) out of the box.

On recent versions of ern (I started with `v0.26`), typescript files worked fine, but they do not on the most recent version.

[This commit](https://github.com/electrode-io/electrode-native/commit/9c30e71190994e74b445fe6004e0049cb0bc609c) added overrides to the RN config, and caused typescript files to not be resolved.

So, this commit just adds ts/tsx files back into the resolved extensions.

Looks like 'backlog' ticket #770 could be closed out due to the work inside RN.

---

Thanks for this fantastic project -- it's incredible just how much surface area is covered by ERN.
Let me know if you have any comments -- happy to refactor/document/test as needed to get this change incorporated :smiley: 
