### PR TITLE
Fix react-native modules order

### DIFF
--- a/ern-container-gen/src/generateContainer.ts
+++ b/ern-container-gen/src/generateContainer.ts
@@ -42,6 +42,18 @@ export async function generateContainer(
 
   config.plugins = sortDependenciesByName(config.plugins)
 
+  const reactNativePlugin = _.find(
+    config.plugins,
+    p => p.basePath === 'react-native'
+  )
+
+  // React-native plugin should be first in the dependencies
+  // Otherwise any module dependent on r-n won't be able to use it
+  config.plugins = [
+    ...reactNativePlugin ? [reactNativePlugin] : [],
+    ...config.plugins.filter(plugin => plugin !== reactNativePlugin)
+  ]
+
   shell.pushd(config.outDir)
   try {
     if (fillContainerHull) {


### PR DESCRIPTION
The modules order might actually be important in certain cases.
In our example `lottie-react-native` depends on `react-native` being built first, though when only resorting to alphabetical ordering we try to build `lottie-react-native` first.

This fix this particular issue, but maybe the order of dependencies problem should be taken further later? As an example for Lottie, `lottie-ios` should also be built before `lottie-react-native`. Luckily for this alphabetical works, but I could see how this might not stand the test of time and other plugins.

Maybe the information about the plugin could be made more public (that might actually already be the case in a cauldron?), and in this case the final user should be responsible for the sorting and the platform should only insure `react-native` comes before the user-defined plugins I think.

Related PR to support LottieReactNative in the manifest: https://github.com/electrode-io/electrode-native-manifest/pull/99