### PR TITLE
Improve logging of mismatching dependencies versions

### DIFF
--- a/ern-orchestrator/package.json
+++ b/ern-orchestrator/package.json
@@ -70,6 +70,7 @@
     "kax":"^1.2.7",
     "lodash": "^4.17.10",
     "semver": "^5.5.0",
+    "treeify": "^1.1.0",
     "validate-npm-package-name": "^3.0.0",
     "yargs": "^7.1.0"
   },

--- a/ern-orchestrator/src/composite.ts
+++ b/ern-orchestrator/src/composite.ts
@@ -111,17 +111,28 @@ export async function validateCompositeNativeDependencies(
   // Validate composite native dependencies
   const resolution = await composite.getResolvedNativeDependencies()
   if (resolution.pluginsWithMismatchingVersions.length > 0) {
+    logMismatchingDependenciesTree(composite, resolution)
     throw new Error(`The following plugins are not using compatible versions : 
      ${resolution.pluginsWithMismatchingVersions.toString()}`)
   }
   try {
-    logResolvedAndMismatchingDependenciesTree(composite, resolution)
+    logResolvedDependenciesTree(composite, resolution)
   } catch (e) {
     log.error(e)
   }
 }
 
 export function logResolvedAndMismatchingDependenciesTree(
+  composite: Composite,
+  resolution: any
+) {
+  logResolvedDependenciesTree(composite, resolution)
+  if (resolution.pluginsWithMismatchingVersions.length > 0) {
+    logMismatchingDependenciesTree(composite, resolution)
+  }
+}
+
+export function logResolvedDependenciesTree(
   composite: Composite,
   resolution: any
 ) {
@@ -132,14 +143,19 @@ export function logResolvedAndMismatchingDependenciesTree(
     resolution.resolved.map(x => PackagePath.fromString(x.basePath)),
     'debug'
   )
-  if (resolution.pluginsWithMismatchingVersions.length > 0) {
-    log.error('[ == MISMATCHING NATIVE DEPENDENCIES ==]')
-    logDependenciesTree(
-      parser,
-      resolution.pluginsWithMismatchingVersions.map(PackagePath.fromString),
-      'error'
-    )
-  }
+}
+
+export function logMismatchingDependenciesTree(
+  composite: Composite,
+  resolution: any
+) {
+  const parser = YarnLockParser.fromPath(path.join(composite.path, 'yarn.lock'))
+  log.error('[ == MISMATCHING NATIVE DEPENDENCIES ==]')
+  logDependenciesTree(
+    parser,
+    resolution.pluginsWithMismatchingVersions.map(PackagePath.fromString),
+    'error'
+  )
 }
 
 export function logDependenciesTree(


### PR DESCRIPTION
In case of mismatching native dependencies versions detected after composite generation (just before bundling), Electrode Native logs the following error :

```
✖ [syncCauldronContainer] An error occurred: Error: The following plugins are not using compatible versions : 
✖      react-native
```

While this log point out the problematic native dependencies names, it doesn't log from which MiniApps the conflict in version is coming from. This PR adds full dependency tree logging to identify precisely which MiniApp(s) are using mismatching native dependencies versions.

```
✖ └─ react-native@0.59.4 [0.59.4]
✖    ├─ MiniAppA@0.0.1 [0.0.1]
✖    ├─ MiniAppB@1.2.2 [1.2.2]
✖    ├─ MiniAppC@1.1.36 [1.1.36]
✖    └─ MiniAppD@1.3.1 [1.3.1]
✖ └─ react-native@0.59.8 [0.59.8]
✖    └─ MiniAppE@0.0.2 [0.0.2]
```