### PR TITLE
Move detachContainerVersionFromRoot to config

### DIFF
--- a/ern-cauldron-api/src/CauldronApi.ts
+++ b/ern-cauldron-api/src/CauldronApi.ts
@@ -378,6 +378,29 @@ export default class CauldronApi {
     )
   }
 
+  public async updateConfig({
+    descriptor,
+    config,
+  }: {
+    descriptor?: NativeApplicationDescriptor
+    config: any
+  }) {
+    if (descriptor && !(await this.hasDescriptor(descriptor))) {
+      throw new Error(`${descriptor} does not exist in Cauldron`)
+    }
+    let newConfig = config
+    const configFilePath = this.getConfigFilePath(descriptor)
+    if (await this.fileStore.hasFile(configFilePath)) {
+      const currentConf = await this.fileStore.getFile(configFilePath)
+      const currentConfObj = JSON.parse((currentConf as Buffer).toString())
+      newConfig = Object.assign(currentConfObj, config)
+    }
+    await this.fileStore.storeFile(
+      configFilePath,
+      JSON.stringify(newConfig, null, 2)
+    )
+  }
+
   public getConfigFilePath(descriptor?: NativeApplicationDescriptor) {
     return descriptor
       ? `config/${descriptor.name ? descriptor.name : ''}${
@@ -955,28 +978,6 @@ export default class CauldronApi {
     const version = await this.getVersion(descriptor)
     version.codePush[deploymentName] = codePushEntries
     return this.commit(`Set codePush entries in ${descriptor.toString()}`)
-  }
-
-  public async enableDetachContainerVersionFromRoot(
-    descriptor: NativeApplicationDescriptor
-  ) {
-    this.throwIfPartialNapDescriptor(descriptor)
-    const version = await this.getVersion(descriptor)
-    version.detachContainerVersionFromRoot = true
-    return this.commit(
-      `Set detachContainerVersionFromRoot to true for ${descriptor.toString()}`
-    )
-  }
-
-  public async disableDetachContainerVersionFromRoot(
-    descriptor: NativeApplicationDescriptor
-  ) {
-    this.throwIfPartialNapDescriptor(descriptor)
-    const version = await this.getVersion(descriptor)
-    version.detachContainerVersionFromRoot = false
-    return this.commit(
-      `Set detachContainerVersionFromRoot to false for ${descriptor.toString()}`
-    )
   }
 
   // =====================================================================================

--- a/ern-cauldron-api/src/CauldronHelper.ts
+++ b/ern-cauldron-api/src/CauldronHelper.ts
@@ -4,7 +4,6 @@ import {
   PackagePath,
   NativeApplicationDescriptor,
   fileUtils,
-  promptUtils,
   NativePlatform,
   normalizeVersionsToSemver,
   utils as coreUtils,
@@ -192,11 +191,6 @@ export class CauldronHelper {
         sourceVersion.container.ernVersion
       )
     }
-    // Copy detachContainerVersionFromRoot
-    if (sourceVersion.detachContainerVersionFromRoot) {
-      await this.cauldron.enableDetachContainerVersionFromRoot(target)
-    }
-
     // Copy description if any
     if (sourceVersion.description) {
       await this.cauldron.addOrUpdateDescription(
@@ -211,6 +205,16 @@ export class CauldronHelper {
         await this.cauldron.setConfig({ descriptor: target, config })
       }
     }
+  }
+
+  public async updateConfig({
+    config,
+    descriptor,
+  }: {
+    config: any
+    descriptor?: NativeApplicationDescriptor
+  }) {
+    return this.cauldron.updateConfig({ config, descriptor })
   }
 
   public async getMostRecentNativeApplicationVersion(
@@ -1152,11 +1156,12 @@ export class CauldronHelper {
     containerVersion: string
   ): Promise<void> {
     await this.cauldron.updateContainerVersion(napDescriptor, containerVersion)
-    const nativeApplicationVersion: CauldronNativeAppVersion = await this.getDescriptor(
+    const detachContainerVersionFromRoot = await this.getConfigForKey(
+      'detachContainerVersionFromRoot',
       napDescriptor
     )
     // Update top level Container version only for non detached container versions
-    if (!nativeApplicationVersion.detachContainerVersionFromRoot) {
+    if (!detachContainerVersionFromRoot) {
       const topLevelContainerVersion = await this.getTopLevelContainerVersion(
         napDescriptor
       )

--- a/ern-cauldron-api/src/types/CauldronNativeAppVersion.ts
+++ b/ern-cauldron-api/src/types/CauldronNativeAppVersion.ts
@@ -8,6 +8,5 @@ export interface CauldronNativeAppVersion extends CauldronObject {
   container: CauldronContainer
   codePush: any
   containerVersion: string
-  detachContainerVersionFromRoot?: boolean
   description?: string
 }

--- a/ern-cauldron-api/src/upgrade-scripts/2.0.0-3.0.0.ts
+++ b/ern-cauldron-api/src/upgrade-scripts/2.0.0-3.0.0.ts
@@ -112,6 +112,25 @@ export default async function upgrade(cauldronApi: CauldronApi) {
       })
       delete cauldron.config
     }
+    //  Move detachContainerVersionFromRoot to config
+    for (const nativeApp of cauldron.nativeApps) {
+      for (const platform of nativeApp.platforms) {
+        for (const version of platform.versions) {
+          if ((version as any).detachContainerVersionFromRoot) {
+            await cauldronApi.updateConfig({
+              config: {
+                detachContainerVersionFromRoot: (version as any)
+                  .detachContainerVersionFromRoot,
+              },
+              descriptor: NativeApplicationDescriptor.fromString(
+                `${nativeApp.name}:${platform.name}:${version.name}`
+              ),
+            })
+            delete (version as any).detachContainerVersionFromRoot
+          }
+        }
+      }
+    }
     cauldron.schemaVersion = '3.0.0'
     await cauldronApi.commit('Upgrade Cauldron schema from v2.0.0 to v3.0.0')
     await cauldronApi.commitTransaction(

--- a/ern-cauldron-api/test/CauldronApi-test.ts
+++ b/ern-cauldron-api/test/CauldronApi-test.ts
@@ -1955,42 +1955,6 @@ describe('CauldronApi.js', () => {
   })
 
   // ==========================================================
-  // enableDetachContainerVersionFromRoot
-  // ==========================================================
-  describe('enableDetachContainerVersionFromRoot', async () => {
-    const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-    await cauldronApi({
-      cauldronDocument: tmpFixture,
-    }).enableDetachContainerVersionFromRoot(
-      NativeApplicationDescriptor.fromString('test:android:17.7.0')
-    )
-    const version = jp.query(
-      tmpFixture,
-      '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")]'
-    )[0]
-
-    expect(version.detachContainerVersionFromRoot).true
-  })
-
-  // ==========================================================
-  // disableDetachContainerVersionFromRoot
-  // ==========================================================
-  describe('enableDetachContainerVersionFromRoot', async () => {
-    const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron))
-    await cauldronApi({
-      cauldronDocument: tmpFixture,
-    }).disableDetachContainerVersionFromRoot(
-      NativeApplicationDescriptor.fromString('test:android:17.7.0')
-    )
-    const version = jp.query(
-      tmpFixture,
-      '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")]'
-    )[0]
-
-    expect(version.detachContainerVersionFromRoot).false
-  })
-
-  // ==========================================================
   // addFile
   // ==========================================================
   describe('addFile', () => {

--- a/ern-cauldron-api/test/CauldronHelper-test.ts
+++ b/ern-cauldron-api/test/CauldronHelper-test.ts
@@ -3034,9 +3034,16 @@ describe('CauldronHelper.js', () => {
 
     it('should update native app container version only[detachContainerVersionFromRoot=true for target descriptor]', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
-      const napVersion = fixture.nativeApps[0].platforms[0].versions[0]
-      napVersion.detachContainerVersionFromRoot = true
-      const cauldronHelper = createCauldronHelper({ cauldronDocument: fixture })
+      const storeTmpDir = createTmpDir()
+      shell.mkdir('-p', path.join(storeTmpDir, 'config'))
+      fs.writeFileSync(
+        path.join(storeTmpDir, 'config', 'test-android-17.7.0.json'),
+        JSON.stringify({ detachContainerVersionFromRoot: true })
+      )
+      const cauldronHelper = createCauldronHelper({
+        cauldronDocument: fixture,
+        storePath: storeTmpDir,
+      })
 
       await cauldronHelper.updateContainerVersion(
         NativeApplicationDescriptor.fromString('test:android:17.7.0'),

--- a/ern-orchestrator/src/syncCauldronContainer.ts
+++ b/ern-orchestrator/src/syncCauldronContainer.ts
@@ -5,7 +5,7 @@ import {
   kax,
   log,
 } from 'ern-core'
-import { getActiveCauldron, CauldronNativeAppVersion } from 'ern-cauldron-api'
+import { getActiveCauldron } from 'ern-cauldron-api'
 import { runCauldronContainerGen } from './container'
 import { runContainerPipelineForDescriptor } from './runContainerPipelineForDescriptor'
 import * as constants from './constants'
@@ -42,10 +42,11 @@ export async function syncCauldronContainer(
     if (containerVersion) {
       cauldronContainerNewVersion = containerVersion
     } else {
-      const napVersion: CauldronNativeAppVersion = await cauldron.getDescriptor(
+      const detachContainerVersionFromRoot = await cauldron.getConfigForKey(
+        'detachContainerVersionFromRoot',
         descriptor
       )
-      cauldronContainerNewVersion = napVersion.detachContainerVersionFromRoot
+      cauldronContainerNewVersion = detachContainerVersionFromRoot
         ? await cauldron.getContainerVersion(descriptor)
         : await cauldron.getTopLevelContainerVersion(descriptor)
       if (cauldronContainerNewVersion) {


### PR DESCRIPTION
`detachContainerVersionFromRoot` is a config property so it should belong to a `config` object. 
However up until now it was incorrectly stored in native application version objects in Cauldron.
This PR corrects this and move this config property where it belongs, in a `config` object. 

