### PR TITLE
Swift: Include type on responseCompletionHandler

### DIFF
--- a/ern-api-gen/resources/swift/libraries/ern/api.mustache
+++ b/ern-api-gen/resources/swift/libraries/ern/api.mustache
@@ -81,7 +81,7 @@
 
     {{#operation}}
     {{^isEvent}}
-    public func {{nickname}}({{#hasRequestParam}}{{#requestParam}}{{{paramName}}}: {{dataType}}, {{/requestParam}}{{/hasRequestParam}}responseCompletionHandler: @escaping ElectrodeBridgeResponseCompletionHandler) {
+    public func {{nickname}}({{#hasRequestParam}}{{#requestParam}}{{{paramName}}}: {{dataType}},{{/requestParam}}{{/hasRequestParam}} responseCompletionHandler: @escaping ({{#responseParam}}{{{dataType}}}{{/responseParam}}?, ElectrodeFailureMessage?) -> ())
         assertionFailure("should override")
     }
 

--- a/ern-api-gen/resources/swift/libraries/ern/apirequests.mustache
+++ b/ern-api-gen/resources/swift/libraries/ern/apirequests.mustache
@@ -32,13 +32,13 @@
     {{#operation}}
     {{^isEvent}}
 
-    public override func {{nickname}}({{#hasRequestParam}}{{#requestParam}}{{{paramName}}}: {{dataType}},{{/requestParam}}{{/hasRequestParam}} responseCompletionHandler: @escaping ElectrodeBridgeResponseCompletionHandler) {
+    public override func {{nickname}}({{#hasRequestParam}}{{#requestParam}}{{{paramName}}}: {{dataType}},{{/requestParam}}{{/hasRequestParam}} responseCompletionHandler: @escaping ({{#responseParam}}{{{dataType}}}{{/responseParam}}?, ElectrodeFailureMessage?) -> ()) {
         let requestProcessor = ElectrodeRequestProcessor<{{#requestParam}}{{{dataType}}}{{/requestParam}}, {{#responseParam}}{{{dataType}}}{{/responseParam}}, Any>(
             requestName: {{{classname}}}.kRequest{{{camelizedNickName}}},
             requestPayload: {{#hasRequestParam}}{{#requestParam}}{{{paramName}}},{{/requestParam}}{{/hasRequestParam}}{{^hasRequestParam}}nil, {{/hasRequestParam}}
             respClass: {{#responseParam}}{{{dataType}}}{{/responseParam}}.self,
             responseItemType: {{#responseParam}}{{#isList}}{{{baseType}}}.self{{/isList}}{{^isList}}nil{{/isList}}{{/responseParam}},
-            responseCompletionHandler: responseCompletionHandler)
+            responseCompletionHandler: { data, errorMessage in responseCompletionHandler(data as? {{#responseParam}}{{{dataType}}}{{/responseParam}}, errorMessage) })
 
         requestProcessor.execute()
     }
@@ -80,13 +80,13 @@ public class {{{requestsImplClassName}}}: {{{classname}}}Requests {
     {{/operation}}
     {{/operations}}
 
-    public override func {{nickname}}({{#hasRequestParam}}{{#requestParam}}{{{paramName}}}: {{dataType}},{{/requestParam}}{{/hasRequestParam}} responseCompletionHandler: @escaping ElectrodeBridgeResponseCompletionHandler) {
+    public override func {{nickname}}({{#hasRequestParam}}{{#requestParam}}{{{paramName}}}: {{dataType}},{{/requestParam}}{{/hasRequestParam}} responseCompletionHandler: @escaping ({{#responseParam}}{{{dataType}}}{{/responseParam}}?, ElectrodeFailureMessage?) -> ()) {
         let requestProcessor = ElectrodeRequestProcessor<{{#requestParam}}{{{dataType}}}{{/requestParam}}, {{#responseParam}}{{{dataType}}}{{/responseParam}}, Any>(
             requestName: {{{classname}}}.kRequest{{{camelizedNickName}}},
             requestPayload: {{#hasRequestParam}}{{#requestParam}}{{{paramName}}},{{/requestParam}}{{/hasRequestParam}}{{^hasRequestParam}}nil, {{/hasRequestParam}}
             respClass: {{#responseParam}}{{{dataType}}}{{/responseParam}}.self,
             responseItemType: {{#responseParam}}{{#isList}}{{{baseType}}}.self{{/isList}}{{^isList}}nil{{/isList}}{{/responseParam}},
-            responseCompletionHandler: responseCompletionHandler)
+            responseCompletionHandler: { data, errorMessage in responseCompletionHandler(data as? {{#responseParam}}{{{dataType}}}{{/responseParam}}, errorMessage) })
 
         requestProcessor.execute()
     }


### PR DESCRIPTION
I'm trying to get the models/types in the generated Swift API client. This seems to do the trick. However, I am no Swift-developer so there might be a better way to do this 😛 . Is it possible to define some generics on the `ElectrodeBridgeResponseCompletionHandler` so we can avoid the casting from Any? -> MyModel ?

Issue: https://github.com/electrode-io/electrode-native/issues/1292