### PR TITLE
Exclude fixtures from language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
-system-tests/* linguist-generated=true
+system-tests/fixtures/* linguist-vendored=true
+ern-api-gen/test/fixtures/* linguist-vendored=true
+ern-runner-gen-android/test/fixtures/* linguist-vendored=true
+ern-runner-gen-ios/test/fixtures/* linguist-vendored=true


### PR DESCRIPTION
Update `.gitattributes` by refining exclusions.

- Use `linguist-vendored` rather than `linguist-generated` so that we diffs will still show in GitHub for these files.
- Exclude only `system-tests/fixtures` rather than complete `system-tests` directory as this directory contains source files that should not be excluded.
- Add exclusions for more fixtures directories.