### PR TITLE
Improve top level error logger

### DIFF
--- a/ern-core/src/utils.ts
+++ b/ern-core/src/utils.ts
@@ -367,10 +367,12 @@ export async function extractJsApiImplementations(plugins: PackagePath[]) {
   return jsApiImplDependencies
 }
 
-export function logErrorAndExitProcess(e: Error | string, code: number = 1) {
+export function logErrorAndExitProcess(e: any, code: number = 1) {
   if (e instanceof Error) {
     log.error(`An error occurred: ${e.message && e.message.trimRight()}`)
     log.debug(e.stack!)
+  } else if (e instanceof Object) {
+    log.error(`An error occurred: ${JSON.stringify(e)}`)
   } else {
     log.error(`An error occurred: ${e}`)
   }


### PR DESCRIPTION
Make sure that we log errors that are of Object type, instead of logging `[object Object]`