### PR TITLE
Create temporary directory if it does not exist

### DIFF
--- a/ern-core/src/createTmpDir.ts
+++ b/ern-core/src/createTmpDir.ts
@@ -1,8 +1,13 @@
 import tmp from 'tmp'
 import config from './config'
+import shell from './shell'
+import fs from 'fs'
 
 export default function(): string {
   const tmpDir = config.getValue('tmp-dir')
+  if (!fs.existsSync(tmpDir)) {
+    shell.mkdir('-p', tmpDir)
+  }
   const retainTmpDir = config.getValue('retain-tmp-dir', false)
   return tmp.dirSync({
     dir: tmpDir,


### PR DESCRIPTION
Using `platform config set` command, it is possible to specify a custom temporary directory to be used by Electrode Native (`tmp-dir` config key).

Unfortunately, after setting a custom temporary directory, any subsequent commands trying to access the directory will fail with error `Error: ENOENT: no such file or directory`.

This PR just creates the temporary directory it it does not exist, to avoid running into this issue, and sparing the user to have to manually create the directory.