### PR TITLE
Allow to selectively disable transformers/publishers

### DIFF
--- a/ern-cauldron-api/test/CauldronApi-test.ts
+++ b/ern-cauldron-api/test/CauldronApi-test.ts
@@ -3093,14 +3093,14 @@ describe('CauldronApi.js', () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
       const api = cauldronApi(tmpFixture)
       await api.addPublisher(
-        'dummy',
+        'jcenter',
         NativeApplicationDescriptor.fromString('test:android'),
         'http://url'
       )
       expect(
         tmpFixture.nativeApps[0].platforms[0].config.containerGenerator
           .publishers
-      ).length(3)
+      ).length(4)
     })
   })
 

--- a/ern-orchestrator/src/runContainerPublishers.ts
+++ b/ern-orchestrator/src/runContainerPublishers.ts
@@ -27,6 +27,14 @@ export async function runContainerPublishers({
 
   if (publishersFromCauldron) {
     for (const publisherFromCauldron of publishersFromCauldron || []) {
+      if (publisherFromCauldron.disabled) {
+        log.info(
+          `Skipping Container Publisher ${
+            publisherFromCauldron.name
+          } (disabled=true)`
+        )
+        continue
+      }
       let extra = publisherFromCauldron.extra
       if (!extra) {
         extra = getDefaultExtraConfigurationOfPublisherFromCauldron({

--- a/ern-orchestrator/src/runContainerTransformers.ts
+++ b/ern-orchestrator/src/runContainerTransformers.ts
@@ -1,5 +1,5 @@
 import { getActiveCauldron, cauldronFileUriScheme } from 'ern-cauldron-api'
-import { NativeApplicationDescriptor, kax } from 'ern-core'
+import { log, NativeApplicationDescriptor, kax } from 'ern-core'
 import { transformContainer } from 'ern-container-transformer'
 import { parseJsonFromStringOrFile } from './parseJsonFromStringOrFile'
 
@@ -28,6 +28,14 @@ export async function runContainerTransformers({
     containerGenConfig && containerGenConfig.transformers
 
   for (const transformerFromCauldron of transformersFromCauldron || []) {
+    if (transformerFromCauldron.disabled) {
+      log.info(
+        `Skipping Container Transformer ${
+          transformerFromCauldron.name
+        } (disabled=true)`
+      )
+      continue
+    }
     let extra = transformerFromCauldron.extra
     if (
       extra &&

--- a/ern-orchestrator/test/runContainerPublishers-test.ts
+++ b/ern-orchestrator/test/runContainerPublishers-test.ts
@@ -51,7 +51,7 @@ describe('runContainerPublishers', () => {
     )
   })
 
-  it('should call publishContainer for each publisher', async () => {
+  it('should call publishContainer only with enabled publishers', async () => {
     const fixture = cloneFixture(fixtures.defaultCauldron)
     sandbox
       .stub(cauldronApi, 'getActiveCauldron')
@@ -64,5 +64,28 @@ describe('runContainerPublishers', () => {
       ),
     })
     sandbox.assert.calledTwice(publishContainerStub)
+    sandbox.assert.calledWith(publishContainerStub, {
+      containerPath: '/Users/foo/test',
+      containerVersion: '1000.0.0',
+      extra: undefined,
+      platform: 'android',
+      publisher: 'git',
+      url:
+        'git@gecgithub01.test.com:react-native/test-react-container-android.git',
+    })
+    sandbox.assert.calledWith(publishContainerStub, {
+      containerPath: '/Users/foo/test',
+      containerVersion: '1000.0.0',
+      extra: {
+        artifactId: 'test-ern-container',
+        groupId: 'com.walmartlabs.ern',
+        mavenPassword: undefined,
+        mavenUser: undefined,
+      },
+      platform: 'android',
+      publisher: 'maven',
+      url:
+        'http://mobilebuild.homeoffice.test.com:8081/nexus/content/repositories/hosted',
+    })
   })
 })

--- a/ern-orchestrator/test/runContainerTransformers-test.ts
+++ b/ern-orchestrator/test/runContainerTransformers-test.ts
@@ -54,7 +54,7 @@ describe('runContainerTransformers', () => {
     )
   })
 
-  it('should call transformContainer for each transformer', async () => {
+  it('should call transformContainer only with enabled transformers', async () => {
     const fixture = cloneFixture(fixtures.defaultCauldron)
     sandbox
       .stub(cauldronApi, 'getActiveCauldron')
@@ -65,6 +65,17 @@ describe('runContainerTransformers', () => {
         'test:android:17.7.0'
       ),
     })
-    sandbox.assert.calledOnce(transformContainerStub)
+    sandbox.assert.calledWith(transformContainerStub, {
+      containerPath: '/Users/foo/test',
+      extra: undefined,
+      platform: 'android',
+      transformer: 'dummy-1',
+    })
+    sandbox.assert.calledWith(transformContainerStub, {
+      containerPath: '/Users/foo/test',
+      extra: undefined,
+      platform: 'android',
+      transformer: 'dummy-3',
+    })
   })
 })

--- a/ern-util-dev/fixtures/default-cauldron-fixture.json
+++ b/ern-util-dev/fixtures/default-cauldron-fixture.json
@@ -15,172 +15,172 @@
       }
     }
   },
-  "nativeApps": [
-  {
+  "nativeApps": [{
     "name": "test",
     "config": {
       "test": "aValue"
     },
-    "platforms": [
-      {
-        "name": "android",
-        "config": {
-          "containerGenerator": {
-            "name": "maven",
-            "containerVersion": "1.16.44",
-            "publishers": [
-              {
-                "name": "github",
-                "url": "git@gecgithub01.test.com:react-native/test-react-container-android.git"
+    "platforms": [{
+      "name": "android",
+      "config": {
+        "containerGenerator": {
+          "name": "maven",
+          "containerVersion": "1.16.44",
+          "publishers": [{
+              "name": "git",
+              "url": "git@gecgithub01.test.com:react-native/test-react-container-android.git"
+            },
+            {
+              "name": "maven",
+              "url": "http://mobilebuild.homeoffice.test.com:8081/nexus/content/repositories/hosted",
+              "disabled": false
+            },
+            {
+              "name": "dummy",
+              "disabled": true
+            }
+          ],
+          "transformers": [{
+              "name": "dummy-1"
+            },
+            {
+              "name": "dummy-2",
+              "disabled": true
+            },
+            {
+              "name": "dummy-3",
+              "disabled": false
+            }
+          ]
+        }
+      },
+      "versions": [{
+          "name": "17.7.0",
+          "containerVersion": "1.16.44",
+          "config": {
+            "test": "value"
+          },
+          "ernPlatformVersion": "1000.0.0",
+          "isReleased": true,
+          "binary": null,
+          "yarnLocks": {
+            "container": "66fba131-2f4f-440d-a81b-492e11858bea",
+            "Production": "a0112c49-4bbc-47a9-ba45-d43e1e84a1a5",
+            "QA": "2ce473a0-0bcc-4727-a72b-5bcd8bbb4ec9"
+          },
+          "container": {
+            "nativeDeps": [
+              "react-native-electrode-bridge@1.4.9",
+              "@test/react-native-test-api@0.17.8",
+              "react-native@0.42.0",
+              "react-native-code-push@1.17.1-beta"
+            ],
+            "miniApps": [
+              "@test/react-native-foo@4.0.0",
+              "react-native-bar@2.0.0"
+            ],
+            "jsApiImpls": [
+              "react-native-my-api-impl@1.0.0"
+            ]
+          },
+          "codePush": {
+            "Production": [{
+                "metadata": {
+                  "deploymentName": "Production",
+                  "isMandatory": false,
+                  "appVersion": "17.7",
+                  "size": 522937,
+                  "releaseMethod": "Upload",
+                  "label": "v16",
+                  "releasedBy": "test@gmail.com",
+                  "rollout": "100"
+                },
+                "miniapps": [
+                  "@test/react-native-foo@4.0.2",
+                  "react-native-bar@2.0.1",
+                  "react-native-abc@1.0.0"
+                ],
+                "jsApiImpls": []
               },
               {
-                "name": "maven",
-                "url": "http://mobilebuild.homeoffice.test.com:8081/nexus/content/repositories/hosted"
-              }
-            ],
-            "transformers": [
-              {
-                "name": "dummy"
-              }
-            ]
-          }
-        },
-        "versions": [
-          {
-            "name": "17.7.0",
-            "containerVersion": "1.16.44",
-            "config": { 
-              "test": "value"
-            },
-            "ernPlatformVersion": "1000.0.0",
-            "isReleased": true,
-            "binary": null,
-            "yarnLocks": {
-              "container": "66fba131-2f4f-440d-a81b-492e11858bea",
-              "Production": "a0112c49-4bbc-47a9-ba45-d43e1e84a1a5",
-              "QA": "2ce473a0-0bcc-4727-a72b-5bcd8bbb4ec9"
-            },
-            "container": {
-              "nativeDeps": [
-                "react-native-electrode-bridge@1.4.9",
-                "@test/react-native-test-api@0.17.8",
-                "react-native@0.42.0",
-                "react-native-code-push@1.17.1-beta"
-              ],
-              "miniApps": [
-                "@test/react-native-foo@4.0.0",
-                "react-native-bar@2.0.0"
-              ],
-              "jsApiImpls": [
-                "react-native-my-api-impl@1.0.0"
-              ]
-            },
-            "codePush": {
-              "Production": [
-                {
-                  "metadata": {
-                    "deploymentName": "Production",
-                    "isMandatory": false,
-                    "appVersion": "17.7",
-                    "size": 522937,
-                    "releaseMethod": "Upload",
-                    "label": "v16",
-                    "releasedBy": "test@gmail.com",
-                    "rollout": "100"
-                  },
-                  "miniapps": [
-                    "@test/react-native-foo@4.0.2",
-                    "react-native-bar@2.0.1",
-                    "react-native-abc@1.0.0"
-                  ],
-                  "jsApiImpls": []
+                "metadata": {
+                  "deploymentName": "Production",
+                  "isMandatory": false,
+                  "appVersion": "17.7",
+                  "size": 522938,
+                  "releaseMethod": "Upload",
+                  "label": "v17",
+                  "releasedBy": "test@gmail.com",
+                  "rollout": "100"
                 },
-                {
-                  "metadata": {
-                    "deploymentName": "Production",
-                    "isMandatory": false,
-                    "appVersion": "17.7",
-                    "size": 522938,
-                    "releaseMethod": "Upload",
-                    "label": "v17",
-                    "releasedBy": "test@gmail.com",
-                    "rollout": "100"
-                  },
-                  "miniapps": [
-                    "@test/react-native-foo@4.0.2",
-                    "react-native-bar@2.0.2"
-                  ],
-                  "jsApiImpls": [
-                    "react-native-my-api-impl@1.0.0"
-                  ]
-                }
-              ],
-              "QA": [
-                {
-                  "metadata": {
-                    "deploymentName": "QA",
-                    "isMandatory": true,
-                    "appVersion": "17.7",
-                    "size": 522938,
-                    "releaseMethod": "Upload",
-                    "label": "v18",
-                    "releasedBy": "test@gmail.com",
-                    "rollout": "100"
-                  },
-                  "miniapps": [
-                    "@test/react-native-foo@4.0.3",
-                    "react-native-bar@2.0.2"
-                  ],
-                  "jsApiImpls": [
-                    "react-native-my-api-impl@1.1.0"
-                  ]
-                }
-              ]
-            }
-          },
-          {
-            "name": "17.8.0",
-            "ernPlatformVersion": "1000.0.0",
-            "isReleased": false,
-            "binary": null,
-            "config": {
-              "codePush": {
-                "appName": "walmart-android",
-                "versionModifiers": [
-                  {
-                    "deploymentName": "QA",
-                    "modifier": "$1-QA"
-                  }
+                "miniapps": [
+                  "@test/react-native-foo@4.0.2",
+                  "react-native-bar@2.0.2"
+                ],
+                "jsApiImpls": [
+                  "react-native-my-api-impl@1.0.0"
                 ]
               }
-            },
-            "container": {
-              "nativeDeps": [
-                "react-native-electrode-bridge@1.4.9",
-                "@test/react-native-test-api@0.17.8",
-                "react-native@0.42.0",
-                "react-native-code-push@1.17.1-beta"
-              ],
-              "miniAppsBranches": [
-                "https://github.com/foo/foo.git#master"
-              ],
-              "miniApps": [
-                "@test/react-native-foo@5.0.0",
-                "react-native-bar@3.0.0",
-                "git+ssh://git@github.com:electrode-io/gitMiniApp.git#0.0.9",
-                "https://github.com/foo/foo.git#6319d9ef0c237907c784a8c472b000d5ff83b49a"
+            ],
+            "QA": [{
+              "metadata": {
+                "deploymentName": "QA",
+                "isMandatory": true,
+                "appVersion": "17.7",
+                "size": 522938,
+                "releaseMethod": "Upload",
+                "label": "v18",
+                "releasedBy": "test@gmail.com",
+                "rollout": "100"
+              },
+              "miniapps": [
+                "@test/react-native-foo@4.0.3",
+                "react-native-bar@2.0.2"
               ],
               "jsApiImpls": [
-                "react-native-my-api-impl@1.0.0"
-              ],
-              "ernVersion": "1000.0.0"
-            },
-            "codePush": {
-            }
+                "react-native-my-api-impl@1.1.0"
+              ]
+            }]
           }
-        ]
-      }
-    ]
-  }
-]
+        },
+        {
+          "name": "17.8.0",
+          "ernPlatformVersion": "1000.0.0",
+          "isReleased": false,
+          "binary": null,
+          "config": {
+            "codePush": {
+              "appName": "walmart-android",
+              "versionModifiers": [{
+                "deploymentName": "QA",
+                "modifier": "$1-QA"
+              }]
+            }
+          },
+          "container": {
+            "nativeDeps": [
+              "react-native-electrode-bridge@1.4.9",
+              "@test/react-native-test-api@0.17.8",
+              "react-native@0.42.0",
+              "react-native-code-push@1.17.1-beta"
+            ],
+            "miniAppsBranches": [
+              "https://github.com/foo/foo.git#master"
+            ],
+            "miniApps": [
+              "@test/react-native-foo@5.0.0",
+              "react-native-bar@3.0.0",
+              "git+ssh://git@github.com:electrode-io/gitMiniApp.git#0.0.9",
+              "https://github.com/foo/foo.git#6319d9ef0c237907c784a8c472b000d5ff83b49a"
+            ],
+            "jsApiImpls": [
+              "react-native-my-api-impl@1.0.0"
+            ],
+            "ernVersion": "1000.0.0"
+          },
+          "codePush": {}
+        }
+      ]
+    }]
+  }]
 }


### PR DESCRIPTION
Add support of a new `disabled` boolean property in `transformers`/`publishers` objects configured in Cauldron.

Setting this property to `true` will disable (bypass) the transformer or publisher, as illustrated below

```json
{
  "name":"git",
  "url":"git@github.com:user/myweatherapp-android-container.git",
  "disabled": true
}
```

This allows for selective disablement of publishers and/or transformers in Cauldron, without having to remove the whole publisher/transformer configuration from Cauldron.

If the property is not present (default) or set to false, the transformer/publisher will be enabled.