### PR TITLE
Requalify error log to warning

### DIFF
--- a/ern-core/src/Manifest.ts
+++ b/ern-core/src/Manifest.ts
@@ -721,7 +721,7 @@ export class Manifest {
       )
       result = this.getApiImplPluginDefaultConfig(plugin, projectName)
     } else {
-      log.error(
+      log.warn(
         `Unsupported plugin. No configuration found in manifest for ${
           plugin.basePath
         }.`


### PR DESCRIPTION
Requalify error log to warning, as it is actually not causing any problem in most cases and wrongly leading users to thinking something went wrong.

We should add a strict mode to actually throw error if no configuration is found in manifest for some plugins.