### PR TITLE
Improve performance of start command

### DIFF
--- a/ern-orchestrator/package.json
+++ b/ern-orchestrator/package.json
@@ -71,6 +71,7 @@
     "fs-readdir-recursive": "^1.1.0",
     "kax":"^2.0.1",
     "lodash": "^4.17.14",
+    "ncp": "^2.0.0",
     "semver": "^5.5.0",
     "treeify": "^1.1.0",
     "validate-npm-package-name": "^3.0.0",

--- a/ern-orchestrator/test/start-test.ts
+++ b/ern-orchestrator/test/start-test.ts
@@ -14,6 +14,7 @@ import * as cauldronApi from 'ern-cauldron-api'
 import * as compositeGen from 'ern-composite-gen'
 import fs from 'fs'
 import path from 'path'
+import ncp from 'ncp'
 const sandbox = sinon.createSandbox()
 
 function cloneFixture(fixture) {
@@ -68,6 +69,7 @@ describe('start', () => {
     sandbox.stub(core, 'createTmpDir').returns('/tmp/dir')
     sandbox.stub(process.stdin, 'resume')
     sandbox.stub(fs, 'existsSync').returns(true)
+    sandbox.stub(ncp, 'ncp').callsFake((source, dest, options, cb) => cb())
   })
 
   function createStubs({
@@ -176,7 +178,7 @@ describe('start', () => {
     sandbox.assert.calledWith(chokidarWatchStub, '/path/to/myMiniApp', {
       cwd: '/path/to/myMiniApp',
       ignoreInitial: true,
-      ignored: ['android/**', 'ios/**'],
+      ignored: ['android/**', 'ios/**', 'node_modules/**', '.git/**'],
       persistent: true,
     })
   })


### PR DESCRIPTION
- Remove MiniApps `node_modules` from file watch (big CPU gain, less resource consumption).
- Only copy MiniApps non hoisted `node_modules` rather than the whole `node_modules` directory (big speed up on copy operation).
