### PR TITLE
Binary store flavor

### DIFF
--- a/docs/cli/binarystore/add.md
+++ b/docs/cli/binarystore/add.md
@@ -18,6 +18,13 @@
 
 * Relative or absolute path to the binary to add to the binary store. For an `Android` binary the path should point to a `.apk` file, whereas of `iOS` it should point to a `.app`.
 
+**Options**  
+
+`--flavor`
+
+* Custom flavor to attach to this binary.
+* The binary of a specific application version (for ex `1.0.0`) can have different flavors, representing different build types of the same application version (for example `Dev`/`Prod`/`QA` ...).
+
 #### Remarks
 
 * This command will only work if the following conditions are met:

--- a/docs/cli/binarystore/get.md
+++ b/docs/cli/binarystore/get.md
@@ -18,6 +18,13 @@
 
 * Relative or absolute path to a directory where the binary will be transfered to. If the directory does not exist, it will be ecreated.
 
+**Options**
+
+`--flavor`
+
+* Custom flavor of this binary that should be retrieved.
+* The binary of a specific application version (for ex `1.0.0`) can have different flavors, representing different build types of the same application version (for example `Dev`/`Prod`/`QA` ...).
+
 #### Remarks
 
 * This command will only work if the following conditions are met:

--- a/docs/cli/binarystore/remove.md
+++ b/docs/cli/binarystore/remove.md
@@ -14,6 +14,13 @@
 
 * A complete native application descriptor (ex: `myapp:android:1.0.0`), representing the native application version associated to this binary.
 
+**Options**  
+
+`--flavor`
+
+* Custom flavor of the binary that should be removed.
+* The binary of a specific application version (for ex `1.0.0`) can have different flavors, representing different build types of the same application version (for example `Dev`/`Prod`/`QA` ...).
+
 #### Remarks
 
 * This command will only work if the following conditions are met:

--- a/docs/cli/start.md
+++ b/docs/cli/start.md
@@ -39,11 +39,6 @@ If you do not pass an argument to this command, you are prompted to select a nat
 `--extraJsDependencies/-e <jsdependencies>`
 * Additional JavaScript dependencies to add to the composite JavaScript bundle.
 
-`--disableBinaryStore`
-
-* Setting this option will bypass retrieval and installation of the binary from the Binary Store.  
-* It can be useful in case you want to use `ern start` command in conjunction with your own mobile application native binary, build locally on your workstation or retrieved from a specific location.
-
 `--host`
 * Host or ip to launch the local packager on *(default: localhost)*
 
@@ -63,6 +58,18 @@ If you do not pass an argument to this command, you are prompted to select a nat
 `iOS`
 `--bundleId/-b`
 *   iOS Bundle Identifier unique to your app.
+
+**Binary Store Specific Options**
+
+`--disableBinaryStore`
+
+* Setting this option will bypass retrieval and installation of the binary from the Binary Store.  
+* It can be useful in case you want to use `ern start` command in conjunction with your own mobile application native binary, build locally on your workstation or retrieved from a specific location.
+
+`--flavor`
+
+* Flavor of the binary to retrieve from the store.
+* The binary of a specific application version (for ex `1.0.0`) can have different flavors, representing different build types of the same application version (for example `Dev`/`Prod`/`QA` ...).
 
 #### Remarks
 

--- a/ern-local-cli/src/commands/start.ts
+++ b/ern-local-cli/src/commands/start.ts
@@ -46,6 +46,9 @@ export const builder = (argv: Argv) => {
       type: 'array',
     })
     .coerce('jsApiImpls', d => d.map(PackagePath.fromString))
+    .option('flavor', {
+      describe: 'Custom binary flavor',
+    })
     .option('miniapps', {
       alias: 'm',
       describe: 'A list of one or more MiniApp(s)',
@@ -79,6 +82,7 @@ export const builder = (argv: Argv) => {
     })
     .group(['packageName', 'activityName'], 'Android binary specific options:')
     .group(['bundleId'], 'iOS binary specific options:')
+    .group(['disableBinaryStore', 'flavor'], 'Binary store specific options:')
     .epilog(epilog(exports))
 }
 
@@ -88,6 +92,7 @@ export const commandHandler = async ({
   bundleId,
   descriptor,
   extraJsDependencies = [],
+  flavor,
   host,
   jsApiImpls,
   miniapps,
@@ -101,6 +106,7 @@ export const commandHandler = async ({
   bundleId?: string
   descriptor?: AppVersionDescriptor
   extraJsDependencies?: PackagePath[]
+  flavor?: string
   host?: string
   jsApiImpls?: PackagePath[]
   miniapps?: PackagePath[]
@@ -120,6 +126,7 @@ export const commandHandler = async ({
     descriptor,
     disableBinaryStore,
     extraJsDependencies,
+    flavor,
     host,
     jsApiImpls,
     miniapps,

--- a/ern-orchestrator/src/start.ts
+++ b/ern-orchestrator/src/start.ts
@@ -24,6 +24,7 @@ export default async function start({
   jsApiImpls,
   miniapps,
   descriptor,
+  flavor,
   watchNodeModules = [],
   packageName,
   activityName,
@@ -37,6 +38,7 @@ export default async function start({
   jsApiImpls?: PackagePath[]
   miniapps?: PackagePath[]
   descriptor?: AppVersionDescriptor
+  flavor?: string
   watchNodeModules?: string[]
   packageName?: string
   activityName?: string
@@ -133,7 +135,7 @@ export default async function start({
         descriptor
       )
       const binaryStore = new ErnBinaryStore(binaryStoreConfig)
-      if (await binaryStore.hasBinary(descriptor)) {
+      if (await binaryStore.hasBinary(descriptor, { flavor })) {
         if (descriptor.platform === 'android') {
           if (
             cauldronStartCommandConfig &&
@@ -149,7 +151,9 @@ export default async function start({
               'You need to provide an Android package name or set it in Cauldron configuration'
             )
           }
-          const apkPath = await binaryStore.getBinary(descriptor)
+          const apkPath = await kax
+            .task('Downloading binary from store')
+            .run(binaryStore.getBinary(descriptor, { flavor }))
           await android.runAndroidApk({ apkPath, packageName, activityName })
         } else if (descriptor.platform === 'ios') {
           if (cauldronStartCommandConfig && cauldronStartCommandConfig.ios) {
@@ -160,7 +164,9 @@ export default async function start({
               'You need to provide an iOS bundle ID or set it in Cauldron configuration'
             )
           }
-          const appPath = await binaryStore.getBinary(descriptor)
+          const appPath = await kax
+            .task('Downloading binary from store')
+            .run(binaryStore.getBinary(descriptor, { flavor }))
           await ios.runIosApp({ appPath, bundleId })
         }
       }


### PR DESCRIPTION
This feature was requested by an internal team but could be of use for any teams making use of [Electrode Native Binary Store](https://github.com/electrode-io/electrode-native-binarystore) along with [ern start](https://native.electrode.io/cli-commands/start) command.

This feature allows to upload a specific binary version to a binary store, using different 'flavors'. 
For example, a team might run different native builds (`Prod`/`Dev`/`Staging`...) of a native application for a single version, while users of `ern start` might want to start a specific binary version flavor.

Prior to this new feature, only one binary could be stored per version in a binary store making things more complex, because in order to get a similar behavior, users would have to create multiple versions in cauldron `1.0.0-Dev`/`1.0.0-QA`/`1.0.0-Prod` just to differentiate binaries in the store and for `ern start`, even if there is absolutely no difference to the containers (so no real need of creating different flavor in Cauldron).

This PR adds a new `--flavor` option to all of the `bundlestore` commands (`add`/`get`/`remove`), making it possible to upload a same binary version multiple times, with a different `flavor` attached to it. 
It also adds a new `--flavor` option to the `ern start` command, so that users of `ern start` can start a specific flavor of a given binary version.