### PR TITLE
Fix fonts assets copy for react native projects

### DIFF
--- a/ern-container-gen/src/copyRnConfigAssets.ts
+++ b/ern-container-gen/src/copyRnConfigAssets.ts
@@ -2,7 +2,6 @@ import {
   handleCopyDirective,
   NativePlatform,
   findDirectoriesHavingRnConfig,
-  shell,
 } from 'ern-core'
 import { getAssetsPath } from './getAssetsPath'
 import readDir from 'fs-readdir-recursive'
@@ -14,6 +13,11 @@ export const supportedAssetsExts = ['.ttf', '.otf']
  * Copy in Container, the assets of all packages found in Composite,
  * that are exporting assets through react-native.config.js.
  * Similar to React Native, only fonts (.ttf/.otf) are supported for now.
+ * This will copy the font assets of all packages that are either
+ * dependencies:
+ * https://github.com/react-native-community/cli/blob/master/docs/dependencies.md
+ * or projects:
+ * https://github.com/react-native-community/cli/blob/master/docs/projects.md
  */
 export async function copyRnConfigAssets({
   compositePath,
@@ -28,8 +32,10 @@ export async function copyRnConfigAssets({
 
   for (const dir of dirs) {
     const rnConfig: any = require(path.join(dir, 'react-native.config.js'))
-    if (rnConfig.dependency && rnConfig.dependency.assets) {
-      for (const assetDir of rnConfig.dependency.assets) {
+    const assets =
+      rnConfig.assets || (rnConfig.dependency && rnConfig.dependency.assets)
+    if (assets) {
+      for (const assetDir of assets) {
         const absDir = path.join(dir, assetDir)
         readDir(absDir)
           .filter(p => {

--- a/ern-container-gen/test/copyRnConfigAssets-test.ts
+++ b/ern-container-gen/test/copyRnConfigAssets-test.ts
@@ -1,11 +1,11 @@
 import { copyRnConfigAssets } from '../src/copyRnConfigAssets'
-import { BaseMiniApp, createTmpDir, PackagePath } from 'ern-core'
+import { createTmpDir } from 'ern-core'
 import { assert } from 'chai'
 import fs from 'fs'
 import path from 'path'
 
 describe('copyRnConfigAssets', () => {
-  it('should copy assets to output directory [android]', async () => {
+  it('should copy dependencies assets to output directory [android]', async () => {
     const compositePath = path.join(
       __dirname,
       'fixtures',
@@ -25,7 +25,7 @@ describe('copyRnConfigAssets', () => {
     )
   })
 
-  it('should copy assets to output directory [ios]', async () => {
+  it('should copy dependencies assets to output directory [ios]', async () => {
     const compositePath = path.join(
       __dirname,
       'fixtures',
@@ -41,6 +41,36 @@ describe('copyRnConfigAssets', () => {
     assert(
       fs.existsSync(
         path.normalize(`${outDir}/ElectrodeContainer/Resources/fakefont2.ttf`)
+      )
+    )
+  })
+
+  it('should copy project assets to output directory [android]', async () => {
+    const compositePath = path.join(
+      __dirname,
+      'fixtures',
+      'CompositeWithRnConfigs'
+    )
+    const outDir = createTmpDir()
+    await copyRnConfigAssets({ compositePath, outDir, platform: 'android' })
+    assert(
+      fs.existsSync(
+        path.normalize(`${outDir}/lib/src/main/assets/fonts/fakefont3.ttf`)
+      )
+    )
+  })
+
+  it('should copy project assets to output directory [ios]', async () => {
+    const compositePath = path.join(
+      __dirname,
+      'fixtures',
+      'CompositeWithRnConfigs'
+    )
+    const outDir = createTmpDir()
+    await copyRnConfigAssets({ compositePath, outDir, platform: 'ios' })
+    assert(
+      fs.existsSync(
+        path.normalize(`${outDir}/ElectrodeContainer/Resources/fakefont3.ttf`)
       )
     )
   })

--- a/ern-container-gen/test/fixtures/CompositeWithRnConfigs/modules/package-d/fonts/fakefont3.ttf
+++ b/ern-container-gen/test/fixtures/CompositeWithRnConfigs/modules/package-d/fonts/fakefont3.ttf
@@ -1,0 +1,1 @@
+fakefont3.ttf

--- a/ern-container-gen/test/fixtures/CompositeWithRnConfigs/modules/package-d/react-native.config.js
+++ b/ern-container-gen/test/fixtures/CompositeWithRnConfigs/modules/package-d/react-native.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  assets: ['./fonts'],
+}


### PR DESCRIPTION
Container generator only copies font assets declared through `react-native.config.js` of [dependencies](https://github.com/react-native-community/cli/blob/master/docs/dependencies.md) packages types, but was not accounting for any font assets declared in `react-native.config.js` of [project](https://github.com/react-native-community/cli/blob/master/docs/dependencies.md) package types (for example MiniApps themselves).

Fixes https://github.com/electrode-io/electrode-native/issues/1348