### PR TITLE
Use --reset-cache option when calling react-native bundle

### DIFF
--- a/ern-core/src/ReactNativeCli.ts
+++ b/ern-core/src/ReactNativeCli.ts
@@ -83,7 +83,8 @@ ${dev ? '--dev=true' : '--dev=false'} \
 ${platform ? `--platform=${platform}` : ''} \
 ${bundleOutput ? `--bundle-output=${bundleOutput}` : ''} \
 ${assetsDest ? `--assets-dest=${assetsDest}` : ''} \
-${sourceMapOutput ? `--sourcemap-output=${sourceMapOutput}` : ''}`
+${sourceMapOutput ? `--sourcemap-output=${sourceMapOutput}` : ''} \
+--reset-cache`
 
     await execp(bundleCommand, { cwd: workingDir })
     return {


### PR DESCRIPTION
Noticed some issues with caching of `.babelrc` for MiniApps relying on a Babel setup, due to the fact that we do not use the `--reset-cache` option when we are creating a bundle through `react-native bundle`.

This PR adds the `--reset-cache` option to `react-native bundle`, so that we don't run into any such metro caching issue.

Workaround for users experiencing issues related to metro caching when creating Containers, while waiting for next release is to manually clear the metro cache through `rm -rf $TMPDIR/metro-cache`