### PR TITLE
Auto resolve host ip for run-ios command

### DIFF
--- a/docs/cli/run-ios.md
+++ b/docs/cli/run-ios.md
@@ -33,7 +33,8 @@
  * Use the previously selected device to avoid prompt
 
 `--host`
-* Host or ip to launch the local packager on *(default: localhost)*
+* Host or ip to launch the local packager on.
+* By default it will use the IP address that is returned by the `ipconfig getifaddr en0` command, and fallback to `localhost` in the case the command fails.
 
 `--port`
 * Port on which the local packager should listen on *(default: 8081)*

--- a/docs/cli/start.md
+++ b/docs/cli/start.md
@@ -44,6 +44,12 @@ If you do not pass an argument to this command, you are prompted to select a nat
 * Setting this option will bypass retrieval and installation of the binary from the Binary Store.  
 * It can be useful in case you want to use `ern start` command in conjunction with your own mobile application native binary, build locally on your workstation or retrieved from a specific location.
 
+`--host`
+* Host or ip to launch the local packager on *(default: localhost)*
+
+`--port`
+* Port on which the local packager should listen on *(default: 8081)*
+
 **Platform Specific Options**
 
 `Android`

--- a/ern-core/src/getLocalIp.ts
+++ b/ern-core/src/getLocalIp.ts
@@ -1,0 +1,21 @@
+import shell from './shell'
+import os from 'os'
+
+/**
+ * Return the local machine ip returned by running
+ * 'ipconfig getifaddr en0' command
+ *
+ * Only supported on Darwin and Linux
+ * Will throw for Windows (implementation TBD if needed)
+ */
+export function getLocalIp() {
+  if (os.platform() === 'win32') {
+    throw new Error('getLocalIp: Unsupported platform win32')
+  }
+  const getIpCmd = shell.exec('ipconfig getifaddr en0')
+  if (getIpCmd.stdout) {
+    return getIpCmd.stdout.trim()
+  } else {
+    throw new Error(`[code: ${getIpCmd.code} stderr: ${getIpCmd.stderr}]`)
+  }
+}

--- a/ern-core/src/index.ts
+++ b/ern-core/src/index.ts
@@ -45,6 +45,7 @@ export { BaseMiniApp } from './BaseMiniApp'
 export { YarnLockParser } from './YarnLockParser'
 export { AndroidResolvedVersions } from './android'
 export { GitHubApi } from './GitHubApi'
+export * from './getLocalIp'
 
 export const config = _config
 export const Platform = _Platform

--- a/ern-local-cli/src/commands/run-ios.ts
+++ b/ern-local-cli/src/commands/run-ios.ts
@@ -1,5 +1,12 @@
 import { epilog, tryCatchWrap } from '../lib'
-import { deviceConfig, log, AppVersionDescriptor, PackagePath } from 'ern-core'
+import {
+  deviceConfig,
+  log,
+  AppVersionDescriptor,
+  PackagePath,
+  shell,
+  getLocalIp,
+} from 'ern-core'
 import { runMiniApp } from 'ern-orchestrator'
 import { Argv } from 'yargs'
 
@@ -32,7 +39,6 @@ export const builder = (argv: Argv) => {
       type: 'boolean',
     })
     .option('host', {
-      default: 'localhost',
       describe: 'Host/IP to use for the local packager',
       type: 'string',
     })
@@ -86,12 +92,21 @@ export const commandHandler = async ({
   }
   deviceConfig.updateDeviceConfig('ios', usePreviousDevice)
 
+  if (!host && dev) {
+    try {
+      host = getLocalIp()
+    } catch (e) {
+      // Swallow
+      log.debug(e)
+    }
+  }
+
   await runMiniApp('ios', {
     baseComposite,
     dependencies,
     descriptor,
     dev,
-    host,
+    host: host || 'localhost',
     mainMiniAppName,
     miniapps,
     port,

--- a/ern-local-cli/src/commands/start.ts
+++ b/ern-local-cli/src/commands/start.ts
@@ -68,6 +68,15 @@ export const builder = (argv: Argv) => {
         'Disable automatic retrieval of the binary from the Binary Store',
       type: 'boolean',
     })
+    .option('host', {
+      describe: 'Host/IP to use for the local packager',
+      type: 'string',
+    })
+    .option('port', {
+      default: '8081',
+      describe: 'Port to use for the local package',
+      type: 'string',
+    })
     .group(['packageName', 'activityName'], 'Android binary specific options:')
     .group(['bundleId'], 'iOS binary specific options:')
     .epilog(epilog(exports))
@@ -79,9 +88,11 @@ export const commandHandler = async ({
   bundleId,
   descriptor,
   extraJsDependencies = [],
+  host,
   jsApiImpls,
   miniapps,
   packageName,
+  port,
   watchNodeModules,
   disableBinaryStore,
 }: {
@@ -90,9 +101,11 @@ export const commandHandler = async ({
   bundleId?: string
   descriptor?: AppVersionDescriptor
   extraJsDependencies?: PackagePath[]
+  host?: string
   jsApiImpls?: PackagePath[]
   miniapps?: PackagePath[]
   packageName?: string
+  port?: string
   watchNodeModules?: string[]
   disableBinaryStore?: boolean
 } = {}) => {
@@ -107,9 +120,11 @@ export const commandHandler = async ({
     descriptor,
     disableBinaryStore,
     extraJsDependencies,
+    host,
     jsApiImpls,
     miniapps,
     packageName,
+    port,
     watchNodeModules,
   })
 }

--- a/ern-orchestrator/src/runMiniApp.ts
+++ b/ern-orchestrator/src/runMiniApp.ts
@@ -130,14 +130,11 @@ export async function runMiniApp(
     log.debug(`Initializing Runner`)
 
     if (dev) {
-      const args: string[] = []
-      if (host) {
-        args.push(`--host ${host}`)
-      }
-      if (port) {
-        args.push(`--port ${port}`)
-      }
-      await reactnative.startPackagerInNewWindow(cwd, args)
+      await reactnative.startPackagerInNewWindow({
+        cwd,
+        host,
+        port,
+      })
     } else {
       log.info('Dev mode not enabled, will not start the packager.')
     }

--- a/ern-orchestrator/src/start.ts
+++ b/ern-orchestrator/src/start.ts
@@ -30,6 +30,8 @@ export default async function start({
   bundleId,
   extraJsDependencies,
   disableBinaryStore,
+  host,
+  port,
 }: {
   baseComposite?: PackagePath
   jsApiImpls?: PackagePath[]
@@ -41,6 +43,8 @@ export default async function start({
   bundleId?: string
   extraJsDependencies?: PackagePath[]
   disableBinaryStore?: boolean
+  host?: string
+  port?: string
 } = {}) {
   const cauldron = await getActiveCauldron({ throwIfNoActiveCauldron: false })
   if (!cauldron && descriptor) {
@@ -110,13 +114,17 @@ export default async function start({
     )
   })
 
-  reactnative.startPackagerInNewWindow(compositeDir, [
-    '--reset-cache',
-    '--providesModuleNodeModules',
-    `react-native,${linkedMiniAppsPackageNames
-      .concat(watchNodeModules)
-      .join(',')}`,
-  ])
+  reactnative.startPackagerInNewWindow({
+    cwd: compositeDir,
+    host,
+    port,
+    provideModuleNodeModules: [
+      'react-native',
+      ...linkedMiniAppsPackageNames,
+      ...watchNodeModules,
+    ],
+    resetCache: true,
+  })
 
   if (descriptor && !disableBinaryStore) {
     const binaryStoreConfig = await cauldron.getBinaryStoreConfig()

--- a/ern-orchestrator/test/runMiniApp-test.ts
+++ b/ern-orchestrator/test/runMiniApp-test.ts
@@ -145,22 +145,22 @@ describe('runMiniApp', () => {
 
   it('should start react native packager with host if provided [local single miniapp]', async () => {
     prepareStubs()
-    await runMiniApp('android', { dev: true, host: 'localhost' })
-    sandbox.assert.calledWith(
-      startPackagerStub,
-      sinon.match.string,
-      sinon.match.array.contains(['--host localhost'])
-    )
+    await runMiniApp('android', { dev: true, host: '192.168.1.1' })
+    sandbox.assert.calledWith(startPackagerStub, {
+      cwd: sinon.match.string,
+      host: '192.168.1.1',
+      port: undefined,
+    })
   })
 
   it('should start react native packager with port if provided [local single miniapp]', async () => {
     prepareStubs()
     await runMiniApp('android', { dev: true, port: '1234' })
-    sandbox.assert.calledWith(
-      startPackagerStub,
-      sinon.match.string,
-      sinon.match.array.contains(['--port 1234'])
-    )
+    sandbox.assert.calledWith(startPackagerStub, {
+      cwd: sinon.match.string,
+      host: undefined,
+      port: '1234',
+    })
   })
 
   it('should generate container for runner [local single miniapp]', async () => {


### PR DESCRIPTION
Auto resolve local machine IP for `run-ios` command so that it is not necessary to manually find IP of machine to provide it to the `--host` option of `run-ios`.
If `--host` option is set on the command line, the value provided will still be used rather than the auto resolved one.

Also adding `host`/`port` options support to `ern start`