### PR TITLE
Improve Container and Composite generation logs

### DIFF
--- a/ern-composite-gen/src/generateComposite.ts
+++ b/ern-composite-gen/src/generateComposite.ts
@@ -7,6 +7,7 @@ import {
   readPackageJson,
   writePackageJson,
   fileUtils,
+  kax,
 } from 'ern-core'
 import { cleanupCompositeDir } from './cleanupCompositeDir'
 import {
@@ -180,7 +181,7 @@ async function installJsPackagesUsingYarnLock({
   // Now that the composite package.json is similar to the one used to generated yarn.lock
   // we can run yarn install to get back to the exact same dependency graph as the previously
   // generated composite
-  await yarn.install()
+  await kax.task('Running yarn install').run(yarn.install())
   await runYarnUsingMiniAppDeltas(miniAppsDeltas)
 }
 
@@ -194,8 +195,11 @@ async function installJsPackagesWithoutYarnLock({
   // No yarn.lock path was provided, just add miniapps one by one
   log.debug('[generateComposite] no yarn lock provided')
   await yarn.init()
-  for (const miniappPath of jsPackages) {
-    await yarn.add(miniappPath)
+  const nbJsPackages = jsPackages.length
+  for (let i = 0; i < nbJsPackages; i++) {
+    await kax
+      .task(`[${i + 1}/${nbJsPackages}] Adding ${jsPackages[i]}`)
+      .run(yarn.add(jsPackages[i]))
   }
 }
 

--- a/ern-composite-gen/src/miniAppsDeltasUtils.ts
+++ b/ern-composite-gen/src/miniAppsDeltasUtils.ts
@@ -1,4 +1,4 @@
-import { log, PackagePath, yarn, utils } from 'ern-core'
+import { log, PackagePath, yarn, utils, kax } from 'ern-core'
 import {
   getYarnLockTopLevelDependencyRe,
   getYarnLockTopLevelGitDependencyRe,
@@ -111,7 +111,9 @@ export async function runYarnUsingMiniAppDeltas(
   if (miniAppsDeltas.new) {
     for (const newMiniAppVersion of miniAppsDeltas.new) {
       log.debug(`Adding new MiniApp ${newMiniAppVersion.toString()}`)
-      await yarn.add(newMiniAppVersion)
+      await kax
+        .task(`Adding ${newMiniAppVersion}`)
+        .run(yarn.add(newMiniAppVersion))
     }
   }
 
@@ -129,7 +131,9 @@ export async function runYarnUsingMiniAppDeltas(
     for (const upgradedMiniAppVersion of miniAppsDeltas.upgraded) {
       log.debug(`Upgrading MiniApp ${upgradedMiniAppVersion.toString()}`)
       // TODO : Once again ... Do we really want upgrade here ?
-      await yarn.upgrade(upgradedMiniAppVersion)
+      await kax
+        .task(`Upgrading ${upgradedMiniAppVersion}`)
+        .run(yarn.upgrade(upgradedMiniAppVersion))
     }
   }
 
@@ -150,7 +154,9 @@ export async function runYarnUsingMiniAppDeltas(
         log.debug(
           `Re-adding git based MiniApp ${sameMiniAppVersion.toString()}`
         )
-        await yarn.add(sameMiniAppVersion)
+        await kax
+          .task(`Adding ${sameMiniAppVersion}`)
+          .run(yarn.add(sameMiniAppVersion))
       }
     }
   }

--- a/ern-local-cli/src/commands/create-composite.ts
+++ b/ern-local-cli/src/commands/create-composite.ts
@@ -5,6 +5,7 @@ import {
   Platform,
   log,
   NativePlatform,
+  kax,
 } from 'ern-core'
 import { getActiveCauldron } from 'ern-cauldron-api'
 import {
@@ -91,6 +92,7 @@ Output directory should either not exist (it will be created) or should be empty
       )
     }
   }
+  outDir = outDir || path.join(Platform.rootDirectory, 'miniAppsComposite')
 
   const cauldron = await getActiveCauldron({ throwIfNoActiveCauldron: false })
   if (!cauldron && !miniapps) {
@@ -137,14 +139,18 @@ Output directory should either not exist (it will be created) or should be empty
       baseComposite || (compositeGenConfig && compositeGenConfig.baseComposite)
   }
 
-  await generateComposite({
-    baseComposite,
-    extraJsDependencies,
-    jsApiImplDependencies: jsApiImpls,
-    miniApps: miniapps!,
-    outDir: outDir || path.join(Platform.rootDirectory, 'miniAppsComposite'),
-    pathToYarnLock,
-  })
+  await kax.task('Generating Composite').run(
+    generateComposite({
+      baseComposite,
+      extraJsDependencies,
+      jsApiImplDependencies: jsApiImpls,
+      miniApps: miniapps!,
+      outDir,
+      pathToYarnLock,
+    })
+  )
+
+  log.info(`Composite successfully generated in ${outDir}`)
 }
 
 export const handler = tryCatchWrap(commandHandler)

--- a/ern-local-cli/src/commands/create-container.ts
+++ b/ern-local-cli/src/commands/create-container.ts
@@ -3,6 +3,9 @@ import {
   NativeApplicationDescriptor,
   NativePlatform,
   kax,
+  Platform,
+  createTmpDir,
+  log,
 } from 'ern-core'
 import { getActiveCauldron } from 'ern-cauldron-api'
 import {
@@ -139,6 +142,8 @@ Output directory should either not exist (it will be created) or should be empty
     }
   }
 
+  compositeDir = compositeDir || createTmpDir()
+
   await logErrorAndExitIfNotSatisfied({
     noGitOrFilesystemPath: {
       extraErrorMessage:
@@ -198,6 +203,7 @@ Output directory should either not exist (it will be created) or should be empty
       })
     )
 
+    outDir = outDir || Platform.getContainerGenOutDirectory(platform)
     await kax.task('Generating Container locally').run(
       runLocalContainerGen(platform, composite, {
         extra: extraObj,
@@ -215,12 +221,17 @@ Output directory should either not exist (it will be created) or should be empty
       })
     )
 
-    await kax.task('Generation Container from Cauldron').run(
+    outDir =
+      outDir || Platform.getContainerGenOutDirectory(descriptor.platform!)
+    await kax.task('Generating Container from Cauldron').run(
       runCauldronContainerGen(descriptor, composite, {
         outDir,
       })
     )
   }
+  log.info(
+    `Container successfully generated in ${outDir}\nComposite generated in ${compositeDir}`
+  )
 }
 
 export const handler = tryCatchWrap(commandHandler)

--- a/ern-orchestrator/src/generateContainerForRunner.ts
+++ b/ern-orchestrator/src/generateContainerForRunner.ts
@@ -34,7 +34,7 @@ export async function generateContainerForRunner(
       })
     )
 
-    await kax.task('Generation Container from Cauldron').run(
+    await kax.task('Generating Container from Cauldron').run(
       runCauldronContainerGen(napDescriptor, composite, {
         outDir,
       })


### PR DESCRIPTION
Improve logs for Composite Generation and fix some Container generation logs.
Will probably ship in patch version `0.31.1` soon given that during Composite Generation no logs at all are displayed in `info` level in `0.31.0`, which is problematic as it might lead users to think the process is stalled.