### PR TITLE
Fix issue impacting run-ios and run-android

### DIFF
--- a/ern-core/src/nativeDependenciesLookup.ts
+++ b/ern-core/src/nativeDependenciesLookup.ts
@@ -8,9 +8,9 @@ import readDir = require('fs-readdir-recursive')
 const NodeModulesLen = 'node_modules'.length
 
 export function findDirectoriesContainingNativeCode(rootDir: string): string[] {
-  return readDir(rootDir).filter(a =>
-    /.swift$|.pbxproj$|.java$|.framework\//.test(a)
-  )
+  return readDir(rootDir)
+    .filter(a => /.swift$|.pbxproj$|.java$|.framework\//.test(a))
+    .filter(a => !/ElectrodeContainer.framework/.test(a))
 }
 
 export function filterDirectories(directories: string[]): string[] {


### PR DESCRIPTION
Fix this error when using `run-ios` or `run-android` commands 

```
✖ runLocalCompositeGen failed: Error: Cannot find module 
'/var/folders/mp/sgcm53dd33b348tm65vwc6_8kv5xkh/T/tmp-
79821uaWi2yRFZMX4/node_modules/[..]/ios/build/Debug-
iphonesimulator/ElectrodeContainer.framework/assets/node_modules/[...]/package.json'
```