### PR TITLE
Make module naming enforcement less restrictive

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -13,9 +13,11 @@ A partial native application descriptor is a string with format `[nativeAppName]
 ## Electrode Native module name
 
 The Electrode Native module name applies to modules created with Electrode Native cli.
-- Electrode Native recommends module name must only contain upper and/or lower case letters.
-- `create-miniapp`, `create-api` and `create-api-impl` commands allow passing Electrode Native module name as it's arguments.
-   For example, `ern create-miniapp Mymovie`, `ern create-api ReactNativeMymovie` will create `MymovieMiniApp` and `react-native-mymovie-api` respectively.
+
+- Module names should be alphanumeric and cannot start with a digit or underscore
+- `create-miniapp`, `create-api` and `create-api-impl` commands allow passing Electrode Native module name as its arguments.
+
+For example, `ern create-miniapp Mymovie`, `ern create-api ReactNativeMymovie` will create `MymovieMiniApp` and `react-native-mymovie-api` respectively.
 
 ## package path
 

--- a/ern-core/src/utils.ts
+++ b/ern-core/src/utils.ts
@@ -268,8 +268,9 @@ export async function reactNativeManifestVersion({
 }
 
 export function isValidElectrodeNativeModuleName(name: string): boolean {
-  return /^[a-zA-Z]+$/.test(name)
+  return /^[A-Z][0-9A-Z_]*$/i.test(name)
 }
+
 /**
  * Download the plugin source given a plugin origin if not already downloaded
  * pluginOrigin: A plugin origin object

--- a/ern-core/test/fixtures/common.js
+++ b/ern-core/test/fixtures/common.js
@@ -22,12 +22,13 @@ export const validElectrodeNativeModuleNames = [
   'myApi',
   'helloworld',
   'MYAPIIMPLEMENTATION',
+  'hell0w0rld',
+  'my_app',
 ]
 
 export const invalidElectrodeNativeModuleNames = [
   'My-App',
-  'my_app',
-  'hell0w0rld',
+  '1nvalid',
   'my*app',
   'my$app',
 ]

--- a/ern-local-cli/test/fixtures/common.js
+++ b/ern-local-cli/test/fixtures/common.js
@@ -45,12 +45,13 @@ export const validElectrodeNativeModuleNames = [
   'myApi',
   'helloworld',
   'MYAPIIMPLEMENTATION',
+  'hell0w0rld',
+  'my_app',
 ]
 
 export const invalidElectrodeNativeModuleNames = [
   'My-App',
-  'my_app',
-  'hell0w0rld',
+  '1nvalid',
   'my*app',
   'my$app',
 ]

--- a/ern-orchestrator/test/fixtures/common.js
+++ b/ern-orchestrator/test/fixtures/common.js
@@ -66,12 +66,13 @@ export const validElectrodeNativeModuleNames = [
   'myApi',
   'helloworld',
   'MYAPIIMPLEMENTATION',
+  'hell0w0rld',
+  'my_app',
 ]
 
 export const invalidElectrodeNativeModuleNames = [
   'My-App',
-  'my_app',
-  'hell0w0rld',
+  '1nvalid',
   'my*app',
   'my$app',
 ]


### PR DESCRIPTION
Most command line generator tools enforce (or suggest) some kind of naming convention (which makes sense!). In the case of `ern`, these enforcements are pretty restrictive. For example, digits are not allowed in _any_ part of the name. Looking at 10+ different project generators (e.g. `react-native`, `create-react-app`, `expo`, `ignite`, `express`, `fastlane`, Android Studio, Xcode, etc), _none_ of them prevent the usage of digits (at least after the first character).

For us, it seems it would make most sense to roughly follow what `react-native` is doing, which is [determined by the following regex](https://github.com/react-native-community/cli/blob/master/packages/cli/src/commands/init/validate.js#L6) in `validate.js` of `react-native-community/cli`:

```js
const NAME_REGEX = /^[$A-Z_][0-9A-Z_$]*$/i;
```

This PR changes the validation for `ern` so it allows underscores and digits (after the first character) for Electrode Native module names. It now almost matches the one used by `react-native`. Note that we are still _not_ allowing the `$` character. It is not clear to me why that character is part of the RN cli regex (it's invalid in the name field of a package.json). Also, a leading underscore is no a valid npm package name, so we're not allowing that as well.
