### PR TITLE
Remove path restrictions from batch command

### DIFF
--- a/ern-local-cli/src/commands/cauldron/batch.ts
+++ b/ern-local-cli/src/commands/cauldron/batch.ts
@@ -110,16 +110,6 @@ export const commandHandler = async ({
       extraErrorMessage:
         'This command cannot work on a non existing native application version',
     },
-    noGitOrFilesystemPath: {
-      extraErrorMessage:
-        'You cannot provide dependency(ies) or MiniApp(s) using git or file scheme for this command. Only the form name@version is allowed.',
-      obj: [...addMiniapps, ...delMiniapps, ...updateMiniapps],
-    },
-    publishedToNpm: {
-      extraErrorMessage:
-        'You can only add or update dependency(ies) or MiniApp(s) wtih version(s) that have been published to NPM',
-      obj: [...addMiniapps, ...updateMiniapps],
-    },
   })
 
   const cauldronCommitMessage = [


### PR DESCRIPTION
Had to use `batch` command and had bad surprise that it was not supporting git based MiniApps.

Looks like we missed updating the command when we added git/fs support to other cauldron access commands. This PR fixes this issue by removing the restrictions.
