### PR TITLE
Fix iOS Container assets

### DIFF
--- a/ern-container-gen/src/reactNativeBundleIos.ts
+++ b/ern-container-gen/src/reactNativeBundleIos.ts
@@ -24,6 +24,7 @@ export async function reactNativeBundleIos({
   const assetsDest = miniAppOutPath
   if (fs.existsSync(assetsDest)) {
     shell.rm('-rf', path.join(assetsDest, '{.*,*}'))
+    shell.mkdir('-p', path.join(assetsDest, 'assets'))
   }
 
   if (!fs.existsSync(miniAppOutPath)) {


### PR DESCRIPTION
Fix an issue introduced in `v0.29.2` causing iOS Container build to fail in case packaged MiniApp(s) were not containing any assets.

Fix https://github.com/electrode-io/electrode-native/issues/1064