### PR TITLE
Use TypeScript transpileOnly flag for tests and dev

### DIFF
--- a/ern-local-cli/src/index.dev.js
+++ b/ern-local-cli/src/index.dev.js
@@ -24,5 +24,5 @@ Module._load = function(file, parent) {
 }
 
 require('tsconfig-paths/register')
-require('ts-node').register({})
+require('ts-node').register({ transpileOnly: true })
 require('./index.ts').default()

--- a/ern-util-dev/bin/ern-mocha.js
+++ b/ern-util-dev/bin/ern-mocha.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 const path = require('path')
 process.env.__ERN_TEST__ = true
+process.env.TS_NODE_TRANSPILE_ONLY = true
 process.env.TS_NODE_PROJECT = path.resolve('..', 'tsconfig.json')
 if (!require('fs').existsSync(require('path').join(process.cwd(), 'test'))) {
   console.log('no tests for project ', process.cwd())

--- a/ern-util-dev/bin/ern-nyc.js
+++ b/ern-util-dev/bin/ern-nyc.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 var fs = require('fs')
-process.env['__ERN_TEST__'] = true
+process.env.__ERN_TEST__ = true
+process.env.TS_NODE_TRANSPILE_ONLY = true
 if (!fs.existsSync('test')) {
   console.log(`No tests found in ${process.cwd()}/test`)
   process.exit(0)


### PR DESCRIPTION
Use `tsnode/register` [transpileModule](https://www.npmjs.com/package/ts-node#cli-and-programmatic-options) to speed up transpilation for tests and ern dev version (1000.0.0).