### PR TITLE
Improve local cauldrons support

### DIFF
--- a/docs/cli/cauldron/repo/add.md
+++ b/docs/cli/cauldron/repo/add.md
@@ -12,12 +12,13 @@
 
 `<alias>`
 
-* Alias to associated to the cauldron repository url.
+* Alias to associate to the cauldron repository.
 
 `<url>`
 
-* HTTPS or SSH url to the Cauldron git repository
-* Can also use `local` as the url. In that case, a local Cauldron repository will be created. Local Cauldrons are only local to the workstation, and thus cannot be used by other users. A local Cauldron can be of use for using a Cauldron with Electrode Native without having to create a remote git repository. It is also much faster than a remote Cauldron given that it does not have to sync with the remote.
+* Local or remote url to the Cauldron git repository to add. 
+* A remote url can be the HTTPS or SSH url to the Cauldron git repository (SSH recommended).
+* A local url can be any valid path to a local directory (empty directory or containing a git repository).
 * For HTTPS urls, the username and password (or token) must be specified in the URL (valid formats are `https://[username]:[password]@[repourl` or `https://[token]@[repourl]`).
 * By default, the `master` branch of the repository will be used. If you need to use a different branch, you can set the branch name you want to use, by appending it at the end of the url using the `#[branch-name]` format (second example below illustrate this).
 
@@ -31,10 +32,13 @@
 **Example**  
 
 `ern cauldron repo add my-cauldron git@github.com:User/Cauldron.git`  
-Add a new Cauldron repository, with alias `my-cauldron`, and url `git@github.com:User/Cauldron.git`, to your local collection of Cauldron repositories. The branch that will be used for this Cauldron will be `master` as no branch was explicitly specified.
+Add a new Cauldron repository, with alias `my-cauldron`, and url `git@github.com:User/Cauldron.git`, to the local collection of Cauldron repositories. The branch that will be used for this Cauldron will be `master` as no branch was explicitly specified.
+
+`ern cauldron repo add my-local-cauldron ~/path/to/local/cauldron`  
+Add a new Cauldron repository with alias `my-local-cauldron` and url pointing to local directory `~/path/to/local/cauldron` to the location collection of Cauldron repositories.
 
 `ern cauldron repo add my-other-cauldron git@github.com:User/OtherCauldron#development --current`  
-Add a new Cauldron repository, with alias `my-other-cauldron`, and url `git@github.com:User/OtherCauldron`, to your local collection of Cauldron repositories and set it at the current activated Cauldron. The branch that will be used for this Cauldron will be `development` as it was explicitly specified in the Cauldron url.
+Add a new Cauldron repository, with alias `my-other-cauldron`, and url `git@github.com:User/OtherCauldron`, to the local collection of Cauldron repositories and set it at the current activated Cauldron. The branch that will be used for this Cauldron will be `development` as it was explicitly specified in the Cauldron url.
 
 #### Remarks
 

--- a/ern-cauldron-api/src/CauldronRepositories.ts
+++ b/ern-cauldron-api/src/CauldronRepositories.ts
@@ -1,17 +1,16 @@
 import { Platform, config, shell } from 'ern-core'
 import { CauldronRepository } from './types'
-import path from 'path'
 
 export class CauldronRepositories {
-  public addRemote({
-    alias,
-    activate,
-    url,
-  }: {
-    alias: string
-    activate?: boolean
-    url: string
-  }): CauldronRepository {
+  public add(
+    alias: string,
+    url: string,
+    {
+      activate,
+    }: {
+      activate?: boolean
+    }
+  ): CauldronRepository {
     this.throwIfAliasExist({ alias })
 
     const supportedGitHttpsSchemeRe = /(^https:\/\/.+:.+@.+$)|(^https:\/\/.+@.+$)/
@@ -24,18 +23,13 @@ https://[token]@[repourl]`)
       }
     }
 
-    return this.add({ alias, activate, url })
-  }
-
-  public addLocal({
-    alias,
-    activate,
-  }: {
-    alias: string
-    activate?: boolean
-  }): CauldronRepository {
-    const url = path.join(Platform.localCauldronsDirectory, alias)
-    return this.add({ alias, activate, url })
+    const cauldronRepositories = config.getValue('cauldronRepositories', {})
+    cauldronRepositories[alias] = url
+    config.setValue('cauldronRepositories', cauldronRepositories)
+    if (activate) {
+      this.activate({ alias })
+    }
+    return { alias, url }
   }
 
   public doesExist({ alias }: { alias: string }) {
@@ -91,24 +85,6 @@ https://[token]@[repourl]`)
   private updateCauldronRepoInUse({ alias }: { alias?: string } = {}) {
     config.setValue('cauldronRepoInUse', alias)
     shell.rm('-rf', Platform.cauldronDirectory)
-  }
-
-  private add({
-    alias,
-    activate,
-    url,
-  }: {
-    alias: string
-    activate?: boolean
-    url: string
-  }): CauldronRepository {
-    const cauldronRepositories = config.getValue('cauldronRepositories', {})
-    cauldronRepositories[alias] = url
-    config.setValue('cauldronRepositories', cauldronRepositories)
-    if (activate) {
-      this.activate({ alias })
-    }
-    return { alias, url }
   }
 
   private throwIfAliasExist({ alias }: { alias: string }) {

--- a/ern-local-cli/src/commands/cauldron/repo/add.ts
+++ b/ern-local-cli/src/commands/cauldron/repo/add.ts
@@ -31,9 +31,7 @@ export const commandHandler = async ({
     )
   }
 
-  url === 'local'
-    ? cauldronRepositories.addLocal({ alias, activate: current })
-    : cauldronRepositories.addRemote({ alias, url, activate: current })
+  cauldronRepositories.add(alias, url, { activate: current })
 
   log.info(`Added Cauldron repository ${url} with alias ${alias}`)
 }


### PR DESCRIPTION
Local Cauldrons support was kind of clumsy.

The fact that one had to use `local` as the Cauldron url was awkward, and on top of that all local Cauldrons were kept in `~/.ern/local-cauldrons` which was not very flexible.

This PR removes the special `local` url value handling. `url` can now be a path to a remote repository, or a path to any local directory. If a local directory path is used, and the directory does not contain a git repository (i.e `.git` directory), it will be created.

This change makes the command `cauldron repo add` more coherent while also improving flexibility as it is now possible to add a local cauldron using any local directory.

**For release notes**
**This is a breaking change**