### PR TITLE
Use dev platform version to regenerate system test  fixtures

### DIFF
--- a/system-tests/regen-fixtures.js
+++ b/system-tests/regen-fixtures.js
@@ -34,6 +34,7 @@ inquirer
     },
   ])
   .then(answers => {
+    shell.exec('ern platform use 1000.0.0')
     shell.exec('ern platform config set logLevel trace')
     shell.exec('ern cauldron repo clear')
     try {


### PR DESCRIPTION
Ensure that system tests regeneration is performed using development platform version (1000.0.0).