### PR TITLE
Move bundle store host config to Cauldron

### DIFF
--- a/docs/cli/bundlestore.md
+++ b/docs/cli/bundlestore.md
@@ -10,6 +10,20 @@ Once a bundle store server is available, any development team or individual deve
 
 The bundle store server keeps all bundles that have been pushed to the different stores, and all these bundles are accessible within the native app. The bundle store also supports source maps out of the box, meaning that if the loaded bundled is crashing at some point, the red screen will show the symbolicated stack trace. Bundle "time machine" and source map support can be very useful, used in conjunction, to pin point the exact location of a crash and in which bundle (which point in time) the problem was introduced.
 
+## Configuring access to bundle store server
+
+The url to the bundle store server should be set in cauldron root configuration (`config/default.json`) as follow :
+
+```json
+{
+  "bundleStore": {
+    "url": "localhost:3000" 
+  }
+}
+```
+
+Once done, any user connected to the Cauldron will have access to the binary store server.
+
 ### Creating a store
 
 Creating a new store can be achieved through the [bundlestore create] command.   

--- a/docs/cli/bundlestore/create.md
+++ b/docs/cli/bundlestore/create.md
@@ -2,7 +2,7 @@
 
 **This command can only be used with access to an [Electrode Native bundle store server]**
 
-**To use this command, the `bundlestore-host` must be set in platform configuration (see [platform config set] command)**
+**To use this command, the `bundleStore` config must be set in cauldron**
 
 ### Description
 

--- a/docs/cli/bundlestore/delete.md
+++ b/docs/cli/bundlestore/delete.md
@@ -2,7 +2,7 @@
 
 **This command can only be used with access to an [Electrode Native bundle store server]**
 
-**To use this command, the `bundlestore-host` must be set in platform configuration (see [platform config set] command)**
+**To use this command, the `bundleStore` config must be set in cauldron**
 
 ### Description
 

--- a/docs/cli/bundlestore/upload.md
+++ b/docs/cli/bundlestore/upload.md
@@ -2,7 +2,7 @@
 
 **This command can only be used with access to an [Electrode Native bundle store server]**
 
-**To use this command, the `bundlestore-host` must be set in platform configuration (see [platform config set] command)**
+**To use this command, the `bundleStore` config must be set in cauldron**
 
 ### Description
 

--- a/docs/cli/bundlestore/use.md
+++ b/docs/cli/bundlestore/use.md
@@ -2,8 +2,7 @@
 
 **This command can only be used with access to an [Electrode Native bundle store server]**
 
-**To use this command, the `bundlestore-host` must be set in platform configuration (see [platform config set] command)**
-
+**To use this command, the `bundleStore` config must be set in cauldron**
 ### Description
 
 Set a store as the current target to upload bundles to

--- a/docs/cli/platform/config/del.md
+++ b/docs/cli/platform/config/del.md
@@ -16,7 +16,6 @@
 
 **Whitelisted properties**
 
-- `bundlestore-host`
 - `codePushAccessKey`
 - `codePushCustomHeaders`
 - `codePushCustomServerUrl`

--- a/docs/cli/platform/config/get.md
+++ b/docs/cli/platform/config/get.md
@@ -16,7 +16,6 @@
 
 **Whitelisted properties**
 
-- `bundlestore-host`
 - `codePushAccessKey`
 - `codePushCustomHeaders`
 - `codePushCustomServerUrl`

--- a/docs/cli/platform/config/set.md
+++ b/docs/cli/platform/config/set.md
@@ -20,10 +20,6 @@
 
 **Configurable properties**
 
-- `bundlestore-host` [string]  
-[Electrode Native bundle store server] host (including port).
-For example `localhost:3000`
-
 - `codePushAccessKey` [string]   
 Code push access key associated with your account 
 

--- a/ern-cauldron-api/src/CauldronHelper.ts
+++ b/ern-cauldron-api/src/CauldronHelper.ts
@@ -1045,6 +1045,12 @@ export class CauldronHelper {
     return this.getConfigForKey('binaryStore', descriptor)
   }
 
+  public async getBundleStoreConfig(
+    descriptor?: AnyAppDescriptor
+  ): Promise<any | void> {
+    return this.getConfigForKey('bundleStore', descriptor)
+  }
+
   public async getCodePushConfig(
     descriptor?: AnyAppDescriptor
   ): Promise<any | void> {

--- a/ern-core/src/BundleStoreEngine.ts
+++ b/ern-core/src/BundleStoreEngine.ts
@@ -13,10 +13,8 @@ export class BundleStoreEngine {
   private readonly sdk: BundleStoreSdk
   private assets: any[]
 
-  constructor() {
-    this.sdk = new BundleStoreSdk(
-      config.getValue('bundlestore-host', 'localhost:3000')
-    )
+  constructor(public readonly host: string) {
+    this.sdk = new BundleStoreSdk(host)
     this.assets = []
 
     ipc.config.silent = true

--- a/ern-local-cli/src/commands/bundlestore/create.ts
+++ b/ern-local-cli/src/commands/bundlestore/create.ts
@@ -1,3 +1,4 @@
+import { getActiveCauldron } from 'ern-cauldron-api'
 import { AppVersionDescriptor, BundleStoreSdk, log, config } from 'ern-core'
 import { epilog, logErrorAndExitIfNotSatisfied, tryCatchWrap } from '../../lib'
 import { Argv } from 'yargs'
@@ -14,12 +15,14 @@ export const builder = (argv: Argv) => {
 
 export const commandHandler = async ({ store }: { store: string }) => {
   await logErrorAndExitIfNotSatisfied({
-    bundleStoreHostIsSet: {
-      extraErrorMessage: `You can use 'ern platform config set bundlestore-host <host>' to set the bundle store server host`,
+    bundleStoreUrlSetInCauldron: {
+      extraErrorMessage: `You should add bundleStore config in your Cauldron`,
     },
   })
 
-  const sdk = new BundleStoreSdk(config.getValue('bundlestore-host'))
+  const cauldron = await getActiveCauldron()
+  const bundleStoreUrl = (await cauldron.getBundleStoreConfig()).url
+  const sdk = new BundleStoreSdk(bundleStoreUrl)
   const accessKey = await sdk.createStore({ store })
 
   config.setValue('bundlestore-id', store)

--- a/ern-local-cli/src/commands/bundlestore/delete.ts
+++ b/ern-local-cli/src/commands/bundlestore/delete.ts
@@ -1,3 +1,4 @@
+import { getActiveCauldron } from 'ern-cauldron-api'
 import { AppVersionDescriptor, BundleStoreSdk, log, config } from 'ern-core'
 import { epilog, logErrorAndExitIfNotSatisfied, tryCatchWrap } from '../../lib'
 import { Argv } from 'yargs'
@@ -14,12 +15,14 @@ export const builder = (argv: Argv) => {
 
 export const commandHandler = async ({ accessKey }: { accessKey: string }) => {
   await logErrorAndExitIfNotSatisfied({
-    bundleStoreHostIsSet: {
-      extraErrorMessage: `You can use 'ern platform config set bundlestore-host <host>' to set the bundle store server host`,
+    bundleStoreUrlSetInCauldron: {
+      extraErrorMessage: `You should add bundleStore config in your Cauldron`,
     },
   })
 
-  const sdk = new BundleStoreSdk(config.getValue('bundlestore-host'))
+  const cauldron = await getActiveCauldron()
+  const bundleStoreUrl = (await cauldron.getBundleStoreConfig()).url
+  const sdk = new BundleStoreSdk(bundleStoreUrl)
 
   const storeId = await sdk.deleteStoreByAccessKey({ accessKey })
 

--- a/ern-local-cli/src/commands/bundlestore/upload.ts
+++ b/ern-local-cli/src/commands/bundlestore/upload.ts
@@ -101,14 +101,16 @@ export const commandHandler = async ({
 'ern bundlestore use <accessKey>' to use an existing store OR 
 'ern bundlestore create <storeName>' to create a new store`,
     },
-    bundleStoreHostIsSet: {
-      extraErrorMessage: `You can use 'ern platform config set bundlestore-host <host>' to set the bundle store server host`,
+    bundleStoreUrlSetInCauldron: {
+      extraErrorMessage: `You should add bundleStore config in your Cauldron`,
     },
   })
 
   const platforms: NativePlatform[] = platform ? [platform] : ['android', 'ios']
 
-  const engine = new BundleStoreEngine()
+  const cauldron = await getActiveCauldron()
+  const bundleStoreUrl = (await cauldron.getBundleStoreConfig()).url
+  const engine = new BundleStoreEngine(bundleStoreUrl)
   if (fromPackager) {
     for (const curPlatform of platforms) {
       const bundleId = await kax
@@ -117,13 +119,6 @@ export const commandHandler = async ({
       log.info(`Successfully uploaded ${curPlatform} bundle [id: ${bundleId}]`)
     }
   } else {
-    const cauldron = await getActiveCauldron({ throwIfNoActiveCauldron: false })
-    if (!cauldron && !miniapps) {
-      throw new Error(
-        "A Cauldron must be active if you don't explicitly provide miniapps"
-      )
-    }
-
     // Full native application descriptor was not provided.
     // Ask the user to select a completeNapDescriptor from a list
     // containing all the native applications versions in the cauldron

--- a/ern-local-cli/src/commands/bundlestore/use.ts
+++ b/ern-local-cli/src/commands/bundlestore/use.ts
@@ -1,3 +1,4 @@
+import { getActiveCauldron } from 'ern-cauldron-api'
 import { AppVersionDescriptor, BundleStoreSdk, log, config } from 'ern-core'
 import { epilog, logErrorAndExitIfNotSatisfied, tryCatchWrap } from '../../lib'
 import { Argv } from 'yargs'
@@ -14,12 +15,14 @@ export const builder = (argv: Argv) => {
 
 export const commandHandler = async ({ accessKey }: { accessKey: string }) => {
   await logErrorAndExitIfNotSatisfied({
-    bundleStoreHostIsSet: {
-      extraErrorMessage: `You can use 'ern platform config set bundlestore-host <host>' to set the bundle store server host`,
+    bundleStoreUrlSetInCauldron: {
+      extraErrorMessage: `You should add bundleStore config in your Cauldron`,
     },
   })
 
-  const sdk = new BundleStoreSdk(config.getValue('bundlestore-host'))
+  const cauldron = await getActiveCauldron()
+  const bundleStoreUrl = (await cauldron.getBundleStoreConfig()).url
+  const sdk = new BundleStoreSdk(bundleStoreUrl)
 
   const store = await sdk.getStoreByAccessKey({ accessKey })
   config.setValue('bundlestore-id', store)

--- a/ern-local-cli/src/lib/logErrorAndExitIfNotSatisfied.ts
+++ b/ern-local-cli/src/lib/logErrorAndExitIfNotSatisfied.ts
@@ -37,7 +37,7 @@ export async function logErrorAndExitIfNotSatisfied({
   isContainerPath,
   isEnvVariableDefined,
   manifestIdExists,
-  bundleStoreHostIsSet,
+  bundleStoreUrlSetInCauldron,
   bundleStoreAccessKeyIsSet,
 }: {
   noGitOrFilesystemPath?: {
@@ -160,7 +160,7 @@ export async function logErrorAndExitIfNotSatisfied({
     id: string
     extraErrorMessage?: string
   }
-  bundleStoreHostIsSet?: {
+  bundleStoreUrlSetInCauldron?: {
     extraErrorMessage?: string
   }
   bundleStoreAccessKeyIsSet?: {
@@ -427,11 +427,11 @@ export async function logErrorAndExitIfNotSatisfied({
       )
       kaxTask.succeed()
     }
-    if (bundleStoreHostIsSet) {
-      kaxTask = kax.task(
-        `Ensuring that bundlestore-host is set in configuration`
+    if (bundleStoreUrlSetInCauldron) {
+      kaxTask = kax.task(`Ensuring that bundleStore url is set in Cauldron`)
+      await Ensure.bundleStoreUrlSetInCauldron(
+        bundleStoreUrlSetInCauldron.extraErrorMessage
       )
-      await Ensure.bundleStoreHostIsSet(bundleStoreHostIsSet.extraErrorMessage)
       kaxTask.succeed()
     }
     if (bundleStoreAccessKeyIsSet) {

--- a/ern-orchestrator/src/Ensure.ts
+++ b/ern-orchestrator/src/Ensure.ts
@@ -557,10 +557,14 @@ export default class Ensure {
     }
   }
 
-  public static bundleStoreHostIsSet(extraErrorMessage: string = '') {
-    if (!config.getValue('bundlestore-host')) {
+  public static async bundleStoreUrlSetInCauldron(
+    extraErrorMessage: string = ''
+  ) {
+    const cauldron = await getActiveCauldron()
+    const bundleStoreConfig = await cauldron.getBundleStoreConfig()
+    if (!bundleStoreConfig || !bundleStoreConfig.url) {
       throw new Error(
-        `bundlestore-host is not set in configuration\n${extraErrorMessage}`
+        `bundleStore url not set in Cauldron\n${extraErrorMessage}`
       )
     }
   }

--- a/ern-orchestrator/src/constants.ts
+++ b/ern-orchestrator/src/constants.ts
@@ -61,9 +61,4 @@ export const availableUserConfigKeys = [
     name: 'ignore-required-ern-version',
     values: [true, false],
   },
-  {
-    desc: 'Bundle Store server host',
-    name: 'bundlestore-host',
-    values: ['string'],
-  },
 ]


### PR DESCRIPTION
Keep bundle store server host info in Cauldron rather than locally (as done for sourcemap and binary store). This way, users won't have to manually set the bundle store host locally on their workstation in order to use it, but will automatically have access to the bundle store server associated to the cauldron they are currently connected to.