### PR TITLE
Replace link and unlink commands with new ones

### DIFF
--- a/docs/cli/link.md
+++ b/docs/cli/link.md
@@ -1,5 +1,8 @@
 ## `ern link`
 
+**This command has been deprecated and will be removed in 0.41.0 release**  
+**Please consider using [ern link add] command instead**
+
 #### Description
 
 * Link to a specified MiniApp directory  
@@ -36,3 +39,4 @@ The `ern link` or the `ern unlink` plus the `ern start` commands are used togeth
  
  [ern start]: ./start.md
  [ern unlink]: ./unlink.md
+ [ern link add]: ./link/add.md

--- a/docs/cli/link/add.md
+++ b/docs/cli/link/add.md
@@ -1,0 +1,38 @@
+## `ern link add`
+
+#### Description
+
+* Add a link to a specified MiniApp directory  
+
+The `ern link add` command is helpful during development of your MiniApps as a way to develop and debug your application. The command is also helpful as a way to use the react-native hot reload feature for your MiniApps when the command is run inside a host application along with other MiniApps.   
+
+The `ern link` add command was developed to help with developing and debugging MiniApps when running them inside a target native host application. This benefit is realized in the following scenario: When you run multiple MiniApps together in the native application, you cannot use the `react-native start` command from within your MiniApp directory and load the bundle from the local react-native packager as you would normally do when running your MiniApp standalone in the runner.
+
+Using the local packager for your MiniApp makes the native application fail whenever it attempts to load another MiniApp—due to the fact that it doesn't find the other MiniApps in your own MiniApp bundle served through the local packager. And, if running a single MiniApp, the react-native packager does not function well with symbolic links.
+
+In response to this scenario, you can use the `ern link add` command to help with developing and debugging MiniApps when running them inside a target native host application.
+
+The `ern link add` or the `ern link rm` plus the `ern start` commands are used together to achieve this.
+
+#### Syntax
+
+`ern link add`  
+
+#### Caveats
+
+1) If you add a JavaScript dependency to your MiniApp (through `ern add`) or update a JavaScript dependency version, you'll have to relaunch the `ern start` command.
+
+#### Remarks
+
+* This command must be executed within a MiniApp working directory.  
+* Any changes to the code of the MiniApp, inside its working directory, are available in the native host application through a manual react-native reload of the MiniApp or through the live/hot reload feature of react-native.  
+* After running the `ern link add` command, the link to the MiniApp directory remains in effect until you unlink it using the `ern link rm` command.  
+* The MiniApps link is used when you use the `ern start` command. This command creates a composite bundle with all the MiniApps contained within the native application and starts the react-native packager for this bundle.
+
+#### Related commands
+
+[ern start] | Start the Electrode Native platform  
+[ern link rm] | Remove the link associated to a MiniApp directory
+
+[ern start]: ../start.md
+[ern link rm]: ./rm.md

--- a/docs/cli/link/rm.md
+++ b/docs/cli/link/rm.md
@@ -1,7 +1,4 @@
-## `ern unlink`
-
-**This command has been deprecated and will be removed in 0.41.0 release**  
-**Please consider using [ern link rm] command instead**
+## `ern link rm`
 
 #### Description
 
@@ -9,7 +6,7 @@
 
 #### Syntax
 
-`ern unlink`
+`ern link rm`
 
 #### Remarks
 
@@ -18,7 +15,6 @@
 
 #### Related commands
 
-[ern link] | Link to a MiniApp directory
+[ern link add] | Add a link to a MiniApp directory
 
-[ern link]: ./link.md
-[ern link rm]: ./link/rm.md
+[ern link add]: ./add.md

--- a/docs/cli/start.md
+++ b/docs/cli/start.md
@@ -98,12 +98,12 @@ If you do not pass an argument to this command, you are prompted to select a nat
 
 * This command can be used to package multiple MiniApps inside a single composite bundle and automatically start the react-native local packager to serve this bundle.  
 * Use this command when you need to launch and develop or debug your MiniApps from within a native host application which contains other MiniApps along with your MiniApp.  
-* This command works with the `ern link` command. For additional information, see the documentation for the `ern link` command.  
+* This command works with the `ern link add` command. For additional information, see the documentation for the `ern link add` command.  
 * When using a binary store, file watcher will be started after the binary is retrieved and installed on the simulator/device. If you are using a binary store and don't want to launch binary from the store, please make sure to use the `--disableBinaryStore` option. Otherwise, file watcher will not be started.
 
 #### Related commands
 
- [ern link] | Link to a MiniApp directory
+[ern link add] | Add a Link to a MiniApp directory
 
-[ern link]: ./link.md
+[ern link add]: ./link/add.md
 [custom Composite]: ./platform-parts/composite/index.md

--- a/docs/guides/multi-miniapps-debug.md
+++ b/docs/guides/multi-miniapps-debug.md
@@ -33,10 +33,10 @@ ern-workspace
 └── MiniAppC
 ```
 
-- `ern link` each of the MiniApps
+- `ern link add` each of the MiniApps
 
 This is needed for proper mapping of source location between the composite and the MiniApp directory, but also to ensure that any changes to the MiniApp directory are properly propagated to the Composite.
-We will just `cd` into our `MiniAppA` and `MiniAppC` directories and run `ern link` command from each of them.
+We will just `cd` into our `MiniAppA` and `MiniAppC` directories and run `ern link add` command from each of them.
 
 - Create a node project in this directory, and add `react-native` dependency to it
 
@@ -110,7 +110,7 @@ ern-workspace
 └── yarn.lock
 ```
 
-The basic setup is now complete. If you need to add more MiniApps over time, just clone any additional MiniApps in the `ern-workspace` directory and make sure to `ern link` the new MiniApp and add a corresponding mapping entry to `sourceMapPathOverrides` configuration.
+The basic setup is now complete. If you need to add more MiniApps over time, just clone any additional MiniApps in the `ern-workspace` directory and make sure to `ern link add` the new MiniApp and add a corresponding mapping entry to `sourceMapPathOverrides` configuration.
 
 We can now start debugging with the help of the [ern start] command.
 

--- a/docs/overview/ern-workflow.md
+++ b/docs/overview/ern-workflow.md
@@ -36,7 +36,7 @@ If you are a MiniApp developer who just wants to open source a MiniApp to be use
 
 **Note** If you are creating MiniApps for a single target mobile application or a very limited set of mobile applications (for example, if you are not creating an open source MiniApp such as only to be used for your company or private mobile applications), your workflow might involve the following:  
 
-- Launch, Debug, Test your MiniApp within the target mobile applications and not on its own in the platform runner. Since your MiniApp may co-exist with other MiniApps in the same mobile application, you will use the Electrode Native `ern link` and/or `ern unlink` and the `ern start` commands to help you in this use case. We don't have built-in support yet to easily launch MiniApps in a target mobile application, but we're looking into it and might be released soon.
+- Launch, Debug, Test your MiniApp within the target mobile applications and not on its own in the platform runner. Since your MiniApp may co-exist with other MiniApps in the same mobile application, you will use the Electrode Native `ern link add` and/or `ern link rm` and the `ern start` commands to help you in this use case. We don't have built-in support yet to easily launch MiniApps in a target mobile application, but we're looking into it and might be released soon.
 
 ### Stage 2: Add or Update MiniApps
 

--- a/ern-local-cli/src/commands/link.ts
+++ b/ern-local-cli/src/commands/link.ts
@@ -1,4 +1,4 @@
-import { MiniApp } from 'ern-core'
+import { log, MiniApp } from 'ern-core'
 import { epilog, tryCatchWrap } from '../lib'
 import { Argv } from 'yargs'
 
@@ -6,10 +6,17 @@ export const command = 'link'
 export const desc = 'Link a MiniApp'
 
 export const builder = (argv: Argv) => {
-  return argv.epilog(epilog(exports))
+  return argv
+    .commandDir('link', {
+      extensions: process.env.ERN_ENV === 'development' ? ['js', 'ts'] : ['js'],
+    })
+    .epilog(epilog(exports))
 }
 
+// COMMAND TO BE REMOVED IN 0.41.0
 export const commandHandler = async () => {
+  log.warn(`This command has been deprecated and will be removed in 0.41.0 release.
+Please consider using 'ern link add' command instead.`)
   await MiniApp.fromCurrentPath().link()
 }
 

--- a/ern-local-cli/src/commands/link/add.ts
+++ b/ern-local-cli/src/commands/link/add.ts
@@ -1,0 +1,15 @@
+import { MiniApp } from 'ern-core'
+import { epilog, tryCatchWrap } from '../../lib'
+import { Argv } from 'yargs'
+
+export const command = 'add'
+export const desc = 'Add a MiniApp link'
+
+export const builder = (argv: Argv) => {
+  return argv.epilog(epilog(exports))
+}
+export const commandHandler = async () => {
+  await MiniApp.fromCurrentPath().link()
+}
+
+export const handler = tryCatchWrap(commandHandler)

--- a/ern-local-cli/src/commands/link/rm.ts
+++ b/ern-local-cli/src/commands/link/rm.ts
@@ -1,0 +1,16 @@
+import { MiniApp } from 'ern-core'
+import { epilog, tryCatchWrap } from '../../lib'
+import { Argv } from 'yargs'
+
+export const command = 'rm'
+export const desc = 'Remove a MiniApp link'
+
+export const builder = (argv: Argv) => {
+  return argv.epilog(epilog(exports))
+}
+
+export const commandHandler = async () => {
+  MiniApp.fromCurrentPath().unlink()
+}
+
+export const handler = tryCatchWrap(commandHandler)

--- a/ern-local-cli/src/commands/unlink.ts
+++ b/ern-local-cli/src/commands/unlink.ts
@@ -1,4 +1,5 @@
-import { MiniApp } from 'ern-core'
+// TO BE REMOVED IN 0.41.0
+import { log, MiniApp } from 'ern-core'
 import { epilog, tryCatchWrap } from '../lib'
 import { Argv } from 'yargs'
 
@@ -10,6 +11,8 @@ export const builder = (argv: Argv) => {
 }
 
 export const commandHandler = async () => {
+  log.warn(`This command has been deprecated and will be removed in 0.41.0 release.
+Please consider using 'ern link rm' command instead.`)
   MiniApp.fromCurrentPath().unlink()
 }
 


### PR DESCRIPTION
Deprecate `ern link` and `ern unlink` commands and replace them with new `ern link add` / `ern link rm` subcommands.

These new commands are functionally equivalent to the deprecated ones. 

Done as a first step to extend `ern link` with additional features (planned for 0.39 release), which will involve the introduction of new `ern link` subcommands. In that context, grouping all `link` related commands is meaningful and much needed.