### PR TITLE
Quick rework of reactNativeBundle functions

### DIFF
--- a/ern-container-gen/src/bundleMiniApps.ts
+++ b/ern-container-gen/src/bundleMiniApps.ts
@@ -18,8 +18,10 @@ export async function bundleMiniApps(
   platform: NativePlatform,
   {
     pathToYarnLock,
+    dev,
   }: {
     pathToYarnLock?: string
+    dev?: boolean
   } = {},
   // JavaScript API implementations
   jsApiImplDependencies?: PackagePath[]

--- a/ern-container-gen/src/reactNativeBundleAndroid.ts
+++ b/ern-container-gen/src/reactNativeBundleAndroid.ts
@@ -5,15 +5,12 @@ import path from 'path'
 export async function reactNativeBundleAndroid({
   workingDir,
   outDir,
+  dev,
 }: {
   workingDir?: string
   outDir: string
+  dev?: boolean
 }): Promise<BundlingResult> {
-  if (!outDir) {
-    throw new Error(
-      '[reactNativeBundleAndroid] missing mandatory outDir parameter'
-    )
-  }
   const libSrcMainPath = path.join(outDir, 'lib', 'src', 'main')
   const bundleOutput = path.join(
     libSrcMainPath,
@@ -32,7 +29,7 @@ export async function reactNativeBundleAndroid({
     const result = await reactnative.bundle({
       assetsDest,
       bundleOutput,
-      dev: false,
+      dev: !!dev,
       entryFile: 'index.android.js',
       platform: 'android',
     })

--- a/ern-container-gen/src/reactNativeBundleIos.ts
+++ b/ern-container-gen/src/reactNativeBundleIos.ts
@@ -5,15 +5,12 @@ import path from 'path'
 export async function reactNativeBundleIos({
   workingDir,
   outDir,
+  dev,
 }: {
   workingDir?: string
   outDir: string
+  dev?: boolean
 }): Promise<BundlingResult> {
-  if (!outDir) {
-    throw new Error(
-      '[reactNativeBundleAndroid] missing mandatory outDir parameter'
-    )
-  }
   const miniAppOutPath = path.join(
     outDir,
     'ElectrodeContainer',
@@ -38,7 +35,7 @@ export async function reactNativeBundleIos({
     const result = await reactnative.bundle({
       assetsDest,
       bundleOutput,
-      dev: false,
+      dev: !!dev,
       entryFile: 'index.ios.js',
       platform: 'ios',
     })


### PR DESCRIPTION
- Accept `dev` flag as a parameter rather than hardcoding it to false
- Remove `outDir` parameter check (enforced by TypeScript)