### PR TITLE
Ensure Manifest id exists in Manifest(s)

### DIFF
--- a/ern-core/src/GitManifest.ts
+++ b/ern-core/src/GitManifest.ts
@@ -7,6 +7,7 @@ import path from 'path'
 import semver from 'semver'
 import Platform from './Platform'
 import log from './log'
+import kax from './kax'
 
 const manifestFileName = 'manifest.json'
 const pluginConfigFileName = 'config.json'
@@ -89,7 +90,7 @@ export default class GitManifest {
    */
   public async syncIfNeeded() {
     if (!this.cachedManifest) {
-      await this.sync()
+      await kax.task(`Syncing ${this.repoRemotePath} Manifest`).run(this.sync())
     }
   }
 

--- a/ern-core/src/GitManifest.ts
+++ b/ern-core/src/GitManifest.ts
@@ -99,6 +99,11 @@ export default class GitManifest {
     return this.cachedManifest
   }
 
+  public async hasManifestId(manifestId: string): Promise<boolean> {
+    const manifest = await this.getManifest()
+    return !Array.isArray(manifest) && manifest[manifestId]
+  }
+
   public async getManifestData({
     manifestId = 'default',
     platformVersion = Platform.currentVersion,

--- a/ern-core/src/Manifest.ts
+++ b/ern-core/src/Manifest.ts
@@ -396,6 +396,20 @@ export class Manifest {
     return url
   }
 
+  public async hasManifestId(manifestId: string): Promise<boolean> {
+    await this.initOverrideManifest()
+    if (this.overrideManifest && this.manifestOverrideType === 'partial') {
+      return (
+        (await this.masterManifest.hasManifestId(manifestId)) ||
+        (await this.overrideManifest.hasManifestId(manifestId))
+      )
+    } else if (this.overrideManifest && this.manifestOverrideType === 'full') {
+      return this.overrideManifest.hasManifestId(manifestId)
+    } else {
+      return this.masterManifest.hasManifestId(manifestId)
+    }
+  }
+
   public async getManifestData({
     manifestId = 'default',
     platformVersion = Platform.currentVersion,

--- a/ern-local-cli/src/commands/add.ts
+++ b/ern-local-cli/src/commands/add.ts
@@ -1,5 +1,5 @@
 import { log, MiniApp, PackagePath } from 'ern-core'
-import { epilog, tryCatchWrap } from '../lib'
+import { epilog, logErrorAndExitIfNotSatisfied, tryCatchWrap } from '../lib'
 import { Argv } from 'yargs'
 
 // Note : We use `pkg` instead of `package` because `package` is
@@ -39,6 +39,14 @@ export const commandHandler = async ({
   packages: string[]
   peer: boolean
 }) => {
+  if (manifestId) {
+    await logErrorAndExitIfNotSatisfied({
+      manifestIdExists: {
+        id: manifestId,
+      },
+    })
+  }
+
   for (const pkg of packages) {
     log.debug(`Adding package: ${pkg}`)
     await MiniApp.fromCurrentPath().addDependency(PackagePath.fromString(pkg), {

--- a/ern-local-cli/src/commands/create-api-impl.ts
+++ b/ern-local-cli/src/commands/create-api-impl.ts
@@ -119,6 +119,14 @@ export const commandHandler = async ({
     })
   }
 
+  if (manifestId) {
+    await logErrorAndExitIfNotSatisfied({
+      manifestIdExists: {
+        id: manifestId,
+      },
+    })
+  }
+
   log.info(`Generating API implementation for ${apiName}`)
   const reactNativeVersion = await coreUtils.reactNativeManifestVersion({
     manifestId,

--- a/ern-local-cli/src/commands/create-api.ts
+++ b/ern-local-cli/src/commands/create-api.ts
@@ -80,6 +80,14 @@ export const commandHandler = async ({
     },
   })
 
+  if (manifestId) {
+    await logErrorAndExitIfNotSatisfied({
+      manifestIdExists: {
+        id: manifestId,
+      },
+    })
+  }
+
   if (schemaPath && !fs.existsSync(schemaPath)) {
     throw new Error(`Cannot resolve path to ${schemaPath}`)
   }

--- a/ern-local-cli/src/commands/create-miniapp.ts
+++ b/ern-local-cli/src/commands/create-miniapp.ts
@@ -69,6 +69,14 @@ export const commandHandler = async ({
     },
   })
 
+  if (manifestId) {
+    await logErrorAndExitIfNotSatisfied({
+      manifestIdExists: {
+        id: manifestId,
+      },
+    })
+  }
+
   if (!checkIfModuleNameContainsSuffix(appName, ModuleTypes.MINIAPP)) {
     appName = await promptUserToUseSuffixModuleName(
       appName,

--- a/ern-local-cli/src/commands/github/align-dependencies.ts
+++ b/ern-local-cli/src/commands/github/align-dependencies.ts
@@ -27,6 +27,7 @@ export const builder = (argv: Argv) => {
       type: 'boolean',
     })
     .option('manifestId', {
+      default: 'default',
       describe:
         'Id of the manifest entry to use to retrieve versions to upgrade to',
       type: 'string',
@@ -48,7 +49,7 @@ export const commandHandler = async ({
   jsApiImplsOnly?: boolean
   manifestId?: string
   miniAppsOnly?: boolean
-}) => {
+} = {}) => {
   descriptor =
     descriptor ||
     (await askUserToChooseANapDescriptorFromCauldron({
@@ -60,6 +61,9 @@ export const commandHandler = async ({
       extraErrorMessage:
         'ERN_GITHUB_TOKEN environment variable must be set, to use `ern github` commands',
       name: 'ERN_GITHUB_TOKEN',
+    },
+    manifestIdExists: {
+      id: manifestId,
     },
     napDescriptorExistInCauldron: {
       descriptor,

--- a/ern-local-cli/src/commands/list/dependencies.ts
+++ b/ern-local-cli/src/commands/list/dependencies.ts
@@ -5,7 +5,7 @@ import {
   shell,
   PackagePath,
 } from 'ern-core'
-import { epilog, tryCatchWrap } from '../../lib'
+import { epilog, logErrorAndExitIfNotSatisfied, tryCatchWrap } from '../../lib'
 import chalk from 'chalk'
 import _ from 'lodash'
 import path from 'path'
@@ -36,6 +36,14 @@ export const commandHandler = async ({
   manifestId?: string
   json?: boolean
 }) => {
+  if (manifestId) {
+    await logErrorAndExitIfNotSatisfied({
+      manifestIdExists: {
+        id: manifestId,
+      },
+    })
+  }
+
   let pathToModule = process.cwd()
   if (module) {
     pathToModule = createTmpDir()

--- a/ern-local-cli/src/commands/platform/plugins/list.ts
+++ b/ern-local-cli/src/commands/platform/plugins/list.ts
@@ -1,5 +1,9 @@
 import { manifest, Platform, log } from 'ern-core'
-import { epilog, tryCatchWrap } from '../../../lib'
+import {
+  epilog,
+  logErrorAndExitIfNotSatisfied,
+  tryCatchWrap,
+} from '../../../lib'
 import { Argv } from 'yargs'
 
 import chalk from 'chalk'
@@ -28,6 +32,14 @@ export const commandHandler = async ({
   manifestId?: string
   platformVersion?: string
 }) => {
+  if (manifestId) {
+    await logErrorAndExitIfNotSatisfied({
+      manifestIdExists: {
+        id: manifestId,
+      },
+    })
+  }
+
   const plugins = await manifest.getNativeDependencies({
     manifestId,
     platformVersion,

--- a/ern-local-cli/src/commands/platform/plugins/search.ts
+++ b/ern-local-cli/src/commands/platform/plugins/search.ts
@@ -1,5 +1,9 @@
 import { manifest, Platform, PackagePath, log } from 'ern-core'
-import { epilog, tryCatchWrap } from '../../../lib'
+import {
+  epilog,
+  logErrorAndExitIfNotSatisfied,
+  tryCatchWrap,
+} from '../../../lib'
 import { Argv } from 'yargs'
 
 import chalk from 'chalk'
@@ -29,6 +33,14 @@ export const commandHandler = async ({
   name: string
   platformVersion?: string
 }) => {
+  if (manifestId) {
+    await logErrorAndExitIfNotSatisfied({
+      manifestIdExists: {
+        id: manifestId,
+      },
+    })
+  }
+
   const plugin = await manifest.getNativeDependency(
     PackagePath.fromString(name),
     { manifestId, platformVersion }

--- a/ern-local-cli/src/commands/regen-api-impl.ts
+++ b/ern-local-cli/src/commands/regen-api-impl.ts
@@ -8,7 +8,7 @@ import {
   PackagePath,
   log,
 } from 'ern-core'
-import { epilog, tryCatchWrap } from '../lib'
+import { epilog, logErrorAndExitIfNotSatisfied, tryCatchWrap } from '../lib'
 import path from 'path'
 import fs from 'fs'
 import semver from 'semver'
@@ -47,6 +47,14 @@ export const handler = async ({
   manifestId?: string
 }) => {
   try {
+    if (manifestId) {
+      await logErrorAndExitIfNotSatisfied({
+        manifestIdExists: {
+          id: manifestId,
+        },
+      })
+    }
+
     const apiImplPackage = await readPackageJson()
 
     let api: PackagePath = await getApi(apiImplPackage)

--- a/ern-local-cli/src/commands/regen-api.ts
+++ b/ern-local-cli/src/commands/regen-api.ts
@@ -1,6 +1,6 @@
 import { ApiGen } from 'ern-api-gen'
 import { manifest, PackagePath, yarn } from 'ern-core'
-import { epilog, tryCatchWrap } from '../lib'
+import { epilog, logErrorAndExitIfNotSatisfied, tryCatchWrap } from '../lib'
 import { Argv } from 'yargs'
 
 export const command = 'regen-api'
@@ -33,6 +33,14 @@ export const commandHandler = async ({
   manifestId?: string
   skipVersion: boolean
 }) => {
+  if (manifestId) {
+    await logErrorAndExitIfNotSatisfied({
+      manifestIdExists: {
+        id: manifestId,
+      },
+    })
+  }
+
   const errorMessage =
     'Run command #yarn info react-native-electrode-bridge versions# to get the valid bridgeVersion'
 

--- a/ern-local-cli/src/commands/upgrade-miniapp.ts
+++ b/ern-local-cli/src/commands/upgrade-miniapp.ts
@@ -1,5 +1,5 @@
-import { MiniApp, Platform, log } from 'ern-core'
-import { epilog, tryCatchWrap } from '../lib'
+import { MiniApp } from 'ern-core'
+import { epilog, logErrorAndExitIfNotSatisfied, tryCatchWrap } from '../lib'
 import { Argv } from 'yargs'
 
 export const command = 'upgrade-miniapp'
@@ -27,6 +27,14 @@ export const commandHandler = async ({
   manifestId?: string
   version?: string
 }) => {
+  if (manifestId) {
+    await logErrorAndExitIfNotSatisfied({
+      manifestIdExists: {
+        id: manifestId,
+      },
+    })
+  }
+
   const miniApp = MiniApp.fromCurrentPath()
   const versionWithoutPrefix = version && version.toString().replace('v', '')
   await miniApp.upgrade({ manifestId, platformVersion: versionWithoutPrefix })

--- a/ern-local-cli/src/lib/logErrorAndExitIfNotSatisfied.ts
+++ b/ern-local-cli/src/lib/logErrorAndExitIfNotSatisfied.ts
@@ -30,6 +30,7 @@ export async function logErrorAndExitIfNotSatisfied({
   isSupportedMiniAppOrJsApiImplVersion,
   isContainerPath,
   isEnvVariableDefined,
+  manifestIdExists,
 }: {
   noGitOrFilesystemPath?: {
     obj: string | PackagePath | Array<string | PackagePath> | void
@@ -147,6 +148,10 @@ export async function logErrorAndExitIfNotSatisfied({
   }
   isEnvVariableDefined?: {
     name: string
+    extraErrorMessage?: string
+  }
+  manifestIdExists?: {
+    id: string
     extraErrorMessage?: string
   }
 } = {}) {
@@ -398,6 +403,16 @@ export async function logErrorAndExitIfNotSatisfied({
       Ensure.isEnvVariableDefined(
         isEnvVariableDefined.name,
         isEnvVariableDefined.extraErrorMessage
+      )
+      kaxTask.succeed()
+    }
+    if (manifestIdExists) {
+      kaxTask = kax.task(
+        `Ensuring that ${manifestIdExists.id} id exists in Manifest(s)`
+      )
+      await Ensure.manifestIdExists(
+        manifestIdExists.id,
+        manifestIdExists.extraErrorMessage
       )
       kaxTask.succeed()
     }

--- a/ern-orchestrator/src/Ensure.ts
+++ b/ern-orchestrator/src/Ensure.ts
@@ -1,4 +1,5 @@
 import {
+  manifest,
   PackagePath,
   NativeApplicationDescriptor,
   utils as coreUtils,
@@ -381,14 +382,10 @@ export default class Ensure {
     extraErrorMessage: string = ''
   ) {
     return new Promise((resolve, reject) => {
-      fs.exists(
-        p,
-        exists =>
-          exists
-            ? resolve()
-            : reject(
-                new Error(`${p} path does not exist.\n${extraErrorMessage}`)
-              )
+      fs.exists(p, exists =>
+        exists
+          ? resolve()
+          : reject(new Error(`${p} path does not exist.\n${extraErrorMessage}`))
       )
     })
   }
@@ -457,9 +454,8 @@ export default class Ensure {
       constants.availableUserConfigKeys.map(e => e.name)
     if (!availablePlatformKeys().includes(key)) {
       const closestKeyName = k =>
-        availablePlatformKeys().reduce(
-          (acc, cur) =>
-            levenshtein.get(acc, k) > levenshtein.get(cur, k) ? cur : acc
+        availablePlatformKeys().reduce((acc, cur) =>
+          levenshtein.get(acc, k) > levenshtein.get(cur, k) ? cur : acc
         )
       throw new Error(
         `Configuration key ${key} does not exists. Did you mean ${closestKeyName(
@@ -516,6 +512,15 @@ export default class Ensure {
   ) {
     if (!process.env[envVarName]) {
       throw new Error(`${envVarName} is not defined\n${extraErrorMessage}`)
+    }
+  }
+
+  public static async manifestIdExists(
+    manifestId: string,
+    extraErrorMessage: string = ''
+  ) {
+    if (!(await manifest.hasManifestId(manifestId))) {
+      throw new Error(`${manifestId} id not found in the Manifest(s)`)
     }
   }
 }


### PR DESCRIPTION
Update all commands accepting a `--manifestId` option, to ensure that if a manifest id is provided, it exists in the Manifest(s) (master and/or override based on configuration).

Also improves logging when syncing Manifest(s) by showing a spinner while the sync is in progress (rather than stalling output).