### PR TITLE
Remove copyFiles directive from ern-container-gen

### DIFF
--- a/ern-container-gen/package.json
+++ b/ern-container-gen/package.json
@@ -44,25 +44,12 @@
     }
   ],
   "scripts": {
-    "build": "ern-typescript && ern-copyfiles",
+    "build": "ern-typescript",
     "test": "ern-mocha",
     "coverage": "ern-nyc",
     "prepublish": "yarn run build",
-    "instrument-dist": "ern-instrument-dist && ern-copyfiles"
+    "instrument-dist": "ern-instrument-dist"
   },
-  "copyFiles": [{
-      "source": "src/generators/android/hull",
-      "dest": "dist/generators/android"
-    },
-    {
-      "source": "src/generators/android/templates",
-      "dest": "dist/generators/android"
-    },
-    {
-      "source": "src/generators/ios/hull",
-      "dest": "dist/generators/ios"
-    }
-  ],
   "license": "Apache-2.0",
   "dependencies": {
     "ern-core": "1000.0.0",


### PR DESCRIPTION
Not used anymore since `ern-container-gen-android` and `ern-container-gen-ios` packages were created.