### PR TITLE
Add a new Cauldron config flag to bypass yarn.lock

### DIFF
--- a/ern-local-cli/src/commands/create-container.ts
+++ b/ern-local-cli/src/commands/create-container.ts
@@ -171,7 +171,19 @@ Output directory should either not exist (it will be created) or should be empty
 
     let pathToYarnLock
     if (descriptor) {
-      pathToYarnLock = await cauldron.getPathToYarnLock(descriptor, 'container')
+      const containerGenConfig = await cauldron.getContainerGeneratorConfig(
+        descriptor
+      )
+      if (!containerGenConfig || !containerGenConfig.bypassYarnLock) {
+        pathToYarnLock = await cauldron.getPathToYarnLock(
+          descriptor,
+          'container'
+        )
+      } else {
+        log.debug(
+          'Bypassing yarn.lock usage as bypassYarnLock flag is set in config'
+        )
+      }
     }
 
     await generateMiniAppsComposite(

--- a/ern-orchestrator/src/codepush.ts
+++ b/ern-orchestrator/src/codepush.ts
@@ -333,6 +333,14 @@ export async function performCodePushOtaUpdate(
       PackagePath.fromString(j.toString())
     )
 
+    const codePushConfig = await cauldron.getCodePushConfig(napDescriptor)
+    if (codePushConfig && codePushConfig.bypassYarnLock) {
+      pathToYarnLock = undefined
+      log.debug(
+        'Bypassing yarn.lock usage as bypassYarnLock flag is set in Cauldron config'
+      )
+    }
+
     await kax
       .task('Generating composite module')
       .run(
@@ -371,7 +379,6 @@ export async function performCodePushOtaUpdate(
 
     // Remove patch digit 0 from target binary version if trimZeroPatchDigit flag is set
     // For example, 19.3.0 => 19.3
-    const codePushConfig = await cauldron.getCodePushConfig(napDescriptor)
     if (
       codePushConfig &&
       codePushConfig.trimZeroPatchDigit &&

--- a/ern-orchestrator/src/container.ts
+++ b/ern-orchestrator/src/container.ts
@@ -164,10 +164,21 @@ export async function runCauldronContainerGen(
     const plugins = await cauldron.getNativeDependencies(napDescriptor)
     const miniapps = await cauldron.getContainerMiniApps(napDescriptor)
     const jsApiImpls = await cauldron.getContainerJsApiImpls(napDescriptor)
-    const pathToYarnLock = await cauldron.getPathToYarnLock(
-      napDescriptor,
-      constants.CONTAINER_YARN_KEY
+    const containerGenConfig = await cauldron.getContainerGeneratorConfig(
+      napDescriptor
     )
+    let pathToYarnLock
+
+    if (!containerGenConfig || !containerGenConfig.bypassYarnLock) {
+      pathToYarnLock = await cauldron.getPathToYarnLock(
+        napDescriptor,
+        constants.CONTAINER_YARN_KEY
+      )
+    } else {
+      log.debug(
+        'Bypassing yarn.lock usage as bypassYarnLock flag is set in Cauldron config'
+      )
+    }
 
     if (!napDescriptor.platform) {
       throw new Error(`${napDescriptor} does not specify a platform`)
@@ -227,11 +238,20 @@ export async function runCaudronBundleGen(
     const cauldron = await getActiveCauldron()
     const miniapps = await cauldron.getContainerMiniApps(napDescriptor)
     const jsApiImpls = await cauldron.getContainerJsApiImpls(napDescriptor)
-    const pathToYarnLock = await cauldron.getPathToYarnLock(
-      napDescriptor,
-      constants.CONTAINER_YARN_KEY
+    const containerGenConfig = await cauldron.getContainerGeneratorConfig(
+      napDescriptor
     )
-
+    let pathToYarnLock
+    if (!containerGenConfig || !containerGenConfig.bypassYarnLock) {
+      pathToYarnLock = await cauldron.getPathToYarnLock(
+        napDescriptor,
+        constants.CONTAINER_YARN_KEY
+      )
+    } else {
+      log.debug(
+        'Bypassing yarn.lock usage as bypassYarnLock flag is set in Cauldron config'
+      )
+    }
     if (!napDescriptor.platform) {
       throw new Error(`${napDescriptor} does not specify a platform`)
     }


### PR DESCRIPTION
Add a new flag `bypassYarnLock` for both `containerGenerator` and `codePush` config objects in Cauldron.

Setting this flag to `true` will bypass `yarn.lock` usage for JS composite generation. 
It will still publish the composite `yarn.lock` to the Cauldron (for tracking purposes and to have a way to know all of the JS packages and versions that are included in any bundle), but won't make use of it to actually generate the composite, recreating a new one upon every generation.

If this flag is not set, it will default to `false` (current behavior).