### PR TITLE
Update yazl to 2.5.1

### DIFF
--- a/ern-core/package.json
+++ b/ern-core/package.json
@@ -84,7 +84,7 @@
     "xcode-ern": "^1.0.12",
     "yarn": "^1.17.3",
     "yauzl": "^2.10.0",
-    "yazl": "^2.4.3"
+    "yazl": "^2.5.1"
   },
   "devDependencies": {
     "ern-util-dev": "1000.0.0"

--- a/ern-core/yarn.lock
+++ b/ern-core/yarn.lock
@@ -2254,7 +2254,7 @@ yazl@^2.4.1:
   dependencies:
     buffer-crc32 "~0.2.3"
 
-yazl@^2.4.3:
+yazl@^2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.5.1.tgz#a3d65d3dd659a5b0937850e8609f22fffa2b5c35"
   integrity sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==

--- a/ern-local-cli/package.json
+++ b/ern-local-cli/package.json
@@ -66,21 +66,21 @@
     "ern-container-publisher": "1000.0.0",
     "ern-container-transformer": "1000.0.0",
     "ern-core": "1000.0.0",
+    "ern-orchestrator": "1000.0.0",
     "ern-runner-gen": "1000.0.0",
     "ern-runner-gen-android": "1000.0.0",
     "ern-runner-gen-ios": "1000.0.0",
-    "ern-orchestrator": "1000.0.0",
     "fast-levenshtein": "^2.0.6",
     "fs-readdir-recursive": "^1.1.0",
     "inquirer": "^3.0.6",
-    "kax":"^2.0.1",
+    "kax": "^2.0.1",
     "lodash": "^4.17.14",
     "semver": "^5.5.0",
-    "treeify":"^1.1.0",
+    "treeify": "^1.1.0",
     "validate-npm-package-name": "^3.0.0",
     "yargs": "^7.1.0",
     "yauzl": "^2.10.0",
-    "yazl": "^2.4.3"
+    "yazl": "^2.5.1"
   },
   "devDependencies": {
     "ern-util-dev": "1000.0.0"

--- a/ern-local-cli/yarn.lock
+++ b/ern-local-cli/yarn.lock
@@ -1435,8 +1435,8 @@ yauzl@^2.9.1:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.0.1"
 
-yazl@^2.4.3:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.4.3.tgz#ec26e5cc87d5601b9df8432dbdd3cd2e5173a071"
+yazl@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.5.1.tgz#a3d65d3dd659a5b0937850e8609f22fffa2b5c35"
   dependencies:
     buffer-crc32 "~0.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9014,7 +9014,7 @@ yauzl@^2.10.0, yauzl@^2.7.0:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
 
-yazl@^2.4.1, yazl@^2.4.3:
+yazl@^2.4.1, yazl@^2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.5.1.tgz#a3d65d3dd659a5b0937850e8609f22fffa2b5c35"
   integrity sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==


### PR DESCRIPTION
A quick minor update `yazl` to `2.5.1`. This update can be performed independently of #1304, and will remove several lines from that PR once rebased.