### PR TITLE
Update start logic

### DIFF
--- a/ern-orchestrator/src/start.ts
+++ b/ern-orchestrator/src/start.ts
@@ -95,12 +95,6 @@ export default async function start({
       pkgName,
       miniAppsLinksObj[pkgName]
     )
-    log.info(
-      `Watching for changes in linked MiniApp directory ${
-        miniAppsLinksObj[pkgName]
-      }`
-    )
-    startLinkSynchronization(compositeDir, pkgName, miniAppsLinksObj[pkgName])
   })
 
   reactnative.startPackagerInNewWindow(compositeDir, [
@@ -151,6 +145,15 @@ export default async function start({
       }
     }
   }
+
+  linkedMiniAppsPackageNames.forEach(pkgName => {
+    log.info(
+      `Watching for changes in linked MiniApp directory ${
+        miniAppsLinksObj[pkgName]
+      }`
+    )
+    startLinkSynchronization(compositeDir, pkgName, miniAppsLinksObj[pkgName])
+  })
 
   log.warn('=========================================================')
   log.warn('Ending this process will stop monitoring linked MiniApps.')


### PR DESCRIPTION
Starting `FSEvents` watcher early on, seems to have side effects on some user workstations, causing failure to properly retrieve the binary from the binary store (if any).

While we are still investigating the cause, starting the watcher after retrieving the binary was confirmed to fix the issue. This is a temporary workaround to be shipped with 0.32 release.