### PR TITLE
Move precommit script to .huskyrc

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "pre-commit": "yarn check:yarnlock && yarn check:lint && yarn prettier && yarn check:regen-fixtures"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "ern-debug": "node --nolazy --inspect-brk=5858 ern-local-cli/src/index.dev.js",
     "istanbul": "istanbul",
     "postmerge": "node auto-rebuild.js",
-    "precommit": "yarn check:yarnlock && yarn check:lint && yarn prettier && yarn check:regen-fixtures",
     "prettier": "pretty-quick --staged",
     "rebuild": "lerna clean --yes && lerna bootstrap && lerna run build",
     "regen-fixtures": "node system-tests/regen-fixtures",


### PR DESCRIPTION
`precommit` hook in scripts got deprecated in recent [husky](https://github.com/typicode/husky) version, so doing it the [new way](https://github.com/typicode/husky#upgrading-from-014)