### PR TITLE
Give access to CauldronApi from CauldronHelper

### DIFF
--- a/ern-cauldron-api/src/CauldronHelper.ts
+++ b/ern-cauldron-api/src/CauldronHelper.ts
@@ -25,6 +25,10 @@ import semver from 'semver'
 export class CauldronHelper {
   private readonly cauldron: CauldronApi
 
+  public get api() {
+    return this.cauldron
+  }
+
   constructor(cauldronApi: CauldronApi) {
     if (!cauldronApi) {
       throw new Error('cauldronApi is required')


### PR DESCRIPTION
Give direct access to `CauldronApi` instance to `CauldronHelper` clients.