### PR TITLE
Use a local cauldron for system tests

### DIFF
--- a/system-tests/fixtures/constants.js
+++ b/system-tests/fixtures/constants.js
@@ -6,8 +6,6 @@ const baseConstants = {
   movieApiPkgName: 'react-native-ernmovie-api',
   movieApiImplName: 'ErnMovieApiImplNative',
   movieApiImplPkgName: 'ern-movie-api-impl',
-  gitUserName: 'ernplatformtest',
-  gitPassword: 'ernplatformtest12345',
   cauldronName: 'cauldron-system-tests',
   systemTestMiniAppName: 'MiniAppSystemTest',
   systemTestMiniAppPkgName: 'miniapp-system-test',
@@ -28,10 +26,6 @@ const baseConstants = {
   movieApiImplNativePkgVersion: '0.0.16'
 }
 
-const compositeConstants = {
-  gitHubCauldronRepositoryName: `${baseConstants.cauldronName}-${randomInt(0, 1000)}`
-}
-
 const pathConstants = {
   pathToJsApiImplFixture: path.join(__dirname, 'api-impl-js'),
   pathToNativeApiImplFixture: path.join(__dirname, 'api-impl-native'),
@@ -43,4 +37,4 @@ const pathConstants = {
   pathToTestApiSchema: path.join(__dirname, 'api', 'testapi-schema.json')
 }
 
-module.exports = Object.freeze(Object.assign({}, baseConstants, compositeConstants, pathConstants))
+module.exports = Object.freeze(Object.assign({}, baseConstants, pathConstants))

--- a/system-tests/tests/misc.js
+++ b/system-tests/tests/misc.js
@@ -30,12 +30,9 @@ process.on('SIGINT', () => afterAll())
 console.log(info(`Entering temporary working directory : ${workingDirectoryPath}`))
 process.chdir(workingDirectoryPath)
 
-console.log(info(`Creating GitHub repository (${f.gitHubCauldronRepositoryName})`))
-shell.exec(`curl -u ${f.gitUserName}:${f.gitPassword} -d '{"name": "${f.gitHubCauldronRepositoryName}"}' https://api.github.com/user/repos`)
-
 // Cauldron repo
 run('cauldron repo clear')
-run(`cauldron repo add ${f.cauldronName} https://${f.gitUserName}:${f.gitPassword}@github.com/${f.gitUserName}/${f.gitHubCauldronRepositoryName}.git --current=false`)
+run(`cauldron repo add ${f.cauldronName} ${tmp.dirSync({ unsafeCleanup: true }).name} --current=false`)
 run(`cauldron repo use ${f.cauldronName}`)
 run('cauldron repo current')
 run('cauldron repo list')

--- a/system-tests/utils/afterAll.js
+++ b/system-tests/utils/afterAll.js
@@ -11,14 +11,6 @@ module.exports = function() {
     '==========================================================================='
   )
   console.log(info('Cleaning up test env'))
-  console.log(info(`Removing GitHub repository (${f.cauldronName})`))
-  shell.exec(
-    `curl -u ${f.gitUserName}:${
-      f.gitPassword
-    } -X DELETE https://api.github.com/repos/${f.gitUserName}/${
-      f.gitHubCauldronRepositoryName
-    }`
-  )
   console.log(info('Deactivating current Cauldron'))
   runErnCommand('cauldron repo clear')
   console.log(info('Removing Cauldron alias'))


### PR DESCRIPTION
Use a local cauldron (created in a temporary directory) for system tests, rather than relying on a remote cauldron (in GitHub). This has two benefits :
- Speeds up the system tests, as we get rid of the incurred lag of working with remote repository.
- No need to publicly expose any credentials or token (more secure).