### PR TITLE
Fail start command if metro server is already running

### DIFF
--- a/ern-local-cli/src/commands/start.ts
+++ b/ern-local-cli/src/commands/start.ts
@@ -8,6 +8,7 @@ import _ from 'lodash'
 import { PackagePath, AppVersionDescriptor } from 'ern-core'
 import { Argv } from 'yargs'
 import untildify from 'untildify'
+import { logErrorAndExitIfNotSatisfied } from '../lib'
 
 export const command = 'start'
 export const desc = 'Start a composite MiniApp'
@@ -123,6 +124,14 @@ export const commandHandler = async ({
   watchNodeModules?: string[]
   disableBinaryStore?: boolean
 } = {}) => {
+  await logErrorAndExitIfNotSatisfied({
+    metroServerIsNotRunning: {
+      extraErrorMessage: `You should kill the current server before running this command.`,
+      host: host || 'localhost',
+      port: port || '8081',
+    },
+  })
+
   if (!miniapps && !descriptor) {
     descriptor = await askUserToChooseANapDescriptorFromCauldron()
   }

--- a/ern-local-cli/src/lib/logErrorAndExitIfNotSatisfied.ts
+++ b/ern-local-cli/src/lib/logErrorAndExitIfNotSatisfied.ts
@@ -39,6 +39,7 @@ export async function logErrorAndExitIfNotSatisfied({
   manifestIdExists,
   bundleStoreUrlSetInCauldron,
   bundleStoreAccessKeyIsSet,
+  metroServerIsNotRunning,
 }: {
   noGitOrFilesystemPath?: {
     obj: string | PackagePath | Array<string | PackagePath> | void
@@ -164,6 +165,11 @@ export async function logErrorAndExitIfNotSatisfied({
     extraErrorMessage?: string
   }
   bundleStoreAccessKeyIsSet?: {
+    extraErrorMessage?: string
+  }
+  metroServerIsNotRunning?: {
+    host: string
+    port: string
     extraErrorMessage?: string
   }
 } = {}) {
@@ -440,6 +446,15 @@ export async function logErrorAndExitIfNotSatisfied({
       )
       await Ensure.bundleStoreAccessKeyIsSet(
         bundleStoreAccessKeyIsSet.extraErrorMessage
+      )
+      kaxTask.succeed()
+    }
+    if (metroServerIsNotRunning) {
+      kaxTask = kax.task(`Ensuring that metro server is not running`)
+      await Ensure.metroServerIsNotRunning(
+        metroServerIsNotRunning.host,
+        metroServerIsNotRunning.port,
+        metroServerIsNotRunning.extraErrorMessage
       )
       kaxTask.succeed()
     }

--- a/ern-orchestrator/package.json
+++ b/ern-orchestrator/package.json
@@ -73,6 +73,7 @@
     "lodash": "^4.17.14",
     "ncp": "^2.0.0",
     "semver": "^5.5.0",
+    "superagent":"^5.1.0",
     "treeify": "^1.1.0",
     "validate-npm-package-name": "^3.0.0",
     "yargs": "^7.1.0"

--- a/ern-orchestrator/src/Ensure.ts
+++ b/ern-orchestrator/src/Ensure.ts
@@ -17,6 +17,8 @@ import fs from 'fs'
 import levenshtein from 'fast-levenshtein'
 import * as constants from './constants'
 import treeify from 'treeify'
+import superagent from 'superagent'
+
 export default class Ensure {
   public static isValidElectrodeNativeModuleName(
     name: string,
@@ -575,5 +577,22 @@ export default class Ensure {
         `bundlestore-accesskey is not set in configuration\n${extraErrorMessage}`
       )
     }
+  }
+
+  public static async metroServerIsNotRunning(
+    host: string,
+    port: string,
+    extraErrorMessage?: string
+  ) {
+    const metroServerUrl = `http://${host}:${port}`
+
+    try {
+      await superagent.get(metroServerUrl)
+    } catch (err) {
+      return
+    }
+    throw new Error(
+      `Metro server is running on ${metroServerUrl}\n${extraErrorMessage}`
+    )
   }
 }


### PR DESCRIPTION
Check if a metro server is already running on target host/port before proceeding with `start` command execution, and fail the command immediately if a server is already running.

The `start` command can take quite a while to run, especially with many MiniApps, and it only used to log a warning at the end of command run in case a packager was already running, which is quite painful because for this command there is no point in having a packager already running, so it usually meant killing the packager and running the command again :(