### PR TITLE
Expose React Native delegate

### DIFF
--- a/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeReactNative.h
+++ b/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeReactNative.h
@@ -50,6 +50,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) NSString *packagerPort;
 @end
 
+@protocol MiniAppViewDelegate <NSObject>
+- (void)rootViewDidChangeIntrinsicSize:(UIView *)rootView;
+@end
+
 ////////////////////////////////////////////////////////////////////////////////
 #pragma mark - ElectrodeReactNative
 /**
@@ -101,23 +105,42 @@ NS_ASSUME_NONNULL_BEGIN
                            properties:(NSDictionary * _Nullable)properties;
 
 /**
- Returns a react native miniapp (from a JSBundle) inside a view controller.
+ Returns a react native miniapp (from a JSBundle).
 
  @param name The name of the mini app, preferably the same name as the jsbundle
  without the extension.
  @param properties Any configuration to set up the mini app with.
- @return A UIViewController containing the view of the miniapp.
+ @return a UIView of the miniapp.
  */
 - (UIView *)miniAppViewWithName:(NSString *)name
                      properties:(NSDictionary *_Nullable)properties;
 
 /**
+ Returns a react native miniapp (from a JSBundle).
+
  @param name The name of the mini app, that is registered with the AppComponent.
  @param properties initialprops for a React Native miniapp.
  @param sizeFlexibilty defines size flexibility type of the root view
- @return UIView
+ @return a UIView of the miniapp.
  */
-- (UIView *)miniAppViewWithName:(NSString *)name properties:(NSDictionary *_Nullable)properties sizeFlexibility:(NSInteger)sizeFlexibilty;
+- (UIView *)miniAppViewWithName:(NSString *)name
+                     properties:(NSDictionary *_Nullable)properties
+                sizeFlexibility:(NSInteger)sizeFlexibilty
+        __attribute((deprecated("use -miniAppViewWithName:properties:sizeFlexibility:delegate instead")));
+
+/**
+ Returns a react native miniapp (from a JSBundle).
+
+ @param name The name of the mini app, that is registered with the AppComponent.
+ @param properties initialprops for a React Native miniapp.
+ @param sizeFlexibilty defines size flexibility type of the root view
+ @param delegate
+ @return a UIView of the miniapp.
+ */
+- (UIView *)miniAppViewWithName:(NSString *)name
+                     properties:(NSDictionary *_Nullable)properties
+                sizeFlexibility:(NSInteger)sizeFlexibilty
+                       delegate:(id<MiniAppViewDelegate> _Nullable)delegate;
 
 /**
  Call this to update an RCTRootView with new props. Calling this with new props will cause the view to be rerendered.

--- a/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeReactNative.m
+++ b/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeReactNative.m
@@ -159,11 +159,23 @@ static dispatch_semaphore_t semaphore;
     return rootView;
 }
 
-- (UIView *)miniAppViewWithName:(NSString *)name properties:(NSDictionary *_Nullable)properties
-            sizeFlexibility:(NSInteger)sizeFlexibilty {
+- (UIView *)miniAppViewWithName:(NSString *)name
+                     properties:(NSDictionary *_Nullable)properties
+                sizeFlexibility:(NSInteger)sizeFlexibilty {
     RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:self.bridge moduleName:name initialProperties:properties];
     rootView.sizeFlexibility = (RCTRootViewSizeFlexibility)sizeFlexibilty;
     rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+    return rootView;
+}
+
+- (UIView *)miniAppViewWithName:(NSString *)name
+                     properties:(NSDictionary *_Nullable)properties
+                sizeFlexibility:(NSInteger)sizeFlexibilty
+                       delegate:(id<MiniAppViewDelegate> _Nullable)delegate {
+    RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:self.bridge moduleName:name initialProperties:properties];
+    rootView.sizeFlexibility = (RCTRootViewSizeFlexibility)sizeFlexibilty;
+    rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+    rootView.delegate = delegate;
     return rootView;
 }
 

--- a/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeReactNative.h
+++ b/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeReactNative.h
@@ -29,6 +29,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) NSString *packagerPort;
 @end
 
+@protocol MiniAppViewDelegate <NSObject>
+- (void)rootViewDidChangeIntrinsicSize:(UIView *)rootView;
+@end
+
 ////////////////////////////////////////////////////////////////////////////////
 #pragma mark - ElectrodeReactNative
 /**
@@ -73,23 +77,42 @@ NS_ASSUME_NONNULL_BEGIN
                            properties:(NSDictionary * _Nullable)properties;
 
 /**
- Returns a react native miniapp (from a JSBundle) inside a view controller.
+ Returns a react native miniapp (from a JSBundle).
 
  @param name The name of the mini app, preferably the same name as the jsbundle
  without the extension.
  @param properties Any configuration to set up the mini app with.
- @return A UIViewController containing the view of the miniapp.
+ @return a UIView of the miniapp.
  */
 - (UIView *)miniAppViewWithName:(NSString *)name
                      properties:(NSDictionary *_Nullable)properties;
 
 /**
+ Returns a react native miniapp (from a JSBundle).
+
  @param name The name of the mini app, that is registered with the AppComponent.
  @param properties initialprops for a React Native miniapp.
  @param sizeFlexibilty defines size flexibility type of the root view
- @return UIView
+ @return a UIView of the miniapp.
  */
-- (UIView *)miniAppViewWithName:(NSString *)name properties:(NSDictionary *_Nullable)properties sizeFlexibility:(NSInteger)sizeFlexibilty;
+- (UIView *)miniAppViewWithName:(NSString *)name
+                     properties:(NSDictionary *_Nullable)properties
+                sizeFlexibility:(NSInteger)sizeFlexibilty
+        __attribute((deprecated("use -miniAppViewWithName:properties:sizeFlexibility:delegate instead")));
+
+/**
+ Returns a react native miniapp (from a JSBundle).
+
+ @param name The name of the mini app, that is registered with the AppComponent.
+ @param properties initialprops for a React Native miniapp.
+ @param sizeFlexibilty defines size flexibility type of the root view.
+ @param delegate
+ @return a UIView of the miniapp.
+ */
+- (UIView *)miniAppViewWithName:(NSString *)name
+                     properties:(NSDictionary *_Nullable)properties
+                sizeFlexibility:(NSInteger)sizeFlexibilty
+                       delegate:(id<MiniAppViewDelegate> _Nullable)delegate;
 
 /**
  Call this to update an RCTRootView with new props. Calling this with new props will cause the view to be rerendered.

--- a/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeReactNative.m
+++ b/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeReactNative.m
@@ -144,11 +144,23 @@ static dispatch_semaphore_t semaphore;
     return rootView;
 }
 
-- (UIView *)miniAppViewWithName:(NSString *)name properties:(NSDictionary *_Nullable)properties
-            sizeFlexibility:(NSInteger)sizeFlexibilty {
+- (UIView *)miniAppViewWithName:(NSString *)name
+                     properties:(NSDictionary *_Nullable)properties
+                sizeFlexibility:(NSInteger)sizeFlexibilty {
     RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:self.bridge moduleName:name initialProperties:properties];
     rootView.sizeFlexibility = (RCTRootViewSizeFlexibility)sizeFlexibilty;
     rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+    return rootView;
+}
+
+- (UIView *)miniAppViewWithName:(NSString *)name
+                     properties:(NSDictionary *_Nullable)properties
+                sizeFlexibility:(NSInteger)sizeFlexibilty
+                       delegate:(id<MiniAppViewDelegate> _Nullable)delegate {
+    RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:self.bridge moduleName:name initialProperties:properties];
+    rootView.sizeFlexibility = (RCTRootViewSizeFlexibility)sizeFlexibilty;
+    rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+    rootView.delegate = delegate;
     return rootView;
 }
 


### PR DESCRIPTION
Adding a new method to expose `RCTRootViewDelegate ` to native app so that it could use it to update the mini app's view frame or height / width constraint layout accordingly. 

`-rootViewDidChangeIntrinsicSize:` will be called by React Native after the mini app's root view's intrinsic content size is changed.