### PR TITLE
Fix path of file to patch for babel with RN59

### DIFF
--- a/ern-container-gen/src/generateMiniAppsComposite.ts
+++ b/ern-container-gen/src/generateMiniAppsComposite.ts
@@ -177,7 +177,7 @@ export async function generateMiniAppsComposite(
 
     // To be removed as soon as react-native-cli make use of metro >= 0.52.0
     // Temporary hacky code to patch an issue present in metro 0.51.1
-    // currently linked with RN 59 RC3 that impacts our bundling process
+    // currently linked with RN 59 that impacts our bundling process
     if (metroVersion === '0.51.1') {
       const pathToFileToPatch = path.join(
         compositeNodeModulesPath,
@@ -224,14 +224,27 @@ export async function generateMiniAppsComposite(
           'reactNativeTransformer.js'
         )
       } else {
-        // For versions of metro > 0.51.0, we are patching the index.js file
+        // For versions of metro >= 0.51.0, we are patching the index.js file
         // https://github.com/facebook/metro/blob/v0.51.0/packages/metro-react-native-babel-transformer/src/index.js#L120
-        pathToFileToPatch = path.join(
+        const pathInCommunityCli = path.join(
           compositeNodeModulesPath,
+          '@react-native-community',
+          'cli',
+          'node_modules',
           'metro-react-native-babel-transformer',
           'src',
           'index.js'
         )
+        if (fs.existsSync(pathInCommunityCli)) {
+          pathToFileToPatch = pathInCommunityCli
+        } else {
+          pathToFileToPatch = path.join(
+            compositeNodeModulesPath,
+            'metro-react-native-babel-transformer',
+            'src',
+            'index.js'
+          )
+        }
       }
 
       const fileToPatch = await fileUtils.readFile(pathToFileToPatch)


### PR DESCRIPTION
In Rn 0.59.0 there is a version mismatch for `metro-react-native-babel-transformer` between [react-native](https://github.com/facebook/react-native/blob/v0.59.0/package.json#L185) which uses `0.51.0` and the new [community cli](https://github.com/react-native-community/react-native-cli/blob/v1.4.1/packages/cli/package.json#L39) introduced in 0.59.0, which uses `0.51.1`.

Because of this, there is two `metro-react-native-babel-transformer` modules that get installed, one at the root of `node_modules`, and another one in the `node_modules` of the community CLI.

Because the community CLI is ultimately the binary that is invoking metro for bundling, we need to patch the `metro-react-native-babel-transformer` of the community CLI, if it's present. Otherwise fallback to the top level one (which would mean that both react-native and CLI are using same version of this dependency)