### PR TITLE
Update Android Container for rn>=0.60.1 support

### DIFF
--- a/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactContainer.java
+++ b/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactContainer.java
@@ -32,6 +32,9 @@ import com.facebook.react.modules.network.OkHttpClientFactory;
 {{/RN_VERSION_GTE_54}}
 import com.facebook.react.modules.network.OkHttpClientProvider;
 import com.facebook.react.shell.MainReactPackage;
+{{#RN_VERSION_GTE_60_1}}
+import com.facebook.soloader.SoLoader;
+{{/RN_VERSION_GTE_60_1}}
 {{#plugins}}
 import com.walmartlabs.ern.container.plugins.{{name}};
 {{/plugins}}
@@ -136,6 +139,10 @@ public class ElectrodeReactContainer {
             {{/apiImplementations}}
      ) {
         if (sElectrodeReactNativeHost == null) {
+            
+            {{#RN_VERSION_GTE_60_1}}
+            SoLoader.init(application, /* native exopackage */ false);
+            {{/RN_VERSION_GTE_60_1}}
 
             // ReactNative general config
 

--- a/ern-core/src/injectReactNativeVersionKeysInObject.ts
+++ b/ern-core/src/injectReactNativeVersionKeysInObject.ts
@@ -8,6 +8,7 @@ export function injectReactNativeVersionKeysInObject(
     RN_VERSION_GTE_45: semver.gte(reactNativeVersion, '0.45.0'),
     RN_VERSION_GTE_54: semver.gte(reactNativeVersion, '0.54.0'),
     RN_VERSION_GTE_59: semver.gte(reactNativeVersion, '0.59.0'),
+    RN_VERSION_GTE_60_1: semver.gte(reactNativeVersion, '0.60.1'),
     RN_VERSION_LT_54: semver.lt(reactNativeVersion, '0.54.0'),
     RN_VERSION_LT_58: semver.lt(reactNativeVersion, '0.58.0-rc.2'),
     RN_VERSION_LT_59: semver.lt(reactNativeVersion, '0.59.0'),


### PR DESCRIPTION
React Native 0.60.1 introduced Hermes support.

One issue (that looks like a bug in React Native, introduced in 0.60.1 and still present in 0.60.5) is that `SoLoader.loadLibrary` method is called before `SoLoader.init` was called, resulting in a `java.lang.RuntimeException: SoLoader.init() not yet called` exception crashing the app.

This is due to a kinda chicken and egg problem, where `ReactInstanceManager` constructor calls [`initializeSoLoaderIfNecessary`](https://github.com/facebook/react-native/blob/v0.60.1/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java#L220) to actually call `SoLoader.init`, but in `ReactInstanceManagerBuilder`, which creates a new instance of `ReactInstanceManager`, a call to [`getDefaultJSExecutorFactory`](https://github.com/facebook/react-native/blob/v0.60.1/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java#L304) is made, which triggers a call to `SoLoader.loadLibrary` before `SoLoader.init` was called.

This probably went unnoticed because application templates for React Native are actually calling `SoLoader.init` during `onCreate` as can be [seen here](https://github.com/facebook/react-native/blob/v0.60.5/template/android/app/src/main/java/com/helloworld/MainApplication.java#L47)

Solution in our case is just to make a call to `SoLoader.init` in the Android Container `initialize` method, before the `ReactInstanceManager` gets created. If for some reason React Native or app is doing it before or after our call, this won't cause any issues, thanks to the fact that `SoLoader.init` is idempotent.

