### PR TITLE
Fix runner backcompatibility

### DIFF
--- a/ern-orchestrator/test/runMiniApp-test.ts
+++ b/ern-orchestrator/test/runMiniApp-test.ts
@@ -100,7 +100,11 @@ describe('runMiniApp', () => {
     existsSyncReturn?: boolean
     miniAppExistInPath?: boolean
   } = {}) {
-    sandbox.stub(fs, 'existsSync').returns(existsSyncReturn)
+    sandbox
+      .stub(fs, 'existsSync')
+      .callsFake(p =>
+        p.toString().endsWith('RunnerConfig.java') ? false : existsSyncReturn
+      )
     sandbox.stub(core.MiniApp, 'existInPath').returns(miniAppExistInPath)
   }
 


### PR DESCRIPTION
This is to fix an issue when the previously generated miniapps tries to execute `ern run-android` command, the container name was not reflecting the one in `build.gradle` causing a build failure. 