### PR TITLE
Exclude iOS Container Libraries directory from system tests

### DIFF
--- a/system-tests/tests/create-api-base-fixture.js
+++ b/system-tests/tests/create-api-base-fixture.js
@@ -4,7 +4,7 @@ const assert = require('../utils/assert')
 const sameDirContent = require('../utils/sameDirContent')
 const f = require('../fixtures/constants')
 
-const filesToIgnore = [
+const excludeFilter = [
   'ElectrodeApiImpl.xcodeproj',
   'project.pbxproj',
   'package.json',
@@ -17,7 +17,7 @@ const filesToIgnore = [
   'SysteTestEventApi.spec.js',
   'SystemTestsApi.spec.js',
   '.yarn-integrity'
-]
+].map(s => `**/${s}`).join(',')
 
 run(`create-api ${f.testApiName} -p ${f.testApiPkgName} --skipNpmCheck`)
-assert(sameDirContent(f.pathToBaseApiFixture, path.join(process.cwd(), f.testApiName), filesToIgnore), 'Generated API differ from reference fixture !')
+assert(sameDirContent(f.pathToBaseApiFixture, path.join(process.cwd(), f.testApiName), { excludeFilter }), 'Generated API differ from reference fixture !')

--- a/system-tests/tests/create-api-complex-fixture.js
+++ b/system-tests/tests/create-api-complex-fixture.js
@@ -4,7 +4,7 @@ const assert = require('../utils/assert')
 const sameDirContent = require('../utils/sameDirContent')
 const f = require('../fixtures/constants')
 
-const filesToIgnore = [
+const excludeFilter = [
   'ElectrodeApiImpl.xcodeproj',
   'project.pbxproj',
   'package.json',
@@ -17,7 +17,7 @@ const filesToIgnore = [
   'SysteTestEventApi.spec.js',
   'SystemTestsApi.spec.js',
   '.yarn-integrity'
-]
+].map(s => `**/${s}`).join(',')
 
 run(`create-api ${f.complexApiName} -p ${f.testApiPkgName}  --schemaPath ${f.pathToComplexApiSchema} --skipNpmCheck`)
-assert(sameDirContent(f.pathToComplexApiFixture, path.join(process.cwd(), f.complexApiName), filesToIgnore), 'Generated API differ from reference fixture !')
+assert(sameDirContent(f.pathToComplexApiFixture, path.join(process.cwd(), f.complexApiName), {excludeFilter}), 'Generated API differ from reference fixture !')

--- a/system-tests/tests/create-api-impl-js-fixture.js
+++ b/system-tests/tests/create-api-impl-js-fixture.js
@@ -3,7 +3,7 @@ const assert = require('../utils/assert')
 const sameDirContent = require('../utils/sameDirContent')
 const f = require('../fixtures/constants')
 
-const filesToIgnore = [
+const excludeFilter = [
   'ElectrodeApiImpl.xcodeproj',
   'project.pbxproj',
   'package.json',
@@ -16,7 +16,7 @@ const filesToIgnore = [
   'SysteTestEventApi.spec.js',
   'SystemTestsApi.spec.js',
   '.yarn-integrity'
-]
+].map(s => `**/${s}`).join(',')
 
 run(`create-api-impl ${f.movieApiPkgName} -p ${f.movieApiImplPkgName} --skipNpmCheck --jsOnly --outputDirectory ${process.cwd()} --force`)
-assert(sameDirContent(f.pathToJsApiImplFixture, process.cwd(), filesToIgnore), 'Generated API JS Impl differ from reference fixture !')
+assert(sameDirContent(f.pathToJsApiImplFixture, process.cwd(), {excludeFilter}), 'Generated API JS Impl differ from reference fixture !')

--- a/system-tests/tests/create-api-impl-native-fixture.js
+++ b/system-tests/tests/create-api-impl-native-fixture.js
@@ -3,7 +3,7 @@ const assert = require('../utils/assert')
 const sameDirContent = require('../utils/sameDirContent')
 const f = require('../fixtures/constants')
 
-const filesToIgnore = [
+const excludeFilter = [
   'ElectrodeApiImpl.xcodeproj',
   'project.pbxproj',
   'package.json',
@@ -16,7 +16,8 @@ const filesToIgnore = [
   'SysteTestEventApi.spec.js',
   'SystemTestsApi.spec.js',
   '.yarn-integrity'
-]
+  'ElectrodeApiImpl/Libraries'
+].map(s => `**/${s}`).join(',')
 
 run(`create-api-impl ${f.movieApiPkgName} -p ${f.movieApiImplPkgName} --skipNpmCheck --nativeOnly --outputDirectory ${process.cwd()} --force`)
-assert(sameDirContent(f.pathToNativeApiImplFixture, process.cwd(), filesToIgnore), 'Generated API Native Impl differ from reference fixture !')
+assert(sameDirContent(f.pathToNativeApiImplFixture, process.cwd(), {excludeFilter}), 'Generated API Native Impl differ from reference fixture !')

--- a/system-tests/tests/create-container-android-fixture.js
+++ b/system-tests/tests/create-container-android-fixture.js
@@ -8,10 +8,10 @@ const miniapps = [
   `${f.movieDetailsMiniAppPkgName}@${f.movieDetailsMiniAppPkgVersion}`
 ]
 
-const filesToIgnoreForDiffs = [
+const excludeFilter = [
   'index.android.bundle',
   'index.android.bundle.meta'
-]
+].map(s => `**/${s}`).join(',')
 
 run(`create-container --miniapps ${miniapps.join(' ')} -p android --dependencies react-native-code-push@5.2.1 --out ${process.cwd()}`)
-assert(sameDirContent(f.pathToAndroidContainerFixture, process.cwd(), filesToIgnoreForDiffs), 'Generated Android Container differ from reference fixture !')
+assert(sameDirContent(f.pathToAndroidContainerFixture, process.cwd(), {excludeFilter}), 'Generated Android Container differ from reference fixture !')

--- a/system-tests/tests/create-container-ios-fixture.js
+++ b/system-tests/tests/create-container-ios-fixture.js
@@ -8,11 +8,10 @@ const miniapps = [
   `${f.movieDetailsMiniAppPkgName}@${f.movieDetailsMiniAppPkgVersion}`
 ]
 
-const filesToIgnoreForDiffs = [
+const excludeFilter = [
     'project.pbxproj',
-    'MiniApp.jsbundle',
-    'MiniApp.jsbundle.meta'
-]
+    'ElectrodeContainer/Libraries/**'
+].map(s => `**/${s}`).join(',')
 
 run(`create-container --miniapps ${miniapps.join(' ')} -p ios --dependencies react-native-code-push@5.2.1 --out ${process.cwd()}`)
-assert(sameDirContent(f.pathToIosContainerFixture, process.cwd(), filesToIgnoreForDiffs), 'Generated IOS Container differ from reference fixture !')
+assert(sameDirContent(f.pathToIosContainerFixture, process.cwd(), {excludeFilter}), 'Generated IOS Container differ from reference fixture !')

--- a/system-tests/utils/sameDirContent.js
+++ b/system-tests/utils/sameDirContent.js
@@ -10,25 +10,32 @@ require('colors')
 // directories is similar (same files and same content for each file -minus
 // the files to be ignore-). It will return false otherwise and log all
 // differences to the console.
-module.exports = function (pathA, pathB, filesToIgnoreContentDiff = []) {
-    let result = true
-    const directoriesDiff = dircompare.compareSync(pathA, pathB, {compareContent: true})
-    for (const diff of directoriesDiff.diffSet) {
-      if (diff.state === 'distinct') {
-        if (!filesToIgnoreContentDiff.includes(diff.name1)) {
-          console.log('A difference in content was found !')
-          console.log(JSON.stringify(diff))
-          let diffLine = jsdiff.diffLines(
-            fs.readFileSync(path.join(diff.path1, diff.name1)).toString(),
-            fs.readFileSync(path.join(diff.path2, diff.name2)).toString())
-          diffLine.forEach(part => {
-            let color = part.added ? 'green'
-              : part.removed ? 'red' : 'grey'
-            process.stderr.write(part.value[color])
-          })
-          result = false
-        }
-      }
+module.exports = function(
+  pathA,
+  pathB,
+  {
+    excludeFilter, // File/directory name exclude filter. Comma separated minimatch patterns.
+  } = {}
+) {
+  let result = true
+  const directoriesDiff = dircompare.compareSync(pathA, pathB, {
+    compareContent: true,
+    excludeFilter,
+  })
+  for (const diff of directoriesDiff.diffSet) {
+    if (diff.state === 'distinct') {
+      console.log('A difference in content was found !')
+      console.log(JSON.stringify(diff))
+      let diffLine = jsdiff.diffLines(
+        fs.readFileSync(path.join(diff.path1, diff.name1)).toString(),
+        fs.readFileSync(path.join(diff.path2, diff.name2)).toString()
+      )
+      diffLine.forEach(part => {
+        let color = part.added ? 'green' : part.removed ? 'red' : 'grey'
+        process.stderr.write(part.value[color])
+      })
+      result = false
     }
-    return result
   }
+  return result
+}


### PR DESCRIPTION
- Improve system tests runner implementation to allow excluding directories in addition to files, using built-in `excludeFilter` of [dir-compare](https://github.com/gliviu/dir-compare) library.
- Exclude `ElectrodeContainer/Libraries` from iOS Container system tests and `ElectrodeApiImpl/Libraries` from iOS API impl system tests (see https://github.com/electrode-io/electrode-native/pull/1307#issue-316123349 for motivation).