### PR TITLE
Add config option to cauldron add nativeapp command

### DIFF
--- a/docs/cli/cauldron/add/nativeapp.md
+++ b/docs/cli/cauldron/add/nativeapp.md
@@ -39,6 +39,22 @@
 
 * Description of the native application version
 
+`--config`
+
+* Configuration to set for this new native application version
+* If not provided, the configuration of the version copied from will be used (if any).
+* There is three different ways to provide the configuration :
+  - **As a json string**  
+  For example `--config '{"configKey": "configValue"}'`  
+  - **As a file path**  
+  For example `--config /Users/username/config.json`  
+  In that case, the configuration will be read from the file
+  - **As a Cauldron file path**  
+  For example `--extra cauldron://config/myapp-android.json`  
+  In that case, the configuration will be read from the file stored in Cauldron.   
+  For this way to work, the file must exist in Cauldron (you can add a file to the cauldron by using the [ern cauldron add file] command).  
+
+
 #### Remarks
 
 * The `ern cauldron add nativeapp <descriptor>` command is usually used when the development of a new version of the native application is started.  

--- a/ern-cauldron-api/src/CauldronHelper.ts
+++ b/ern-cauldron-api/src/CauldronHelper.ts
@@ -76,9 +76,11 @@ export class CauldronHelper {
   public async addNativeApplicationVersion(
     descriptor: NativeApplicationDescriptor,
     {
+      config,
       copyFromVersion,
       description,
     }: {
+      config?: any
       copyFromVersion?: string
       description?: string
     } = {}
@@ -97,6 +99,7 @@ export class CauldronHelper {
           : copyFromVersion
       await this.addDescriptor(descriptor)
       await this.copyNativeApplicationVersion({
+        shouldCopyConfig: !!!config,
         source: new NativeApplicationDescriptor(
           descriptor.name,
           descriptor.platform,
@@ -110,14 +113,19 @@ export class CauldronHelper {
         await this.cauldron.addOrUpdateDescription(descriptor, description)
       }
     }
+    if (config) {
+      await this.cauldron.setConfig({ descriptor, config })
+    }
   }
 
   public async copyNativeApplicationVersion({
     source,
     target,
+    shouldCopyConfig,
   }: {
     source: NativeApplicationDescriptor
     target: NativeApplicationDescriptor
+    shouldCopyConfig?: boolean
   }) {
     if (!(await this.cauldron.hasDescriptor(source))) {
       throw new Error(`Source descriptor ${source} does not exist in Cauldron`)
@@ -196,10 +204,12 @@ export class CauldronHelper {
         sourceVersion.description
       )
     }
-    // Copy configuration if any
-    const config = await this.getConfigStrict(source)
-    if (config) {
-      await this.cauldron.setConfig({ descriptor: target, config })
+    // Copy configuration if we should (and if any)
+    if (shouldCopyConfig) {
+      const config = await this.getConfigStrict(source)
+      if (config) {
+        await this.cauldron.setConfig({ descriptor: target, config })
+      }
     }
   }
 

--- a/ern-cauldron-api/test/CauldronHelper-test.ts
+++ b/ern-cauldron-api/test/CauldronHelper-test.ts
@@ -3494,6 +3494,7 @@ describe('CauldronHelper.js', () => {
       )
       await cauldronHelper.addNativeApplicationVersion(targetDescriptor)
       await cauldronHelper.copyNativeApplicationVersion({
+        shouldCopyConfig: true,
         source: sourceDescriptor,
         target: targetDescriptor,
       })
@@ -3516,6 +3517,37 @@ describe('CauldronHelper.js', () => {
         fs.readFileSync(pathToTargetConfig).toString()
       )
       expect(targetConfig).deep.equal(sourceConfig)
+    })
+
+    it('should not copy the config', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper({
+        cauldronDocument: fixture,
+      })
+      const sourceDescriptor = NativeApplicationDescriptor.fromString(
+        'test:android:17.7.0'
+      )
+      const targetDescriptor = NativeApplicationDescriptor.fromString(
+        'test:android:20.0.0'
+      )
+      await cauldronHelper.addNativeApplicationVersion(targetDescriptor)
+      await cauldronHelper.copyNativeApplicationVersion({
+        shouldCopyConfig: false,
+        source: sourceDescriptor,
+        target: targetDescriptor,
+      })
+      const pathToSourceConfig = path.join(
+        fileStoreTmpDir,
+        'config',
+        'test-android-17.7.0.json'
+      )
+      const pathToTargetConfig = path.join(
+        fileStoreTmpDir,
+        'config',
+        'test-android-20.0.0.json'
+      )
+      const hasCreatedConfig = fs.existsSync(pathToTargetConfig)
+      expect(hasCreatedConfig).false
     })
 
     it('should copy the container version', async () => {


### PR DESCRIPTION
Add a `--config` option to `cauldron add nativeapp` command, that can be used to set the configuration to use for this new native application version.