### PR TITLE
Fix CLI epilog documentation url

### DIFF
--- a/ern-local-cli/src/lib/epilog.ts
+++ b/ern-local-cli/src/lib/epilog.ts
@@ -7,10 +7,13 @@ export function epilog({ command }: { command: string }) {
   const version = `v${semver.major(Platform.currentVersion)}.${semver.minor(
     Platform.currentVersion
   )}`
-  const rootUrl = `https://native.electrode.io/v/${version}/cli-commands`
+  const rootUrl =
+    Platform.currentVersion === '1000.0.0'
+      ? `https://native.electrode.io/cli-commands`
+      : `https://native.electrode.io/v/${version}/cli-commands`
   const commandWithoutOptions = command.split(' ')[0]
   const idx = _.indexOf(process.argv, commandWithoutOptions)
-  let commandPath = _.slice(process.argv, 2, idx).join('/')
+  let commandPath = _.slice(process.argv, 2, idx).join('-')
   commandPath = commandPath ? `/${commandPath}` : ''
   return `More info about this command @ ${chalk.bold(
     `${rootUrl}${commandPath}/${commandWithoutOptions}.html`


### PR DESCRIPTION
- Fix CLI command documentation url for nested commands such as `cauldron repo list`

**Before (invalid)** 
https://native.electrode.io/v/v0.31/cli-commands/cauldron/repo/list.html

**After (valid)**
https://native.electrode.io/v/v0.31/cli-commands/cauldron-repo/list.html

- Fix CLI command documentation for url for dev platform version 1000.0.0, which should point to master documentation.

**Before (invalid)** 
https://native.electrode.io/v/v1000.0.0/cli-commands/create-container.html

**After (valid)**
https://native.electrode.io/cli-commands/create-container.html