### PR TITLE
Improve Android Container generator dependencies resolution

### DIFF
--- a/ern-container-gen-android/src/hull/lib/build.gradle
+++ b/ern-container-gen-android/src/hull/lib/build.gradle
@@ -31,8 +31,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:{{{supportLibraryVersion}}}'
-  {{#pluginCompile}}
-    {{{compileStatement}}}
-  {{/pluginCompile}}
+  {{#implementations}}
+    {{{.}}}
+  {{/implementations}}
 }

--- a/system-tests/fixtures/android-container/lib/build.gradle
+++ b/system-tests/fixtures/android-container/lib/build.gradle
@@ -31,7 +31,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    api 'com.walmartlabs.ern:react-native:0.59.4'
     implementation 'com.nimbusds:nimbus-jose-jwt:5.1'
+    implementation 'com.walmartlabs.ern:react-native:0.59.4'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
 }


### PR DESCRIPTION
Perform the following pre-processing for dependencies (declared by plugins) to be added in the Android Container as `implementation` statements :`

- Dedupe 
Multiple plugins might be using a same dependency (including version). This previously would have resulted into multiple `implementation` statements added for same exact dependency. 

- Align support library version
Electrode Native offers to choose a support library version to use for the Container, or use an internal default. Prior to this change, any support library (group `com.android.support`) used by a plugin would have been injected as such including version used by the plugin, resulting in different versions of the support library. 

- Keep highest versions
If a dependency is used by multiple plugins but with a different version, just keep the highest version rather than injecting multiple implementation statements for the same dependency but with different versions