### PR TITLE
Add support for GitHub SSH urls

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -28,6 +28,11 @@ Package in remote git repository:
 - `https://github.com/electrode-io/MovieListMiniApp.git`
 - `https://github.com/electrode-io/MovieListMiniApp.git#0.0.9`
 
+For GitHub SSH urls it is also possible to use the default GitHub format:
+
+- `git@github.com/electrode-io/MovieListMiniApp.git`
+- `git@github.com/electrode-io/MovieListMiniApp.git#0.0.9`
+
 The string following the optional `#` denotes a branch/tag or specific commit SHA.
 
 Package on local file system :

--- a/ern-core/src/PackagePath.ts
+++ b/ern-core/src/PackagePath.ts
@@ -10,10 +10,14 @@ const GIT_SSH_PATH_RE = new RegExp(/^git\+ssh:\/\/.+$/)
 const GIT_SSH_PATH_VERSION_RE = new RegExp(/^(git\+ssh:\/\/.+)#(.+)$/)
 const GIT_HTTPS_PATH_RE = new RegExp(/^https:\/\/.+$/)
 const GIT_HTTPS_PATH_VERSION_RE = new RegExp(/^(https:\/\/.+)#(.+)$/)
+const GITHUB_SSH_PATH_RE = new RegExp(/^git@[^:]+:[^\/]+\/.+\.git$/)
+const GITHUB_SSH_PATH_VERSION_RE = new RegExp(/^git@[^:]+:[^\/]+\/.+\.git#.+$/)
 const GIT_PATH_RE = new RegExp(
   `${GIT_SSH_PATH_RE.source}|${GIT_SSH_PATH_VERSION_RE.source}|${
     GIT_HTTPS_PATH_RE.source
-  }|${GIT_HTTPS_PATH_VERSION_RE.source}`
+  }|${GIT_HTTPS_PATH_VERSION_RE.source}|${GITHUB_SSH_PATH_VERSION_RE.source}|${
+    GITHUB_SSH_PATH_RE.source
+  }`
 )
 const REGISTRY_PATH_VERSION_RE = new RegExp(/^(.+)@(.+)$/)
 
@@ -52,7 +56,14 @@ export class PackagePath {
    * @param path Full path to the package (registry|git|file)
    */
   constructor(path: string) {
-    this.fullPath = path
+    // Transform GitHub SSH urls
+    if (
+      GITHUB_SSH_PATH_VERSION_RE.test(path) ||
+      GITHUB_SSH_PATH_RE.test(path)
+    ) {
+      path = `git+ssh://${path.replace(':', '/')}`
+    }
+
     if (GIT_SSH_PATH_VERSION_RE.test(path)) {
       this.basePath = GIT_SSH_PATH_VERSION_RE.exec(path)![1]
       this.version = GIT_SSH_PATH_VERSION_RE.exec(path)![2]
@@ -71,6 +82,7 @@ export class PackagePath {
     } else {
       this.basePath = path
     }
+    this.fullPath = path
   }
 
   get isGitPath(): boolean {


### PR DESCRIPTION
Due to the fact that `yarn` commands expect git ssh urls to be formatted in a specific way, it makes it more complicated to add a MiniApp from a GitHub repository as some url reformatting is required before using `ern` comamnds.

This PR adds support for GitHub SSH urls format, so that it is now possible to just copy/paste the git ssh url from GitHub, improving user experience.

Behind the scene, all that Electrode Native will do, is to transform the url to the proper format for internal use.