### PR TITLE
Fix createTmpDir when no tmp-dir config key is set

### DIFF
--- a/ern-core/src/createTmpDir.ts
+++ b/ern-core/src/createTmpDir.ts
@@ -5,7 +5,7 @@ import fs from 'fs'
 
 export default function(): string {
   const tmpDir = config.getValue('tmp-dir')
-  if (!fs.existsSync(tmpDir)) {
+  if (tmpDir && !fs.existsSync(tmpDir)) {
     shell.mkdir('-p', tmpDir)
   }
   const retainTmpDir = config.getValue('retain-tmp-dir', false)


### PR DESCRIPTION
Do no check for `tmpDir` directory existence if this variable is `undefined` (when not explicitly set through `tmp-dir` config key)