### PR TITLE
Fix android native api implementation config

### DIFF
--- a/ern-container-gen-android/src/AndroidGenerator.ts
+++ b/ern-container-gen-android/src/AndroidGenerator.ts
@@ -89,7 +89,10 @@ export default class AndroidGenerator implements ContainerGenerator {
       throw new Error('react-native plugin does not have a version !')
     }
 
-    let mustacheView: any = {}
+    let mustacheView: any = {
+      customRepos: [],
+      permissions: [],
+    }
     injectReactNativeVersionKeysInObject(
       mustacheView,
       reactNativePlugin.version
@@ -257,11 +260,25 @@ export default class AndroidGenerator implements ContainerGenerator {
               }
             }
           }
+
+          if (pluginConfig.android.repositories) {
+            mustacheView.customRepos.push(...pluginConfig.android.repositories)
+          }
+
+          if (pluginConfig.android.permissions) {
+            mustacheView.customPermissions.push(
+              ...pluginConfig.android.permissions
+            )
+          }
         }
       } finally {
         shell.popd()
       }
     }
+
+    // Dedupe repositories and permissions
+    mustacheView.customRepos = _.uniq(mustacheView.customRepos)
+    mustacheView.customPermissions = _.uniq(mustacheView.customPermissions)
 
     dependencies.regular.push(
       `com.walmartlabs.ern:react-native:${reactNativePlugin.version}`

--- a/ern-container-gen-android/src/hull/build.gradle
+++ b/ern-container-gen-android/src/hull/build.gradle
@@ -19,11 +19,9 @@ allprojects {
         jcenter()
         mavenCentral()
         maven { url 'https://jitpack.io' }
-       {{#plugins}}
        {{#customRepos}}
        {{{.}}}
        {{/customRepos}}
-       {{/plugins}}
     }
 
     tasks.withType(JavaCompile) {

--- a/ern-container-gen-android/src/hull/lib/src/main/AndroidManifest.xml
+++ b/ern-container-gen-android/src/hull/lib/src/main/AndroidManifest.xml
@@ -2,11 +2,9 @@
     package="com.walmartlabs.ern.container">
    <uses-permission android:name="android.permission.INTERNET" />
    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
-   {{#plugins}}
    {{#customPermissions}}
    <uses-permission android:name="{{{.}}}" />
    {{/customPermissions}}
-   {{/plugins}}
     <application>
       {{#miniApps}}
        <activity android:name="com.walmartlabs.ern.container.miniapps.{{{pascalCaseName}}}Activity"

--- a/ern-container-gen/src/generatePluginsMustacheViews.ts
+++ b/ern-container-gen/src/generatePluginsMustacheViews.ts
@@ -38,16 +38,6 @@ export async function generatePluginsMustacheViews(
       pluginView.configurable = pluginHook.configurable
     }
 
-    pluginView.customRepos = []
-    if (pluginConfig.android && pluginConfig.android.repositories) {
-      pluginView.customRepos.push(...pluginConfig.android.repositories)
-    }
-
-    pluginView.customPermissions = []
-    if (pluginConfig.android && pluginConfig.android.permissions) {
-      pluginView.customPermissions.push(...pluginConfig.android.permissions)
-    }
-
     if (containerHeader) {
       pluginView.containerHeader = containerHeader
     }


### PR DESCRIPTION
Fix issue with custom Android permissions and repositories configured in native api implementation package.json, not being injected in the generated Container.

Fixed through a quick small refactoring, centralizing plugin configuration inject in AndroidGenerator but also taking care of deduping repositories/permissions which was not done previously (small cherry on the cake in addition to the fix ;)).