### PR TITLE
Add internal support to generate source map with bundle

### DIFF
--- a/ern-container-gen/src/bundleMiniApps.ts
+++ b/ern-container-gen/src/bundleMiniApps.ts
@@ -1,10 +1,4 @@
-import {
-  BundlingResult,
-  kax,
-  MiniApp,
-  NativePlatform,
-  PackagePath,
-} from 'ern-core'
+import { BundlingResult, kax, NativePlatform, PackagePath } from 'ern-core'
 import { reactNativeBundleAndroid } from './reactNativeBundleAndroid'
 import { reactNativeBundleIos } from './reactNativeBundleIos'
 import { clearReactPackagerCache } from './clearReactPackagerCache'
@@ -19,9 +13,11 @@ export async function bundleMiniApps(
   {
     pathToYarnLock,
     dev,
+    sourceMapOutput,
   }: {
     pathToYarnLock?: string
     dev?: boolean
+    sourceMapOutput?: string
   } = {},
   // JavaScript API implementations
   jsApiImplDependencies?: PackagePath[]
@@ -39,11 +35,19 @@ export async function bundleMiniApps(
 
   clearReactPackagerCache()
 
-  return kax
-    .task('Running Metro Bundler')
-    .run(
-      platform === 'android'
-        ? reactNativeBundleAndroid({ workingDir: compositeMiniAppDir, outDir })
-        : reactNativeBundleIos({ workingDir: compositeMiniAppDir, outDir })
-    )
+  return kax.task('Running Metro Bundler').run(
+    platform === 'android'
+      ? reactNativeBundleAndroid({
+          dev,
+          outDir,
+          sourceMapOutput,
+          workingDir: compositeMiniAppDir,
+        })
+      : reactNativeBundleIos({
+          dev,
+          outDir,
+          sourceMapOutput,
+          workingDir: compositeMiniAppDir,
+        })
+  )
 }

--- a/ern-container-gen/src/reactNativeBundleAndroid.ts
+++ b/ern-container-gen/src/reactNativeBundleAndroid.ts
@@ -3,13 +3,15 @@ import fs from 'fs'
 import path from 'path'
 
 export async function reactNativeBundleAndroid({
-  workingDir,
-  outDir,
   dev,
+  outDir,
+  sourceMapOutput,
+  workingDir,
 }: {
-  workingDir?: string
-  outDir: string
   dev?: boolean
+  outDir: string
+  sourceMapOutput?: string
+  workingDir?: string
 }): Promise<BundlingResult> {
   const libSrcMainPath = path.join(outDir, 'lib', 'src', 'main')
   const bundleOutput = path.join(
@@ -32,6 +34,7 @@ export async function reactNativeBundleAndroid({
       dev: !!dev,
       entryFile: 'index.android.js',
       platform: 'android',
+      sourceMapOutput,
     })
     return result
   } finally {

--- a/ern-container-gen/src/reactNativeBundleIos.ts
+++ b/ern-container-gen/src/reactNativeBundleIos.ts
@@ -3,13 +3,15 @@ import fs from 'fs'
 import path from 'path'
 
 export async function reactNativeBundleIos({
-  workingDir,
-  outDir,
   dev,
+  outDir,
+  sourceMapOutput,
+  workingDir,
 }: {
-  workingDir?: string
-  outDir: string
   dev?: boolean
+  outDir: string
+  sourceMapOutput?: string
+  workingDir?: string
 }): Promise<BundlingResult> {
   const miniAppOutPath = path.join(
     outDir,
@@ -38,6 +40,7 @@ export async function reactNativeBundleIos({
       dev: !!dev,
       entryFile: 'index.ios.js',
       platform: 'ios',
+      sourceMapOutput,
     })
     return result
   } finally {

--- a/ern-core/src/ReactNativeCli.ts
+++ b/ern-core/src/ReactNativeCli.ts
@@ -17,6 +17,8 @@ export interface BundlingResult {
   dev: boolean
   // Full path to the bundle
   bundlePath: string
+  // Full path to the source map (if any)
+  sourceMapPath?: string
 }
 
 export default class ReactNativeCli {
@@ -47,6 +49,7 @@ export default class ReactNativeCli {
     assetsDest,
     platform,
     workingDir,
+    sourceMapOutput,
   }: {
     entryFile: string
     dev: boolean
@@ -54,13 +57,15 @@ export default class ReactNativeCli {
     assetsDest: string
     platform: string
     workingDir?: string
+    sourceMapOutput?: string
   }): Promise<BundlingResult> {
     const bundleCommand = `${this.binaryPath} bundle \
 ${entryFile ? `--entry-file=${entryFile}` : ''} \
 ${dev ? '--dev=true' : '--dev=false'} \
 ${platform ? `--platform=${platform}` : ''} \
 ${bundleOutput ? `--bundle-output=${bundleOutput}` : ''} \
-${assetsDest ? `--assets-dest=${assetsDest}` : ''}`
+${assetsDest ? `--assets-dest=${assetsDest}` : ''} \
+${sourceMapOutput ? `--sourcemap-output=${sourceMapOutput}` : ''}`
 
     await execp(bundleCommand, { cwd: workingDir })
     return {
@@ -68,6 +73,7 @@ ${assetsDest ? `--assets-dest=${assetsDest}` : ''}`
       bundlePath: bundleOutput,
       dev,
       platform,
+      sourceMapPath: sourceMapOutput,
     }
   }
 


### PR DESCRIPTION
Not used yet, but adding support to create source map along with bundle.
Will be of use for upcoming Sentry integration.