### PR TITLE
Fix Cauldron upgrade script

### DIFF
--- a/ern-cauldron-api/src/upgrade-scripts/2.0.0-3.0.0.ts
+++ b/ern-cauldron-api/src/upgrade-scripts/2.0.0-3.0.0.ts
@@ -43,6 +43,7 @@ export default async function upgrade(cauldronApi: CauldronApi) {
     const cauldron = await cauldronApi.getCauldron()
     // Patch container generator configs by moving publishers
     // and transformers to new pipeline object
+    patchContainerGenConfig(cauldron)
     for (const nativeApp of cauldron.nativeApps) {
       patchContainerGenConfig(nativeApp)
       for (const platform of nativeApp.platforms) {


### PR DESCRIPTION
Script was not properly converting top level Cauldron `containerGenerator` config if present.