### PR TITLE
Relax cauldron del miniapps command

### DIFF
--- a/ern-local-cli/src/commands/cauldron/del/miniapps.ts
+++ b/ern-local-cli/src/commands/cauldron/del/miniapps.ts
@@ -75,11 +75,6 @@ export const commandHandler = async ({
       extraErrorMessage:
         'This command cannot work on a non existing native application version',
     },
-    noGitOrFilesystemPath: {
-      extraErrorMessage:
-        'You cannot provide MiniApp(s) using git or file scheme for this command. Only the form miniapp@version is allowed.',
-      obj: miniapps,
-    },
   })
 
   const cauldronCommitMessage = [


### PR DESCRIPTION
It should be possible to remove a git or file based MiniApp from a Container, given that it is now possible (since a few versions already) to add git (or more recently, file based) MiniApps to a Container.

Remove the deprecated historical restriction from command so that this command also works for git/fs MiniApps.