### PR TITLE
Fix electrode native local cli install

### DIFF
--- a/ern-core/src/Platform.ts
+++ b/ern-core/src/Platform.ts
@@ -115,9 +115,12 @@ export default class Platform {
       shell.pushd(pathToVersion)
       if (this.isYarnInstalled()) {
         // Favor yarn if it is installed as it will greatly speed up install
-        execSync(`yarn add ${ERN_LOCAL_CLI_PACKAGE}@${version} --exact`, {
-          cwd: pathToVersion,
-        })
+        execSync(
+          `yarn add ${ERN_LOCAL_CLI_PACKAGE}@${version} --exact --ignore-engines`,
+          {
+            cwd: pathToVersion,
+          }
+        )
       } else {
         execSync(`npm install ${ERN_LOCAL_CLI_PACKAGE}@${version} --exact`, {
           cwd: pathToVersion,

--- a/ern-core/test/Platform-test.ts
+++ b/ern-core/test/Platform-test.ts
@@ -231,7 +231,7 @@ describe('Platform', () => {
       Platform.installPlatform('3.0.0')
       sandbox.assert.calledWith(
         execSyncStub,
-        'yarn add ern-local-cli@3.0.0 --exact',
+        'yarn add ern-local-cli@3.0.0 --exact --ignore-engines',
         sinon.match.any
       )
     })


### PR DESCRIPTION
Fix an issue in local CLI installation (when using `ern platform use` or `ern platform install` commands) that could lead in failed local CLI installations depending on the Node version used.