### PR TITLE
Add initial Babel support

### DIFF
--- a/ern-container-gen/src/generateMiniAppsComposite.ts
+++ b/ern-container-gen/src/generateMiniAppsComposite.ts
@@ -5,6 +5,7 @@ import {
   yarn,
   readPackageJson,
   writePackageJson,
+  fileUtils,
 } from 'ern-core'
 import { cleanupMiniAppsCompositeDir } from './cleanupMiniAppsCompositeDir'
 import {
@@ -122,15 +123,142 @@ export async function generateMiniAppsComposite(
 
     let entryIndexJsContent = ''
 
+    const dependencies: string[] = []
     compositePackageJson = await readPackageJson('.')
     for (const dependency of Object.keys(compositePackageJson.dependencies)) {
       entryIndexJsContent += `import '${dependency}'\n`
+      dependencies.push(dependency)
     }
 
     await runAfterJsCompositeGenerationScript(outDir)
 
-    log.debug('Removing .babelrc files from all modules')
-    shell.rm('-rf', path.join('node_modules', '**', '.babelrc'))
+    const compositeNodeModulesPath = path.join(outDir, 'node_modules')
+
+    // Any dependency that has the useBabelRc set in their package.json
+    // as follow ...
+    //
+    // "ern": {
+    //   "useBabelRc": true
+    // }
+    //
+    // ... is added to the babelRcRoots array, so that we can properly
+    // configure Babel to process the .babelrc of these dependencies.
+    const babelRcRoots: string[] = []
+    for (const dependency of dependencies) {
+      if (fs.existsSync(path.join(compositeNodeModulesPath, dependency))) {
+        const depPackageJson = await readPackageJson(
+          path.join(compositeNodeModulesPath, dependency)
+        )
+        if (depPackageJson.ern && depPackageJson.ern.useBabelRc === true) {
+          babelRcRoots.push(`./node_modules/${dependency}`)
+        }
+      }
+    }
+
+    const pathToMetroNodeModuleDir = path.join(
+      compositeNodeModulesPath,
+      'metro'
+    )
+    let metroPackageJson
+    if (fs.existsSync(pathToMetroNodeModuleDir)) {
+      metroPackageJson = await readPackageJson(pathToMetroNodeModuleDir)
+    }
+    const metroVersion = metroPackageJson ? metroPackageJson.version : '0.0.0'
+
+    const pathToReactNativeNodeModuleDir = path.join(
+      compositeNodeModulesPath,
+      'react-native'
+    )
+
+    const reactNativePackageJson = await readPackageJson(
+      pathToReactNativeNodeModuleDir
+    )
+    const compositeReactNativeVersion = reactNativePackageJson.version
+
+    // If React Native version is greater or equal than 0.56.0
+    // it is using Babel 7
+    // In that case, because we still want to process .babelrc
+    // of some MiniApps that need their .babelrc to be processed
+    // during bundling, we need to use the babelrcRoots option of
+    // Babel 7 (https://babeljs.io/docs/en/options#babelrcroots)
+    // Unfortunately, there is no way -as of metro latest version-
+    // to provide this option to the metro bundler.
+    // A pull request will be opened to metro to properly support
+    // this option, but meanwhile, we are just directly patching the
+    // metro transformer source file to make use of this option.
+    // This code will be kept even when a new version of metro supporting
+    // this option will be released, to keep backward compatibility.
+    // It will be deprecated at some point.
+    if (
+      semver.gte(compositeReactNativeVersion, '0.56.0') &&
+      babelRcRoots.length > 0
+    ) {
+      let pathToFileToPatch
+      if (semver.lt(metroVersion, '0.51.0')) {
+        // For versions of metro < 0.51.0, we are patching the reactNativeTransformer.js file
+        // https://github.com/facebook/metro/blob/v0.50.0/packages/metro/src/reactNativeTransformer.js#L120
+        pathToFileToPatch = path.join(
+          pathToMetroNodeModuleDir,
+          'src',
+          'reactNativeTransformer.js'
+        )
+      } else {
+        // For versions of metro > 0.51.0, we are patching the index.js file
+        // https://github.com/facebook/metro/blob/v0.51.0/packages/metro-react-native-babel-transformer/src/index.js#L120
+        pathToFileToPatch = path.join(
+          compositeNodeModulesPath,
+          'metro-react-native-babel-transformer',
+          'src',
+          'index.js'
+        )
+      }
+
+      const fileToPatch = await fileUtils.readFile(pathToFileToPatch)
+      const lineToPatch = `let config = Object.assign({}, babelRC, extraConfig);`
+      // Just add extra code line to inject babelrcRoots option
+      const patch = `extraConfig.babelrcRoots = ${JSON.stringify(
+        babelRcRoots,
+        null,
+        2
+      )}
+${lineToPatch}`
+      const patchedFile = fileToPatch.replace(lineToPatch, patch)
+      await fileUtils.writeFile(pathToFileToPatch, patchedFile)
+    }
+
+    // If React Native version is less than 0.56 it is still using Babel 6.
+    // In that case .babelrc files will be processed in any node_modules
+    // which is not a desired behavior.
+    // Therefore we just remove all .babelrc from all node_modules.
+    // We only keep .babelrc of node_modules that are "whitelisted",
+    // as we want them to be processed.
+    if (semver.lt(compositeReactNativeVersion, '0.56.0')) {
+      log.debug('Removing .babelrc files from all modules')
+      if (babelRcRoots.length > 0) {
+        log.debug(
+          `Preserving .babelrc of whitelisted node_modules : ${JSON.stringify(
+            babelRcRoots,
+            null,
+            2
+          )}`
+        )
+        for (const babelRcRoot of babelRcRoots) {
+          shell.cp(
+            path.join(babelRcRoot, '.babelrc'),
+            path.join(babelRcRoot, '.babelrcback')
+          )
+        }
+      }
+      shell.rm('-rf', path.join('node_modules', '**', '.babelrc'))
+      if (babelRcRoots.length > 0) {
+        for (const babelRcRoot of babelRcRoots) {
+          shell.cp(
+            path.join(babelRcRoot, '.babelrcback'),
+            path.join(babelRcRoot, '.babelrc')
+          )
+        }
+      }
+    }
 
     log.debug('Creating top level composite .babelrc')
     const compositeBabelRc: { plugins: any[]; presets?: string[] } = {
@@ -140,94 +268,93 @@ export async function generateMiniAppsComposite(
     // Ugly hacky way of handling module-resolver babel plugin
     // At least it has some guarantees to make it safer but its just a temporary
     // solution until we figure out a more proper way of handling this plugin
-    log.debug('Taking care of potential Babel plugins used by MiniApps')
-    let moduleResolverAliases = {}
-    for (const dependency of Object.keys(compositePackageJson.dependencies)) {
-      const miniAppPackagePath = path.join(outDir, 'node_modules', dependency)
-      let miniAppPackageJson
-      try {
-        miniAppPackageJson = await readPackageJson(miniAppPackagePath)
-      } catch (e) {
-        // swallow (for test. to be fixed)
-        continue
-      }
-      const miniAppName = miniAppPackageJson.name
-      if (miniAppPackageJson.babel) {
-        if (miniAppPackageJson.babel.plugins) {
-          for (const babelPlugin of miniAppPackageJson.babel.plugins) {
-            if (Array.isArray(babelPlugin)) {
-              if (babelPlugin.includes('module-resolver')) {
-                // Copy over module-resolver plugin & config to top level composite .babelrc
-                log.debug(
-                  `Taking care of module-resolver Babel plugin for ${miniAppName} MiniApp`
-                )
-                if (compositeBabelRc.plugins.length === 0) {
-                  // First MiniApp to add module-resolver plugin & config
-                  // easy enough, we just copy over the plugin & config
-                  compositeBabelRc.plugins.push(<any>babelPlugin)
-                  for (const x of babelPlugin) {
-                    if (x instanceof Object && x.alias) {
-                      moduleResolverAliases = x.alias
-                      break
+    // THIS WHOLE CODE BLOCK SHOULD BE REMOVED SOON
+    // STARTING WITH BABEL7 IN RN56 WE HAVE A NEW WAY OF TAKING CARE OF BABEL MODULE RESOLVER
+    // REMOVE AS SOON AS INTERNAL RN WALMART APPS ARE USING A VERSION OF RN >= 0.56.0
+    if (semver.lt(compositeReactNativeVersion, '0.56.0')) {
+      log.debug('Taking care of potential Babel plugins used by MiniApps')
+      let moduleResolverAliases = {}
+      for (const dependency of Object.keys(compositePackageJson.dependencies)) {
+        const miniAppPackagePath = path.join(
+          compositeNodeModulesPath,
+          dependency
+        )
+        let miniAppPackageJson
+        try {
+          miniAppPackageJson = await readPackageJson(miniAppPackagePath)
+        } catch (e) {
+          // swallow (for test. to be fixed)
+          continue
+        }
+        const miniAppName = miniAppPackageJson.name
+        if (miniAppPackageJson.babel) {
+          if (miniAppPackageJson.babel.plugins) {
+            for (const babelPlugin of miniAppPackageJson.babel.plugins) {
+              if (Array.isArray(babelPlugin)) {
+                if (babelPlugin.includes('module-resolver')) {
+                  // Copy over module-resolver plugin & config to top level composite .babelrc
+                  log.debug(
+                    `Taking care of module-resolver Babel plugin for ${miniAppName} MiniApp`
+                  )
+                  if (compositeBabelRc.plugins.length === 0) {
+                    // First MiniApp to add module-resolver plugin & config
+                    // easy enough, we just copy over the plugin & config
+                    compositeBabelRc.plugins.push(<any>babelPlugin)
+                    for (const x of babelPlugin) {
+                      if (x instanceof Object && x.alias) {
+                        moduleResolverAliases = x.alias
+                        break
+                      }
                     }
-                  }
-                } else {
-                  // Another MiniApp  has already declared module-resolver
-                  // plugin & config. If we have conflicts for aliases, we'll just abort
-                  // bundling as of now to avoid generating a potentially unstable bundle
-                  for (const item of babelPlugin) {
-                    if (item instanceof Object && item.alias) {
-                      for (const aliasKey of Object.keys(item.alias)) {
-                        if (
-                          moduleResolverAliases[aliasKey] &&
-                          moduleResolverAliases[aliasKey] !==
-                            item.alias[aliasKey]
-                        ) {
-                          throw new Error(
-                            'Babel module-resolver alias conflict'
-                          )
-                        } else if (!moduleResolverAliases[aliasKey]) {
-                          moduleResolverAliases[aliasKey] = item.alias[aliasKey]
+                  } else {
+                    // Another MiniApp  has already declared module-resolver
+                    // plugin & config. If we have conflicts for aliases, we'll just abort
+                    // bundling as of now to avoid generating a potentially unstable bundle
+                    for (const item of babelPlugin) {
+                      if (item instanceof Object && item.alias) {
+                        for (const aliasKey of Object.keys(item.alias)) {
+                          if (
+                            moduleResolverAliases[aliasKey] &&
+                            moduleResolverAliases[aliasKey] !==
+                              item.alias[aliasKey]
+                          ) {
+                            throw new Error(
+                              'Babel module-resolver alias conflict'
+                            )
+                          } else if (!moduleResolverAliases[aliasKey]) {
+                            moduleResolverAliases[aliasKey] =
+                              item.alias[aliasKey]
+                          }
                         }
                       }
                     }
                   }
+                } else {
+                  log.warn(
+                    `Unsupported Babel plugin type ${babelPlugin.toString()} in ${miniAppName} MiniApp`
+                  )
                 }
               } else {
                 log.warn(
                   `Unsupported Babel plugin type ${babelPlugin.toString()} in ${miniAppName} MiniApp`
                 )
               }
-            } else {
-              log.warn(
-                `Unsupported Babel plugin type ${babelPlugin.toString()} in ${miniAppName} MiniApp`
-              )
             }
           }
+          log.debug(
+            `Removing babel object from ${miniAppName} MiniApp package.json`
+          )
+          delete miniAppPackageJson.babel
+          await writePackageJson(miniAppPackagePath, miniAppPackageJson)
         }
-        log.debug(
-          `Removing babel object from ${miniAppName} MiniApp package.json`
-        )
-        delete miniAppPackageJson.babel
-        await writePackageJson(miniAppPackagePath, miniAppPackageJson)
       }
     }
 
     const pathToCodePushNodeModuleDir = path.join(
-      outDir,
-      'node_modules',
+      compositeNodeModulesPath,
       'react-native-code-push'
     )
-    const pathToReactNativeNodeModuleDir = path.join(
-      outDir,
-      'node_modules',
-      'react-native'
-    )
 
-    const reactNativePackageJson = await readPackageJson(
-      pathToReactNativeNodeModuleDir
-    )
-    const compositeReactNativeVersion = reactNativePackageJson.version
     if (semver.gte(compositeReactNativeVersion, '0.57.0')) {
       compositeBabelRc.presets = ['module:metro-react-native-babel-preset']
     } else {

--- a/ern-core/src/YarnCli.ts
+++ b/ern-core/src/YarnCli.ts
@@ -37,7 +37,7 @@ export class YarnCli {
     // this is really weird]
     if (dependencyPath.isFilePath) {
       const tmpDirPath = createTmpDir()
-      shell.cp('-R', `${dependencyPath.basePath}/*`, tmpDirPath)
+      shell.cp('-R', path.join(dependencyPath.basePath, '{.*,*}'), tmpDirPath)
       shell.rm('-rf', path.join(tmpDirPath, 'node_modules'))
       dependencyPath = PackagePath.fromString(`file:${tmpDirPath}`)
     }


### PR DESCRIPTION
This PR adds initial Babel support for MiniApps.

Prior to this PR, any `.babelrc` file present in the root of a MiniApp was not considered during bundling. This was problematic for MiniApps that wanted to make use of some Babel plugins.

Unfortunately, proper support for Babel 7 requires a bit of hacking, because when we generate 
a `composite` bundle of multiple MiniApps, we can consider the composite as a 'virtual monorepo' composed of different MiniApps, therefore the .babelrc is not at the top level / root of the bundling working directory. With Babel 7 (RN >= 0.56.0) we need to make use of the [babelrcRoots](https://babeljs.io/docs/en/options#babelrcroots) option of Babel to specify 'whitelisted' directories containing `.babelrc` files to be processed (MiniApps typically), otherwise they are ignored. 
The problem is that as of now, the [metro](https://github.com/facebook/metro) bundler does not offer a way to provide this option. 
We will open a pull request to metro soon, but meanwhile, and to maintain backward compatibility until metro offer this option, we rely on patching a metro source file prior to bundling, to add this option.

With this PR, any MiniApp will be able to make use of Babel plugins by using a valid `.babelrc` file at the root of the MiniApp, and setting the `useBabelRc` flag in the `ern` section of their `package.json`, as follow 

```json
"ern": {
  "useBabelRc": true
}
```

 to let Electrode Native know that this MiniApp `.babelrc` should be processed during bundling.