### PR TITLE
Fix an issue with start command for linked MiniApps

### DIFF
--- a/ern-composite-gen/package.json
+++ b/ern-composite-gen/package.json
@@ -47,6 +47,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "ern-core": "1000.0.0",
+    "fs-extra": "^8.1.0",
     "fs-readdir-recursive": "^1.1.0",
     "mustache": "^2.3.1",
     "uuid": "^3.3.2",

--- a/ern-composite-gen/src/cleanupCompositeDir.ts
+++ b/ern-composite-gen/src/cleanupCompositeDir.ts
@@ -1,17 +1,18 @@
-import { shell } from 'ern-core'
+import fs from 'fs-extra'
 import path from 'path'
 
-export function cleanupCompositeDir(dir: string) {
-  shell.rm(
-    '-rf',
-    [
-      '.babelrc',
-      'index.android.js',
-      'index.ios.js',
-      'index.js',
-      'node_modules',
-      'package.json',
-      'yarn.lock',
-    ].map(file => path.join(dir, file))
-  )
+export async function cleanupCompositeDir(dir: string) {
+  const filesAndDirsToRemove = [
+    '.babelrc',
+    'index.android.js',
+    'index.ios.js',
+    'index.js',
+    'node_modules',
+    'package.json',
+    'yarn.lock',
+  ].map(p => path.join(dir, p))
+
+  for (const p of filesAndDirsToRemove) {
+    await fs.remove(p)
+  }
 }

--- a/ern-composite-gen/src/generateComposite.ts
+++ b/ern-composite-gen/src/generateComposite.ts
@@ -113,7 +113,9 @@ async function generateFullComposite(
   } = {}
 ) {
   if (fs.existsSync(outDir)) {
-    cleanupCompositeDir(outDir)
+    await kax
+      .task('Cleaning up existing composite directory')
+      .run(cleanupCompositeDir(outDir))
   } else {
     shell.mkdir('-p', outDir)
   }

--- a/ern-orchestrator/package.json
+++ b/ern-orchestrator/package.json
@@ -68,6 +68,7 @@
     "ern-runner-gen-android": "1000.0.0",
     "ern-runner-gen-ios": "1000.0.0",
     "fast-levenshtein": "^2.0.6",
+    "fs-extra": "^8.1.0",
     "fs-readdir-recursive": "^1.1.0",
     "kax":"^2.0.1",
     "lodash": "^4.17.14",

--- a/ern-orchestrator/test/start-test.ts
+++ b/ern-orchestrator/test/start-test.ts
@@ -12,7 +12,7 @@ import {
 } from 'ern-cauldron-api'
 import * as cauldronApi from 'ern-cauldron-api'
 import * as compositeGen from 'ern-composite-gen'
-import fs from 'fs'
+import fs from 'fs-extra'
 import path from 'path'
 import ncp from 'ncp'
 const sandbox = sinon.createSandbox()

--- a/yarn.lock
+++ b/yarn.lock
@@ -3421,6 +3421,15 @@ fs-extra@^7.0.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-minipass@^1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.6.tgz#2c5cc30ded81282bfe8a0d7c7c1853ddeb102c07"
@@ -3772,7 +3781,7 @@ got@^6.7.1:
     unzip-response "^2.0.1"
     url-parse-lax "^1.0.0"
 
-graceful-fs@^4.1.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.2.2:
+graceful-fs@^4.1.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
   integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==


### PR DESCRIPTION
Only copying non hoisted packages of MiniApp(s) over to composite rather than the whole node_modules directory of the MiniApp was a mistake, as it could result in some missing packages at runtime under certain contexts.

This PR goes back to the old way (pre 0.38.0) of copying the whole node_modules directory of linked MiniApp(s) to the composite, fixing the issue (at the cost of start command taking longer to run). Also includes a quick refactoring and adding more logs (spinner) improving UX of the command.