### PR TITLE
Rename octokit deprecated parameter

### DIFF
--- a/ern-core/src/GitHubApi.ts
+++ b/ern-core/src/GitHubApi.ts
@@ -236,10 +236,8 @@ export class GitHubApi {
     }
 
     const res = await this.octokit.repos.getCommit({
-      commit_sha: ofBranch
-        ? this.fullBranchRef(ofBranch!)
-        : this.fullTagRef(ofTag!),
       owner: this.owner,
+      ref: ofBranch ? this.fullBranchRef(ofBranch!) : this.fullTagRef(ofTag!),
       repo: this.repo,
     })
 


### PR DESCRIPTION
Rename `commit_sha` to `ref`, addressing the following runtime warn log :

```
Deprecation: [@octokit/rest] "commit_sha" parameter is deprecated for ".repos.getCommit()". 
Use "ref" instead
```