### PR TITLE
Fix a bug with composite when dealing with fs MiniApps

### DIFF
--- a/ern-composite-gen/src/Composite.ts
+++ b/ern-composite-gen/src/Composite.ts
@@ -73,7 +73,7 @@ export class Composite {
       const ppValue = PackagePath.fromString(this.packageJson.dependencies[key])
       const ppKey = PackagePath.fromString(key)
 
-      if (this.config.miniApps.some(p => p.basePath === ppValue.basePath)) {
+      if (ppValue.isFilePath) {
         result.push({
           packagePath: ppValue,
           path: path.join(this.path, 'node_modules', key),


### PR DESCRIPTION
Fix a bug in the Composite class, causing MiniApps retrieved from the file system (rather than git or npm registry) to be improperly recognized as such, leading to multiple issues.