### PR TITLE
Add injection configuration support for native api impls

### DIFF
--- a/ern-api-impl-gen/src/ApiImpl.ts
+++ b/ern-api-impl-gen/src/ApiImpl.ts
@@ -189,6 +189,32 @@ function ernifyPackageJson(
     containerGen,
     moduleType,
   }
+
+  if (nativeOnly) {
+    packageJson.ern.pluginConfig = {
+      android: {
+        root: 'android/lib',
+      },
+      ios: {
+        copy: [
+          {
+            dest: '{{{projectName}}}/APIImpls',
+            source: 'ios/ElectrodeApiImpl/APIImpls/*',
+          },
+        ],
+        pbxproj: {
+          addSource: [
+            {
+              from: 'ios/ElectrodeApiImpl/APIImpls/*.swift',
+              group: 'APIImpls',
+              path: 'APIImpls',
+            },
+          ],
+        },
+      },
+    }
+  }
+
   packageJson.keywords
     ? packageJson.keywords.push(moduleType)
     : (packageJson.keywords = [moduleType])

--- a/system-tests/fixtures/api-impl-native/ReactNativeErnmovieApiImplNative/package.json
+++ b/system-tests/fixtures/api-impl-native/ReactNativeErnmovieApiImplNative/package.json
@@ -14,7 +14,29 @@
         "Movies"
       ]
     },
-    "moduleType": "ern-native-api-impl"
+    "moduleType": "ern-native-api-impl",
+    "pluginConfig": {
+      "android": {
+        "root": "android/lib"
+      },
+      "ios": {
+        "copy": [
+          {
+            "dest": "{{{projectName}}}/APIImpls",
+            "source": "ios/ElectrodeApiImpl/APIImpls/*"
+          }
+        ],
+        "pbxproj": {
+          "addSource": [
+            {
+              "from": "ios/ElectrodeApiImpl/APIImpls/*.swift",
+              "group": "APIImpls",
+              "path": "APIImpls"
+            }
+          ]
+        }
+      }
+    }
   },
   "keywords": [
     "ern-native-api-impl"


### PR DESCRIPTION
Two things in this PR related to native api implementations.

1. For Android, only copy the api implementation source in the Container (before this change, the bridge + api source code was injected in the Container). No changes for IOS because it was already behaving correctly by only injecting API Implementation source files in the Container.

2. A `pluginConfig` object is now added to the `ern` object in the `package.json` of the native api implementation project. This gives access to all plugin injection configuration directives, such as `dependencies` / `copy` / `permissions`, to add dependencies or permissions used by the native api implementation, to the Container, in the exact same way as it's done for native modules injection. If no `pluginConfig` object is found in the `ern` section, this will fallback to using default plugin configuration for native api implementation from electrode native (backward compatibility).