### PR TITLE
Add support to code push packages from git

### DIFF
--- a/docs/cli/code-push/release.md
+++ b/docs/cli/code-push/release.md
@@ -19,14 +19,16 @@
 `--miniapps`
 
 * One or more MiniApps (separated by spaces) version(s) to CodePush.
-* Only NPM published versions can be provided.
-* You cannot use the `file` or `git` schemes for the MiniApp(s).
+* You can use npm published versions or git based path (SHA or tag only).
+* If you are CodePushing a MiniApp that is using a git path in Container, please CodePush using a git path. If you are CodePushing a MiniApp that is using a npm published version in the Container, please CodePush using an npm published version. Do not mix.
+* You can't use the `file` scheme for the MiniApp(s).
 
 `--jsApiImpls`
 
 * One or more JS API implementations (separated by spaces) version(s) to CodePush.
-* Only NPM published versions can be provided.
-* You cannot use the `file` or `git` schemes for the MiniApp(s).
+* You can use npm published versions or git based path (SHA or tag only).
+* If you are CodePushing a JS API implementation that is using a git path in Container, please CodePush using a git path. If you are CodePushing a JS API implementation that is using a npm published version in the Container, please CodePush using an npm published version. Do not mix.
+* You can't use the `file` scheme for the MiniApp(s).
 
 `--descriptors/-d <descriptors..>`
 


### PR DESCRIPTION
Update `code-push release` command to allow CodePush of packages using git paths.
This was a historical technical restriction that does not apply anymore.
