### PR TITLE
Fix system-tests excludeFilter array

### DIFF
--- a/system-tests/tests/create-api-impl-native-fixture.js
+++ b/system-tests/tests/create-api-impl-native-fixture.js
@@ -15,7 +15,7 @@ const excludeFilter = [
   'WalmartItemApi.spec.js',
   'SysteTestEventApi.spec.js',
   'SystemTestsApi.spec.js',
-  '.yarn-integrity'
+  '.yarn-integrity',
   'ElectrodeApiImpl/Libraries'
 ].map(s => `**/${s}`).join(',')
 


### PR DESCRIPTION
Not sure how this one slipped through the tests... 😉