### PR TITLE
Fix cauldron add nativeapp with unexisting version to copy from

### DIFF
--- a/ern-cauldron-api/src/CauldronHelper.ts
+++ b/ern-cauldron-api/src/CauldronHelper.ts
@@ -100,14 +100,20 @@ export class CauldronHelper {
         copyFromVersion === 'latest'
           ? (await this.getMostRecentNativeApplicationVersion(descriptor)).name
           : copyFromVersion
+      const sourceVersion = new AppVersionDescriptor(
+        descriptor.name,
+        descriptor.platform,
+        version
+      )
+      if (!(await this.cauldron.hasDescriptor(sourceVersion))) {
+        throw new Error(
+          `Cannot copy from unexisting source version ${sourceVersion}`
+        )
+      }
       await this.addDescriptor(descriptor)
       await this.copyNativeApplicationVersion({
         shouldCopyConfig: !!!config,
-        source: new AppVersionDescriptor(
-          descriptor.name,
-          descriptor.platform,
-          version
-        ),
+        source: sourceVersion,
         target: descriptor,
       })
     } else {


### PR DESCRIPTION
When using `cauldron add nativeapp` command with the `--copyFromVersion` option, the command will misbehave if the version to copy from does not exist in the Cauldron.

Indeed, it will add the new native application version in the Cauldron, with nothing in it and then throw an error, which is not the desired behavior. We don't want the command to create the native application version in Cauldron in that case. 

This PR fixes this problem