### PR TITLE
Add getCodePushEntries method overload

### DIFF
--- a/ern-cauldron-api/src/CauldronApi.ts
+++ b/ern-cauldron-api/src/CauldronApi.ts
@@ -210,12 +210,21 @@ export default class CauldronApi {
   }
 
   public async getCodePushEntries(
+    descriptor: AppVersionDescriptor
+  ): Promise<{ [deploymentName: string]: CauldronCodePushEntry[] }>
+  public async getCodePushEntries(
     descriptor: AppVersionDescriptor,
     deploymentName: string
-  ): Promise<CauldronCodePushEntry[]> {
+  ): Promise<CauldronCodePushEntry[]>
+  public async getCodePushEntries(
+    descriptor: AppVersionDescriptor,
+    deploymentName?: string
+  ): Promise<
+    | { [deploymentName: string]: CauldronCodePushEntry[] }
+    | CauldronCodePushEntry[]
+  > {
     const version = await this.getVersion(descriptor)
-    const result = version.codePush[deploymentName]
-    return result
+    return deploymentName ? version.codePush[deploymentName] : version.codePush
   }
 
   public async getContainerMiniApps(

--- a/ern-cauldron-api/src/types/CauldronNativeAppVersion.ts
+++ b/ern-cauldron-api/src/types/CauldronNativeAppVersion.ts
@@ -1,12 +1,13 @@
 import { CauldronContainer } from './CauldronContainer'
 import { CauldronObject } from './CauldronObject'
+import { CauldronCodePushEntry } from './CauldronCodePushEntry'
 
 export interface CauldronNativeAppVersion extends CauldronObject {
   isReleased: boolean
   binary?: string
   yarnLocks: any
   container: CauldronContainer
-  codePush: any
+  codePush: { [deploymentName: string]: CauldronCodePushEntry[] }
   containerVersion: string
   description?: string
 }


### PR DESCRIPTION
Add new `getCodePushEntries` method overload to `CauldronApi`, to retrieve all of the Code Push entries across deployment names, and not limited to a specific deployment name.