### PR TITLE
Multi runner android

### DIFF
--- a/ern-orchestrator/src/launchRunner.ts
+++ b/ern-orchestrator/src/launchRunner.ts
@@ -1,31 +1,26 @@
 import { android, ios } from 'ern-core'
 import { launchOnDevice } from './launchOnDevice'
 import { launchOnSimulator } from './launchOnSimulator'
+import { LaunchRunnerConfig } from 'ern-runner-gen/src/types/LaunchRunnerConfig'
 
-export async function launchRunner({
-  platform,
-  pathToRunner,
-}: {
-  platform: string
-  pathToRunner: string
-}) {
-  if (platform === 'android') {
-    return launchAndroidRunner(pathToRunner)
-  } else if (platform === 'ios') {
-    return launchIosRunner(pathToRunner)
+export async function launchRunner(config: LaunchRunnerConfig) {
+  if (config.platform === 'android') {
+    return launchAndroidRunner(config)
+  } else if (config.platform === 'ios') {
+    return launchIosRunner(config)
   }
 }
 
-async function launchAndroidRunner(pathToAndroidRunner: string) {
+async function launchAndroidRunner(config: LaunchRunnerConfig) {
   return android.runAndroidProject({
-    packageName: 'com.walmartlabs.ern',
-    projectPath: pathToAndroidRunner,
+    packageName: config.extra.packageName,
+    projectPath: config.pathToRunner,
   })
 }
 
-async function launchIosRunner(pathToIosRunner: string) {
+async function launchIosRunner(config: LaunchRunnerConfig) {
   const iosDevices = ios.getiPhoneRealDevices()
   return iosDevices && iosDevices.length > 0
-    ? launchOnDevice(pathToIosRunner, iosDevices)
-    : launchOnSimulator(pathToIosRunner)
+    ? launchOnDevice(config.pathToRunner, iosDevices)
+    : launchOnSimulator(config.pathToRunner)
 }

--- a/ern-orchestrator/test/launchRunner-test.ts
+++ b/ern-orchestrator/test/launchRunner-test.ts
@@ -22,7 +22,11 @@ describe('launchRunner', () => {
   })
 
   it('should call runAndroidProject to launch the Android runner [android]', async () => {
-    await launchRunner({ platform: 'android', pathToRunner: '/Users/foo/test' })
+    await launchRunner({
+      extra: { packageName: 'com.walmartlabs.ern' },
+      pathToRunner: '/Users/foo/test',
+      platform: 'android',
+    })
     sandbox.assert.calledWith(runAndroidProjectStub, {
       packageName: 'com.walmartlabs.ern',
       projectPath: '/Users/foo/test',

--- a/ern-orchestrator/test/runMiniApp-test.ts
+++ b/ern-orchestrator/test/runMiniApp-test.ts
@@ -204,8 +204,10 @@ describe('runMiniApp', () => {
       containerPath: sinon.match.string,
       containerVersion: '1.0.0',
       extra: {
-        artifactId: 'runner-ern-container',
+        artifactId: 'runner-ern-container-myminiapp',
         groupId: 'com.walmartlabs.ern',
+        packageFilePath: 'com/walmartlabs/ern/myminiapp',
+        packageName: 'com.walmartlabs.ern.myminiapp',
       },
       platform: 'android',
       publisher: sinon.match.any,
@@ -218,7 +220,12 @@ describe('runMiniApp', () => {
     await runMiniApp('android')
     sandbox.assert.calledWith(androidRunnerGenStub.regenerateRunnerConfig, {
       extra: {
-        androidConfig: {},
+        androidConfig: {
+          artifactId: 'runner-ern-container-myminiapp',
+          groupId: 'com.walmartlabs.ern',
+          packageFilePath: 'com/walmartlabs/ern/myminiapp',
+          packageName: 'com.walmartlabs.ern.myminiapp',
+        },
         containerGenWorkingDir: Platform.containerGenDirectory,
       },
       mainMiniAppName: 'myMiniApp',
@@ -234,11 +241,25 @@ describe('runMiniApp', () => {
   it('should only regenerate the runner config if runner project already exists [local single miniapp] with android build config', async () => {
     prepareStubs({ existsSyncReturn: true })
     await runMiniApp('android', {
-      extra: { androidConfig: { compileSdkVersion: '28' } },
+      extra: {
+        androidConfig: {
+          artifactId: 'runner-ern-container-myminiapp',
+          compileSdkVersion: '28',
+          groupId: 'com.walmartlabs.ern',
+          packageFilePath: 'com/walmartlabs/ern/myminiapp',
+          packageName: 'com.walmartlabs.ern.myminiapp',
+        },
+      },
     })
     sandbox.assert.calledWith(androidRunnerGenStub.regenerateRunnerConfig, {
       extra: {
-        androidConfig: { compileSdkVersion: '28' },
+        androidConfig: {
+          artifactId: 'runner-ern-container-myminiapp',
+          compileSdkVersion: '28',
+          groupId: 'com.walmartlabs.ern',
+          packageFilePath: 'com/walmartlabs/ern/myminiapp',
+          packageName: 'com.walmartlabs.ern.myminiapp',
+        },
         containerGenWorkingDir: Platform.containerGenDirectory,
       },
       mainMiniAppName: 'myMiniApp',
@@ -265,7 +286,12 @@ describe('runMiniApp', () => {
 
     sandbox.assert.calledWith(androidRunnerGenStub.regenerateRunnerConfig, {
       extra: {
-        androidConfig: {},
+        androidConfig: {
+          artifactId: 'runner-ern-container-myminiappa',
+          groupId: 'com.walmartlabs.ern',
+          packageFilePath: 'com/walmartlabs/ern/myminiappa',
+          packageName: 'com.walmartlabs.ern.myminiappa',
+        },
         containerGenWorkingDir: Platform.containerGenDirectory,
       },
       mainMiniAppName: 'myMiniAppA',
@@ -290,7 +316,12 @@ describe('runMiniApp', () => {
 
     sandbox.assert.calledWith(androidRunnerGenStub.regenerateRunnerConfig, {
       extra: {
-        androidConfig: {},
+        androidConfig: {
+          artifactId: 'runner-ern-container-myminiapp',
+          groupId: 'com.walmartlabs.ern',
+          packageFilePath: 'com/walmartlabs/ern/myminiapp',
+          packageName: 'com.walmartlabs.ern.myminiapp',
+        },
         containerGenWorkingDir: Platform.containerGenDirectory,
       },
       mainMiniAppName: 'myMiniApp',

--- a/ern-runner-gen-android/src/hull/app/build.gradle
+++ b/ern-runner-gen-android/src/hull/app/build.gradle
@@ -14,7 +14,7 @@ android {
     compileSdkVersion {{{compileSdkVersion}}}
     buildToolsVersion "{{{buildToolsVersion}}}"
     defaultConfig {
-        applicationId "com.walmartlabs.ern"
+        applicationId "com.walmartlabs.ern.{{{lowerCaseMiniAppName}}}"
         minSdkVersion {{{minSdkVersion}}}
         targetSdkVersion {{{targetSdkVersion}}}
         versionCode 1
@@ -75,5 +75,5 @@ android {
 
 dependencies {
     // Recompile this dependency on every build as it can be updated at any time (snapshot)
-    api('com.walmartlabs.ern:runner-ern-container:1.0.0') { changing = true }
+    api('{{{groupId}}}:{{{artifactId}}}:1.0.0') { changing = true }
 }

--- a/ern-runner-gen-android/src/hull/app/src/main/AndroidManifest.xml
+++ b/ern-runner-gen-android/src/hull/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.walmartlabs.ern" >
+  package="com.walmartlabs.ern.{{{lowerCaseMiniAppName}}}">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/ern-runner-gen-android/src/hull/app/src/main/java/com/walmartlabs/ern/miniapp/MainActivity.java
+++ b/ern-runner-gen-android/src/hull/app/src/main/java/com/walmartlabs/ern/miniapp/MainActivity.java
@@ -1,4 +1,4 @@
-package com.walmartlabs.ern;
+package com.walmartlabs.ern.{{{lowerCaseMiniAppName}}};
 
 import android.content.Intent;
 import android.os.Bundle;

--- a/ern-runner-gen-android/src/hull/app/src/main/java/com/walmartlabs/ern/miniapp/MainApplication.java
+++ b/ern-runner-gen-android/src/hull/app/src/main/java/com/walmartlabs/ern/miniapp/MainApplication.java
@@ -1,9 +1,9 @@
-package com.walmartlabs.ern;
+package com.walmartlabs.ern.{{{lowerCaseMiniAppName}}};
 
 import android.app.Application;
 
 import com.walmartlabs.ern.container.ElectrodeReactContainer;
-import com.walmartlabs.ern.RunnerConfig;
+import com.walmartlabs.ern.{{{lowerCaseMiniAppName}}}.RunnerConfig;
 
 public class MainApplication extends Application {
 

--- a/ern-runner-gen-android/src/hull/app/src/main/java/com/walmartlabs/ern/miniapp/RunnerConfig.java
+++ b/ern-runner-gen-android/src/hull/app/src/main/java/com/walmartlabs/ern/miniapp/RunnerConfig.java
@@ -1,4 +1,9 @@
+{{#isOldRunner}}
 package com.walmartlabs.ern;
+{{/isOldRunner}}
+{{^isOldRunner}}
+package com.walmartlabs.ern.{{{lowerCaseMiniAppName}}};
+{{/isOldRunner}}
 
 //
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/ern-runner-gen-android/src/hull/app/src/main/res/values/strings.xml
+++ b/ern-runner-gen-android/src/hull/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">ErnRunner</string>
-    <string name="welcome_message">Welcome to ErnRunner App</string>
+    <string name="app_name">{{{miniAppName}}}</string>
+    <string name="welcome_message">Welcome to {{{miniAppName}}} Runner App</string>
     <string name="welcome_suggestion">Force close to reload ern mini-app bundle</string>
 </resources>

--- a/ern-runner-gen-android/test/AndroidRunnerGenerator-test.ts
+++ b/ern-runner-gen-android/test/AndroidRunnerGenerator-test.ts
@@ -24,6 +24,14 @@ describe('AndroidRunnerGenerator', () => {
 
   it('should generate simple-android-runner fixture given same configuration ', async () => {
     await getRunnerGeneratorForPlatform('android').generate({
+      extra: {
+        androidConfig: {
+          artifactId: 'runner-ern-container-dummy',
+          groupId: 'com.walmartlabs.ern',
+          packageFilePath: 'com/walmartlabs/ern/dummy',
+          packageName: 'com.walmartlabs.ern.dummy',
+        },
+      },
       mainMiniAppName: 'dummy',
       outDir: simpleAndroidRunnerTestGeneratedPath,
       reactNativeVersion: '0.59.8',
@@ -41,6 +49,14 @@ describe('AndroidRunnerGenerator', () => {
 
   it('should re-generate configuration of simple-android-runner fixture given same configuration ', async () => {
     await getRunnerGeneratorForPlatform('android').regenerateRunnerConfig({
+      extra: {
+        androidConfig: {
+          artifactId: 'runner-ern-container-dummy',
+          groupId: 'com.walmartlabs.ern',
+          packageFilePath: 'com/walmartlabs/ern/dummy',
+          packageName: 'com.walmartlabs.ern.dummy',
+        },
+      },
       mainMiniAppName: 'dummy',
       outDir: simpleAndroidRunnerTestGeneratedPath,
       reactNativeVersion: '0.59.8',

--- a/ern-runner-gen-android/test/fixtures/simple-android-runner/app/build.gradle
+++ b/ern-runner-gen-android/test/fixtures/simple-android-runner/app/build.gradle
@@ -14,7 +14,7 @@ android {
     compileSdkVersion 28
     buildToolsVersion "28.0.3"
     defaultConfig {
-        applicationId "com.walmartlabs.ern"
+        applicationId "com.walmartlabs.ern.dummy"
         minSdkVersion 19
         targetSdkVersion 28
         versionCode 1
@@ -60,5 +60,5 @@ android {
 
 dependencies {
     // Recompile this dependency on every build as it can be updated at any time (snapshot)
-    api('com.walmartlabs.ern:runner-ern-container:1.0.0') { changing = true }
+    api('com.walmartlabs.ern:runner-ern-container-dummy:1.0.0') { changing = true }
 }

--- a/ern-runner-gen-android/test/fixtures/simple-android-runner/app/src/main/AndroidManifest.xml
+++ b/ern-runner-gen-android/test/fixtures/simple-android-runner/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.walmartlabs.ern" >
+  package="com.walmartlabs.ern.dummy">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/ern-runner-gen-android/test/fixtures/simple-android-runner/app/src/main/java/com/walmartlabs/ern/myminiappa/MainActivity.java
+++ b/ern-runner-gen-android/test/fixtures/simple-android-runner/app/src/main/java/com/walmartlabs/ern/myminiappa/MainActivity.java
@@ -1,4 +1,4 @@
-package com.walmartlabs.ern;
+package com.walmartlabs.ern.dummy;
 
 import android.content.Intent;
 import android.os.Bundle;

--- a/ern-runner-gen-android/test/fixtures/simple-android-runner/app/src/main/java/com/walmartlabs/ern/myminiappa/MainApplication.java
+++ b/ern-runner-gen-android/test/fixtures/simple-android-runner/app/src/main/java/com/walmartlabs/ern/myminiappa/MainApplication.java
@@ -1,9 +1,9 @@
-package com.walmartlabs.ern;
+package com.walmartlabs.ern.dummy;
 
 import android.app.Application;
 
 import com.walmartlabs.ern.container.ElectrodeReactContainer;
-import com.walmartlabs.ern.RunnerConfig;
+import com.walmartlabs.ern.dummy.RunnerConfig;
 
 public class MainApplication extends Application {
 

--- a/ern-runner-gen-android/test/fixtures/simple-android-runner/app/src/main/java/com/walmartlabs/ern/myminiappa/RunnerConfig.java
+++ b/ern-runner-gen-android/test/fixtures/simple-android-runner/app/src/main/java/com/walmartlabs/ern/myminiappa/RunnerConfig.java
@@ -1,4 +1,4 @@
-package com.walmartlabs.ern;
+package com.walmartlabs.ern.dummy;
 
 //
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/ern-runner-gen-android/test/fixtures/simple-android-runner/app/src/main/res/values/strings.xml
+++ b/ern-runner-gen-android/test/fixtures/simple-android-runner/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">ErnRunner</string>
-    <string name="welcome_message">Welcome to ErnRunner App</string>
+    <string name="app_name">dummy</string>
+    <string name="welcome_message">Welcome to dummy Runner App</string>
     <string name="welcome_suggestion">Force close to reload ern mini-app bundle</string>
 </resources>

--- a/ern-runner-gen/src/types/LaunchRunnerConfig.ts
+++ b/ern-runner-gen/src/types/LaunchRunnerConfig.ts
@@ -1,0 +1,17 @@
+import { NativePlatform } from 'ern-core'
+export interface LaunchRunnerConfig {
+  /**
+   * Directory where the native platform project is located.
+   */
+  pathToRunner: string
+
+  /**
+   * Target native platform
+   */
+  platform: NativePlatform
+
+  /**
+   * Extra configuration needed to launch the miniapp.
+   */
+  extra?: any
+}


### PR DESCRIPTION
This PR adds the enhancement #1296  for Android. 

With this change, when `ern run-android` command is executed, instead of creating an `ErnRunner` app it will create a MiniApp specific runner app. Also, the container dependency will be named based on the mini app. 

Old Runner vs New Runner

<p align="center">
<img src="https://user-images.githubusercontent.com/4269110/64571305-50d01200-d318-11e9-9c95-c10ff1123bba.png" width="300"> <img src="https://user-images.githubusercontent.com/4269110/64571320-5f1e2e00-d318-11e9-9a76-b9df3c5e8742.png" width="300">
</p>
