### PR TITLE
Allow override manifest without plugins directory

### DIFF
--- a/ern-core/src/GitManifest.ts
+++ b/ern-core/src/GitManifest.ts
@@ -130,14 +130,20 @@ export default class GitManifest {
   public getPluginsConfigurationDirectories(
     maxVersion: string = Platform.currentVersion
   ): string[] {
-    return _(fs.readdirSync(path.join(this.repoAbsoluteLocalPath, 'plugins')))
-      .filter(
-        d =>
-          ERN_VERSION_DIRECTORY_RE.test(d) &&
-          semver.lte(ERN_VERSION_DIRECTORY_RE.exec(d)![1], maxVersion)
-      )
-      .map(d => path.join(this.repoAbsoluteLocalPath, 'plugins', d))
-      .value()
+    const pathToPluginsDirectory = path.join(
+      this.repoAbsoluteLocalPath,
+      'plugins'
+    )
+    return fs.existsSync(pathToPluginsDirectory)
+      ? _(fs.readdirSync(pathToPluginsDirectory))
+          .filter(
+            d =>
+              ERN_VERSION_DIRECTORY_RE.test(d) &&
+              semver.lte(ERN_VERSION_DIRECTORY_RE.exec(d)![1], maxVersion)
+          )
+          .map(d => path.join(pathToPluginsDirectory, d))
+          .value()
+      : []
   }
 
   /**


### PR DESCRIPTION
It should be possible for an override manifest repository, in its simplest form, to only contain a root `manifest.json` document without any `plugins` directory.

As of now this scenario is making Electrode Native throw the following error`ENOENT: no such file or directory, scandir '[...]/plugins` whenever trying to access the override manifest.

This PR fix this problem to allow override manifests without a `plugins` directory present.