### PR TITLE
Fix code push deployment name config lookup

### DIFF
--- a/ern-local-cli/src/lib/askUserForCodePushDeploymentName.ts
+++ b/ern-local-cli/src/lib/askUserForCodePushDeploymentName.ts
@@ -7,11 +7,10 @@ export async function askUserForCodePushDeploymentName(
   message?: string
 ): Promise<string> {
   const cauldron = await getActiveCauldron()
-  const conf = await cauldron.getConfig(napDescriptor)
-  const hasCodePushDeploymentsConfig =
-    conf && conf.codePush && conf.codePush.deployments
+  const conf = await cauldron.getCodePushConfig(napDescriptor)
+  const hasCodePushDeploymentsConfig = conf && conf.deployments
   const choices = hasCodePushDeploymentsConfig
-    ? conf && conf.codePush.deployments
+    ? conf && conf.deployments
     : undefined
 
   const { userSelectedDeploymentName } = await inquirer.prompt(<


### PR DESCRIPTION
Use `getCodePushConfig` rather than `getConfig` for proper lookup (bubble up config levels)