### PR TITLE
Remove app config when removing an app from Cauldron

### DIFF
--- a/ern-cauldron-api/src/CauldronApi.ts
+++ b/ern-cauldron-api/src/CauldronApi.ts
@@ -351,6 +351,16 @@ export default class CauldronApi {
     )
   }
 
+  public async delConfig(descriptor?: NativeApplicationDescriptor) {
+    if (descriptor && !(await this.hasDescriptor(descriptor))) {
+      throw new Error(`${descriptor} does not exist in Cauldron`)
+    }
+    const configFilePath = this.getConfigFilePath(descriptor)
+    if (await this.fileStore.hasFile(configFilePath)) {
+      await this.fileStore.removeFile(configFilePath)
+    }
+  }
+
   public async setConfig({
     descriptor,
     config,

--- a/ern-cauldron-api/src/CauldronHelper.ts
+++ b/ern-cauldron-api/src/CauldronHelper.ts
@@ -1133,6 +1133,10 @@ export class CauldronHelper {
     )
   }
 
+  public async delConfig(napDescriptor?: NativeApplicationDescriptor) {
+    return this.cauldron.delConfig(napDescriptor)
+  }
+
   public getCauldronConfigLevelMatchingDescriptor(
     napDescriptor?: NativeApplicationDescriptor
   ) {

--- a/ern-local-cli/src/commands/cauldron/del/nativeapp.ts
+++ b/ern-local-cli/src/commands/cauldron/del/nativeapp.ts
@@ -31,7 +31,10 @@ export const commandHandler = async ({
     },
   })
   const cauldron = await getActiveCauldron()
+  await cauldron.beginTransaction()
+  await cauldron.delConfig(descriptor)
   await cauldron.removeDescriptor(descriptor)
+  await cauldron.commitTransaction(`Remove ${descriptor}`)
   log.info(`${descriptor} successfully removed from the Cauldron`)
 }
 


### PR DESCRIPTION
Remove associated app configuration file if any exist when using `cauldron del nativeapp` command