### PR TITLE
Address deprecated octokit function

### DIFF
--- a/ern-core/src/GitHubApi.ts
+++ b/ern-core/src/GitHubApi.ts
@@ -235,9 +235,11 @@ export class GitHubApi {
       ofBranch = await this.getDefaultBranch()
     }
 
-    const res = await this.octokit.repos.getCommitRefSha({
+    const res = await this.octokit.repos.getCommit({
+      commit_sha: ofBranch
+        ? this.fullBranchRef(ofBranch!)
+        : this.fullTagRef(ofTag!),
       owner: this.owner,
-      ref: ofBranch ? this.fullBranchRef(ofBranch!) : this.fullTagRef(ofTag!),
       repo: this.repo,
     })
 


### PR DESCRIPTION
As indicated in these release notes, https://github.com/octokit/rest.js/issues/620#issuecomment-497024159, `getCommitRefSha` function of Octokit is now deprecated and will be removed in a future version.

This PR replace the use of `getCommitRefSha` with `getCommit`.

