### PR TITLE
Add a way to update all MiniApps to a specific version

### DIFF
--- a/docs/cli/cauldron/update/miniapps.md
+++ b/docs/cli/cauldron/update/miniapps.md
@@ -21,6 +21,8 @@
   - Registry path missing version (ex: `MiniApp`)
   - Registry path using a version range (ex: `MiniApp@^1.0.0`)
 
+* Can also be set to **all** . In this case, all MiniApps will be updated to a single specific version specified by the `--targetVersion` option.
+
 
 **Options**  
 
@@ -41,6 +43,11 @@ Example: If the current container version is 1.2.3 and a version is not included
 * Publish the Container even if it's identical to the current one. This can be used to perform some sort of Container promotion.  
 For example, if you are generating development Containers using `1000.0.X` versioning convention and want to promote a development Container to a release Container using a different version (`18.0.0` for example), you can use this flag to perform this.
 **Default** False. If Container is identical to the current one, if won't be published again.
+
+ `--targetVersion`
+
+ * Only used when running **ern cauldron update miniapps all**.
+ * The target version to update all MiniApps to.
 
 #### Remarks
 


### PR DESCRIPTION
Add a way to update all MiniApps to a specific version, which can be of use to simplify workflows (mostly CI).

For example, if we want to update all MiniApps version in a Container to a specific release branch (`Release/1.3.0` for example). For example, the following command:

```
ern cauldron update miniapps git+ssh://git@github.com/foo/app-one.git#Release/1.3.0 git+ssh://git@github.com/foo/app-two.git#Release/1.3.0 git+ssh://git@github.com/foo/app-three.git#Release/1.3.0
```

Can now be simplified to :

```
ern cauldron update miniapps all --targetVersion Release/1.3.0
```