### PR TITLE
Add new create-composite command

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -63,6 +63,7 @@
 - [compat-check](cli/compat-check.md)
 - [create-api-impl](cli/create-api-impl.md)
 - [create-api](cli/create-api.md)
+- [create-composite](cli/create-composite.md)
 - [create-container](cli/create-container.md)
 - [publish-container](cli/publish-container.md)
 - [transform-container](cli/transform-container.md)

--- a/docs/cli/create-composite.md
+++ b/docs/cli/create-composite.md
@@ -1,0 +1,50 @@
+## `ern create-composite`
+
+#### Description
+
+* Create a JS Composite project locally.
+
+#### Syntax
+
+`ern create-composite`  
+
+**Options**  
+
+`--descriptor/-d <descriptor>`
+
+* Create a new JS Composite including all the MiniApps listed in the Cauldron for the given *complete native application descriptor*  
+
+`--extraJsDependencies/-e <dependencies>`
+
+* Add extra JavaScript dependencies to the JS Composite project. 
+
+`--fromGitBranches`
+
+* Create Composite using the latest commits made to each of the MiniApp branches (HEAD), rather than using the MiniApps SHAs that are inside the current Container version.  
+* This flag is only used when creating a Composite from a Cauldron descriptor  
+* This flag will be ignored if the target descriptor does not contain any MiniApps tracking git branches
+**Default** false
+
+`--jsApiImpls`
+
+* One or more JS API implementation(s) to add to the JS Composite project.
+* The  JS API implementation(s) passed to this command can be a valid Yarn package format or a Git format or file scheme.  
+* This option can only be used if the `--descriptor` option is not used.
+
+`--miniapps/-m <miniapps>`
+
+* One or more MiniApps to add to the JS Composite project.
+* The MiniApps passed to this command can be a valid Yarn package format or a Git format or file scheme.  
+* This option can only be used if the `--descriptor` option is not used.
+
+`--outDir/--out <directory>`
+
+* Specify the directory to output the generated JS Composite project to
+* The output directory should either not exist (it will be created) or be empty
+* **Default**  If this option is not provided, the Composite is generated in the default platform directory `~/.ern/containergen/miniAppsComposite`.
+
+#### Related commands
+
+[ern create-container] | Creates a Container locally
+
+[ern create-container]: ./create-container.md

--- a/docs/cli/create-container.md
+++ b/docs/cli/create-container.md
@@ -2,19 +2,13 @@
 
 #### Description
 
-* Create a new container (native or JavaScript only) locally to the workstation.
+* Create a new Container locally.
 
 #### Syntax
 
 `ern create-container`  
 
 **Options**  
-
-`--jsOnly/--js`
-
-* Create a JavaScript-only container  
-* A JavaScript-only container is also known as a *MiniApps composite*.   
-* **Default**  If this option is not used, a full native container including the JavaScript bundle containing all MiniApps, is generated.
 
 `--descriptor/-d <descriptor>`
 
@@ -23,8 +17,9 @@
 
 `--fromGitBranches`
 
-* Create Container from MiniApps git branches, rather than from current MiniApps SHAs inside the current Container version  
+* Create Container using the latest commits made to each of the MiniApp branches (HEAD), rather than using the MiniApps SHAs that are inside the current Container version.  
 * This flag is only used when creating a Container from a Cauldron descriptor  
+* This flag will be ignored if the target descriptor does not contain any MiniApps tracking git branches
 **Default** false
 
 `--miniapps/-m <miniapps>`
@@ -35,7 +30,7 @@
 `--dependencies/--deps <dependencies>`
 
 * Inject the provided extra native dependencies in your locally generated container  
-* This option can only be used when generating a container that is not JavaScript only (`--js` switch), or based on a native application version from Cauldron (`--descriptor` option).  
+* This option can only be used when generating a container that is not based on a native application version from Cauldron (`--descriptor` option).  
 For the latter, if you want to add extra native dependencies to your container that are not listed as dependencies of any of the MiniApps, you can instead use the `ern cauldron add dependencies` command to add the extra native dependencies directly in the native application version stored in Cauldron.  
 You can only provide published dependencies to this command.  
 You cannot use the Git or file package descriptors for referring to the dependencies.
@@ -47,7 +42,8 @@ You cannot use the Git or file package descriptors for referring to the dependen
 
 `--outDir/--out <directory>`
 
-* Specify the output directory where the container generated project should be stored upon creation  
+* Specify the directory to output the generated container to
+* The output directory should either not exist (it will be created) or be empty
 * **Default**  If this option is not provided, the container is generated in the default platform directory `~/.ern/containergen/out`.
 
 `--ignoreRnpmAssets`
@@ -72,12 +68,17 @@ You cannot use the Git or file package descriptors for referring to the dependen
 #### Remarks
 
 * The `ern create-container` command can be used to create a container locally, for development, debugging and experimentation purposes.  
-* Container generation and publication are two separate processes. If you want to publish your Container (to a git or maven repository) after locally creating it, you can make use of the `ern publish-container` command.
+* Container generation and transformation/publication are separate processes (see `Related commands` section below for specific commands) 
 * To create a container that is published so that your native application team can use the container, you should use one of the Cauldron commands to add your MiniApps to a specified native application version in the Cauldron, which will trigger the generation and publication of a Container. See *Related commands*.  
-* For Android OS, the Container is also published to your local Maven repository.  
 
 #### Related commands
 
+[ern transform-container] | Transform a local Container.
 [ern publish-container] | Publish a local Container.
+[ern create-composite] | Creates a JS Composite project locally
 
+[ern transform-container]: ./transform-container.md
 [ern publish-container]: ./publish-container.md
+[ern create-composite]: ./create-composite.md
+
+

--- a/ern-local-cli/src/commands/create-composite.ts
+++ b/ern-local-cli/src/commands/create-composite.ts
@@ -1,0 +1,139 @@
+import { generateMiniAppsComposite } from 'ern-container-gen'
+import {
+  PackagePath,
+  NativeApplicationDescriptor,
+  Platform,
+  log,
+  NativePlatform,
+} from 'ern-core'
+import { getActiveCauldron } from 'ern-cauldron-api'
+import {
+  epilog,
+  logErrorAndExitIfNotSatisfied,
+  tryCatchWrap,
+  askUserToChooseANapDescriptorFromCauldron,
+} from '../lib'
+import _ from 'lodash'
+import { Argv } from 'yargs'
+import fs from 'fs'
+import path from 'path'
+
+export const command = 'create-composite'
+export const desc = 'Create a JS composite project locally'
+
+export const builder = (argv: Argv) => {
+  return argv
+    .option('descriptor', {
+      alias: 'd',
+      describe: 'Full native application descriptor',
+      type: 'string',
+    })
+    .coerce('descriptor', d =>
+      NativeApplicationDescriptor.fromString(d, { throwIfNotComplete: true })
+    )
+    .option('extraJsDependencies', {
+      alias: 'e',
+      describe: 'Additional JS dependency(ies)',
+      type: 'array',
+    })
+    .coerce('extraJsDependencies', d => d.map(PackagePath.fromString))
+    .option('fromGitBranches', {
+      describe: 'Favor MiniApp(s) branches',
+      type: 'boolean',
+    })
+    .option('jsApiImpls', {
+      describe: 'One or more JS API implementation(s)',
+      type: 'array',
+    })
+    .coerce('jsApiImpls', d => d.map(PackagePath.fromString))
+    .option('miniapps', {
+      alias: 'm',
+      describe: 'One or more MiniApp(s)',
+      type: 'array',
+    })
+    .coerce('miniapps', d => d.map(PackagePath.fromString))
+    .option('outDir', {
+      alias: 'out',
+      describe: 'Output directory',
+      type: 'string',
+    })
+    .epilog(epilog(exports))
+}
+
+export const commandHandler = async ({
+  descriptor,
+  extraJsDependencies,
+  fromGitBranches,
+  jsApiImpls,
+  miniapps,
+  outDir,
+}: {
+  descriptor?: NativeApplicationDescriptor
+  extraJsDependencies?: PackagePath[]
+  fromGitBranches?: boolean
+  jsApiImpls?: PackagePath[]
+  miniapps?: PackagePath[]
+  outDir?: string
+  platform?: NativePlatform
+} = {}) => {
+  if (outDir && fs.existsSync(outDir)) {
+    if (fs.readdirSync(outDir).length > 0) {
+      throw new Error(
+        `${outDir} directory exists and is not empty.
+Output directory should either not exist (it will be created) or should be empty.`
+      )
+    }
+  }
+
+  const cauldron = await getActiveCauldron({ throwIfNoActiveCauldron: false })
+  if (!cauldron && !miniapps) {
+    throw new Error(
+      "A Cauldron must be active if you don't explicitly provide miniapps"
+    )
+  }
+
+  // Full native application selector was not provided.
+  // Ask the user to select a completeNapDescriptor from a list
+  // containing all the native applications versions in the cauldron
+  // Not needed if miniapps are directly provided
+  if (!descriptor && !miniapps) {
+    descriptor = await askUserToChooseANapDescriptorFromCauldron()
+  }
+
+  let pathToYarnLock
+  if (descriptor) {
+    await logErrorAndExitIfNotSatisfied({
+      napDescriptorExistInCauldron: {
+        descriptor,
+        extraErrorMessage:
+          'You cannot create a composite for a non-existing native application version.',
+      },
+    })
+    miniapps = await cauldron.getContainerMiniApps(descriptor, {
+      favorGitBranches: !!fromGitBranches,
+    })
+    jsApiImpls = await cauldron.getContainerJsApiImpls(descriptor)
+    const containerGenConfig = await cauldron.getContainerGeneratorConfig(
+      descriptor
+    )
+    if (!containerGenConfig || !containerGenConfig.bypassYarnLock) {
+      pathToYarnLock = await cauldron.getPathToYarnLock(descriptor, 'container')
+    } else {
+      log.debug(
+        'Bypassing yarn.lock usage as bypassYarnLock flag is set in config'
+      )
+    }
+  }
+
+  await generateMiniAppsComposite(
+    miniapps!,
+    outDir || path.join(Platform.rootDirectory, 'miniAppsComposite'),
+    {
+      extraJsDependencies,
+      pathToYarnLock,
+    },
+    jsApiImpls
+  )
+}
+
+export const handler = tryCatchWrap(commandHandler)

--- a/ern-orchestrator/src/container.ts
+++ b/ern-orchestrator/src/container.ts
@@ -154,15 +154,17 @@ export async function runCauldronContainerGen(
   {
     outDir,
     compositeMiniAppDir,
+    favorGitBranches
   }: {
     outDir?: string
     compositeMiniAppDir?: string
+    favorGitBranches?: boolean
   } = {}
 ): Promise<ContainerGenResult> {
   try {
     const cauldron = await getActiveCauldron()
     const plugins = await cauldron.getNativeDependencies(napDescriptor)
-    const miniapps = await cauldron.getContainerMiniApps(napDescriptor)
+    const miniapps = await cauldron.getContainerMiniApps(napDescriptor, { favorGitBranches })
     const jsApiImpls = await cauldron.getContainerJsApiImpls(napDescriptor)
     const containerGenConfig = await cauldron.getContainerGeneratorConfig(
       napDescriptor


### PR DESCRIPTION
The current way to create a JS composite project is to use the `create-container` command along with the `--jsOnly` flag.

There is -at least- two problems with the current approach :

1. It creates confusion around platform concepts understanding, especially for new comers. 
The JS Composite is not a Container in itself, so why should one use a `create-container` command to create a Composite when they are not the same?

2. It makes the `create-container` command logic more complex to accommodate this specific option, also because of the fact that some options of the command can only be used when `--jsOnly` is present or the opposite (also on a most fundamental design note, the current command allows to `create a Container` OR `create a Composite`. When a single command can do two different things, that's a code smell).

For these reasons, this PR introduces a new command `create-composite` that can be used ... well ... to create a Composite. It removes the `--jsOnly` logic from the `create-container` command and marks this option as deprecated, informing the user to use the new `create-composite` command in case this option is set.

**For release notes** : This is a breaking change !