### PR TITLE
Sort platform versions

### DIFF
--- a/ern-core/src/Platform.ts
+++ b/ern-core/src/Platform.ts
@@ -94,7 +94,7 @@ export default class Platform {
   public static get versions(): string[] {
     return JSON.parse(
       execSync(`npm info ${ERN_LOCAL_CLI_PACKAGE} versions --json`).toString()
-    )
+    ).sort(semver.compare)
   }
 
   // Install a given platform version

--- a/ern-core/test/Platform-test.ts
+++ b/ern-core/test/Platform-test.ts
@@ -15,7 +15,7 @@ const sandbox = sinon.createSandbox()
 describe('Platform', () => {
   let ernHomePath
   const processEnvErnHomeBackup = process.env.ern_home
-  const platformVersions = '["1.0.0", "2.0.0", "3.0.0"]'
+  const platformVersions = '["1.0.0", "2.0.0", "3.0.0", "1.0.1"]'
   let execSyncStub
   let isYarnInstalledReturn = true
   let throwOnExecSync = false
@@ -208,8 +208,8 @@ describe('Platform', () => {
   })
 
   describe('versions', () => {
-    it('should return the list of versions', () => {
-      expect(Platform.versions).eql(JSON.parse(platformVersions))
+    it('should return the list of versions in ascending order', () => {
+      expect(Platform.versions).eql(['1.0.0', '1.0.1', '2.0.0', '3.0.0'])
     })
   })
 


### PR DESCRIPTION
Update `Platform.versions` method so that it returns versions in sorted ascending order.

Done in case we have to publish a patch version for an older ern version than current minor version line. This shouldn't happen as we don't offer patch support for such versions, but there could be exceptions to this rule.

If this ever happens, there will be a problem with `ern platform use latest` command, which just pop the latest element from the versions array returned by `npm info` command. Problem is that this command will return the versions ordered by publication time, meaning that if latest version is `0.38.0` and we publish `0.30.1`, then, `ern platform use latest` command will install `0.30.1` which is not the expected behavior.