### PR TITLE
Improve iOS Runner build failure reporting

### DIFF
--- a/ern-orchestrator/src/buildIosRunner.ts
+++ b/ern-orchestrator/src/buildIosRunner.ts
@@ -26,7 +26,11 @@ export async function buildIosRunner(pathToIosRunner: string, udid: string) {
       code === 0
         ? resolve()
         : reject(
-            new Error(`XCode xcbuild command failed with exit code ${code}`)
+            new Error(`iOS Runner build failed [xcbuild exit code ${code}].
+To troubleshoot this build failure, we recommend building the Runner iOS project from XCode.
+You can open the Runner project in XCode manually or by running 'open ios/ErnRunner.xcodeproj'.
+Building the Runner from XCode will provide more meaningful error reporting that can be of help 
+to pinpoint the cause of the build failure.`)
           )
     })
   })

--- a/ern-orchestrator/src/launchRunner.ts
+++ b/ern-orchestrator/src/launchRunner.ts
@@ -25,9 +25,7 @@ async function launchAndroidRunner(pathToAndroidRunner: string) {
 
 async function launchIosRunner(pathToIosRunner: string) {
   const iosDevices = ios.getiPhoneRealDevices()
-  if (iosDevices && iosDevices.length > 0) {
-    launchOnDevice(pathToIosRunner, iosDevices)
-  } else {
-    launchOnSimulator(pathToIosRunner)
-  }
+  return iosDevices && iosDevices.length > 0
+    ? launchOnDevice(pathToIosRunner, iosDevices)
+    : launchOnSimulator(pathToIosRunner)
 }


### PR DESCRIPTION
- Return a `Promise` rather than `void` from `launchIosRunner` function so that in case of an error being thrown we don't end up with an ugly `UnhandledPromiseRejectionWarning`.

- Improve error message in case of iOS Runner build failure, by giving some suggestion to the user to help troubleshoot the build issue further (rather than just facing a bare xcbuild error code without any clue of what to do next).

**Before**

```
(node:31119) UnhandledPromiseRejectionWarning: Error: XCode xcbuild command failed with exit code 65.
    at ChildProcess.xcodebuildProc.on.code (/Users/blemair/Code/electrode-native/ern-orchestrator/src/buildIosRunner.ts:33:30)
    at emitTwo (events.js:126:13)
    at ChildProcess.emit (events.js:214:7)
    at maybeClose (internal/child_process.js:925:16)
    at Socket.stream.socket.on (internal/child_process.js:346:11)
    at emitOne (events.js:116:13)
    at Socket.emit (events.js:211:7)
    at Pipe._handle.close [as _onclose] (net.js:557:12)
(node:31119) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
(node:31119) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

**After**

```
✖ An error occurred: iOS Runner build failed [xcbuild exit code 65].
✖ To troubleshoot this build failure, we recommend building the Runner iOS project from XCode.
✖ You can open the Runner project in XCode manually or by running 'open ios/ErnRunner.xcodeproj'.
✖ Building the Runner from XCode will provide more meaningful error reporting that can be of help
✖ to pinpoint the cause of the build failure.
```