### PR TITLE
Improve Cauldron getPublisher method

### DIFF
--- a/ern-cauldron-api/src/CauldronHelper.ts
+++ b/ern-cauldron-api/src/CauldronHelper.ts
@@ -342,7 +342,15 @@ export class CauldronHelper {
     name: string
   ) {
     const publishers = await this.getPublishers(descriptor)
-    return publishers && publishers.find(p => p.name === name)
+    const publisherPackage = PackagePath.fromString(name)
+    return (
+      publishers &&
+      publishers.find(p =>
+        PackagePath.fromString(p.name).same(publisherPackage, {
+          ignoreVersion: true,
+        })
+      )
+    )
   }
 
   public async getNativeAppsForPlatform(


### PR DESCRIPTION
Improves `getPublisher` method, so that it properly returns the publisher from Cauldron, if a version is present in the string.

For example, if in Cauldron a publisher `name` is defined as `ern-container-publisher-git@^1.2.1` -legit-, this method would not have work when invoked as follow `getPublisher('ern-container-publisher-git')`, because of string comparison expecting exact match.

With this new implementation, because we are using `PackagePath` and ignoring version, the method will work as expected.