### PR TITLE
implement ReactInstanceHolder to return instance manager 

### DIFF
--- a/ern-container-gen-android/src/AndroidGenerator.ts
+++ b/ern-container-gen-android/src/AndroidGenerator.ts
@@ -328,7 +328,7 @@ export default class AndroidGenerator implements ContainerGenerator {
       p => p.basePath === 'react-native-code-push'
     )
     if (reactNativeCodePushPlugin) {
-      mustacheView.loadJsBundleFromCustomPath = true
+      mustacheView.isCodePushPluginIncluded = true
     }
   }
 

--- a/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactContainer.java
+++ b/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactContainer.java
@@ -41,9 +41,10 @@ import com.ern.api.impl.{{apiName}}ApiController;
 import com.ern.api.impl.{{apiName}}ApiRequestHandlerProvider;
 {{/hasConfig}}
 {{/apiImplementations}}
-{{#loadJsBundleFromCustomPath}}
+{{#isCodePushPluginIncluded}}
 import com.microsoft.codepush.react.CodePush;
-{{/loadJsBundleFromCustomPath}}
+import com.microsoft.codepush.react.ReactInstanceHolder;
+{{/isCodePushPluginIncluded}}
 {{#hasElectrodeBridgePlugin}}
 import com.walmartlabs.electrode.reactnative.bridge.helpers.Logger;
 {{/hasElectrodeBridgePlugin}}
@@ -157,7 +158,9 @@ public class ElectrodeReactContainer {
             }
 
             sElectrodeReactNativeHost = new ElectrodeReactNativeHost(application);
-
+            {{#isCodePushPluginIncluded}}
+            CodePush.setReactInstanceHolder(sElectrodeReactNativeHost);
+            {{/isCodePushPluginIncluded}}
             askForOverlayPermissionIfDebug(application);
 
             sReactPackages.add(new MainReactPackage());
@@ -278,7 +281,7 @@ public class ElectrodeReactContainer {
         }
     }
 
-    private static class ElectrodeReactNativeHost extends ReactNativeHost {
+    private static class ElectrodeReactNativeHost extends ReactNativeHost {{#isCodePushPluginIncluded}}implements ReactInstanceHolder{{/isCodePushPluginIncluded}}{
 
         private ElectrodeReactNativeHost(Application application) {
             super(application);
@@ -333,13 +336,13 @@ public class ElectrodeReactContainer {
             return reactInstanceManager;
         }
 
-        {{#loadJsBundleFromCustomPath}}
+        {{#isCodePushPluginIncluded}}
         @javax.annotation.Nullable
         @Override
         protected String getJSBundleFile() {
             return CodePush.getJSBundleFile();
         }
-        {{/loadJsBundleFromCustomPath}}
+        {{/isCodePushPluginIncluded}}
     }
 
     {{#RN_VERSION_GTE_54}}

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactContainer.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactContainer.java
@@ -33,6 +33,7 @@ import com.facebook.react.shell.MainReactPackage;
 import com.walmartlabs.ern.container.plugins.CodePushPlugin;
 import com.walmartlabs.ern.container.plugins.BridgePlugin;
 import com.microsoft.codepush.react.CodePush;
+import com.microsoft.codepush.react.ReactInstanceHolder;
 import com.walmartlabs.electrode.reactnative.bridge.helpers.Logger;
 
 import java.lang.reflect.InvocationTargetException;
@@ -128,7 +129,7 @@ public class ElectrodeReactContainer {
             }
 
             sElectrodeReactNativeHost = new ElectrodeReactNativeHost(application);
-
+            CodePush.setReactInstanceHolder(sElectrodeReactNativeHost);
             askForOverlayPermissionIfDebug(application);
 
             sReactPackages.add(new MainReactPackage());
@@ -240,7 +241,7 @@ public class ElectrodeReactContainer {
         }
     }
 
-    private static class ElectrodeReactNativeHost extends ReactNativeHost {
+    private static class ElectrodeReactNativeHost extends ReactNativeHost implements ReactInstanceHolder{
 
         private ElectrodeReactNativeHost(Application application) {
             super(application);


### PR DESCRIPTION
@deepueg Thanks for spotting the instanceManager not being able to resolve the react instance.
Credits to @deepueg 👍 for working together together on this issue.

https://github.com/Microsoft/react-native-code-push/blob/3144c916018fab077231e88d8718ad3a1cb0a7d8/docs/setup-android.md

Per the read me it explicitly suggests `CodePush.setReactInstanceHolder(mReactNativeHost)` that eliminates need of having a need for 
```@SuppressWarnings({"unused", "FieldCanBeLocal"})
    protected ReactInstanceManager mReactInstanceManager;
```

Unlikely before it doesn't use reflection to resolve the react instance. We will clean up the internal native app's.

