### PR TITLE
Rebase cauldron from upstream before pushing

### DIFF
--- a/ern-cauldron-api/src/BaseGit.ts
+++ b/ern-cauldron-api/src/BaseGit.ts
@@ -35,9 +35,13 @@ export default class BaseGit implements ITransactional {
   }
 
   public async push() {
-    return this.repository
-      ? this.git.push(GIT_REMOTE_NAME, this.branch)
-      : Promise.resolve()
+    return this.repository ? this.rebaseAndPush() : Promise.resolve()
+  }
+
+  public async rebaseAndPush() {
+    await this.git.raw(['fetch', GIT_REMOTE_NAME])
+    await this.git.raw(['rebase', `${GIT_REMOTE_NAME}/${this.branch}`])
+    return this.git.push(GIT_REMOTE_NAME, this.branch)
   }
 
   public async sync() {


### PR DESCRIPTION
This way, even if the Cauldron was modified in some way during the execution of a command, the command won't fail with an error on `git push`, as long as the changes made are not conflicting with the changes made by the command.
For example, with this change, it is now possible to update configuration files in the Cauldron while a Cauldron Container Generation is running separately, without causing the container generation to fail in the end on git push.