### PR TITLE
Add unit test reporting to azure pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,9 @@
 trigger:
   - master
 
+variables:
+  ENV_AZURE_PIPELINE: true
+
 jobs:
   - job: Windows
     pool:

--- a/azure/templates/unit-tests.yml
+++ b/azure/templates/unit-tests.yml
@@ -15,3 +15,10 @@ steps:
   - script: |
       yarn test:unit
     displayName: 'Run unit tests'
+  - task: PublishTestResults@2
+    condition: succeededOrFailed()
+    inputs:
+      testResultsFormat: 'JUnit'
+      testResultsFiles: 'ern-*/test-results.xml'
+      mergeTestResults: true
+      testRunTitle: $(Agent.OS)

--- a/ern-core/src/Platform.ts
+++ b/ern-core/src/Platform.ts
@@ -112,7 +112,7 @@ export default class Platform {
 
     try {
       shell.mkdir('-p', path.join(pathToVersion, 'node_modules'))
-      process.chdir(pathToVersion)
+      shell.pushd(pathToVersion)
       if (this.isYarnInstalled()) {
         // Favor yarn if it is installed as it will greatly speed up install
         execSync(`yarn add ${ERN_LOCAL_CLI_PACKAGE}@${version} --exact`, {
@@ -129,6 +129,8 @@ export default class Platform {
       )
       shell.rm('-rf', pathToVersion)
       throw e
+    } finally {
+      shell.popd()
     }
   }
 

--- a/ern-core/test/fixtures/common.js
+++ b/ern-core/test/fixtures/common.js
@@ -12,9 +12,9 @@ export const oneAvdList = ['Nexus6API23M']
 export const oneAvd = 'Nexus6API23M'
 export const activityName = 'ChaiActivity'
 export const projectPath = 'projectPath'
-export const getDeviceResult = `emulator-5554\tdevice${
+export const getDeviceResult = `List of devices attached${
   os.EOL
-}8XV7N16516003608\tdevice`
+}emulator-5554\tdevice${os.EOL}8XV7N16516003608\tdevice`
 export const oneUdid = 'A1213FE6-BDA8-424B-972C-4EA0480C3497'
 
 export const validElectrodeNativeModuleNames = [

--- a/ern-util-dev/bin/ern-mocha.js
+++ b/ern-util-dev/bin/ern-mocha.js
@@ -1,14 +1,36 @@
 #!/usr/bin/env node
 const path = require('path')
+const shell = require('shelljs')
 process.env.__ERN_TEST__ = true
 process.env.TS_NODE_TRANSPILE_ONLY = true
 process.env.TS_NODE_PROJECT = path.resolve('..', 'tsconfig.json')
+const testCwd = process.cwd()
 if (!require('fs').existsSync(require('path').join(process.cwd(), 'test'))) {
-  console.log('no tests for project ', process.cwd())
+  console.log('no tests for project ', testCwd)
   process.exit(0)
 }
-console.log(`running tests in ${process.cwd()}`)
+console.log(`running tests in ${testCwd}`)
 process.argv.push('-r', 'ts-node/register')
 process.argv.push('-r', 'tsconfig-paths/register')
+if (process.env.ENV_AZURE_PIPELINE) {
+  // Create `node_modules/mocha` in current module directory
+  // and copy top level `node_modules/mocha/package.json` to
+  // this directory.
+  // Done due to the fact that mocha-junit-reporter doesn't
+  // currently play well with mono-repo setup as it looks for
+  // mocha package.json in node_modules of current directory.
+  // See https://github.com/michaelleeallen/mocha-junit-reporter/blob/v1.23.0/index.js#L17
+  // But because we are using a mono-repo, mocha node module
+  // is hoisted in top level (root) directory.
+  // To remove once mocha-junit-reporter is updated to support
+  // mono-repo setup.
+  shell.mkdir('-p', path.join(testCwd, 'node_modules', 'mocha'))
+  shell.cp(
+    '-rf',
+    path.resolve('..', 'node_modules', 'mocha', 'package.json'),
+    path.join(testCwd, 'node_modules', 'mocha', 'package.json')
+  )
+  process.argv.push('--reporter', 'mocha-junit-reporter')
+}
 process.argv.push('test/*-test.{ts,js}')
 require('mocha/bin/_mocha')

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "setup-dev": "node setup-dev.js",
     "test": "yarn test:unit && yarn test:system",
     "test:system": "lerna run build && lerna run instrument-dist && node system-tests/system-tests",
-    "test:unit": "lerna run test"
+    "test:unit": "lerna run test --no-bail"
   },
   "workspaces": [
     "./ern-*"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "jsonpath": "^1.0.1",
     "lerna": "3.13.4",
     "mocha": "^6.1.4",
+    "mocha-junit-reporter": "^1.23.0",
     "mock-fs": "^4.9.0",
     "npm": "^6.9.0",
     "nyc": "14.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1976,6 +1976,11 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+charenc@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+  integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
+
 check-error@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
@@ -2500,6 +2505,11 @@ cross-spawn@^6.0.0:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+crypt@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
+  integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
 crypto-random-string@^1.0.0:
   version "1.0.0"
@@ -4141,7 +4151,7 @@ is-binary-path@^2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
-is-buffer@^1.1.5:
+is-buffer@^1.1.5, is-buffer@~1.1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -5228,6 +5238,15 @@ md5-file@^4.0.0:
   resolved "https://registry.yarnpkg.com/md5-file/-/md5-file-4.0.0.tgz#f3f7ba1e2dd1144d5bf1de698d0e5f44a4409584"
   integrity sha512-UC0qFwyAjn4YdPpKaDNw6gNxRf7Mcx7jC1UGCY4boCzgvU2Aoc1mOGzTtrjjLKhM5ivsnhoKpQVxKPp+1j1qwg==
 
+md5@^2.1.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
+  integrity sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=
+  dependencies:
+    charenc "~0.0.1"
+    crypt "~0.0.1"
+    is-buffer "~1.1.1"
+
 meant@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/meant/-/meant-1.0.1.tgz#66044fea2f23230ec806fb515efea29c44d2115d"
@@ -5442,6 +5461,17 @@ mkpath@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/mkpath/-/mkpath-0.1.0.tgz#7554a6f8d871834cc97b5462b122c4c124d6de91"
   integrity sha1-dVSm+Nhxg0zJe1RisSLEwSTW3pE=
+
+mocha-junit-reporter@^1.23.0:
+  version "1.23.0"
+  resolved "https://registry.yarnpkg.com/mocha-junit-reporter/-/mocha-junit-reporter-1.23.0.tgz#c5ad7f10b5aa9a7cc6e169b6bf15baf2700266ca"
+  integrity sha512-pmpnEO4iDTmLfrT2RKqPsc5relG4crnDSGmXPuGogdda27A7kLujDNJV4EbTbXlVBCZXggN9rQYPEWMkOv4AAA==
+  dependencies:
+    debug "^2.2.0"
+    md5 "^2.1.0"
+    mkdirp "~0.5.1"
+    strip-ansi "^4.0.0"
+    xml "^1.0.0"
 
 mocha@^6.1.4:
   version "6.1.4"
@@ -8713,6 +8743,11 @@ xml2js@^0.4.5:
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
+
+xml@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
 xmlbuilder@8.2.2:
   version "8.2.2"


### PR DESCRIPTION
This PR updates our unit test setup along with azure pipeline configuration, to enable azure test reporting for Electrode Native unit tests.

Test reports will now be generated whenever a build that runs unit tests is triggered (whenever a PR is opened for example), they are generated for both Windows/Linux and MacOS. For example the screenshot below shows a test report with one test failure on Windows only.

![Screenshot from 2019-06-22 15-24-31](https://user-images.githubusercontent.com/1390588/59969481-b7584780-9502-11e9-9178-f3323ecd6a4d.png)