### PR TITLE
Fix create-composite command when no config exist

### DIFF
--- a/ern-local-cli/src/commands/create-composite.ts
+++ b/ern-local-cli/src/commands/create-composite.ts
@@ -136,7 +136,7 @@ Output directory should either not exist (it will be created) or should be empty
     )
     baseComposite =
       baseComposite || (compositeGenConfig && compositeGenConfig.baseComposite)
-    resolutions = compositeGenConfig.resolutions
+    resolutions = compositeGenConfig && compositeGenConfig.resolutions
   }
 
   await kax.task('Generating Composite').run(


### PR DESCRIPTION
If there is no resolved `compositeGenerator` generator config found in Cauldron when running the `create-composite` command, it will throw an error because `compositeGenConfig` will end up being undefined :( 

This PR fixes this issue.