### PR TITLE
Expose a new method for getting the view of a Mini App

### DIFF
--- a/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeReactNative.h
+++ b/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeReactNative.h
@@ -89,13 +89,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Returns a react native miniapp (from a JSBundle) inside a view controller.
- 
- @param name The name of the mini app, preferably the same name as the jsbundle
- without the extension.
+
+ @param name The name of the mini app, preferably the same name as the jsbundle without the extension.
  @param properties Any configuration to set up the mini app with.
  @return A UIViewController containing the view of the miniapp.
  */
 - (UIViewController *)miniAppWithName:(NSString *)name
                            properties:(NSDictionary * _Nullable)properties;
+
+/**
+   Returns a react native miniapp (from a JSBundle) inside a view.
+
+   @param name The name of the mini app, preferably the same name as the jsbundle without the extension.
+   @param properties Any configuration to set up the mini app with.
+   @return A UIView containing the view of the miniapp.
+*/
+- (UIView *)miniAppViewWithName:(NSString *)name
+                     properties:(NSDictionary *)properties;
 @end
 NS_ASSUME_NONNULL_END

--- a/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeReactNative.m
+++ b/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeReactNative.m
@@ -87,6 +87,7 @@ static dispatch_semaphore_t semaphore;
 @interface ElectrodeReactNative ()
 @property (nonatomic, strong) RCTBridge *bridge;
 @property (nonatomic, strong) ElectrodeBridgeDelegate *bridgeDelegate;
+- (RCTRootView *)rootViewWithName:(NSString *)name properties:(NSDictionary *)properties;
 @end
 
 @implementation ElectrodeReactNative
@@ -138,16 +139,30 @@ static dispatch_semaphore_t semaphore;
 
     UIViewController *miniAppViewController = nil;
 
-    // Build out the view controller
-    // Use the bridge to generate the view
-    RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:self.bridge moduleName:name initialProperties:properties];
-
-    rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+    RCTRootView *rootView = [self rootViewWithName:name properties: properties];
 
     miniAppViewController = [UIViewController new];
     miniAppViewController.view = rootView;
 
-    return miniAppViewController;}
+    return miniAppViewController;
+}
+
+- (UIView *)miniAppViewWithName:(NSString *)name
+                     properties:(NSDictionary *)properties
+{
+  RCTRootView *rootView = [self rootViewWithName:name properties: properties];
+  return rootView;
+}
+
+- (RCTRootView *)rootViewWithName:(NSString *)name
+                       properties:(NSDictionary *)properties
+{
+  // Build out the view controller
+  // Use the bridge to generate the view
+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:self.bridge moduleName:name initialProperties:properties];
+  rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+  return rootView;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 #pragma mark - Convenience Methods


### PR DESCRIPTION
Users often want to use only the RCTView from a mini app.
We should allow them to do so.