### PR TITLE
Fix Android runner generator for pre 64bit generation

### DIFF
--- a/ern-core/src/injectReactNativeVersionKeysInObject.ts
+++ b/ern-core/src/injectReactNativeVersionKeysInObject.ts
@@ -7,8 +7,10 @@ export function injectReactNativeVersionKeysInObject(
   return Object.assign(object, {
     RN_VERSION_GTE_45: semver.gte(reactNativeVersion, '0.45.0'),
     RN_VERSION_GTE_54: semver.gte(reactNativeVersion, '0.54.0'),
+    RN_VERSION_GTE_59: semver.gte(reactNativeVersion, '0.59.0'),
     RN_VERSION_LT_54: semver.lt(reactNativeVersion, '0.54.0'),
     RN_VERSION_LT_58: semver.lt(reactNativeVersion, '0.58.0-rc.2'),
+    RN_VERSION_LT_59: semver.lt(reactNativeVersion, '0.59.0'),
     reactNativeVersion,
   })
 }

--- a/ern-runner-gen-android/src/hull/app/build.gradle
+++ b/ern-runner-gen-android/src/hull/app/build.gradle
@@ -20,13 +20,23 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        {{#RN_VERSION_LT_59}}
+        ndk {
+            abiFilters "armeabi-v7a", "x86"
+        }
+        {{/RN_VERSION_LT_59}}
     }
     splits {
        abi {
            reset()
            enable enableSeparateBuildPerCPUArchitecture
            universalApk false  // If true, also generate a universal APK
+           {{#RN_VERSION_LT_59}}
+           include "armeabi-v7a", "x86"
+           {{/RN_VERSION_LT_59}}
+           {{#RN_VERSION_GTE_59}}
            include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
+           {{/RN_VERSION_GTE_59}}
        }
    }
     buildTypes {
@@ -48,7 +58,12 @@ android {
        variant.outputs.each { output ->
            // For each separate APK per architecture, set a unique version code as described here:
            // http://tools.android.com/tech-docs/new-build-system/user-guide/apk-splits
+           {{#RN_VERSION_LT_59}}
+           def versionCodes = ["armeabi-v7a":1, "x86":2]
+           {{/RN_VERSION_LT_59}}
+           {{#RN_VERSION_GTE_59}}
            def versionCodes = ["armeabi-v7a":1, "x86":2, "arm64-v8a": 3, "x86_64": 4]
+           {{/RN_VERSION_GTE_59}}
            def abi = output.getFilter(com.android.build.OutputFile.ABI)
            if (abi != null) {  // null for the universal-debug, universal-release variants
                output.versionCodeOverride =


### PR DESCRIPTION
Fix Android Runner generator so that it creates a proper `build.gradle` when used with versions of React Native < 0.59 that don't have 64bit support.

