### PR TITLE
Add new create-plugin-config command

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -66,6 +66,7 @@
 - [create-api](cli/create-api.md)
 - [create-composite](cli/create-composite.md)
 - [create-container](cli/create-container.md)
+- [create-plugin-config](cli/create-plugin-config.md)
 - [publish-container](cli/publish-container.md)
 - [transform-container](cli/transform-container.md)
 - [create-miniapp](cli/create-miniapp.md)

--- a/docs/cli/create-plugin-config.md
+++ b/docs/cli/create-plugin-config.md
@@ -1,0 +1,31 @@
+## `ern create-plugin-config`
+
+#### Description
+
+* Automatically generates the Manifest configuration of a given React Native plugin
+
+#### Syntax
+
+`ern create-plugin-config <plugin>`
+
+**Arguments**
+
+`<plugin>`
+
+* The npm package name of the React Native plugin for which to generate configuration. If no version is specified, latest will be considered. 
+
+#### Examples
+
+`ern create-plugin-config react-native-foo-plugin`
+
+Creates a plugin configuration for `react-native-foo-plugin` latest version
+
+`ern create-plugin-config react-native-foo-plugin@1.2.0`
+
+Creates a plugin configuration for `react-native-foo-plugin` version `1.2.0`
+
+#### Remarks
+
+* This command needs to be run from the root of a cloned Manifest repository
+* This command only creates the configuration in the manifest locally. You will need to manually review/test and then git add/commit/push the changes to the Manifest repository. 
+*  This command will fail in case it detects that the plugin should be configurable as it doesn't support Configurable Plugin config generation.

--- a/ern-core/package.json
+++ b/ern-core/package.json
@@ -50,6 +50,7 @@
     "decompress-zip": "^0.3.1",
     "fs-readdir-recursive": "^1.1.0",
     "get-folder-size": "^2.0.0",
+    "gradle-to-js":"^1.2.1",
     "inquirer": "^3.0.6",
     "lodash": "^4.17.10",
     "mustache": "^2.3.1",

--- a/ern-core/src/AndroidPluginConfigGenerator.ts
+++ b/ern-core/src/AndroidPluginConfigGenerator.ts
@@ -1,0 +1,221 @@
+import path from 'path'
+import readDir from 'fs-readdir-recursive'
+import g2js from 'gradle-to-js/lib/parser'
+import { readFile } from './fileUtil'
+import Mustache from 'mustache'
+import log from './log'
+
+const template = `package com.walmartlabs.ern.container.plugins;
+
+import android.app.Application;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.facebook.react.ReactInstanceManagerBuilder;
+import com.facebook.react.ReactPackage;
+import {{fullyQualifiedPackageClassName}};
+
+public class {{packageClassName}}Plugin implements ReactPlugin {
+    public ReactPackage hook(@NonNull Application application,
+                     @Nullable ReactPluginConfig config) {
+        return new {{packageClassName}}();
+    }
+}`
+
+export class AndroidPluginConfigGenerator {
+  public static fromPath(p: string) {
+    return new AndroidPluginConfigGenerator(p)
+  }
+
+  public readonly root: string
+  public readonly files: string[]
+
+  private readonly excludedDirectoriesRe = new RegExp(/sample|demo|example/i)
+  private readonly exclusions: string[] = [
+    'com.facebook.react:react-native',
+    'fileTree(include',
+  ]
+
+  private constructor(p: string) {
+    this.root = p
+    this.files = readDir(p, x => !this.excludedDirectoriesRe.test(x))
+  }
+
+  public async generateConfig({
+    revolveBuildGradlePath,
+    resolveDependencyVersion,
+  }: {
+    revolveBuildGradlePath: (buildGradlePaths: string[]) => Promise<string>
+    resolveDependencyVersion: (dependency: string) => Promise<string>
+  }): Promise<any> {
+    if (!this.doesPluginSupportAndroid) {
+      throw new Error('No Android project found')
+    }
+    const config: any = {}
+    let buildGradlePath
+    if (this.gradlePaths.length > 1) {
+      if (this.androidManifestPaths.length > 1) {
+        buildGradlePath = await revolveBuildGradlePath(this.gradlePaths)
+      } else {
+        const manifestPath = this.androidManifestPaths[0]
+        // find build.gradle path closest to AndroidManifest.xml
+        let p = path.dirname(manifestPath)
+        while (p !== '.') {
+          if (this.gradlePaths.map(path.dirname).includes(p)) {
+            buildGradlePath = path.join(p, 'build.gradle')
+            break
+          }
+          p = path.dirname(p)
+        }
+      }
+    } else {
+      buildGradlePath = this.gradlePaths[0]
+    }
+
+    config.root = path.dirname(buildGradlePath)
+    config.dependencies = await this.getDependenciesFromBuildGradle(
+      path.join(this.root, buildGradlePath),
+      resolveDependencyVersion
+    )
+
+    return config
+  }
+
+  public get doesPluginSupportAndroid() {
+    return this.gradlePaths.length > 0
+  }
+
+  public async getDependenciesFromBuildGradle(
+    p: string,
+    resolveDependencyVersion: (dependency: string) => Promise<string>
+  ) {
+    const parsed: any = await g2js.parseFile(p)
+    const res = await Promise.all(
+      parsed.dependencies
+        .filter((x: any) => !/testImplementation|testCompile/.test(x.type))
+        .filter((x: any) => !this.exclusions.includes(`${x.group}:${x.name}`))
+        .filter((x: any) => !this.exclusions.some(y => x.name.includes(y)))
+        .map(async (x: any) => {
+          if (x.group) {
+            return `${x.group}:${x.name}:${x.version}`
+          } else {
+            // Handle this kind of string where version is dynnamicaly retrieved
+            // "com.android.support:exifinterface:${safeExtGet('supportLibVersion', '28.0.0')}"
+            const match = x.name.replace('"', '').match(/^(.+):(.+):(.+)/)
+            if (match) {
+              const [, group, name, version] = match
+              const versionMatch = version.match(/\d+.\d+.\d+/)
+              if (versionMatch) {
+                return `${group}:${name}:${versionMatch[0]}`
+              } else {
+                // Handle this kind of string where version cannot be found inline
+                // com.google.android.gms:play-services-vision:$googlePlayServicesVisionVersion
+                const resolvedVersion = await resolveDependencyVersion(
+                  `${group}:${name}`
+                )
+                return `${group}:${name}:${resolvedVersion}`
+              }
+            }
+            log.debug(`Ignoring ${x.name}`)
+            return ''
+          }
+        })
+    )
+    return res.filter((x: string) => x !== '')
+  }
+
+  public async generatePluginJavaSource(): Promise<any> {
+    const packageImpl = await this.findReactPackageImplementationFile()
+    const absPath = path.join(this.root, packageImpl)
+    const packageName = await this.getJavaPackageDeclarationFromSource(absPath)
+    const packageClassName = await this.getClassNameFromSource(absPath)
+    const fullyQualifiedPackageClassName = `${packageName}.${packageClassName}`
+
+    if (await this.hasNonDefaultConstructor(absPath, packageClassName)) {
+      if (!(await this.hasDefaultConstructor(absPath, packageClassName))) {
+        throw new Error(
+          `Non default constructors found in ${packageClassName} class.
+${packageImpl}.
+A Configurable Plugin implementation might be required.
+Automated Configurable Plugin generation is not yet supported`
+        )
+      } else {
+        log.warn(`Non default constructors detected.
+It might be needed to manually update the plugin config to make it a configurable plugin.`)
+      }
+    }
+
+    return {
+      content: Mustache.render(template, {
+        fullyQualifiedPackageClassName,
+        packageClassName,
+      }),
+      filename: `${packageClassName}Plugin.java`,
+    }
+  }
+
+  public async findReactPackageImplementationFile(): Promise<string> {
+    let candidates = this.files.filter(x => x.endsWith('Package.java'))
+    let result
+    if (candidates.length === 0) {
+      candidates = this.files.filter(x => x.endsWith('.java'))
+    }
+    for (const candidate of candidates) {
+      const content = await readFile(path.join(this.root, candidate))
+      if (/implements ReactPackage/.test(content)) {
+        // Found it ! Unless there are multiple ReactPackage impls
+        // Should check if that's the case and fail
+        result = candidate
+      }
+    }
+    if (!result) {
+      throw new Error('ReactPackage implementation not found')
+    }
+    return result
+  }
+
+  public async getJavaPackageDeclarationFromSource(p: string): Promise<string> {
+    const content = await readFile(p)
+    const match = content.match(/package (.+);/)
+    if (!match) {
+      throw new Error(`No package declaration found in ${p}`)
+    }
+    return match[1]
+  }
+
+  public async getClassNameFromSource(p: string): Promise<string> {
+    const content = await readFile(p)
+    const match = content.match(/class (.+) implements ReactPackage/)
+    if (!match) {
+      throw new Error(`No class implementing ReactPackage found in ${p}`)
+    }
+    return match[1]
+  }
+
+  public async hasDefaultConstructor(
+    p: string,
+    className: string
+  ): Promise<boolean> {
+    const content = await readFile(p)
+    const re = new RegExp(`public ${className}\\((\\t*|\\s*)\\)`, 'g')
+    return re.test(content)
+  }
+
+  public async hasNonDefaultConstructor(
+    p: string,
+    className: string
+  ): Promise<any | null> {
+    const content = await readFile(p)
+    const re = new RegExp(`public ${className}\\(\\S+`, 'g')
+    const match = content.match(re)
+    return match && match.length > 0
+  }
+
+  get gradlePaths(): string[] {
+    return this.files.filter(x => x.endsWith('build.gradle'))
+  }
+
+  get androidManifestPaths(): string[] {
+    return this.files.filter(x => x.endsWith('AndroidManifest.xml'))
+  }
+}

--- a/ern-core/src/IosPluginConfigGenerator.ts
+++ b/ern-core/src/IosPluginConfigGenerator.ts
@@ -1,0 +1,77 @@
+import path from 'path'
+import readDir from 'fs-readdir-recursive'
+
+export class IosPluginConfigGenerator {
+  public static fromPath(p: string) {
+    return new IosPluginConfigGenerator(p)
+  }
+
+  public readonly root: string
+  public readonly files: string[]
+
+  private readonly excludedDirectoriesRe = new RegExp(/sample|demo|example/i)
+
+  private constructor(p: string) {
+    this.root = p
+    this.files = readDir(p, x => !this.excludedDirectoriesRe.test(x))
+  }
+
+  public async generateConfig({
+    resolvePbxProjPath,
+  }: {
+    resolvePbxProjPath: (pbxProjPaths: string[]) => Promise<string>
+  }): Promise<any> {
+    if (!this.doesPluginSupportIos) {
+      throw new Error('No iOS project found')
+    }
+    const config: any = {}
+    const pbxProjPath: string =
+      this.pbxprojPaths.length > 1
+        ? await resolvePbxProjPath(this.pbxprojPaths)
+        : this.pbxprojPaths[0]
+    const projName = this.getProjectName(pbxProjPath)
+    const xcodeprojPath = path.dirname(pbxProjPath)
+    const rootXCodeProjPath = path.dirname(xcodeprojPath)
+    config.copy = [
+      {
+        dest: `{{{projectName}}}/Libraries/${projName}`,
+        source: `${rootXCodeProjPath}/**`,
+      },
+    ]
+
+    config.pbxproj = {
+      addHeaderSearchPath: [
+        `\"$(SRCROOT)/{{{projectName}}}/Libraries/${projName}/**\"`,
+      ],
+      addProject: [
+        {
+          group: 'Libraries',
+          path: `${projName}/${projName}.xcodeproj`,
+          staticLibs: [
+            {
+              name: `lib${projName}.a`,
+              target: projName,
+            },
+          ],
+        },
+      ],
+    }
+    return config
+  }
+
+  public get doesPluginSupportIos() {
+    return this.pbxprojPaths.length > 0
+  }
+
+  public getProjectName(pbxProjPath: string) {
+    let match = pbxProjPath.match(/.+\/(.+)\.xcodeproj/)
+    if (!match) {
+      match = pbxProjPath.match(/^(.+)\.xcodeproj/)
+    }
+    return match![1]
+  }
+
+  get pbxprojPaths(): string[] {
+    return this.files.filter(x => x.endsWith('.pbxproj'))
+  }
+}

--- a/ern-core/src/PluginConfigGenerator.ts
+++ b/ern-core/src/PluginConfigGenerator.ts
@@ -1,0 +1,68 @@
+import log from './log'
+import { AndroidPluginConfigGenerator } from './AndroidPluginConfigGenerator'
+import { IosPluginConfigGenerator } from './IosPluginConfigGenerator'
+
+export class PluginConfigGenerator {
+  public static async generateFromPath({
+    pluginPath,
+    revolveBuildGradlePath,
+    resolvePbxProjPath,
+    resolveDependencyVersion,
+  }: {
+    pluginPath: string
+    revolveBuildGradlePath: (buildGradlePaths: string[]) => Promise<string>
+    resolvePbxProjPath: (pbxProjPaths: string[]) => Promise<string>
+    resolveDependencyVersion: (dependency: string) => Promise<string>
+  }): Promise<{
+    pluginConfig: any
+    androidPluginSource: { filename: string; content: string } | void
+  }> {
+    const result: any = {}
+    const androidGenerator = AndroidPluginConfigGenerator.fromPath(pluginPath)
+    const iosGenerator = IosPluginConfigGenerator.fromPath(pluginPath)
+
+    if (androidGenerator.doesPluginSupportAndroid) {
+      try {
+        const androidConfig = await androidGenerator.generateConfig({
+          resolveDependencyVersion,
+          revolveBuildGradlePath,
+        })
+        const androidPluginSource = await androidGenerator.generatePluginJavaSource()
+        result.pluginConfig = result.pluginConfig || {}
+        result.pluginConfig.android = androidConfig
+        result.androidPluginSource = androidPluginSource
+
+        log.info('Generated Android plugin configuration')
+      } catch (e) {
+        throw new Error(`Failed to generate Android Plugin Configuration.
+  
+Reason: ${e.message}`)
+      }
+    } else {
+      log.warn(
+        `[Skipping Android generation] Looks like this plugin does not support Android.`
+      )
+    }
+
+    if (iosGenerator.doesPluginSupportIos) {
+      try {
+        const iosConfig = await iosGenerator.generateConfig({
+          resolvePbxProjPath,
+        })
+        result.pluginConfig = result.pluginConfig || {}
+        result.pluginConfig.ios = iosConfig
+        log.info('Generated iOS plugin configuration')
+      } catch (e) {
+        throw new Error(`Failed to generate iOS Plugin Configuration.
+  
+Reason: ${e.message}`)
+      }
+    } else {
+      log.warn(
+        `[Skipping iOS generation] Looks like this plugin does not support iOS.`
+      )
+    }
+
+    return result
+  }
+}

--- a/ern-core/src/index.ts
+++ b/ern-core/src/index.ts
@@ -77,7 +77,10 @@ export {
 
 export { BundlingResult } from './ReactNativeCli'
 
+export { AndroidPluginConfigGenerator } from './AndroidPluginConfigGenerator'
+export { IosPluginConfigGenerator } from './IosPluginConfigGenerator'
 export { ManifestOverrideConfig } from './Manifest'
+export { PluginConfigGenerator } from './PluginConfigGenerator'
 
 export { NativePlatform } from './NativePlatform'
 export { FsCache } from './FsCache'

--- a/ern-core/test/AndroidPluginConfigGenerator-test.ts
+++ b/ern-core/test/AndroidPluginConfigGenerator-test.ts
@@ -1,0 +1,35 @@
+import { AndroidPluginConfigGenerator } from '../src/AndroidPluginConfigGenerator'
+import path from 'path'
+import { expect } from 'chai'
+
+describe('AndroidPluginConfigGenerator', () => {
+  const fixutresPath = path.join(
+    __dirname,
+    'fixtures',
+    'PluginConfigGenerator',
+    'android'
+  )
+
+  const dependenciesFixturePath = path.join(fixutresPath, 'dependencies')
+  const dependenciesBuildGradlePath = path.join(
+    dependenciesFixturePath,
+    'build.gradle'
+  )
+
+  describe('getDependenciesFromBuildGradle', () => {
+    it('should get dependencies', async () => {
+      const sut = AndroidPluginConfigGenerator.fromPath(dependenciesFixturePath)
+      const dependencies = await sut.getDependenciesFromBuildGradle(
+        dependenciesBuildGradlePath,
+        () => Promise.resolve('1.0.0')
+      )
+      expect(dependencies).deep.equal([
+        'com.google.zxing:core:3.3.3',
+        'com.drewnoakes:metadata-extractor:2.11.0',
+        'com.android.support:exifinterface:28.0.0',
+        'com.android.support:support-annotations:28.0.0',
+        'com.android.support:support-v4:28.0.0',
+      ])
+    })
+  })
+})

--- a/ern-core/test/fixtures/PluginConfigGenerator/android/dependencies/build.gradle
+++ b/ern-core/test/fixtures/PluginConfigGenerator/android/dependencies/build.gradle
@@ -1,0 +1,58 @@
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
+buildscript {
+  repositories {
+    google()
+    maven {
+      url 'https://maven.google.com'
+    }
+    jcenter()
+  }
+
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.3.1'
+  }
+}
+
+apply plugin: 'com.android.library'
+
+android {
+  compileSdkVersion safeExtGet('compileSdkVersion', 28)
+  buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
+
+  defaultConfig {
+    minSdkVersion safeExtGet('minSdkVersion', 16)
+    targetSdkVersion safeExtGet('targetSdkVersion', 28)
+  }
+
+  lintOptions {
+    abortOnError false
+    warning 'InvalidPackage'
+  }
+}
+
+repositories {
+  google()
+  jcenter()
+  maven {
+   url 'https://maven.google.com'
+  }
+  maven { url "https://jitpack.io" }
+  maven {
+    // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+    url "$rootDir/../node_modules/react-native/android"
+  }
+}
+
+dependencies {
+  def googlePlayServicesVisionVersion = safeExtGet('googlePlayServicesVisionVersion', safeExtGet('googlePlayServicesVersion', '17.0.2'))
+
+  implementation 'com.facebook.react:react-native:+'
+  implementation "com.google.zxing:core:3.3.3"
+  implementation "com.drewnoakes:metadata-extractor:2.11.0"
+  implementation "com.android.support:exifinterface:${safeExtGet('supportLibVersion', '28.0.0')}"
+  implementation "com.android.support:support-annotations:${safeExtGet('supportLibVersion', '28.0.0')}"
+  implementation "com.android.support:support-v4:${safeExtGet('supportLibVersion', '28.0.0')}"
+}

--- a/ern-local-cli/src/commands/create-plugin-config.ts
+++ b/ern-local-cli/src/commands/create-plugin-config.ts
@@ -1,0 +1,84 @@
+import {
+  readPackageJson,
+  PackagePath,
+  PluginConfigGenerator,
+  createTmpDir,
+  shell,
+  yarn,
+  promptUtils,
+} from 'ern-core'
+
+import { epilog, tryCatchWrap, askUserInput } from '../lib'
+import { Argv } from 'yargs'
+import fs from 'fs'
+import path from 'path'
+
+export const command = 'create-plugin-config <plugin>'
+export const desc = 'Create plugin configuration for the manifest'
+export const builder = (argv: Argv) => {
+  return argv.coerce('plugin', PackagePath.fromString).epilog(epilog(exports))
+}
+
+// Bump this version whenever Electrode Native plugin configuration
+// offers new features or has structural changes
+const manifestBaseErnVersion = '0.14.0'
+
+export const commandHandler = async ({ plugin }: { plugin: PackagePath }) => {
+  if (!fs.existsSync('manifest.json')) {
+    throw new Error(`No manifest.json file found in current directory.
+Make sure this command is run from a Manifest directory.`)
+  }
+
+  const tmpDir = createTmpDir()
+
+  try {
+    shell.pushd(tmpDir)
+    await yarn.init()
+    await yarn.add(plugin)
+  } finally {
+    shell.popd()
+  }
+
+  const pluginPath = path.join(tmpDir, 'node_modules', plugin.basePath)
+  const conf = await PluginConfigGenerator.generateFromPath({
+    pluginPath,
+    resolveDependencyVersion: x =>
+      askUserInput({
+        message: `Cannot resolve version for ${x}. Enter the version to use`,
+      }),
+    resolvePbxProjPath: x =>
+      promptUtils.askUserToChooseAnOption(
+        x,
+        'Select the .pbxproj associated to this plugin'
+      ),
+    revolveBuildGradlePath: x =>
+      promptUtils.askUserToChooseAnOption(
+        x,
+        'Select the build.gradle associated to this plugin'
+      ),
+  })
+  const pluginPackageJson = await readPackageJson(pluginPath)
+  const pluginVersion = pluginPackageJson.version
+  const pathToPluginConfig = path.join(
+    'plugins',
+    `ern_v${manifestBaseErnVersion}+`,
+    `${plugin.basePath}_v${pluginVersion}+`
+  )
+  if (!fs.existsSync(pathToPluginConfig)) {
+    shell.mkdir('-p', pathToPluginConfig)
+  } else {
+    throw new Error(`path ${pathToPluginConfig} already exist`)
+  }
+  fs.writeFileSync(
+    path.join(pathToPluginConfig, 'config.json'),
+    JSON.stringify(conf.pluginConfig, null, 2)
+  )
+  if (conf.androidPluginSource) {
+    fs.writeFileSync(
+      path.join(pathToPluginConfig, conf.androidPluginSource.filename),
+      conf.androidPluginSource.content
+    )
+  }
+}
+
+export const handler = tryCatchWrap(commandHandler)

--- a/ern-local-cli/src/lib/askUserInput.ts
+++ b/ern-local-cli/src/lib/askUserInput.ts
@@ -1,0 +1,16 @@
+import inquirer from 'inquirer'
+
+export async function askUserInput({
+  message,
+}: {
+  message: string
+}): Promise<string> {
+  const { result } = await inquirer.prompt([
+    <inquirer.Question>{
+      message,
+      name: 'result',
+      type: 'input',
+    },
+  ])
+  return result
+}

--- a/ern-local-cli/src/lib/index.ts
+++ b/ern-local-cli/src/lib/index.ts
@@ -29,3 +29,4 @@ export { askUserForCodePushLabel } from './askUserForCodePushLabel'
 export {
   emptyContainerIfSingleMiniAppOrJsApiImpl,
 } from './emptyContainerIfSingleMiniAppOrJsApiImpl'
+export { askUserInput } from './askUserInput'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2386,6 +2386,13 @@ graceful-fs@^4.1.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3,
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
   integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
 
+gradle-to-js@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/gradle-to-js/-/gradle-to-js-1.2.1.tgz#1ee6a9db7ea18e35ee7c5b61a4fd60642a9c628e"
+  integrity sha512-HO13qBGUb7jCztEJYVu+s7iLMgN+Hlbi5UeNT+Kw2TT/Wvzx52whwg172/xDufz2kOaXJkp4PXVTRMbDbQG1Vw==
+  dependencies:
+    lodash.merge "4.6.1"
+
 graphlib@^2.1.1:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/graphlib/-/graphlib-2.1.5.tgz#6afe1afcc5148555ec799e499056795bd6938c87"
@@ -3388,6 +3395,11 @@ lodash.isequal@^4.0.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+
+lodash.merge@4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
+  integrity sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==
 
 lodash.template@^4.0.2:
   version "4.4.0"


### PR DESCRIPTION
Add a new `create-plugin-config` command which can be used to automatically generate plugin configuration files for the Manifest.

This command has to be run from within the root of a Manifest directory (most likely a clone Manifest repository). 

For example to add a plugin configuration for `react-native-foo` plugin version `1.2.3`,  the following command could be run in the root of a Manifest directory :

`ern create-plugin-config react-native-foo@1.2.3`

Assuming the plugin supports both iOS and Android, and that its configuration can be generated by the command, this will result in the following directories and files to be generated.

```
plugins/ern_v0.14.0+/react-native-foo_v1.2.3+/config.json
plugins/ern_v0.14.0+/react-native-foo_v1.2.3+/ReactNativeFooPlugin.java
```

This plugin configuration generator was evaluated against all plugins currently present in our master manifest and was able to automatically generate the configuration of ~80% of them. The remaining 20% are mostly plugins that are configurable (for example `react-native-code-push`), which is not -yet- supported by the generator, in which case it will properly fail with an informative error message.

This generator has room for improvements, mostly regarding Configurable plugin support, even though that's a tough one to implement. 
Also for Android it won't add any permissions. This is very hard to detect (unless maybe parsing the README.md file of the plugin for hints). It will still generate the plugin configuration but it's up to the user to manually add permissions in the plugin config (or in the app itself)
For Android it does not support transitive dependencies detection (rare).

Still, in most use cases it will generate a proper config, avoiding the burden of manual configuration through copy/paste or at least giving a head start with proper skeleton.

Let's use this command when adding new plugins from now on and see how it behaves.