### PR TITLE
Fix cauldron add nativeapp command

### DIFF
--- a/ern-local-cli/src/commands/cauldron/add/nativeapp.ts
+++ b/ern-local-cli/src/commands/cauldron/add/nativeapp.ts
@@ -74,9 +74,10 @@ export const commandHandler = async ({
       descriptor
     )
     if (
-      await askUserConfirmation(
+      mostRecentVersion &&
+      (await askUserConfirmation(
         `Do you want to copy data from version (${mostRecentVersion.name}) ?`
-      )
+      ))
     ) {
       copyFromVersion = mostRecentVersion.name
     }


### PR DESCRIPTION
Fix `cauldron add nativeapp` command throwing exception in case no other version of the application was found in Cauldron.