### PR TITLE
Do not mustache jniLibs when generating Android Container

### DIFF
--- a/ern-container-gen-android/src/AndroidGenerator.ts
+++ b/ern-container-gen-android/src/AndroidGenerator.ts
@@ -234,6 +234,7 @@ export default class AndroidGenerator implements ContainerGenerator {
       f => !f.endsWith('.jar') && !f.endsWith('.aar') && !f.endsWith('.git')
     )
     const pathLibSrcMain = path.join('lib', 'src', 'main')
+    const pathLibSrcMainJniLibs = path.join('lib', 'src', 'main', 'jniLibs')
     const pathLibSrcMainAssets = path.join('lib', 'src', 'main', 'assets')
     const pathLibSrcMainJavaCom = path.join(pathLibSrcMain, 'java', 'com')
     const pathLibSrcMainJavaComWalmartlabsErnContainer = path.join(
@@ -246,7 +247,8 @@ export default class AndroidGenerator implements ContainerGenerator {
       if (
         (file.startsWith(pathLibSrcMainJavaCom) &&
           !file.startsWith(pathLibSrcMainJavaComWalmartlabsErnContainer)) ||
-        file.startsWith(pathLibSrcMainAssets)
+        file.startsWith(pathLibSrcMainAssets) ||
+        file.startsWith(pathLibSrcMainJniLibs)
       ) {
         // We don't want to Mustache process library files. It can lead to bad things
         // We also don't want to process assets files ...


### PR DESCRIPTION
Some Android native modules are including native libraries (`.so` files) to be stored in the `jniLibs` directory of the Container.

Because this directory is not included in the directories to be excluded from Mustache processing, this is leading to Container generation failure when such native modules are included in the Container.

This PR adds `lib/src/main/jniLibs` directory to the list of Mustache exclusions.