### PR TITLE
Relax rule for adding package to container

### DIFF
--- a/ern-cauldron-api/src/CauldronApi.ts
+++ b/ern-cauldron-api/src/CauldronApi.ts
@@ -1131,9 +1131,8 @@ export default class CauldronApi {
         `${pkg.basePath} does not exist in ${descriptor} Container`
       )
     }
-    container[key] = _.map(
-      container[key],
-      e => (e === existingPkg ? pkg.fullPath : e)
+    container[key] = _.map(container[key], e =>
+      e === existingPkg ? pkg.fullPath : e
     )
     return this.commit(
       `Update ${pkg.basePath} to version ${
@@ -1148,7 +1147,9 @@ export default class CauldronApi {
     key: ContainerPackagesArrayKey
   ): Promise<void> {
     this.throwIfPartialNapDescriptor(descriptor)
-    this.throwIfNoVersionInPackagePath(pkg)
+    if (!pkg.isFilePath) {
+      this.throwIfNoVersionInPackagePath(pkg)
+    }
     const container = (await this.getVersion(descriptor)).container
     if (!container[key]) {
       container[key] = []


### PR DESCRIPTION
Relax guard clause in `addPackageToContainer` method to only throw if no version is set for registry and git packages. 

Do not throw if there is no version set for a file system located package as it will always be the case. This allows proper adding  of file system located packages to Container.