### PR TITLE
Update Azure pipeline for unit tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,58 +1,19 @@
 trigger:
-- master
+  - master
 
 jobs:
-- job: Windows
-  pool:
-    vmImage: 'vs2017-win2016'
-  steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: '10.x'
-    displayName: 'Install Node.js'
-  - script: |
-      npm install
-      npm run rebuild
-    displayName: 'npm install and build'
-  - script: |
-      npm run check:lint
-    displayName: 'lint checks'
-  - script: |
-      npm run test:unit
-    displayName: 'unit tests'
-- job: macOS
-  pool:
-    vmImage: 'macOS-10.13'
-  steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: '10.x'
-    displayName: 'Install Node.js'
-  - script: |
-      npm install
-      npm run rebuild
-    displayName: 'npm install and build'
-  - script: |
-      npm run check:lint
-    displayName: 'lint checks'
-  - script: |
-      npm run test:unit
-    displayName: 'unit tests'
-- job: Linux
-  pool:
-    vmImage: 'ubuntu-latest'
-  steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: '10.x'
-    displayName: 'Install Node.js'
-  - script: |
-      npm install
-      npm run rebuild
-    displayName: 'npm install and build'
-  - script: |
-      npm run check:lint
-    displayName: 'lint checks'
-  - script: |
-      npm run test:unit
-    displayName: 'unit tests'
+  - job: Windows
+    pool:
+      vmImage: 'win1803'
+    steps:
+      - template: azure/templates/unit-tests.yml
+  - job: macOS
+    pool:
+      vmImage: 'macOS-10.13'
+    steps:
+      - template: azure/templates/unit-tests.yml
+  - job: Linux
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+      - template: azure/templates/unit-tests.yml

--- a/azure/templates/unit-tests.yml
+++ b/azure/templates/unit-tests.yml
@@ -1,0 +1,17 @@
+steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '10.x'
+    displayName: 'Install Node.js'
+  - script: |
+      yarn install
+    displayName: 'Install'
+  - script: |
+      yarn build
+    displayName: 'Build'
+  - script: |
+      yarn check:lint
+    displayName: 'Run lint checks'
+  - script: |
+      yarn test:unit
+    displayName: 'Run unit tests'

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "keywords": [],
   "license": "Apache-2.0",
   "scripts": {
+    "build": "lerna run build",
     "check": "yarn check:lint && yarn check:yarnlock",
     "check:lint": "tslint -c tslint.json '**/src/**/*.ts' '**/test/**/*.ts' -e '**/node_modules/**'",
     "check:yarnlock": "node yarn-lock-check",


### PR DESCRIPTION
- Create a template to avoid step duplication for each agent pool.
- Split install/build steps into two distinct steps.
- Use yarn rather than npm for all steps.
- Update display name of all steps.
- Add new build script to npm scripts to only run `lerna run build` (as `lern clean` and `lerna bootstrap` are unnecessary for fresh setup .. bootstrap is not even needed anymore because of the use of yarn workspaces, will remove it later) .