### PR TITLE
New codepush promote option to reuse relase binary version

### DIFF
--- a/docs/cli/code-push/promote.md
+++ b/docs/cli/code-push/promote.md
@@ -12,6 +12,12 @@
 
 **Options**  
 
+`--reuseReleaseBinaryVersion`
+
+* Indicates whether to reuse the target binary version that was used for the initial release
+* If omitted, and `targetBinaryVersion` is not set, the promotion will target the exact version of the descriptor
+* This option is mutually exclusive with `targetBinaryVersion`
+
 `--sourceDescriptor <descriptor>`
 
 * Specify the native application version from which to promote a release in the form of a *complete native application descriptor*.
@@ -40,11 +46,13 @@ If no `targetDescriptors` nor a `targetSemVerDescriptor` is specified, the comma
 * **Default** The command will prompt to input the deployment name, or display a list of deployment names stored in the Cauldron, to choose from.
 
 `--targetBinaryVersion/-t <targetBinaryVersion>`
-* Semver expression that specifies the binary app version this release is targeting
-* If omitted, the release will target the exact version of the descriptor
-* If versionModifier is specified in the codePush config , exact version of the descriptor is appended to versionModifier
+
+* Semver expression that specifies the binary app version this promotion is targeting
+* If omitted, and `reuseReleaseBinaryVersion` is not set, the promotion will target the exact version of the descriptor
+* If `versionModifier` is specified in the codePush config, it will be applied
 * For using `targetBinaryVersion` option users must target only 1 descriptor
 * For using `targetBinaryVersion` option users cannot use semVerDescriptor
+* This option is mutually exclusive with `reuseReleaseBinaryVersion`
 
 `--mandatory/-m`
 

--- a/ern-local-cli/src/commands/code-push/promote.ts
+++ b/ern-local-cli/src/commands/code-push/promote.ts
@@ -43,6 +43,11 @@ export const builder = (argv: Argv) => {
       describe: 'Specifies whether this release should be considered mandatory',
       type: 'boolean',
     })
+    .option('reuseReleaseBinaryVersion', {
+      describe:
+        'Indicates whether to reuse the target binary version that was used for the initial release',
+      type: 'boolean',
+    })
     .option('rollout', {
       alias: 'r',
       default: 100,
@@ -96,6 +101,7 @@ export const commandHandler = async ({
   force,
   label,
   mandatory,
+  reuseReleaseBinaryVersion,
   sourceDeploymentName,
   targetBinaryVersion,
   targetDeploymentName,
@@ -109,6 +115,7 @@ export const commandHandler = async ({
   force?: boolean
   label?: string
   mandatory?: boolean
+  reuseReleaseBinaryVersion?: boolean
   sourceDeploymentName?: string
   targetBinaryVersion?: string
   targetDeploymentName?: string
@@ -125,6 +132,12 @@ export const commandHandler = async ({
       targetBinaryVersion,
     },
   })
+
+  if (reuseReleaseBinaryVersion && targetBinaryVersion) {
+    throw new Error(
+      `reuseReleaseBinaryVersion and targetBinaryVersion options are mutually exclusive`
+    )
+  }
 
   sourceDescriptor =
     sourceDescriptor ||
@@ -214,6 +227,7 @@ export const commandHandler = async ({
       force,
       label,
       mandatory,
+      reuseReleaseBinaryVersion,
       rollout,
       targetBinaryVersion,
     }

--- a/ern-orchestrator/test/codepush-test.ts
+++ b/ern-orchestrator/test/codepush-test.ts
@@ -430,6 +430,89 @@ describe('codepush', () => {
       })
     })
 
+    it('should reuse the initial release binary version if reuseReleaseBinaryVersion is set', async () => {
+      prepareStubs()
+
+      await sut.performCodePushPromote(
+        testAndroid1770Descriptor,
+        [testAndroid1770Descriptor],
+        'QA',
+        'Production',
+        {
+          description: 'new description',
+          label: 'v18',
+          reuseReleaseBinaryVersion: true,
+          rollout: 100,
+        }
+      )
+
+      sandbox.assert.calledWith(
+        codePushSdkStub.promote,
+        'testAndroid',
+        'QA',
+        'Production',
+        {
+          appVersion: '~17.7',
+          description: 'new description',
+          isMandatory: false,
+          label: 'v18',
+          rollout: 100,
+        }
+      )
+    })
+
+    it('should not reuse the initial release binary version if reuseReleaseBinaryVersion is not set', async () => {
+      prepareStubs()
+
+      await sut.performCodePushPromote(
+        testAndroid1770Descriptor,
+        [testAndroid1770Descriptor],
+        'QA',
+        'Production',
+        {
+          description: 'new description',
+          label: 'v18',
+          rollout: 100,
+        }
+      )
+
+      sandbox.assert.calledWith(
+        codePushSdkStub.promote,
+        'testAndroid',
+        'QA',
+        'Production',
+        {
+          appVersion: '17.7.0',
+          description: 'new description',
+          isMandatory: false,
+          label: 'v18',
+          rollout: 100,
+        }
+      )
+    })
+
+    it('should throw if both reuseReleaseBinaryVersion and targetBinaryVersion are set', async () => {
+      prepareStubs()
+      codePushSdkStub.promote.rejects(new Error('fail'))
+
+      assert(
+        await doesThrow(
+          sut.performCodePushPromote,
+          sut,
+          testAndroid1770Descriptor,
+          [testAndroid1770Descriptor],
+          'QA',
+          'Production',
+          {
+            label: 'v18',
+            reuseReleaseBinaryVersion: true,
+            rollout: 100,
+            targetBinaryVersion: '17.7.0',
+          }
+        )
+      )
+    })
+
     it('should properly update target deployment yarn lock id in Cauldron', async () => {
       prepareStubs()
 

--- a/ern-util-dev/fixtures/default-cauldron-fixture.json
+++ b/ern-util-dev/fixtures/default-cauldron-fixture.json
@@ -74,7 +74,7 @@
               "metadata": {
                 "deploymentName": "QA",
                 "isMandatory": true,
-                "appVersion": "17.7",
+                "appVersion": "~17.7",
                 "size": 522938,
                 "releaseMethod": "Upload",
                 "label": "v18",


### PR DESCRIPTION
Introducing new `--reuseReleaseBinaryVersion` option to `codepush promote` command.
This flag is mutually exclusive with `--targetBinaryVersion`.

If set, it will reuse the version present in the `appVersion` field of the CodePush metadata entry/entries associated to the/each release(s) to promote (`targetBinaryVersion` that was/were used to perform the initial release)

Closes https://github.com/electrode-io/electrode-native/issues/1229