### PR TITLE
Add new description property to nap version in Cauldron

### DIFF
--- a/docs/cli/cauldron/add/nativeapp.md
+++ b/docs/cli/cauldron/add/nativeapp.md
@@ -35,6 +35,10 @@
 * If you use the `--copyFromVersion/-c <version>` option, you do not need to add all MiniApps again after creating a new native application version in the Cauldron.  
 * This option is commonly used.  
 
+`--description`  
+
+* Description of the native application version
+
 #### Remarks
 
 * The `ern cauldron add nativeapp <descriptor>` command is usually used when the development of a new version of the native application is started.  

--- a/docs/cli/cauldron/update/nativeapp.md
+++ b/docs/cli/cauldron/update/nativeapp.md
@@ -2,7 +2,7 @@
 
 #### Description
 
-* Update the release status of a native application version in the Cauldron.  
+* Update one or more properties of a native application version. 
 
 #### Syntax
 
@@ -16,18 +16,22 @@
 
 **Options**  
 
-`isReleased`
-* **Default**  The release status is true.  
+`--isReleased`
+
+* Release status of the native application version.  
+
+`--description`  
+
+* Description of the native application version.
 
 #### Remarks
 
 * The `descriptor` value should be a *complete native application descriptor*.  
-* The `ern cauldron update nativeapp <descriptor> [isReleased]` command works only on a specified native application version.  
+* The `ern cauldron update nativeapp <descriptor>` command works only on a specified native application version.  
 * Switching a native application version from `non released` status to `released` status changes the behavior of some commands.  
-* When a native application version is released, its container is frozen and nothing can be added or removed from the container. However, you can use `CodePush` updates targeting this native application version using the `ern code-push` command.
 
 #### Related commands
 
-[ern cauldron add nativeapp] | Update the release status of a native application version in the Cauldron.
+[ern cauldron add nativeapp] | Add a new native application version to the currently activated Cauldron
 
 [ern cauldron add nativeapp]: ../add/nativeapp.md

--- a/ern-cauldron-api/src/CauldronApi.ts
+++ b/ern-cauldron-api/src/CauldronApi.ts
@@ -553,6 +553,16 @@ export default class CauldronApi {
     }
   }
 
+  public async addOrUpdateDescription(
+    descriptor: NativeApplicationDescriptor,
+    description: string
+  ): Promise<void> {
+    this.throwIfPartialNapDescriptor(descriptor)
+    const version = await this.getVersion(descriptor)
+    version.description = description
+    await this.commit(`Update description of ${descriptor.toString()}`)
+  }
+
   public async hasMiniAppBranchInContainer(
     descriptor: NativeApplicationDescriptor,
     miniApp: PackagePath

--- a/ern-cauldron-api/src/CauldronHelper.ts
+++ b/ern-cauldron-api/src/CauldronHelper.ts
@@ -62,13 +62,26 @@ export class CauldronHelper {
     return this.cauldron.addDescriptor(napDescriptor)
   }
 
+  public async addOrUpdateDescription(
+    descriptor: NativeApplicationDescriptor,
+    description: string
+  ) {
+    return this.cauldron.addOrUpdateDescription(descriptor, description)
+  }
+
   public async removeDescriptor(napDescriptor: NativeApplicationDescriptor) {
     return this.cauldron.removeDescriptor(napDescriptor)
   }
 
   public async addNativeApplicationVersion(
     descriptor: NativeApplicationDescriptor,
-    { copyFromVersion }: { copyFromVersion?: string } = {}
+    {
+      copyFromVersion,
+      description,
+    }: {
+      copyFromVersion?: string
+      description?: string
+    } = {}
   ) {
     if (descriptor.isPartial) {
       throw new Error(`${descriptor} is partial`)
@@ -93,6 +106,9 @@ export class CauldronHelper {
       })
     } else {
       await this.addDescriptor(descriptor)
+      if (description) {
+        await this.cauldron.addOrUpdateDescription(descriptor, description)
+      }
     }
   }
 
@@ -171,6 +187,14 @@ export class CauldronHelper {
     // Copy detachContainerVersionFromRoot
     if (sourceVersion.detachContainerVersionFromRoot) {
       await this.cauldron.enableDetachContainerVersionFromRoot(target)
+    }
+
+    // Copy description if any
+    if (sourceVersion.description) {
+      await this.cauldron.addOrUpdateDescription(
+        target,
+        sourceVersion.description
+      )
     }
   }
 

--- a/ern-cauldron-api/src/schemas.ts
+++ b/ern-cauldron-api/src/schemas.ts
@@ -12,6 +12,7 @@ export const nativeApplicationVersion = Joi.object({
   codePush: Joi.object().default({}),
   container: container.default(),
   containerVersion: Joi.string().optional(), // optional for Backward Compat. Required in ERN 0.5.0
+  description: Joi.string().optional(),
   isReleased: Joi.boolean()
     .optional()
     .default(false),

--- a/ern-cauldron-api/src/types/CauldronNativeAppVersion.ts
+++ b/ern-cauldron-api/src/types/CauldronNativeAppVersion.ts
@@ -9,4 +9,5 @@ export interface CauldronNativeAppVersion extends CauldronObject {
   codePush: any
   containerVersion: string
   detachContainerVersionFromRoot?: boolean
+  description?: string
 }

--- a/ern-cauldron-api/test/CauldronApi-test.ts
+++ b/ern-cauldron-api/test/CauldronApi-test.ts
@@ -1175,6 +1175,75 @@ describe('CauldronApi.js', () => {
   })
 
   // ==========================================================
+  // addOrUpdateDescription
+  // ==========================================================
+
+  describe('addOrUpdateDescription', () => {
+    it('should add a description if it does not exist yet', async () => {
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      const newDescription = 'new description'
+      await cauldronApi(tmpFixture).addOrUpdateDescription(
+        NativeApplicationDescriptor.fromString('test:android:17.7.0'),
+        newDescription
+      )
+      const version = jp.query(
+        tmpFixture,
+        '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")]'
+      )[0]
+      expect(version.description).eql(newDescription)
+    })
+
+    it('should update a description if it already exist', async () => {
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      const updatedDescription = 'updated description'
+      await cauldronApi(tmpFixture).addOrUpdateDescription(
+        NativeApplicationDescriptor.fromString('test:android:17.8.0'),
+        updatedDescription
+      )
+      const version = jp.query(
+        tmpFixture,
+        '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.8.0")]'
+      )[0]
+      expect(version.description).eql(updatedDescription)
+    })
+
+    it('should commit the document store', async () => {
+      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
+      const api = cauldronApi(tmpFixture)
+      const commitStub = sandbox.stub(documentStore, 'commit')
+      await api.addOrUpdateDescription(
+        NativeApplicationDescriptor.fromString('test:android:17.7.0'),
+        'new description'
+      )
+      sinon.assert.calledOnce(commitStub)
+    })
+
+    it('should throw if the descriptor is partial', async () => {
+      const api = cauldronApi()
+      assert(
+        await doesThrow(
+          api.addOrUpdateDescription,
+          api,
+          NativeApplicationDescriptor.fromString('test:android'),
+          'new description'
+        )
+      )
+    })
+
+    it('should throw if the version does not exists', async () => {
+      const api = cauldronApi()
+      assert(
+        await doesThrow(
+          api.addOrUpdateDescription,
+          api,
+          NativeApplicationDescriptor.fromString('test:android:0.1.0'),
+          'new description'
+        )
+      )
+    })
+  })
+
+  // ==========================================================
   // removeNativeDependencyFromContainer
   // ==========================================================
   describe('removeNativeDependencyFromContainer', () => {

--- a/ern-local-cli/src/commands/cauldron/add/nativeapp.ts
+++ b/ern-local-cli/src/commands/cauldron/add/nativeapp.ts
@@ -19,6 +19,10 @@ export const builder = (argv: Argv) => {
       describe: 'Copy Cauldron data from a previous native application version',
       type: 'string',
     })
+    .option('description', {
+      describe: 'Description of the native application version',
+      type: 'string',
+    })
     .coerce('descriptor', d =>
       NativeApplicationDescriptor.fromString(d, { throwIfNotComplete: true })
     )
@@ -31,9 +35,11 @@ export const builder = (argv: Argv) => {
 
 export const commandHandler = async ({
   copyFromVersion,
+  description,
   descriptor,
 }: {
   copyFromVersion?: string
+  description?: string
   descriptor: NativeApplicationDescriptor
 }) => {
   let cauldron
@@ -72,6 +78,10 @@ export const commandHandler = async ({
   await kax
     .task(`Adding ${descriptor}`)
     .run(cauldron.addNativeApplicationVersion(descriptor, { copyFromVersion }))
+
+  if (description) {
+    await cauldron.addOrUpdateDescription(descriptor, description)
+  }
 
   await kax
     .task('Updating Cauldron')

--- a/ern-local-cli/src/commands/cauldron/update/nativeapp.ts
+++ b/ern-local-cli/src/commands/cauldron/update/nativeapp.ts
@@ -12,12 +12,16 @@ export const desc = 'Update a native application info in cauldron'
 
 export const builder = (argv: Argv) => {
   return argv
+    .option('description', {
+      describe: 'Description of the native application version',
+      type: 'string',
+    })
     .coerce('descriptor', d =>
       NativeApplicationDescriptor.fromString(d, { throwIfNotComplete: true })
     )
     .option('isReleased', {
       alias: 'r',
-      default: true,
+      default: undefined,
       describe: 'true if version is released, false otherwise',
       type: 'boolean',
     })
@@ -25,11 +29,13 @@ export const builder = (argv: Argv) => {
 }
 
 export const commandHandler = async ({
+  description,
   descriptor,
-  isReleased = true,
+  isReleased,
 }: {
+  description?: string
   descriptor: NativeApplicationDescriptor
-  isReleased: boolean
+  isReleased?: boolean
 }) => {
   await logErrorAndExitIfNotSatisfied({
     napDescriptorExistInCauldron: {
@@ -40,8 +46,14 @@ export const commandHandler = async ({
   })
 
   const cauldron = await getActiveCauldron()
-  cauldron.updateNativeAppIsReleased(descriptor, isReleased)
-  log.info(`Successfully updated release status of ${descriptor}`)
+  if (isReleased !== undefined) {
+    await cauldron.updateNativeAppIsReleased(descriptor, isReleased)
+    log.info(`Successfully updated release status of ${descriptor}`)
+  }
+  if (description) {
+    await cauldron.addOrUpdateDescription(descriptor, description)
+    log.info(`Successfully updated description of ${descriptor}`)
+  }
 }
 
 export const handler = tryCatchWrap(commandHandler)

--- a/ern-util-dev/fixtures/default-cauldron-fixture.json
+++ b/ern-util-dev/fixtures/default-cauldron-fixture.json
@@ -178,7 +178,8 @@
             ],
             "ernVersion": "1000.0.0"
           },
-          "codePush": {}
+          "codePush": {},
+          "description": "Some description for 17.8.0 version"
         }
       ]
     }]


### PR DESCRIPTION
Add a new optional string property `description` to native application version object stored in Cauldron.

Because we are starting to see some Electrode Native workflows that are making use of specific 'fake' native application versions to build different 'flavors' of containers, it can be useful to have a description string associated to these custom native application versions to describe what the version is used for.

- Updates `cauldron add nativeapp` command with new `description` option 
- Updates `cauldron update nativeapp` command with new `description` option 

**Breaking Change**

The `cauldron update nativeapp` command was defaulting `isReleased` flag to `true` if not provided. 
This was a mistake, especially now that the command can update one or more properties in target native application version.
This PR corrects this. If the `isReleased` option is not provided, it won't be updated in Cauldron. 
