### PR TITLE
Add support for local override manifest

### DIFF
--- a/ern-core/src/Manifest.ts
+++ b/ern-core/src/Manifest.ts
@@ -393,10 +393,14 @@ export class Manifest {
           overrideManifestConfig.url
         )
         this.manifestOverrideType = overrideManifestConfig.type
-        this.overrideManifest = new GitManifest(
-          Platform.overrideManifestDirectory,
-          manifestOverrideUrl
-        )
+        if (fs.existsSync(manifestOverrideUrl)) {
+          this.overrideManifest = new GitManifest(manifestOverrideUrl)
+        } else {
+          this.overrideManifest = new GitManifest(
+            Platform.overrideManifestDirectory,
+            manifestOverrideUrl
+          )
+        }
       }
     }
   }


### PR DESCRIPTION
Making it easier to work on plugin configuration, as any changes to the local manifest directory being used, won't be overwritten by a force sync to remote repo any time manifest is accessed.