### PR TITLE
Update metro resolver sourceExts config

### DIFF
--- a/ern-composite-gen/src/generateComposite.ts
+++ b/ern-composite-gen/src/generateComposite.ts
@@ -580,10 +580,10 @@ async function createRnCliConfig({ outDir }: { outDir: string }) {
   let sourceExts
   if (semver.gte(compositeReactNativeVersion, '0.57.0')) {
     sourceExts =
-      "module.exports = { resolver: { sourceExts: ['jsx', 'mjs', 'js', 'ts', 'tsx'] } };"
+      "module.exports = { resolver: { sourceExts: ['jsx', 'js', 'ts', 'tsx', 'mjs'] } };"
   } else {
     sourceExts =
-      "module.exports = { getSourceExts: () => ['jsx', 'mjs', 'js', 'ts', 'tsx'] }"
+      "module.exports = { getSourceExts: () => ['jsx', 'js', 'ts', 'tsx', 'mjs'] }"
   }
   await fileUtils.writeFile(path.join(outDir, 'rn-cli.config.js'), sourceExts)
 }


### PR DESCRIPTION
Fix an issue noticed when using `fetch` with React Native 60, resulting in the following error (`EventTarget.apply is not a function`) :

![Screen Shot 2019-09-11 at 1 42 00 PM](https://user-images.githubusercontent.com/1390588/64733644-f8288280-d499-11e9-8c41-41bb86700459.png)

After investigation it is due to [event-target-shim](https://github.com/mysticatea/event-target-shim) `.mjs` file to be imported rather than the `.js` file ([these two files are exposed in dist](https://github.com/mysticatea/event-target-shim/tree/master/dist)). For some unknown reason yet, the `.mjs` source is leading to this error. 

This PR just updates the metro resolver configuration, updating the `sourceExts` array to give `.js` files precedence over `.mjs` files. This way when the metro resolver has to resolve a file and has a choice between the two extensions, it will pick the `.js` one over the `.mjs` one.

This fixes the issue noticed with `fetch`.

To be shipped in patch release `0.37.6`