### PR TITLE
Fix iOS simulator selection

### DIFF
--- a/ern-core/src/ios.ts
+++ b/ern-core/src/ios.ts
@@ -61,7 +61,10 @@ export async function askUserToSelectAniPhoneSimulator() {
   }))
 
   // Check if user has set the usePreviousEmulator flag to true
-  const deviceConfig = ernConfig.getValue(deviceConfigUtil.IOS_DEVICE_CONFIG)
+  const deviceConfig = ernConfig.getValue(
+    deviceConfigUtil.IOS_DEVICE_CONFIG,
+    {}
+  )
   if (choices && deviceConfig) {
     if (deviceConfig.usePreviousDevice) {
       // Get the name of previously used simulator


### PR DESCRIPTION
Fixes 

```
An error occurred: Cannot set property 'deviceId' of undefined
```

after selecting an iOS simulator to launch.

Has been reported by a user, and is due to the fact that if for some reason `iOSDeviceConfig` object is not present in `.ernrc`, `ernConfig.getValue` will return `undefined` (if no other default value specified). Later on in the code we do `deviceConfig.deviceId = [...]` leading to the error being thrown.

The fix is just to return `{}` empty object as default value, rather than `undefined` if `iOSDeviceConfig` object is missing from `.ernrc`