### PR TITLE
Add some git pre-push checks

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,6 +1,7 @@
 {
   "hooks": {
     "pre-commit": "yarn check:yarnlock && yarn check:lint && yarn prettier && yarn check:regen-fixtures",
-    "post-merge": "node auto-rebuild.js"
+    "post-merge": "node auto-rebuild.js",
+    "pre-push": "yarn build && yarn test:unit"
   }
 }


### PR DESCRIPTION
It is unfortunately common of developers (myself included) not to run a build and unit tests before pushing a branch to the remote.

Because of this, we frequently see PRs checks failing because of some TypeScript type checking or transpilation issue, or some unit test failing.

For this reason, and to drastically reduce the number of PRs failing checks, this PR adds a `pre-push` commit hook (run whenever using `git push`), which will run a build of Electrode Native (to catch any TypeScript related issue) followed by a run of all unit tests (to catch any failing unit tests) before pushing to the remote.