### PR TITLE
Fix use of NODE_ENV

### DIFF
--- a/ern-local-cli/src/commands/binarystore.ts
+++ b/ern-local-cli/src/commands/binarystore.ts
@@ -5,8 +5,7 @@ export const desc = 'Binary store access commands'
 export const builder = (argv: Argv) => {
   return argv
     .commandDir('binarystore', {
-      extensions:
-        process.env.NODE_ENV === 'development' ? ['js', 'ts'] : ['js'],
+      extensions: process.env.ERN_ENV === 'development' ? ['js', 'ts'] : ['js'],
     })
     .demandCommand(1, 'binarystore needs a command')
     .strict()

--- a/ern-local-cli/src/commands/cauldron.ts
+++ b/ern-local-cli/src/commands/cauldron.ts
@@ -5,8 +5,7 @@ export const desc = 'Cauldron access commands'
 export const builder = (argv: Argv) => {
   return argv
     .commandDir('cauldron', {
-      extensions:
-        process.env.NODE_ENV === 'development' ? ['js', 'ts'] : ['js'],
+      extensions: process.env.ERN_ENV === 'development' ? ['js', 'ts'] : ['js'],
     })
     .demandCommand(1, 'cauldron needs a command')
     .strict()

--- a/ern-local-cli/src/commands/cauldron/add.ts
+++ b/ern-local-cli/src/commands/cauldron/add.ts
@@ -5,8 +5,7 @@ export const desc = 'Add objects to the Cauldron'
 export const builder = (argv: Argv) => {
   return argv
     .commandDir('add', {
-      extensions:
-        process.env.NODE_ENV === 'development' ? ['js', 'ts'] : ['js'],
+      extensions: process.env.ERN_ENV === 'development' ? ['js', 'ts'] : ['js'],
     })
     .demandCommand(1, 'add needs a command')
     .strict()

--- a/ern-local-cli/src/commands/cauldron/config.ts
+++ b/ern-local-cli/src/commands/cauldron/config.ts
@@ -5,8 +5,7 @@ export const desc = 'Manage configuration stored in Cauldron'
 export const builder = (argv: Argv) => {
   return argv
     .commandDir('config', {
-      extensions:
-        process.env.NODE_ENV === 'development' ? ['js', 'ts'] : ['js'],
+      extensions: process.env.ERN_ENV === 'development' ? ['js', 'ts'] : ['js'],
     })
     .demandCommand(1, 'Need a command')
     .strict()

--- a/ern-local-cli/src/commands/cauldron/del.ts
+++ b/ern-local-cli/src/commands/cauldron/del.ts
@@ -5,8 +5,7 @@ export const desc = 'Remove objects from the Cauldron'
 export const builder = (argv: Argv) => {
   return argv
     .commandDir('del', {
-      extensions:
-        process.env.NODE_ENV === 'development' ? ['js', 'ts'] : ['js'],
+      extensions: process.env.ERN_ENV === 'development' ? ['js', 'ts'] : ['js'],
     })
     .demandCommand(1, 'add needs a command')
     .strict()

--- a/ern-local-cli/src/commands/cauldron/get.ts
+++ b/ern-local-cli/src/commands/cauldron/get.ts
@@ -5,8 +5,7 @@ export const desc = 'Get objects from the Cauldron'
 export const builder = (argv: Argv) => {
   return argv
     .commandDir('get', {
-      extensions:
-        process.env.NODE_ENV === 'development' ? ['js', 'ts'] : ['js'],
+      extensions: process.env.ERN_ENV === 'development' ? ['js', 'ts'] : ['js'],
     })
     .demandCommand(1, 'add needs a command')
     .strict()

--- a/ern-local-cli/src/commands/cauldron/repo.ts
+++ b/ern-local-cli/src/commands/cauldron/repo.ts
@@ -5,8 +5,7 @@ export const desc = 'Manage Cauldron git repository(ies)'
 export const builder = (argv: Argv) => {
   return argv
     .commandDir('repo', {
-      extensions:
-        process.env.NODE_ENV === 'development' ? ['js', 'ts'] : ['js'],
+      extensions: process.env.ERN_ENV === 'development' ? ['js', 'ts'] : ['js'],
     })
     .demandCommand(1, 'repo needs a command')
     .strict()

--- a/ern-local-cli/src/commands/cauldron/update.ts
+++ b/ern-local-cli/src/commands/cauldron/update.ts
@@ -5,8 +5,7 @@ export const desc = 'Update objects in the Cauldron'
 export const builder = (argv: Argv) => {
   return argv
     .commandDir('update', {
-      extensions:
-        process.env.NODE_ENV === 'development' ? ['js', 'ts'] : ['js'],
+      extensions: process.env.ERN_ENV === 'development' ? ['js', 'ts'] : ['js'],
     })
     .demandCommand(1, 'Need a command')
     .strict()

--- a/ern-local-cli/src/commands/code-push.ts
+++ b/ern-local-cli/src/commands/code-push.ts
@@ -5,8 +5,7 @@ export const desc = 'code-push commands'
 export const builder = (argv: Argv) => {
   return argv
     .commandDir('code-push', {
-      extensions:
-        process.env.NODE_ENV === 'development' ? ['js', 'ts'] : ['js'],
+      extensions: process.env.ERN_ENV === 'development' ? ['js', 'ts'] : ['js'],
     })
     .demandCommand(1, 'code-push needs a command')
     .strict()

--- a/ern-local-cli/src/commands/github.ts
+++ b/ern-local-cli/src/commands/github.ts
@@ -5,8 +5,7 @@ export const desc = 'Helper commands for GitHub based MiniApps'
 export const builder = (argv: Argv) => {
   return argv
     .commandDir('github', {
-      extensions:
-        process.env.NODE_ENV === 'development' ? ['js', 'ts'] : ['js'],
+      extensions: process.env.ERN_ENV === 'development' ? ['js', 'ts'] : ['js'],
     })
     .demandCommand(1, 'github needs a command')
     .strict()

--- a/ern-local-cli/src/commands/list.ts
+++ b/ern-local-cli/src/commands/list.ts
@@ -5,8 +5,7 @@ export const desc = 'List information associated to an Electrode Native module'
 export const builder = (argv: Argv) => {
   return argv
     .commandDir('list', {
-      extensions:
-        process.env.NODE_ENV === 'development' ? ['js', 'ts'] : ['js'],
+      extensions: process.env.ERN_ENV === 'development' ? ['js', 'ts'] : ['js'],
     })
     .demandCommand(1, 'list needs a command')
     .strict()

--- a/ern-local-cli/src/commands/platform.ts
+++ b/ern-local-cli/src/commands/platform.ts
@@ -5,8 +5,7 @@ export const desc = 'Platform related commands'
 export const builder = (argv: Argv) => {
   return argv
     .commandDir('platform', {
-      extensions:
-        process.env.NODE_ENV === 'development' ? ['js', 'ts'] : ['js'],
+      extensions: process.env.ERN_ENV === 'development' ? ['js', 'ts'] : ['js'],
     })
     .demandCommand(1, 'platform needs a command')
     .strict()

--- a/ern-local-cli/src/commands/platform/config.ts
+++ b/ern-local-cli/src/commands/platform/config.ts
@@ -5,8 +5,7 @@ export const desc = 'Manage ern platform configuration'
 export const builder = (argv: Argv) => {
   return argv
     .commandDir('config', {
-      extensions:
-        process.env.NODE_ENV === 'development' ? ['js', 'ts'] : ['js'],
+      extensions: process.env.ERN_ENV === 'development' ? ['js', 'ts'] : ['js'],
     })
     .demandCommand(1, 'config needs a command')
     .strict()

--- a/ern-local-cli/src/commands/platform/plugins.ts
+++ b/ern-local-cli/src/commands/platform/plugins.ts
@@ -5,8 +5,7 @@ export const desc = 'Plugins access commands'
 export const builder = (argv: Argv) => {
   return argv
     .commandDir('plugins', {
-      extensions:
-        process.env.NODE_ENV === 'development' ? ['js', 'ts'] : ['js'],
+      extensions: process.env.ERN_ENV === 'development' ? ['js', 'ts'] : ['js'],
     })
     .demandCommand(1, 'plugins needs a command')
 }

--- a/ern-local-cli/src/index.dev.js
+++ b/ern-local-cli/src/index.dev.js
@@ -3,7 +3,7 @@ const path = require('path')
 const Module = require('module')
 const oload = Module._load
 
-process.env.NODE_ENV = 'development'
+process.env.ERN_ENV = 'development'
 process.env.TS_NODE_PROJECT = path.resolve(
   __dirname,
   '..',

--- a/ern-local-cli/src/index.ts
+++ b/ern-local-cli/src/index.ts
@@ -181,8 +181,7 @@ const logLevelStringToEnum = level => {
 
   return yargs
     .commandDir('commands', {
-      extensions:
-        process.env.NODE_ENV === 'development' ? ['js', 'ts'] : ['js'],
+      extensions: process.env.ERN_ENV === 'development' ? ['js', 'ts'] : ['js'],
     })
     .demandCommand(1, 'Need a command')
     .help('help')


### PR DESCRIPTION
If a user has the `NODE_ENV` globally defined and set to `development`, or is running `NODE_ENV=development ern` then `ern` will fail, because we use the `NODE_ENV` variable internally for Electrode Native development, to transpile TypeScript files on the fly rather than using pre-transpiled sources.

This result in an error such as 

```
SyntaxError: Unexpected token export
    at createScript (vm.js:80:10)
```

because the release versions of Electrode Native are already pre-transpiled.

The `NODE_ENV` variable is widely used conventionally, so to avoid running into such issue, this PR replace `NODE_ENV` with `ERN_ENV` variable name.
