### PR TITLE
Fix dependencies sync with Cauldron

### DIFF
--- a/ern-composite-gen/src/Composite.ts
+++ b/ern-composite-gen/src/Composite.ts
@@ -6,6 +6,8 @@ import {
   readPackageJsonSync,
   BaseMiniApp,
   nativeDepenciesVersionResolution,
+  manifest,
+  NativePlatform,
 } from 'ern-core'
 import { CompositeGeneratorConfig } from './types'
 import { generateComposite } from './generateComposite'
@@ -58,6 +60,24 @@ export class Composite {
     return nativeDepenciesVersionResolution.resolveNativeDependenciesVersionsEx(
       nativeDependencies
     )
+  }
+
+  public async getInjectableNativeDependencies(
+    platform: NativePlatform
+  ): Promise<any> {
+    const dependencies = await this.getResolvedNativeDependencies()
+    const result: PackagePath[] = []
+    for (const dependency of dependencies.resolved) {
+      const pluginConfig = await manifest.getPluginConfig(dependency)
+      if (pluginConfig) {
+        if (platform === 'android' && pluginConfig.android) {
+          result.push(dependency)
+        } else if (platform === 'ios' && pluginConfig.ios) {
+          result.push(dependency)
+        }
+      }
+    }
+    return result
   }
 
   /**

--- a/ern-orchestrator/src/container.ts
+++ b/ern-orchestrator/src/container.ts
@@ -88,27 +88,9 @@ export async function runCauldronContainerGen(
       throw new Error(`${napDescriptor} does not specify a platform`)
     }
 
-    const compositeNativeDeps = await composite.getResolvedNativeDependencies()
-
-    // Final native dependencies are the one that are in Composite
-    // plus any extra ones present in the Cauldron that are not
-    // in the Composite
-    const extraCauldronNativeDependencies = _.differenceBy(
-      cauldronNativeDependencies,
-      compositeNativeDeps.resolved,
-      'basePath'
+    const plugins = await composite.getInjectableNativeDependencies(
+      napDescriptor.platform
     )
-    log.debug(
-      `extraCauldronNativeDependencies: ${JSON.stringify(
-        extraCauldronNativeDependencies,
-        null,
-        2
-      )}`
-    )
-    const plugins = [
-      ...extraCauldronNativeDependencies,
-      ...compositeNativeDeps.resolved,
-    ]
 
     const platform = napDescriptor.platform
     const containerGeneratorConfig = await cauldron.getContainerGeneratorConfig(

--- a/ern-orchestrator/src/syncCauldronContainer.ts
+++ b/ern-orchestrator/src/syncCauldronContainer.ts
@@ -84,10 +84,12 @@ export async function syncCauldronContainer(
     )
 
     // Sync native dependencies in Cauldron
-    const compositeNativeDeps = await composite.getResolvedNativeDependencies()
+    const compositeNativeDeps = await composite.getInjectableNativeDependencies(
+      platform
+    )
     await cauldron.setNativeDependenciesInContainer(
       descriptor,
-      compositeNativeDeps.resolved
+      compositeNativeDeps
     )
 
     // Generate Container from Cauldron


### PR DESCRIPTION
Ensures that only native dependencies that are actually injected in the Container are reported in the Cauldron `nativeDeps` array.