### PR TITLE
Add initial React Native 0.60 support for Android

### DIFF
--- a/docs/platform-parts/container/container-integration.md
+++ b/docs/platform-parts/container/container-integration.md
@@ -147,6 +147,30 @@ You can configure `androidConfig` in the cauldron as show below.
 }
 ```
 
+##### JavaScript Engine (RN 0.60 and above)
+
+Starting with React Native 0.60, the JavaScript engine is distributed separately from the React Native AAR.
+Also, prior to this version, JavaScriptCore was the only JavaScript engine that could be used on Android for React Native applications. Starting with this new version, it is now possible to use alternative JavaScript engines such as Hermes.
+
+With React Native 0.60.0, JavaScriptCore engine now comes in two variants : `android-jsc` and `android-jsc-intl`. The later is the international variant. It includes ICU i18n library and necessary data allowing to use e.g. Date.toLocaleString and String.localeCompare that give correct results when using with locales other than en-US. This variant is about 6MiB larger per architecture.
+
+Electrode Native does not yet support Hermes JavaScript engine, but it supports the two variants of  JavaScriptCore. By default, the version of JavaScriptCore used by Electrode Native will be set to the latest version available at the time of Electrode Native version release and will be communicated in the release notes. The default JavaScriptCore variant will always be the non international one.
+
+It is possible to change these defaults, using the `androidConfig` object of `containerGenerator` as shown below.  
+
+```json
+{
+  "containerGenerator": {
+    "androidConfig": {
+      "jscVersion": "245459",
+      "jscVariant": "android-jsc"
+    }
+  }
+}
+```
+
+`jscVersion` is the version of the JavaScriptCore engine while `jscVariant` is the variant (`android-jsc` or `android-jsc-intl`).
+
 #### iOS
 
 An Electrode Native container can be added as a dependency to an Xcode project in two ways:

--- a/ern-composite-gen/src/generateComposite.ts
+++ b/ern-composite-gen/src/generateComposite.ts
@@ -8,6 +8,7 @@ import {
   writePackageJson,
   fileUtils,
   kax,
+  YarnLockParser,
 } from 'ern-core'
 import { cleanupCompositeDir } from './cleanupCompositeDir'
 import {
@@ -90,7 +91,6 @@ Composite output directory should either not exist (it will be created) or shoul
     if (extraJsDependencies) {
       await installExtraJsDependencies({ outDir, extraJsDependencies })
     }
-    await patchMetro51({ outDir })
   } finally {
     shell.popd()
   }
@@ -134,14 +134,26 @@ async function generateFullComposite(
     await addBabelrcRoots({ outDir })
     await createCompositeBabelRc({ outDir })
     await createRnCliConfig({ outDir })
-    await patchPackageJsonForCodePush({ outDir })
     if (resolutions) {
       await applyYarnResolutions({ outDir, resolutions })
     }
-    await patchMetro51({ outDir })
+    const rnVersion = await getCompositeReactNativeVersion({ outDir })
+    await addReactNativeDependencyToPackageJson(outDir, rnVersion)
+    if (semver.lt(rnVersion, '0.60.0')) {
+      await patchMetro51({ outDir })
+    }
   } finally {
     shell.popd()
   }
+}
+
+async function addReactNativeDependencyToPackageJson(
+  dir: string,
+  version: string
+) {
+  const compositePackageJson = await readPackageJson(dir)
+  compositePackageJson.dependencies['react-native'] = version
+  await writePackageJson(dir, compositePackageJson)
 }
 
 async function installJsPackagesUsingYarnLock({
@@ -419,12 +431,7 @@ async function getCompositeMetroVersion({
 async function patchMetro51({ outDir }: { outDir: string }) {
   const metroVersion = await getCompositeMetroVersion({ outDir })
   const compositeNodeModulesPath = path.join(outDir, 'node_modules')
-  // To be removed as soon as react-native-cli make use of metro >= 0.52.0
-  // Temporary hacky code to patch an issue present in metro 0.51.1
-  // currently linked with RN 59 that impacts our bundling process
-  // EDIT: This will not be needed anymore starting with React Native 0.60.0
-  // as it is using CLI v2x line, using metro 0.53
-  // https://github.com/react-native-community/cli/blob/v2.0.0/packages/cli/package.json#L36
+  // Only of use for RN < 0.60.0
   if (metroVersion === '0.51.1') {
     const pathToFileToPatch = path.join(
       compositeNodeModulesPath,
@@ -573,47 +580,6 @@ async function createRnCliConfig({ outDir }: { outDir: string }) {
       "module.exports = { getSourceExts: () => ['jsx', 'mjs', 'js', 'ts', 'tsx'] }"
   }
   await fileUtils.writeFile(path.join(outDir, 'rn-cli.config.js'), sourceExts)
-}
-
-async function patchPackageJsonForCodePush({ outDir }: { outDir: string }) {
-  const compositePackageJson = await readPackageJson(outDir)
-  const compositeNodeModulesPath = path.join(outDir, 'node_modules')
-  const compositeReactNativeVersion = await getCompositeReactNativeVersion({
-    outDir,
-  })
-
-  const pathToCodePushNodeModuleDir = path.join(
-    compositeNodeModulesPath,
-    'react-native-code-push'
-  )
-
-  // If code push plugin is present we need to do some additional work
-  if (fs.existsSync(pathToCodePushNodeModuleDir)) {
-    //
-    // The following code will need to be uncommented and properly reworked or included
-    // in a different way, once Cart and TYP don't directly depend on code push directly
-    // We will work with Cart team in that direction
-    //
-    // await yarn.add(codePushPlugin.name, codePushPlugin.version)
-    // content += `import codePush from "react-native-code-push"\n`
-    // content += `codePush.sync()`
-
-    // We need to add some info to package.json for CodePush
-    // In order to run, code push needs to find the following in package.json
-    // - name & version
-    // - react-native in the dependency block
-    // TODO :For now we hardcode these values for demo purposes. That being said it
-    // might not be needed to do something better because it seems like
-    // code push is not making a real use of this data
-    // Investigate further.
-    // https://github.com/Microsoft/code-push/blob/master/cli/script/command-executor.ts#L1246
-    compositePackageJson.dependencies[
-      'react-native'
-    ] = compositeReactNativeVersion
-    compositePackageJson.name = 'container'
-    compositePackageJson.version = '0.0.1'
-    await writePackageJson(outDir, compositePackageJson)
-  }
 }
 
 async function installJsPackages({

--- a/ern-container-gen-android/package.json
+++ b/ern-container-gen-android/package.json
@@ -63,8 +63,10 @@
   "dependencies": {
     "ern-container-gen": "1000.0.0",
     "ern-core": "1000.0.0",
+    "decompress-zip": "^0.3.1",
     "lodash": "^4.17.14",
-    "fs-readdir-recursive": "^1.1.0"
+    "fs-readdir-recursive": "^1.1.0",
+    "semver":"^6.0.0"
   },
   "devDependencies": {
     "ern-util-dev": "1000.0.0",


### PR DESCRIPTION
Update Composite and Container generators for proper support of React Native 0.60.

**Composite generator update**

- For React Native 0.60, the react-native dependency need to be present inside the `dependency` object of the composite package.json. Otherwise metro bundler will complain.
Adding `react-native` dependency in composite package.json was only done if react-native-code-push native module was detected, as it had a similar requirement. 
However some other things were done in `patchPackageJsonForCodePush` function, for example setting `name` and `version` fields of package.json. This is not needed anymore though because composite generator have moved to use `yarn init` a while back, which already sets these fields. Because the `react-native` dependency needs to be set in composite package.json for code push and now react native (meaning it should always be there), code has just been refactored to get rid of `patchPackageJsonForCodePush` (now useless) and a new function `addReactNativeDependencyToPackageJson` was created to specifically add the react native dependency to the composite package.json.

- For React Native 0.60 (and above) there is no more need to patch metro resolver, as the bug being patched was only present in metro 0.51 (React Native 0.60 is using metro >= 0.53), so we just skip this function call.

**Android Container generator update**

- Starting with RN 0.60, JavaScriptCore engine (`libjsc.so` native library files for different architectures) is not distributed inside the React Native AAR any longer but distributed inside a separate AAR that is itself distributed as a node package. Also, this library now comes in two variants : `android-jsc` and `android-jsc-intl`.
Update to Android Container generator is to retrieve the node package containing the JavaScriptCore engine, extract (unzip) the AAR content, to get access to the `libjsc.so` files, and inject these files in the `jniLibs` of the Container, so that JavaScriptCore engine is shipped inside the Container. 
Also added code to let users choose between `android-jsc` or `android-jsc-intl` variant of JavaScriptCore (default to `android-jsc`, as react-native does), through container generator configuration, as well as to select the version of JavaScriptCore to be used (default to `245459`).

This PR does not add support for alternative JavaScript engine (Hermes), this will be added later on.

[`com.walmartlabs.ern:react-native:0.60.0`](https://repo1.maven.org/maven2/com/walmartlabs/ern/react-native/0.60.0/) AAR artifact has been published to Maven Central for proper testing/validation. We will publish latest version of 0.60 line (0.60.5) to Maven Central soon and this should be the version targeted for upcoming Electrode Native release (0.38.0).

Please note that `ern run-android` will not work with the default runner hull. It will only work with `hullx` introduced in 0.37.0 which has been converted to AndroidX. To get access to this hull, just add a dependency on `ern-navigation` to the MiniApp and regenerate the hull (by trashing the MiniApp `android` directory and running `ern run-android` command again).