### PR TITLE
Fix issue with ern start directories exclusion

### DIFF
--- a/ern-orchestrator/src/start.ts
+++ b/ern-orchestrator/src/start.ts
@@ -238,10 +238,11 @@ async function replacePackageInCompositeWithLinkedPackage(
     'node_modules/react-native',
     'node_modules/react',
     'node_modules/react-native-electrode-bridge',
+    '.git',
   ].map(f => path.join(sourceLinkDir, f))
 
   const excludedDirectoriesRE = new RegExp(
-    `^((?!${excludedDirectories.join('|')}).*)`
+    `^((?!${excludedDirectories.map(f => `${f}$`).join('|')}).*)`
   )
 
   // Trash the package in the composite directory, and recreate it with current


### PR DESCRIPTION
Fix an issue with `start` command impacting some users. 

This issue causes metro packager to fail with `Unable to resolve module` error when using `start` with linked MiniApps, under some circumstances.

Root cause of the issue is that some directories of linked MiniApps that should be copied over to the composite, are not properly copied over due to an invalid directory exclusion filtering regex.

This PR fixes the issue by fixing the invalid regex. Previous regex would incorrectly lead to excluding some directories such as `[...]node_modules/react-native-foo-bar/` because it was matching the `node_modules/react-native` regex. 

At the same time, this PR also add the `.git` directory to the directory exclusion list as it is not necessary to copy it over to the composite (also improving runtime of the `start` command, as git repositories directories can get quite big).