### PR TITLE
ability to pass compileOptions via android config

### DIFF
--- a/docs/cli/create-container.md
+++ b/docs/cli/create-container.md
@@ -52,7 +52,7 @@
 * Optional extra configuration specific to creating container
 * Override the android build config during container generation by passing `androidConfig` attributes
   - **As a json string**  
-  For example `--extra '{"androidConfig": {"androidGradlePlugin": "3.2.1","buildToolsVersion": "28.0.3","compileSdkVersion": "28","gradleDistributionVersion": "4.6","minSdkVersion": "19","supportLibraryVersion": "28.0.0","targetSdkVersion": "28"}}'`    
+  For example `--extra '{"androidConfig": {"androidGradlePlugin": "3.2.1","buildToolsVersion": "28.0.3","compileSdkVersion": "28","gradleDistributionVersion": "4.6","minSdkVersion": "19","sourceCompatibility": "VERSION_1_8","supportLibraryVersion": "28.0.0","targetCompatibility": "VERSION_1_8","targetSdkVersion": "28"}}'`    
   - **As a file path**  
   For example `--extra /Users/username/my-container-config.json`  
   In that case, the configuration will be read from the file.  

--- a/docs/cli/run-android.md
+++ b/docs/cli/run-android.md
@@ -23,7 +23,7 @@
 * Optional extra configuration specific to local container and runner
 * Override the android build config during local container generation and runner project by passing `androidConfig` attributes
   - **As a json string**  
-  For example `--extra '{"androidConfig": {"androidGradlePlugin": "3.2.1","buildToolsVersion": "28.0.3","compileSdkVersion": "28","gradleDistributionVersion": "4.6","minSdkVersion": "19","supportLibraryVersion": "28.0.0","targetSdkVersion": "28"}}'`    
+  For example `--extra '{"androidConfig": {"androidGradlePlugin": "3.2.1","buildToolsVersion": "28.0.3","compileSdkVersion": "28","gradleDistributionVersion": "4.6","minSdkVersion": "19","sourceCompatibility": "VERSION_1_8","supportLibraryVersion": "28.0.0","targetCompatibility": "VERSION_1_8","targetSdkVersion": "28"}}'`    
   - **As a file path**  
   For example `--extra /Users/username/my-container-config.json`  
   In that case, the configuration will be read from the file.  

--- a/docs/platform-parts/container/container-integration.md
+++ b/docs/platform-parts/container/container-integration.md
@@ -112,6 +112,10 @@ The following android build parameters can be configured with application specif
 
 - `minSdkVersion` - The minimum API level that the application targets.
 
+- `sourceCompatibility` - Defines which language version of Java your source files should be treated as. It can take a valid [Java Version](https://docs.gradle.org/current/javadoc/org/gradle/api/JavaVersion.html) 
+
+- `targetCompatibility` - Defines the minimum JVM version your code should run on, i.e. it determines the version of byte code the compiler generates. It can take a valid [Java Version](https://docs.gradle.org/current/javadoc/org/gradle/api/JavaVersion.html)
+
 - `targetSdkVersion` - The designated API Level that the application targets
 
   ```groovy

--- a/ern-api-impl-gen/hull/android/lib/build.gradle
+++ b/ern-api-impl-gen/hull/android/lib/build.gradle
@@ -16,7 +16,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-
+    compileOptions {
+        sourceCompatibility JavaVersion.{{{sourceCompatibility}}}
+        targetCompatibility JavaVersion.{{{targetCompatibility}}}
+    }
     lintOptions {
         abortOnError false
     }
@@ -24,14 +27,13 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+
+    implementation 'androidx.appcompat:appcompat:{{{androidxAppcompactVersion}}}'
+    implementation 'androidx.lifecycle:lifecycle-extensions:{{{androidxLifecycleExtrnsionsVersion}}}'
+    implementation 'com.walmartlabs.ern:react-native:{{{reactNativeVersion}}}'
+
     androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     testImplementation 'junit:junit:4.12'
-
-    implementation 'androidx.appcompat:appcompat:{{{androidxAppcompactVersion}}}'
-    implementation 'androidx.lifecycle:lifecycle-extensions:{{{androidxLifecycleExtrnsionsVersion}}}'
-
-
-    implementation 'com.walmartlabs.ern:react-native:{{{reactNativeVersion}}}'
 }

--- a/ern-container-gen-android/src/hull/lib/build.gradle
+++ b/ern-container-gen-android/src/hull/lib/build.gradle
@@ -25,6 +25,10 @@ android {
             minifyEnabled false
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.{{{sourceCompatibility}}}
+        targetCompatibility JavaVersion.{{{targetCompatibility}}}
+    }
     configurations.all {
         resolutionStrategy.force 'com.google.code.findbugs:jsr305:3.0.0'
     }

--- a/ern-core/src/android.ts
+++ b/ern-core/src/android.ts
@@ -20,6 +20,8 @@ export const DEFAULT_GRADLE_DISTRIBUTION_VERSION = '5.4.1'
 export const DEFAULT_MIN_SDK_VERSION = '19'
 export const DEFAULT_SUPPORT_LIBRARY_VERSION = '28.0.0'
 export const DEFAULT_TARGET_SDK_VERSION = '28'
+export const DEFAULT_SOURCE_COMPATIBILITY = 'VERSION_1_8'
+export const DEFAULT_TARGET_COMPATIBILITY = 'VERSION_1_8'
 
 export interface AndroidResolvedVersions {
   androidGradlePlugin: string
@@ -29,7 +31,9 @@ export interface AndroidResolvedVersions {
   compileSdkVersion: string
   gradleDistributionVersion: string
   minSdkVersion: string
+  sourceCompatibility: string
   supportLibraryVersion: string
+  targetCompatibility: string
   targetSdkVersion: string
 }
 
@@ -41,7 +45,9 @@ export function resolveAndroidVersions({
   compileSdkVersion = DEFAULT_COMPILE_SDK_VERSION,
   gradleDistributionVersion = DEFAULT_GRADLE_DISTRIBUTION_VERSION,
   minSdkVersion = DEFAULT_MIN_SDK_VERSION,
+  sourceCompatibility = DEFAULT_SOURCE_COMPATIBILITY,
   supportLibraryVersion = DEFAULT_SUPPORT_LIBRARY_VERSION,
+  targetCompatibility = DEFAULT_TARGET_COMPATIBILITY,
   targetSdkVersion = DEFAULT_TARGET_SDK_VERSION,
 } = {}): AndroidResolvedVersions {
   return {
@@ -52,7 +58,9 @@ export function resolveAndroidVersions({
     compileSdkVersion,
     gradleDistributionVersion,
     minSdkVersion,
+    sourceCompatibility,
     supportLibraryVersion,
+    targetCompatibility,
     targetSdkVersion,
   }
 }

--- a/ern-core/test/android-test.ts
+++ b/ern-core/test/android-test.ts
@@ -240,7 +240,9 @@ describe('android.js', () => {
         compileSdkVersion: android.DEFAULT_COMPILE_SDK_VERSION,
         gradleDistributionVersion: android.DEFAULT_GRADLE_DISTRIBUTION_VERSION,
         minSdkVersion: android.DEFAULT_MIN_SDK_VERSION,
+        sourceCompatibility: android.DEFAULT_SOURCE_COMPATIBILITY,
         supportLibraryVersion: android.DEFAULT_SUPPORT_LIBRARY_VERSION,
+        targetCompatibility: android.DEFAULT_TARGET_COMPATIBILITY,
         targetSdkVersion: android.DEFAULT_TARGET_SDK_VERSION,
       })
     })
@@ -249,6 +251,8 @@ describe('android.js', () => {
       const versions = android.resolveAndroidVersions({
         androidGradlePlugin: '3.0.0',
         minSdkVersion: '15',
+        sourceCompatibility: 'VERSION_1_9',
+        targetCompatibility: 'VERSION_1_9',
       })
       expect(versions).deep.equal({
         androidGradlePlugin: '3.0.0',
@@ -259,7 +263,9 @@ describe('android.js', () => {
         compileSdkVersion: android.DEFAULT_COMPILE_SDK_VERSION,
         gradleDistributionVersion: android.DEFAULT_GRADLE_DISTRIBUTION_VERSION,
         minSdkVersion: '15',
+        sourceCompatibility: 'VERSION_1_9',
         supportLibraryVersion: android.DEFAULT_SUPPORT_LIBRARY_VERSION,
+        targetCompatibility: 'VERSION_1_9',
         targetSdkVersion: android.DEFAULT_TARGET_SDK_VERSION,
       })
     })
@@ -273,7 +279,9 @@ describe('android.js', () => {
         compileSdkVersion: '27',
         gradleDistributionVersion: '4.5',
         minSdkVersion: '15',
+        sourceCompatibility: 'VERSION_1_9',
         supportLibraryVersion: '27.0.0',
+        targetCompatibility: 'VERSION_1_9',
         targetSdkVersion: '27',
       })
       expect(versions).deep.equal({
@@ -284,7 +292,9 @@ describe('android.js', () => {
         compileSdkVersion: '27',
         gradleDistributionVersion: '4.5',
         minSdkVersion: '15',
+        sourceCompatibility: 'VERSION_1_9',
         supportLibraryVersion: '27.0.0',
+        targetCompatibility: 'VERSION_1_9',
         targetSdkVersion: '27',
       })
     })

--- a/ern-runner-gen-android/src/hull/app/build.gradle
+++ b/ern-runner-gen-android/src/hull/app/build.gradle
@@ -45,6 +45,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.{{{sourceCompatibility}}}
+        targetCompatibility JavaVersion.{{{targetCompatibility}}}
+    }
     // Need this to avoid build conflict with jsr version which comes with react-native
     configurations.all {
         resolutionStrategy.force 'com.google.code.findbugs:jsr305:3.0.0'

--- a/ern-runner-gen-android/test/fixtures/simple-android-runner/app/build.gradle
+++ b/ern-runner-gen-android/test/fixtures/simple-android-runner/app/build.gradle
@@ -35,6 +35,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
     // Need this to avoid build conflict with jsr version which comes with react-native
     configurations.all {
         resolutionStrategy.force 'com.google.code.findbugs:jsr305:3.0.0'

--- a/ern-runner-gen-android/test/fixtures/simple-android-runner/app/src/main/java/com/walmartlabs/ern/dummy/MainActivity.java
+++ b/ern-runner-gen-android/test/fixtures/simple-android-runner/app/src/main/java/com/walmartlabs/ern/dummy/MainActivity.java
@@ -1,0 +1,28 @@
+package com.walmartlabs.ern.dummy;
+
+import androidx.annotation.NonNull;
+
+import com.ern.api.impl.navigation.ElectrodeBaseActivity;
+
+// This is the main activity that gets launched upon app start
+// It just launches the activity containing the miniapp
+// Feel free to modify it at your convenience.
+
+public class MainActivity extends ElectrodeBaseActivity {
+
+    @NonNull
+    @Override
+    public String getRootComponentName() {
+        return "dummy";
+    }
+
+     @Override
+    protected int mainLayout() {
+        return R.layout.activity_main;
+    }
+
+    @Override
+    public int getFragmentContainerId() {
+        return R.id.fragment_container;
+    }
+}

--- a/ern-runner-gen-android/test/fixtures/simple-android-runner/app/src/main/java/com/walmartlabs/ern/dummy/MainApplication.java
+++ b/ern-runner-gen-android/test/fixtures/simple-android-runner/app/src/main/java/com/walmartlabs/ern/dummy/MainApplication.java
@@ -1,0 +1,20 @@
+package com.walmartlabs.ern.dummy;
+
+import android.app.Application;
+
+import com.walmartlabs.ern.container.ElectrodeReactContainer;
+import com.walmartlabs.ern.dummy.RunnerConfig;
+
+public class MainApplication extends Application {
+
+  @Override
+  public void onCreate() {
+    super.onCreate();
+
+    ElectrodeReactContainer.initialize(
+            this,
+            new ElectrodeReactContainer.Config().isReactNativeDeveloperSupport(RunnerConfig.RN_DEV_SUPPORT_ENABLED)
+            /* Add your additional plugins configuration here */);
+  }
+
+}

--- a/ern-runner-gen-android/test/fixtures/simple-android-runner/app/src/main/java/com/walmartlabs/ern/dummy/RunnerConfig.java
+++ b/ern-runner-gen-android/test/fixtures/simple-android-runner/app/src/main/java/com/walmartlabs/ern/dummy/RunnerConfig.java
@@ -1,0 +1,16 @@
+package com.walmartlabs.ern.dummy;
+
+//
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+// GENERATED RUNNER CONFIGURATION
+// DO NOT EDIT MANUALLY
+// CHANGES TO THIS FILE WILL BE OVERWRITTEN BY NEXT RUN OF ern run-android COMMAND
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+import com.walmartlabs.ern.container.miniapps.DummyActivity;
+final class RunnerConfig {
+  static final Class MAIN_MINIAPP_ACTIVITY_CLASS =  DummyActivity.class;
+  static final boolean RN_DEV_SUPPORT_ENABLED = false;
+  static final String PACKAGER_HOST = "localhost";
+  static final String PACKAGER_PORT = "8081";
+}

--- a/ern-runner-gen-android/test/regen-fixtures.ts
+++ b/ern-runner-gen-android/test/regen-fixtures.ts
@@ -14,6 +14,7 @@ getRunnerGeneratorForPlatform('android')
   .regenerateRunnerConfig({
     mainMiniAppName: 'dummy',
     outDir: pathToGeneratedFixtures,
+    reactNativeVersion: '0.60.5',
     targetPlatform: 'android',
   })
   .then(() => {

--- a/system-tests/fixtures/android-container/lib/build.gradle
+++ b/system-tests/fixtures/android-container/lib/build.gradle
@@ -25,6 +25,10 @@ android {
             minifyEnabled false
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
     configurations.all {
         resolutionStrategy.force 'com.google.code.findbugs:jsr305:3.0.0'
     }

--- a/system-tests/fixtures/api-impl-js/ReactNativeErnmovieApiImplJs/yarn.lock
+++ b/system-tests/fixtures/api-impl-js/ReactNativeErnmovieApiImplJs/yarn.lock
@@ -10,17 +10,17 @@
     "@babel/highlight" "^7.0.0"
 
 "@babel/core@^7.0.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.6.0.tgz#9b00f73554edd67bebc86df8303ef678be3d7b48"
-  integrity sha512-FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.6.4.tgz#6ebd9fe00925f6c3e177bb726a188b5f578088ff"
+  integrity sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==
   dependencies:
     "@babel/code-frame" "^7.5.5"
-    "@babel/generator" "^7.6.0"
-    "@babel/helpers" "^7.6.0"
-    "@babel/parser" "^7.6.0"
+    "@babel/generator" "^7.6.4"
+    "@babel/helpers" "^7.6.2"
+    "@babel/parser" "^7.6.4"
     "@babel/template" "^7.6.0"
-    "@babel/traverse" "^7.6.0"
-    "@babel/types" "^7.6.0"
+    "@babel/traverse" "^7.6.3"
+    "@babel/types" "^7.6.3"
     convert-source-map "^1.1.0"
     debug "^4.1.0"
     json5 "^2.1.0"
@@ -29,16 +29,15 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.0.0", "@babel/generator@^7.6.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.6.0.tgz#e2c21efbfd3293ad819a2359b448f002bfdfda56"
-  integrity sha512-Ms8Mo7YBdMMn1BYuNtKuP/z0TgEIhbcyB8HVR6PPNYp4P61lMsABiS4A3VG1qznjXVCf3r+fVHhm4efTYVsySA==
+"@babel/generator@^7.0.0", "@babel/generator@^7.6.3", "@babel/generator@^7.6.4":
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.6.4.tgz#a4f8437287bf9671b07f483b76e3bb731bc97671"
+  integrity sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==
   dependencies:
-    "@babel/types" "^7.6.0"
+    "@babel/types" "^7.6.3"
     jsesc "^2.5.1"
     lodash "^4.17.13"
     source-map "^0.5.0"
-    trim-right "^1.0.1"
 
 "@babel/helper-annotate-as-pure@^7.0.0":
   version "7.0.0"
@@ -215,13 +214,13 @@
     "@babel/traverse" "^7.1.0"
     "@babel/types" "^7.2.0"
 
-"@babel/helpers@^7.6.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.6.0.tgz#21961d16c6a3c3ab597325c34c465c0887d31c6e"
-  integrity sha512-W9kao7OBleOjfXtFGgArGRX6eCP0UEcA2ZWEWNkJdRZnHhW4eEbeswbG3EwaRsnQUAEGWYgMq1HsIXuNNNy2eQ==
+"@babel/helpers@^7.6.2":
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.6.2.tgz#681ffe489ea4dcc55f23ce469e58e59c1c045153"
+  integrity sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==
   dependencies:
     "@babel/template" "^7.6.0"
-    "@babel/traverse" "^7.6.0"
+    "@babel/traverse" "^7.6.2"
     "@babel/types" "^7.6.0"
 
 "@babel/highlight@^7.0.0":
@@ -233,10 +232,10 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.6.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.0.tgz#3e05d0647432a8326cb28d0de03895ae5a57f39b"
-  integrity sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==
+"@babel/parser@^7.0.0", "@babel/parser@^7.6.0", "@babel/parser@^7.6.3", "@babel/parser@^7.6.4":
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.4.tgz#cb9b36a7482110282d5cb6dd424ec9262b473d81"
+  integrity sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==
 
 "@babel/plugin-external-helpers@^7.0.0":
   version "7.2.0"
@@ -270,9 +269,9 @@
     "@babel/plugin-syntax-nullish-coalescing-operator" "^7.2.0"
 
 "@babel/plugin-proposal-object-rest-spread@^7.0.0":
-  version "7.5.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz#61939744f71ba76a3ae46b5eea18a54c16d22e58"
-  integrity sha512-F2DxJJSQ7f64FyTVl5cw/9MWn6naXGdk3Q3UhDbFEEHv+EilCPoeRD3Zh/Utx1CJz4uyKlQ4uH+bJPbEhMV7Zw==
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz#8ffccc8f3a6545e9f78988b6bf4fe881b88e8096"
+  integrity sha512-LDBXlmADCsMZV1Y9OQwMc0MyGZ8Ta/zlD9N67BfQT8uYwkRswiu2hU6nJKrjrt/58aH/vqfQlR/9yId/7A2gWw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
@@ -387,9 +386,9 @@
     "@babel/helper-plugin-utils" "^7.0.0"
 
 "@babel/plugin-transform-block-scoping@^7.0.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.0.tgz#c49e21228c4bbd4068a35667e6d951c75439b1dc"
-  integrity sha512-tIt4E23+kw6TgL/edACZwP1OUKrjOTyMrFMLoT5IOFrfMRabCgekjqFd5o6PaAMildBu46oFkekIdMuGkkPEpA==
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.3.tgz#6e854e51fbbaa84351b15d4ddafe342f3a5d542a"
+  integrity sha512-7hvrg75dubcO3ZI2rjYTzUrEuh1E9IyDEhhB6qfcooxhDA33xx2MasuLVgdxzcP6R/lipAC6n9ub9maNW6RKdw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     lodash "^4.17.13"
@@ -431,9 +430,9 @@
     "@babel/helper-plugin-utils" "^7.0.0"
 
 "@babel/plugin-transform-flow-strip-types@^7.0.0":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.4.4.tgz#d267a081f49a8705fc9146de0768c6b58dccd8f7"
-  integrity sha512-WyVedfeEIILYEaWGAUWzVNyqG4sfsNooMhXWsu/YzOvVGcsnPb5PguysjJqI3t3qiaYj0BR8T2f5njdjTGe44Q==
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.6.3.tgz#8110f153e7360cfd5996eee68706cfad92d85256"
+  integrity sha512-l0ETkyEofkqFJ9LS6HChNIKtVJw2ylKbhYMlJ5C6df+ldxxaLIyXY4yOdDQQspfFpV8/vDiaWoJlvflstlYNxg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-flow" "^7.2.0"
@@ -540,9 +539,9 @@
     regenerator-transform "^0.14.0"
 
 "@babel/plugin-transform-runtime@^7.0.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.0.tgz#85a3cce402b28586138e368fce20ab3019b9713e"
-  integrity sha512-Da8tMf7uClzwUm/pnJ1S93m/aRXmoYNDD7TkHua8xBDdaAs54uZpTWvEt6NGwmoVMb9mZbntfTqmG2oSzN/7Vg==
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.2.tgz#2669f67c1fae0ae8d8bf696e4263ad52cb98b6f8"
+  integrity sha512-cqULw/QB4yl73cS5Y0TZlQSjDvNkzDbu0FurTZyHlJpWE5T3PCMdnyV+xXoH1opr1ldyHODe3QAX3OMAii5NxA==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"
@@ -557,9 +556,9 @@
     "@babel/helper-plugin-utils" "^7.0.0"
 
 "@babel/plugin-transform-spread@^7.0.0":
-  version "7.2.2"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz#3103a9abe22f742b6d406ecd3cd49b774919b406"
-  integrity sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.6.2.tgz#fc77cf798b24b10c46e1b51b1b88c2bf661bb8dd"
+  integrity sha512-DpSvPFryKdK1x+EDJYCy28nmAaIMdxmhot62jAXF/o99iA33Zj2Lmcp3vDmz+MUh0LNYVPvfj5iC3feb3/+PFg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
@@ -580,27 +579,27 @@
     "@babel/helper-plugin-utils" "^7.0.0"
 
 "@babel/plugin-transform-typescript@^7.0.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.6.0.tgz#48d78405f1aa856ebeea7288a48a19ed8da377a6"
-  integrity sha512-yzw7EopOOr6saONZ3KA3lpizKnWRTe+rfBqg4AmQbSow7ik7fqmzrfIqt053osLwLE2AaTqGinLM2tl6+M/uog==
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.6.3.tgz#dddb50cf3b8b2ef70b22e5326e9a91f05a1db13b"
+  integrity sha512-aiWINBrPMSC3xTXRNM/dfmyYuPNKY/aexYqBgh0HBI5Y+WO5oRAqW/oROYeYHrF4Zw12r9rK4fMk/ZlAmqx/FQ==
   dependencies:
     "@babel/helper-create-class-features-plugin" "^7.6.0"
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-typescript" "^7.2.0"
 
 "@babel/plugin-transform-unicode-regex@^7.0.0":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz#ab4634bb4f14d36728bf5978322b35587787970f"
-  integrity sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.6.2.tgz#b692aad888a7e8d8b1b214be6b9dc03d5031f698"
+  integrity sha512-orZI6cWlR3nk2YmYdb0gImrgCUwb5cBUwjf6Ks6dvNVvXERkwtJWOQaEOjPiu0Gu1Tq6Yq/hruCZZOOi9F34Dw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-regex" "^7.4.4"
-    regexpu-core "^4.5.4"
+    regexpu-core "^4.6.0"
 
 "@babel/register@^7.0.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.6.0.tgz#76b6f466714680f4becafd45beeb2a7b87431abf"
-  integrity sha512-78BomdN8el+x/nkup9KwtjJXuptW5oXMFmP11WoM2VJBjxrKv4grC3qjpLL8RGGUYUGsm57xnjYFM2uom+jWUQ==
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.6.2.tgz#25765a922202cb06f8bdac5a3b1e70cd6bf3dd45"
+  integrity sha512-xgZk2LRZvt6i2SAUWxc7ellk4+OYRgS3Zpsnr13nMS1Qo25w21Uu8o6vTOAqNaxiqrnv30KTYzh9YWY2k21CeQ==
   dependencies:
     find-cache-dir "^2.0.0"
     lodash "^4.17.13"
@@ -609,9 +608,9 @@
     source-map-support "^0.5.9"
 
 "@babel/runtime@^7.0.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.0.tgz#4fc1d642a9fd0299754e8b5de62c631cf5568205"
-  integrity sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.3.tgz#935122c74c73d2240cafd32ddb5fc2a6cd35cf1f"
+  integrity sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==
   dependencies:
     regenerator-runtime "^0.13.2"
 
@@ -624,25 +623,25 @@
     "@babel/parser" "^7.6.0"
     "@babel/types" "^7.6.0"
 
-"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.4.4", "@babel/traverse@^7.5.5", "@babel/traverse@^7.6.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.6.0.tgz#389391d510f79be7ce2ddd6717be66d3fed4b516"
-  integrity sha512-93t52SaOBgml/xY74lsmt7xOR4ufYvhb5c5qiM6lu4J/dWGMAfAh6eKw4PjLes6DI6nQgearoxnFJk60YchpvQ==
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.4.4", "@babel/traverse@^7.5.5", "@babel/traverse@^7.6.2", "@babel/traverse@^7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.6.3.tgz#66d7dba146b086703c0fb10dd588b7364cec47f9"
+  integrity sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==
   dependencies:
     "@babel/code-frame" "^7.5.5"
-    "@babel/generator" "^7.6.0"
+    "@babel/generator" "^7.6.3"
     "@babel/helper-function-name" "^7.1.0"
     "@babel/helper-split-export-declaration" "^7.4.4"
-    "@babel/parser" "^7.6.0"
-    "@babel/types" "^7.6.0"
+    "@babel/parser" "^7.6.3"
+    "@babel/types" "^7.6.3"
     debug "^4.1.0"
     globals "^11.1.0"
     lodash "^4.17.13"
 
-"@babel/types@^7.0.0", "@babel/types@^7.2.0", "@babel/types@^7.3.0", "@babel/types@^7.4.4", "@babel/types@^7.5.5", "@babel/types@^7.6.0":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.6.1.tgz#53abf3308add3ac2a2884d539151c57c4b3ac648"
-  integrity sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==
+"@babel/types@^7.0.0", "@babel/types@^7.2.0", "@babel/types@^7.3.0", "@babel/types@^7.4.4", "@babel/types@^7.5.5", "@babel/types@^7.6.0", "@babel/types@^7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.6.3.tgz#3f07d96f854f98e2fbd45c64b0cb942d11e8ba09"
+  integrity sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.13"
@@ -657,19 +656,19 @@
     minimist "^1.2.0"
 
 "@hapi/address@2.x.x":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.1.tgz#61395b5ed94c4cb19c2dc4c85969cff3d40d583f"
-  integrity sha512-DYuHzu978pP1XW1GD3HGvLnAFjbQTIgc2+V153FGkbS2pgo9haigCdwBnUDrbhaOkgiJlbZvoEqDrcxSLHpiWA==
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.2.tgz#1c794cd6dbf2354d1eb1ef10e0303f573e1c7222"
+  integrity sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q==
 
 "@hapi/bourne@1.x.x":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@hapi/bourne/-/bourne-1.3.2.tgz#0a7095adea067243ce3283e1b56b8a8f453b242a"
   integrity sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==
 
-"@hapi/hoek@8.x.x":
-  version "8.2.4"
-  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.2.4.tgz#684a14f4ca35d46f44abc87dfc696e5e4fe8a020"
-  integrity sha512-Ze5SDNt325yZvNO7s5C4fXDscjJ6dcqLFXJQ/M7dZRQCewuDj2iDUuBi6jLQt+APbW9RjjVEvLr35FXuOEqjow==
+"@hapi/hoek@8.x.x", "@hapi/hoek@^8.3.0":
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.3.2.tgz#91e7188edebc5d876f0b91a860f555ff06f0782b"
+  integrity sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA==
 
 "@hapi/joi@^15.0.3":
   version "15.1.1"
@@ -682,11 +681,11 @@
     "@hapi/topo" "3.x.x"
 
 "@hapi/topo@3.x.x":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-3.1.3.tgz#c7a02e0d936596d29f184e6d7fdc07e8b5efce11"
-  integrity sha512-JmS9/vQK6dcUYn7wc2YZTqzIKubAQcJKu2KCKAru6es482U5RT5fP1EXCPtlXpiK7PR0On/kpQKI4fRKkzpZBQ==
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-3.1.6.tgz#68d935fa3eae7fdd5ab0d7f953f3205d8b2bfc29"
+  integrity sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==
   dependencies:
-    "@hapi/hoek" "8.x.x"
+    "@hapi/hoek" "^8.3.0"
 
 "@jest/console@^24.9.0":
   version "24.9.0"
@@ -835,9 +834,9 @@
   integrity sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==
 
 "@types/yargs@^13.0.0":
-  version "13.0.2"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.2.tgz#a64674fc0149574ecd90ba746e932b5a5f7b3653"
-  integrity sha512-lwwgizwk/bIIU+3ELORkyuOgDjCh7zuWDFqRtPPhhVgq9N1F7CvLNKg1TX4f2duwtKQ0p044Au9r1PLIXHrIzQ==
+  version "13.0.3"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.3.tgz#76482af3981d4412d65371a318f992d33464a380"
+  integrity sha512-K8/LfZq2duW33XW/tFwEAfnZlqIfVsoyRB3kfXdPXYhl0nfM8mmh7GS0jg7WrX2Dgq/0Ha/pR1PaR+BvmWwjiQ==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -1066,9 +1065,9 @@ babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
   integrity sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==
 
 babel-preset-fbjs@^3.1.2, babel-preset-fbjs@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-fbjs/-/babel-preset-fbjs-3.2.0.tgz#c0e6347d3e0379ed84b3c2434d3467567aa05297"
-  integrity sha512-5Jo+JeWiVz2wHUUyAlvb/sSYnXNig9r+HqGAOSfh5Fzxp7SnAaR/tEGRJ1ZX7C77kfk82658w6R5Z+uPATTD9g==
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-fbjs/-/babel-preset-fbjs-3.3.0.tgz#a6024764ea86c8e06a22d794ca8b69534d263541"
+  integrity sha512-7QTLTCd2gwB2qGoi5epSULMHugSVgpcVt5YAeiFO9ABLrutDQzKfGwzxgZHLpugq8qMdg/DhRZDZ5CLKxBkEbw==
   dependencies:
     "@babel/plugin-proposal-class-properties" "^7.0.0"
     "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
@@ -1129,9 +1128,9 @@ basic-auth@~2.0.0:
     safe-buffer "5.1.2"
 
 big-integer@^1.6.7:
-  version "1.6.45"
-  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.45.tgz#1bf2fa1271bfd20d4c52c3d6c6f08cab8d91c77e"
-  integrity sha512-nmb9E7oEtVJ7SmSCH/DeJobXyuRmaofkpoQSimMFu3HKJ5MADtM825SPLhDuWhZ6TElLAQtgJbQmBZuHIRlZoA==
+  version "1.6.47"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.47.tgz#e1e9320e26c4cc81f64fbf4b3bb20e025bf18e2d"
+  integrity sha512-9t9f7X3as2XGX8b52GqG6ox0GvIdM86LyIXASJnDCFhYNgt+A+MByQZ3W2PyMRZjEvG5f8TEbSPfEotVuMJnQg==
 
 bplist-creator@0.0.7:
   version "0.0.7"
@@ -1172,9 +1171,9 @@ braces@^2.3.1:
     to-regex "^3.0.1"
 
 bser@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.0.tgz#65fc784bf7f87c009b973c12db6546902fa9c7b5"
-  integrity sha512-8zsjWrQkkBoLK6uxASk1nJ2SKv97ltiGDo6A3wA0/yRPz+CwmEyDo0hUrhIuukG2JHpAl3bvFIixw2/3Hi0DOg==
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
+  integrity sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==
   dependencies:
     node-int64 "^0.4.0"
 
@@ -1264,9 +1263,9 @@ chardet@^0.4.0:
   integrity sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=
 
 chownr@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.2.tgz#a18f1e0b269c8a6a5d3c86eb298beb14c3dd7bf6"
-  integrity sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.3.tgz#42d837d5239688d55f303003a508230fa6727142"
+  integrity sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==
 
 ci-info@^2.0.0:
   version "2.0.0"
@@ -1359,9 +1358,9 @@ colorette@^1.0.7:
   integrity sha512-6S062WDQUXi6hOfkO/sBPVwE5ASXY4G2+b4atvhJfSsuUUhIaUKlkjLe9692Ipyt5/a+IPF5aVTu3V5gvXq5cg==
 
 commander@^2.19.0:
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
-  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 commander@~2.13.0:
   version "2.13.0"
@@ -1446,9 +1445,9 @@ core-js@^1.0.0:
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
 core-js@^2.2.2, core-js@^2.4.1:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
-  integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
+  version "2.6.10"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.10.tgz#8a5b8391f8cc7013da703411ce5b585706300d7f"
+  integrity sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==
 
 core-util-is@~1.0.0:
   version "1.0.2"
@@ -1624,16 +1623,16 @@ encoding@^0.1.11:
     iconv-lite "~0.4.13"
 
 end-of-stream@^1.1.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
-  integrity sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
+  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
 
 envinfo@^7.1.0:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.3.1.tgz#892e42f7bf858b3446d9414ad240dbaf8da52f09"
-  integrity sha512-GvXiDTqLYrORVSCuJCsWHPXF5BFvoWMQA9xX4YVjPT1jyS3aZEHUBwjzxU/6LTPF9ReHgVEbX7IEN5UvSXHw/A==
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.4.0.tgz#bef4ece9e717423aaf0c3584651430b735ad6630"
+  integrity sha512-FdDfnWnCVjxTTpWE3d6Jgh5JDIA3Cw7LCgpM/pI7kK1ORkjaqI2r6NqQ+ln2j0dfpgxY00AWieSvtkiZQKIItA==
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.2"
@@ -1994,9 +1993,9 @@ get-value@^2.0.3, get-value@^2.0.6:
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
 glob@^7.1.1, glob@^7.1.3:
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
-  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.5.tgz#6714c69bee20f3c3e64c4dd905553e532b40cdc0"
+  integrity sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -2080,9 +2079,9 @@ hermesvm@^0.1.0:
   integrity sha512-EosSDeUqTTGvlc9vQiy5Y/9GBlucEyo6lYuxg/FnukHCD/CP3NYeDAGV54TyZ19FgSqMEoPgOH9cyxvv8epQ1g==
 
 hosted-git-info@^2.1.4:
-  version "2.8.4"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.4.tgz#44119abaf4bc64692a16ace34700fed9c03e2546"
-  integrity sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.5.tgz#759cfcf2c4d156ade59b0b2dfabddc42a6b9c70c"
+  integrity sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==
 
 http-errors@~1.7.2:
   version "1.7.3"
@@ -2103,9 +2102,9 @@ iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
     safer-buffer ">= 2.1.2 < 3"
 
 ignore-walk@^3.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.2.tgz#99d83a246c196ea5c93ef9315ad7b0819c35069b"
-  integrity sha512-EXyErtpHbn75ZTsOADsfx6J/FPo6/5cjev46PXrcTpd8z3BoRkXgYu9/JVqrI7tusjmwCZutGeRJeU0Wo1e4Cw==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
+  integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
   dependencies:
     minimatch "^3.0.4"
 
@@ -2472,9 +2471,9 @@ json-stable-stringify@^1.0.1:
     jsonify "~0.0.0"
 
 json5@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
-  integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.1.tgz#81b6cb04e9ba496f1c7005d07b4368a2638f90b6"
+  integrity sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==
   dependencies:
     minimist "^1.2.0"
 
@@ -2938,9 +2937,9 @@ mime-db@1.40.0:
   integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
 
 "mime-db@>= 1.40.0 < 2":
-  version "1.41.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.41.0.tgz#9110408e1f6aa1b34aef51f2c9df3caddf46b6a0"
-  integrity sha512-B5gxBI+2K431XW8C2rcc/lhppbuji67nf9v39eH8pkWoZDxnAL0PxdpH32KYRScniF8qDHBDlI+ipgg5WrCUYw==
+  version "1.42.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.42.0.tgz#3e252907b4c7adb906597b4b65636272cf9e7bac"
+  integrity sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==
 
 mime-db@~1.23.0:
   version "1.23.0"
@@ -3005,20 +3004,20 @@ minimist@^1.1.1, minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
-minipass@^2.2.1, minipass@^2.6.0, minipass@^2.6.4:
-  version "2.6.5"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.6.5.tgz#1c245f9f2897f70fd4a219066261ce6c29f80b18"
-  integrity sha512-ewSKOPFH9blOLXx0YSE+mbrNMBFPS+11a2b03QZ+P4LVrUHW/GAlqeYC7DBknDyMWkHzrzTpDhUvy7MUxqyrPA==
+minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
+  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
   dependencies:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
 minizlib@^1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.2.tgz#6f0ccc82fa53e1bf2ff145f220d2da9fa6e3a166"
-  integrity sha512-hR3At21uSrsjjDTWrbu0IMLTpnkpv8IIMFDFaoz43Tmu4LkmAXfH44vNNzpTnf+OAQQCHrb91y/wc2J4x5XgSQ==
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
+  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
   dependencies:
-    minipass "^2.2.1"
+    minipass "^2.9.0"
 
 mixin-deep@^1.2.0:
   version "1.3.2"
@@ -3188,9 +3187,9 @@ npm-bundled@^1.0.1:
   integrity sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==
 
 npm-packlist@^1.1.6:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.4.tgz#866224233850ac534b63d1a6e76050092b5d2f44"
-  integrity sha512-zTLo8UcVYtDU3gdeaFu2Xu0n0EvelfHDGuqtNIn5RO7yQj4H1TqNdBc/yZjxnWA0PVB8D3Woyp0i5B43JwQ6Vw==
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.6.tgz#53ba3ed11f8523079f1457376dd379ee4ea42ff4"
+  integrity sha512-u65uQdb+qwtGvEJh/DgQgW1Xg7sqeNbmxYyrvlNznaVTjV3E5P6F/EFjM+BVHXl7JJlsdG8A64M0XI8FI/IOlg==
   dependencies:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
@@ -3598,9 +3597,9 @@ react-devtools-core@^3.6.1:
     ws "^3.3.1"
 
 react-is@^16.8.1, react-is@^16.8.4:
-  version "16.9.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
-  integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
+  version "16.11.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.11.0.tgz#b85dfecd48ad1ce469ff558a882ca8e8313928fa"
+  integrity sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw==
 
 react-native-electrode-bridge@1.5.x:
   version "1.5.19"
@@ -3729,7 +3728,7 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
-regexpu-core@^4.5.4:
+regexpu-core@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.6.0.tgz#2037c18b327cfce8a6fea2a4ec441f2432afb8b6"
   integrity sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==
@@ -3742,9 +3741,9 @@ regexpu-core@^4.5.4:
     unicode-match-property-value-ecmascript "^1.1.0"
 
 regjsgen@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.5.0.tgz#a7634dc08f89209c2049adda3525711fb97265dd"
-  integrity sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.5.1.tgz#48f0bf1a5ea205196929c0d9798b42d1ed98443c"
+  integrity sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==
 
 regjsparser@^0.6.0:
   version "0.6.0"
@@ -4247,13 +4246,13 @@ symbol-observable@1.0.1:
   integrity sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=
 
 tar@^4:
-  version "4.4.11"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.11.tgz#7ac09801445a3cf74445ed27499136b5240ffb73"
-  integrity sha512-iI4zh3ktLJKaDNZKZc+fUONiQrSn9HkCFzamtb7k8FFmVilHVob7QsLX/VySAW8lAviMzMbFw4QtFb4errwgYA==
+  version "4.4.13"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
+  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
   dependencies:
     chownr "^1.1.1"
     fs-minipass "^1.2.5"
-    minipass "^2.6.4"
+    minipass "^2.8.6"
     minizlib "^1.2.1"
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
@@ -4336,11 +4335,6 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
-
-trim-right@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
-  integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
 type-fest@^0.7.1:
   version "0.7.1"
@@ -4602,9 +4596,9 @@ yallist@^2.1.2:
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
 yallist@^3.0.0, yallist@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
-  integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yargs-parser@^11.1.1:
   version "11.1.1"

--- a/system-tests/fixtures/api-impl-native/ReactNativeErnmovieApiImplNative/android/lib/build.gradle
+++ b/system-tests/fixtures/api-impl-native/ReactNativeErnmovieApiImplNative/android/lib/build.gradle
@@ -16,7 +16,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
     lintOptions {
         abortOnError false
     }
@@ -24,14 +27,13 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+
+    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
+    implementation 'com.walmartlabs.ern:react-native:0.60.5'
+
     androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     testImplementation 'junit:junit:4.12'
-
-    implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
-
-
-    implementation 'com.walmartlabs.ern:react-native:0.60.5'
 }

--- a/system-tests/fixtures/api-impl-native/ReactNativeErnmovieApiImplNative/ios/ElectrodeApiImpl.xcodeproj/project.pbxproj
+++ b/system-tests/fixtures/api-impl-native/ReactNativeErnmovieApiImplNative/ios/ElectrodeApiImpl.xcodeproj/project.pbxproj
@@ -16,75 +16,75 @@
 		48500A991E2FF55B009B6610 /* ElectrodeReactNative.m in Sources */ = {isa = PBXBuildFile; fileRef = 48500A971E2FF55B009B6610 /* ElectrodeReactNative.m */; };
 		968333D71E54E3470031C565 /* ElectrodeBridgeDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 968333D51E54E3470031C565 /* ElectrodeBridgeDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		968333D81E54E3470031C565 /* ElectrodeBridgeDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 968333D61E54E3470031C565 /* ElectrodeBridgeDelegate.m */; };
-		9FFFB709FA934199B8371C61 /* BirthYear.swift in Sources */ = {isa = PBXBuildFile; fileRef = 922AB0516B794DE199B9C2FA /* BirthYear.swift */; };
-		B564A86FC75846948872FAE3 /* Movie.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89444EF457C44E4BA8568BF4 /* Movie.swift */; };
-		77C865A1071F4320A4015BCC /* MoviesAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D9F065F09BA497C9D19A8F4 /* MoviesAPI.swift */; };
-		FA670D7560914A589B0FCE2B /* MoviesRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2040C7A12F48B99AFDB78E /* MoviesRequests.swift */; };
-		C636FC82FEF4421CAB6CC086 /* Person.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A87EEFE9D02499B88560CB1 /* Person.swift */; };
-		FCCC88BA9B40441881CB2CCA /* Synopsis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746E0A02ADE6412EB6410CDB /* Synopsis.swift */; };
-		95FA7029C262409882F17FFF /* BirthYear.swift in Headers */ = {isa = PBXBuildFile; fileRef = 922AB0516B794DE199B9C2FA /* BirthYear.swift */; settings = {ATTRIBUTES = (Public, ); }; };
-		675152A6B90D48F6B5E5423C /* Movie.swift in Headers */ = {isa = PBXBuildFile; fileRef = 89444EF457C44E4BA8568BF4 /* Movie.swift */; settings = {ATTRIBUTES = (Public, ); }; };
-		11CDB21C18AD48418FD47233 /* MoviesAPI.swift in Headers */ = {isa = PBXBuildFile; fileRef = 3D9F065F09BA497C9D19A8F4 /* MoviesAPI.swift */; settings = {ATTRIBUTES = (Public, ); }; };
-		205CE59DB2054B0F9A002AB0 /* MoviesRequests.swift in Headers */ = {isa = PBXBuildFile; fileRef = 4B2040C7A12F48B99AFDB78E /* MoviesRequests.swift */; settings = {ATTRIBUTES = (Public, ); }; };
-		164210A9789C4649A3528D7C /* Person.swift in Headers */ = {isa = PBXBuildFile; fileRef = 3A87EEFE9D02499B88560CB1 /* Person.swift */; settings = {ATTRIBUTES = (Public, ); }; };
-		5796ABC351204FA28783A1D0 /* Synopsis.swift in Headers */ = {isa = PBXBuildFile; fileRef = 746E0A02ADE6412EB6410CDB /* Synopsis.swift */; settings = {ATTRIBUTES = (Public, ); }; };
-		1D29B26C1DF14F00904D7AC7 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 342ACF96D6004DC3BA3ECB4A /* libReact.a */; };
-		F38D5A88B53245EC8602899B /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B8377F0EC1644AD087327E76 /* libRCTActionSheet.a */; };
-		9EFE1764FF904EABA3C3C567 /* libRCTImage.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 756CCFE460A74914B31F152F /* libRCTImage.a */; };
-		1DFD252BC2674C6695E497A7 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A00A5B08C01A4E9FAB6AC128 /* libRCTAnimation.a */; };
-		D18E55B006A74C8E93F222DD /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D31630C788847C795184181 /* libRCTText.a */; };
-		731C7D69EC664CB0AB9E26D0 /* libRCTWebSocket.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DA8CB8DF5660447DB08588B9 /* libRCTWebSocket.a */; };
-		CEF4A00F578A4B5A923F335D /* libRCTLinking.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D587F64962B54B42BCE87221 /* libRCTLinking.a */; };
-		E891452223214EFDB4D832C3 /* libRCTNetwork.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 29279E8AB8A34CADBF2E12E5 /* libRCTNetwork.a */; };
-		D31F656E0C4F44D3A1CE5F64 /* libRCTSettings.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 879203F5F2D04719A2E77912 /* libRCTSettings.a */; };
-		7ED53936168041438C60A6BC /* libRCTVibration.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 57C87EFEFAC746178BA5AD09 /* libRCTVibration.a */; };
-		59D427DD6D244CBE8E650DBE /* libRCTCameraRoll.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8750E888785C4AC5B682995C /* libRCTCameraRoll.a */; };
-		9EAF4616667E4D5E946ACDC3 /* libART.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EC0521DEC3C240BCBBAAABEF /* libART.a */; };
-		C3CBC753A1FB4911A4DB720B /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2A5956E2AADA44929787B251 /* JavaScriptCore.framework */; };
-		BBC1A7AF1CEB451A93DAD2CD /* ElectrodeObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A36683066BC490889DF4393 /* ElectrodeObject.swift */; };
-		C13F2C3D2330409F994D2E31 /* Bridgeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8673ED2F04D47958AE2E8DC /* Bridgeable.swift */; };
-		FA96F01717664CA7B932C20E /* ElectrodeRequestHandlerProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED899B5E7CDA465C8D654D54 /* ElectrodeRequestHandlerProcessor.swift */; };
-		0D26150FE4EA4A85AEF975B9 /* ElectrodeRequestProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72926F73F12148E48BF3E8FC /* ElectrodeRequestProcessor.swift */; };
-		AA3F41E300FA4F49B95DBFF0 /* ElectrodeUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = E165BC6B41C9411CA0E180AC /* ElectrodeUtilities.swift */; };
-		C9CF3234AB2341AFB4649A98 /* EventListenerProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C66D0AE0F04E7183ECEE4C /* EventListenerProcessor.swift */; };
-		F002B5EFD5CD4332B6DE381C /* EventProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3B8C73DB8341DF84D68A61 /* EventProcessor.swift */; };
-		9553CFA0BC434CCD92FC69BF /* Processor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F09E853E565444288CD1964C /* Processor.swift */; };
-		F3CC2B941C034C539C37FC3F /* None.swift in Sources */ = {isa = PBXBuildFile; fileRef = D537440A144B4B878288603C /* None.swift */; };
-		B9CF8B6DE246400F84005064 /* ElectrodeBridgeEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 821B84A2A482485A97E9283E /* ElectrodeBridgeEvent.m */; };
-		851B536347604511B6E3A1DF /* ElectrodeBridgeFailureMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = F7BA40A42A084F4FA3F273A6 /* ElectrodeBridgeFailureMessage.m */; };
-		353D6A2F14A94507BA484DC3 /* ElectrodeBridgeHolder.m in Sources */ = {isa = PBXBuildFile; fileRef = 454B74BB01D04911BC46DE7C /* ElectrodeBridgeHolder.m */; };
-		C6E475A6A4FC4EC6ABD6FD63 /* ElectrodeBridgeMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = FA3D9732CAC64FF9BF4DA10E /* ElectrodeBridgeMessage.m */; };
-		F7916C8A50AC42D1B1CBE6CE /* ElectrodeBridgeProtocols.m in Sources */ = {isa = PBXBuildFile; fileRef = 94A12E1EC03C405990498784 /* ElectrodeBridgeProtocols.m */; };
-		F0497EFD088C48959542CF8B /* ElectrodeBridgeRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D6C8ACFDF684F6B9670237B /* ElectrodeBridgeRequest.m */; };
-		06FB3ABAEE7F49D2AB29D060 /* ElectrodeBridgeResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A78C56A2BD94F8D9670B207 /* ElectrodeBridgeResponse.m */; };
-		8C3AE94331BE4A128AC95ABE /* ElectrodeBridgeTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = F9AB3F8332E943B5B5C6070B /* ElectrodeBridgeTransaction.m */; };
-		A24494D32E82492DB19F7214 /* ElectrodeBridgeTransceiver.m in Sources */ = {isa = PBXBuildFile; fileRef = 98B9046C45844779B41D5151 /* ElectrodeBridgeTransceiver.m */; };
-		20212A28174C4E66A6C09EB5 /* ElectrodeEventDispatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DB5A3306FA945308A2CE6F4 /* ElectrodeEventDispatcher.m */; };
-		A9758458F8DD48B79CE51A95 /* ElectrodeEventRegistrar.m in Sources */ = {isa = PBXBuildFile; fileRef = B56DA748483D47E5B2820C4F /* ElectrodeEventRegistrar.m */; };
-		B3E66CBC1EF846A59559F7B6 /* ElectrodeRequestDispatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 1283577C4EFC4094840520AF /* ElectrodeRequestDispatcher.m */; };
-		0584D37782D44684B94DAB8E /* ElectrodeRequestRegistrar.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A981CC9CF3C4C419884A133 /* ElectrodeRequestRegistrar.m */; };
-		628998D472D7457DB8E3C0EC /* ElectrodeLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EA3D4EC06B64B1DB8064458 /* ElectrodeLogger.m */; };
-		C23EAF2CB1474B0E8DDF2DF8 /* ElectrodeBridgeEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E52B1E80A394F31A798B099 /* ElectrodeBridgeEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FE1E25388CFA4579A4B74323 /* ElectrodeBridgeFailureMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = B4E57F46A5764F04BD3B4F69 /* ElectrodeBridgeFailureMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		87498F35A38A4C4D9957A267 /* ElectrodeBridgeHolder.h in Headers */ = {isa = PBXBuildFile; fileRef = 1288768B5F864D9CA8352858 /* ElectrodeBridgeHolder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A65961AC242F402FA33C1870 /* ElectrodeBridgeMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = A0A4B741955942139F174160 /* ElectrodeBridgeMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		17D981AAAAF2409D8220271B /* ElectrodeBridgeProtocols.h in Headers */ = {isa = PBXBuildFile; fileRef = 2AF0643E2004494590BC19B2 /* ElectrodeBridgeProtocols.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D874B8FCBD2741AE9757177B /* ElectrodeBridgeRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 544D80E6740C4A4FA51E6260 /* ElectrodeBridgeRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6E8CE40513D0426E9AF4CC73 /* ElectrodeBridgeTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = F3FC08E34E024FBDB01030E7 /* ElectrodeBridgeTransaction.h */; };
-		2C412BD40F424C09B8420E20 /* ElectrodeBridgeTransceiver.h in Headers */ = {isa = PBXBuildFile; fileRef = 9442118C673445808FD8FB2F /* ElectrodeBridgeTransceiver.h */; };
-		EC98153D553345FEB1392FFE /* ElectrodeBridgeTransceiver_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 47C408392DAC4AF08E05C347 /* ElectrodeBridgeTransceiver_Internal.h */; };
-		332138ACE45B40C4BE902653 /* ElectrodeEventDispatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = BAE20E8B32804BAF8040B9C6 /* ElectrodeEventDispatcher.h */; };
-		1F42260A5273410DA41E0822 /* ElectrodeEventRegistrar.h in Headers */ = {isa = PBXBuildFile; fileRef = A4190F10A88342CE9336B5D6 /* ElectrodeEventRegistrar.h */; };
-		FC6180DC037142A88A353178 /* ElectrodeRequestDispatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = A1D0EBB0C58F4B87817F92CA /* ElectrodeRequestDispatcher.h */; };
-		B122825FE1BE4B94BF69A882 /* ElectrodeRequestRegistrar.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C40D7317CA742C58FE043BA /* ElectrodeRequestRegistrar.h */; };
-		6C68C376F7B84ECF898737B2 /* ElectrodeReactNativeBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = DAD2D24668D7419994AEA019 /* ElectrodeReactNativeBridge.h */; };
-		FCA3F3A6EF6B488F9D07BABC /* ElectrodeBridgeResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 7F54A0B8AF294B0DBB75439B /* ElectrodeBridgeResponse.h */; };
-		A267DB259E6E45118C7EA2CE /* ElectrodeLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 17DB6581B3DE48BF8E550663 /* ElectrodeLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9C41B75D74C4481A3DCA8E8 /* RequestHandlerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A57738B93AF4C989CEC135B /* RequestHandlerConfig.swift */; };
-		8508E94F74C74474A7E2DE2F /* RequestHandlerProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E23073932764A4494D0A022 /* RequestHandlerProvider.swift */; };
-		15401B3EFC2B40A683BA6AF9 /* MoviesApiController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84419EE64FA5431CBA6CF718 /* MoviesApiController.swift */; };
-		2F53C92653994F51A6CCC6C4 /* MoviesApiRequestHandlerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9BDC4A11AC4923A4C3A3A5 /* MoviesApiRequestHandlerDelegate.swift */; };
-		7B5B02311BA442F4B33714E3 /* MoviesApiRequestHandlerProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F860445AE44DCC8BF853D2 /* MoviesApiRequestHandlerProvider.swift */; };
+		BA97D74343BA490382F059E3 /* BirthYear.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B10AEDF1C742A89D8FFAE0 /* BirthYear.swift */; };
+		0FB692E011474519B2FCF855 /* Movie.swift in Sources */ = {isa = PBXBuildFile; fileRef = F008A3DD55B1439E9629003C /* Movie.swift */; };
+		7D4E5A2E68FD41259E7C5D43 /* MoviesAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D1A8D89BE0424181B26C1C /* MoviesAPI.swift */; };
+		C59360F3F535408BBABA4517 /* MoviesRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EB7520044374421B02CD5B9 /* MoviesRequests.swift */; };
+		9AF196F7CBEE404098257C65 /* Person.swift in Sources */ = {isa = PBXBuildFile; fileRef = B035902C85D642CB913025E0 /* Person.swift */; };
+		8562544B4A09418CB51D7D60 /* Synopsis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 014CE5E2222F4AED975FC696 /* Synopsis.swift */; };
+		2E5D54881DF34A2C83D98DED /* BirthYear.swift in Headers */ = {isa = PBXBuildFile; fileRef = 13B10AEDF1C742A89D8FFAE0 /* BirthYear.swift */; settings = {ATTRIBUTES = (Public, ); }; };
+		65D73A592D9B4307A22D6235 /* Movie.swift in Headers */ = {isa = PBXBuildFile; fileRef = F008A3DD55B1439E9629003C /* Movie.swift */; settings = {ATTRIBUTES = (Public, ); }; };
+		EDCAB009C0FD4523BA5A8820 /* MoviesAPI.swift in Headers */ = {isa = PBXBuildFile; fileRef = 51D1A8D89BE0424181B26C1C /* MoviesAPI.swift */; settings = {ATTRIBUTES = (Public, ); }; };
+		C1F53B09F3124B9D86911E8D /* MoviesRequests.swift in Headers */ = {isa = PBXBuildFile; fileRef = 8EB7520044374421B02CD5B9 /* MoviesRequests.swift */; settings = {ATTRIBUTES = (Public, ); }; };
+		6667F5FA0F684D2EBBEBB230 /* Person.swift in Headers */ = {isa = PBXBuildFile; fileRef = B035902C85D642CB913025E0 /* Person.swift */; settings = {ATTRIBUTES = (Public, ); }; };
+		56FE4D76E8D54FA9BD71DAB7 /* Synopsis.swift in Headers */ = {isa = PBXBuildFile; fileRef = 014CE5E2222F4AED975FC696 /* Synopsis.swift */; settings = {ATTRIBUTES = (Public, ); }; };
+		91A62DCA98F04190A9BD81AF /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4530D0C4E2354B75AA715F09 /* libReact.a */; };
+		422E0ED3434F41059ADC4BE3 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8659CA6AA91F4125AB8F7B6B /* libRCTActionSheet.a */; };
+		209BD438A04A4CBE867D770E /* libRCTImage.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 675DD353DA434F3887E3F07E /* libRCTImage.a */; };
+		A6B5CA0431E2452994315E57 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F285AF6B832D4DF1B0FE570D /* libRCTAnimation.a */; };
+		77895A0769F44EAE88975765 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 695896FB4B024D6D8574AAA4 /* libRCTText.a */; };
+		C93A5A05069D4A5583611AD8 /* libRCTWebSocket.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DDA5EAEB810649F09F05CBBC /* libRCTWebSocket.a */; };
+		3BC7CAABE7F4444DBF347712 /* libRCTLinking.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 06CC3837B38545D5B8700231 /* libRCTLinking.a */; };
+		523DB60953474C5F85C39C8A /* libRCTNetwork.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 79B0B5EC498741B7A2CEB13C /* libRCTNetwork.a */; };
+		A378DCF570CC4C46A714AE4F /* libRCTSettings.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 20A0C4D4891C45ED8153BE83 /* libRCTSettings.a */; };
+		C6C3286384744FD8A2405EEE /* libRCTVibration.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4DF73984DD4641139953D2BE /* libRCTVibration.a */; };
+		5EA30A436C2948C48944ED8A /* libRCTCameraRoll.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EDA16051889D48A297C2FC05 /* libRCTCameraRoll.a */; };
+		E3F81227A6024FDD9A839347 /* libART.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 81914CD829AE40F2B1C19EF3 /* libART.a */; };
+		3403260EAACA4995B4560D4B /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F9ECB7A5F13444D2AFB8F28B /* JavaScriptCore.framework */; };
+		D357DFB910AB4F3C8CCAE049 /* ElectrodeObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8DCB96FFB44F22BA880A89 /* ElectrodeObject.swift */; };
+		29B05768E2CB46EE8E8D97ED /* Bridgeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E1F8DD5FA04A9B923C2CD7 /* Bridgeable.swift */; };
+		A21D7C2770F243F2B6CEB19D /* ElectrodeRequestHandlerProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5085D58461F343F387419197 /* ElectrodeRequestHandlerProcessor.swift */; };
+		CEA3E8ECC8694C549F50D2A5 /* ElectrodeRequestProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB845D93BBF447E82BCABA5 /* ElectrodeRequestProcessor.swift */; };
+		A240144532924676A6211059 /* ElectrodeUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56F3299C2A046BAA4E6602C /* ElectrodeUtilities.swift */; };
+		CD55DCEABDA7429A998FBAFC /* EventListenerProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F33C74A7288445AB49578DA /* EventListenerProcessor.swift */; };
+		280FB03914EB468FBB853D9E /* EventProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B816B2FEBBA45F0AB210566 /* EventProcessor.swift */; };
+		3A460D3484E1456191A39C83 /* Processor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D007763A434C2C86B8E9EB /* Processor.swift */; };
+		6FF96C47C6E5442093FEAD63 /* None.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23E7C2BDEDD46A9BC9CBB91 /* None.swift */; };
+		159B1DE3D12B4CBAB910D579 /* ElectrodeBridgeEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = FD9500C534864B2F82D2F37A /* ElectrodeBridgeEvent.m */; };
+		9BF86B1A55824858A9232819 /* ElectrodeBridgeFailureMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 982BEE6587D24E9BB3D26D3A /* ElectrodeBridgeFailureMessage.m */; };
+		0603AA7A10CA4479ADAA3682 /* ElectrodeBridgeHolder.m in Sources */ = {isa = PBXBuildFile; fileRef = D6C52BD44FD34335B6C09A0A /* ElectrodeBridgeHolder.m */; };
+		C8F68C30B4A043E78A068664 /* ElectrodeBridgeMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 64D4D954FF6A48E3A963D7B3 /* ElectrodeBridgeMessage.m */; };
+		55815C5C070843EA87B45305 /* ElectrodeBridgeProtocols.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D3B569F92CF4E13B44C8F06 /* ElectrodeBridgeProtocols.m */; };
+		EAE7142CBE8F4D71A3DB73D1 /* ElectrodeBridgeRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 058AC462661445CAAD000E54 /* ElectrodeBridgeRequest.m */; };
+		1D51194FAD2B44679E42D615 /* ElectrodeBridgeResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 3117C44ABF77458DB6EF587D /* ElectrodeBridgeResponse.m */; };
+		526403837DA34F4993170BF8 /* ElectrodeBridgeTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C3DB500F91242868D053568 /* ElectrodeBridgeTransaction.m */; };
+		CF5C601A7EEF462D87145919 /* ElectrodeBridgeTransceiver.m in Sources */ = {isa = PBXBuildFile; fileRef = AC604D6C094D4278A7E55079 /* ElectrodeBridgeTransceiver.m */; };
+		795ACC6907DB4258B9FDECBA /* ElectrodeEventDispatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = DB9A4863CB4A4584832617BE /* ElectrodeEventDispatcher.m */; };
+		C6C44602E4DB49CA9FC47D1E /* ElectrodeEventRegistrar.m in Sources */ = {isa = PBXBuildFile; fileRef = 928134793E4E4EF8A6B5FC6E /* ElectrodeEventRegistrar.m */; };
+		C8F1718893D94907B16552C9 /* ElectrodeRequestDispatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 95A00CBC1C484252B2F211B6 /* ElectrodeRequestDispatcher.m */; };
+		7462F357C17A4A0885F84703 /* ElectrodeRequestRegistrar.m in Sources */ = {isa = PBXBuildFile; fileRef = 91D43B65FD464155BE3C8A4E /* ElectrodeRequestRegistrar.m */; };
+		0653AF9860FC42A5B7DA1354 /* ElectrodeLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = B6EF756CCC1949F69CEFC27C /* ElectrodeLogger.m */; };
+		6920D1139E0548A39AFCAE46 /* ElectrodeBridgeEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = BCA323016FCE4EF8B4A64C3E /* ElectrodeBridgeEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ED3B37211CC240E68A8B15BE /* ElectrodeBridgeFailureMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = D3FC3FC2F01B4468AE582A26 /* ElectrodeBridgeFailureMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		034E83165FFD410EAED42C80 /* ElectrodeBridgeHolder.h in Headers */ = {isa = PBXBuildFile; fileRef = 4534DD8F036246958656447B /* ElectrodeBridgeHolder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		491EA01390A544F3844E90FF /* ElectrodeBridgeMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = B7E82C42D9AF4AEDBE2A9665 /* ElectrodeBridgeMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		272CB7ADBB554DC8A3019E45 /* ElectrodeBridgeProtocols.h in Headers */ = {isa = PBXBuildFile; fileRef = F222C0CDC0C04D1EABFA4FC2 /* ElectrodeBridgeProtocols.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E829ECCBB295434CAFBA27B3 /* ElectrodeBridgeRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = AF03853308A340CE8DF58A45 /* ElectrodeBridgeRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D54E2BD324064BD58C2F5247 /* ElectrodeBridgeTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = 58CC99F571AA4324AB296D3A /* ElectrodeBridgeTransaction.h */; };
+		73189C98E92C4370B00A1BBC /* ElectrodeBridgeTransceiver.h in Headers */ = {isa = PBXBuildFile; fileRef = E88B3B8AB16744069F71E4B7 /* ElectrodeBridgeTransceiver.h */; };
+		B332553A8D3648CD96E96F97 /* ElectrodeBridgeTransceiver_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E6CE102096D4D42BA4B7249 /* ElectrodeBridgeTransceiver_Internal.h */; };
+		4CAE95209C894F15B6F94B3E /* ElectrodeEventDispatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 025B3B66AC294FA69EB38FD1 /* ElectrodeEventDispatcher.h */; };
+		3BB484FF8855407E988C0D87 /* ElectrodeEventRegistrar.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB594DD6347402E9EAF1A7D /* ElectrodeEventRegistrar.h */; };
+		9C85E44439D04BB18B38DB0B /* ElectrodeRequestDispatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = D999DACBBA4C436A98DA1651 /* ElectrodeRequestDispatcher.h */; };
+		86377534357B4D16A184D56C /* ElectrodeRequestRegistrar.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A9267DEB21E4C20971E4EBE /* ElectrodeRequestRegistrar.h */; };
+		FF533697BBF84834A2FE3AAB /* ElectrodeReactNativeBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 227C4CB93C7849A09DF5A0B5 /* ElectrodeReactNativeBridge.h */; };
+		1E2FDB1E92DF4CA081F9A207 /* ElectrodeBridgeResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CB72912321B418B94D904C1 /* ElectrodeBridgeResponse.h */; };
+		E5AAD8A1E3F74E4A90A7CD82 /* ElectrodeLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = AA96309E76764F4699FCC9AC /* ElectrodeLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8CFD80B054854A91AAC3D36E /* RequestHandlerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6B4D9E10D54495DAE63FD07 /* RequestHandlerConfig.swift */; };
+		732A58B500C54BF1820AEB1F /* RequestHandlerProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDF4B79503FC4C1CA75FDEF2 /* RequestHandlerProvider.swift */; };
+		FE216A0EB8FA4CDF856C5356 /* MoviesApiController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24BAF44817164401BD4F9261 /* MoviesApiController.swift */; };
+		53486FBBB3EB4325BDAF00BA /* MoviesApiRequestHandlerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9991E74604B946DA913DD416 /* MoviesApiRequestHandlerDelegate.swift */; };
+		A51D611E410C4CED8DCA55B6 /* MoviesApiRequestHandlerProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6BB3A45FE04A9889730931 /* MoviesApiRequestHandlerProvider.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -95,170 +95,170 @@
 			remoteGlobalIDString = 485009E21E2FF23B009B6610;
 			remoteInfo = ElectrodeApiImpl;
 		};
-		EE1DBF2392A94B8FAE9EA52D /* PBXContainerItemProxy */ = {
+		121F726F8740469088E0ABEB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = C524D9876CE64F81867DFFA7 /* React.xcodeproj */;
+			containerPortal = 1B74240B2FED4DAF85225D8A /* React.xcodeproj */;
 			proxyType = 1;
-			remoteGlobalIDString = 1D29B26C1DF14F00904D7AC7;
+			remoteGlobalIDString = 91A62DCA98F04190A9BD81AF;
 			remoteInfo = React;
 		};
-		9B00B06B0ABD47B4B1DAB48D /* PBXContainerItemProxy */ = {
+		B0151E15752A45759B41A30B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = C524D9876CE64F81867DFFA7 /* React.xcodeproj */;
+			containerPortal = 1B74240B2FED4DAF85225D8A /* React.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 83CBBA2E1A601D0E00E9B192;
 			remoteInfo = React;
 		};
-		20625B9C7B0A424880FCE5F3 /* PBXContainerItemProxy */ = {
+		68375611FBB84BD78ACA4D0E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = A4064CFB9A0A4EBB8FC79DAA /* RCTActionSheet.xcodeproj */;
+			containerPortal = F29154365FDD475B946E5302 /* RCTActionSheet.xcodeproj */;
 			proxyType = 1;
-			remoteGlobalIDString = F38D5A88B53245EC8602899B;
+			remoteGlobalIDString = 422E0ED3434F41059ADC4BE3;
 			remoteInfo = RCTActionSheet;
 		};
-		94AD3FA22C9E428BAC291CB7 /* PBXContainerItemProxy */ = {
+		21B0C6B3E4A54CA486DFFD1B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = A4064CFB9A0A4EBB8FC79DAA /* RCTActionSheet.xcodeproj */;
+			containerPortal = F29154365FDD475B946E5302 /* RCTActionSheet.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 134814201AA4EA6300B7C361;
 			remoteInfo = RCTActionSheet;
 		};
-		DD7EADE1A0B746708E9E462F /* PBXContainerItemProxy */ = {
+		004C372D30524488B9FF6FFF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = CD75E435684348F39C854F37 /* RCTImage.xcodeproj */;
+			containerPortal = 2BBBBA557F2D447BA790EC99 /* RCTImage.xcodeproj */;
 			proxyType = 1;
-			remoteGlobalIDString = 9EFE1764FF904EABA3C3C567;
+			remoteGlobalIDString = 209BD438A04A4CBE867D770E;
 			remoteInfo = RCTImage;
 		};
-		34224277956349EDAF2976D5 /* PBXContainerItemProxy */ = {
+		8D6A7438F39C40BE9CBD03DD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = CD75E435684348F39C854F37 /* RCTImage.xcodeproj */;
+			containerPortal = 2BBBBA557F2D447BA790EC99 /* RCTImage.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 58B5115D1A9E6B3D00147676;
 			remoteInfo = RCTImage;
 		};
-		03774759791944ACB1CCBC5B /* PBXContainerItemProxy */ = {
+		5446D4C3FD8B48C78C8CA8EF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = EBA9F2845C5648DBB47A488A /* RCTAnimation.xcodeproj */;
+			containerPortal = E0B63C72661C4141BAD93506 /* RCTAnimation.xcodeproj */;
 			proxyType = 1;
-			remoteGlobalIDString = 1DFD252BC2674C6695E497A7;
+			remoteGlobalIDString = A6B5CA0431E2452994315E57;
 			remoteInfo = RCTAnimation;
 		};
-		E4581D952885429A91ED69C6 /* PBXContainerItemProxy */ = {
+		28D98B1892CB427094C30EB6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = EBA9F2845C5648DBB47A488A /* RCTAnimation.xcodeproj */;
+			containerPortal = E0B63C72661C4141BAD93506 /* RCTAnimation.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 134814201AA4EA6300B7C361;
 			remoteInfo = RCTAnimation;
 		};
-		93884F884A6B48AD9DAAC0BB /* PBXContainerItemProxy */ = {
+		FD0C94CB12304ADB8D3F7E9C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 5E99B0891E684A61ACF345FA /* RCTText.xcodeproj */;
+			containerPortal = 1F6809096DE14F03B961AF47 /* RCTText.xcodeproj */;
 			proxyType = 1;
-			remoteGlobalIDString = D18E55B006A74C8E93F222DD;
+			remoteGlobalIDString = 77895A0769F44EAE88975765;
 			remoteInfo = RCTText;
 		};
-		7A1280F8D847461DA2F65956 /* PBXContainerItemProxy */ = {
+		D8EE690E111A4B0A87AA865B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 5E99B0891E684A61ACF345FA /* RCTText.xcodeproj */;
+			containerPortal = 1F6809096DE14F03B961AF47 /* RCTText.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 58B5119B1A9E6C1200147676;
 			remoteInfo = RCTText;
 		};
-		CFAA3CEB493843B895C79274 /* PBXContainerItemProxy */ = {
+		31F1CCDBAADF4266B7774D72 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 7DFEB507D6D84D2CB01B428D /* RCTWebSocket.xcodeproj */;
+			containerPortal = 62D7C7DF48064D1A8B13468D /* RCTWebSocket.xcodeproj */;
 			proxyType = 1;
-			remoteGlobalIDString = 731C7D69EC664CB0AB9E26D0;
+			remoteGlobalIDString = C93A5A05069D4A5583611AD8;
 			remoteInfo = RCTWebSocket;
 		};
-		F679EA0410A045B59A3D1975 /* PBXContainerItemProxy */ = {
+		9FC62972570848F2A85BE1E4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 7DFEB507D6D84D2CB01B428D /* RCTWebSocket.xcodeproj */;
+			containerPortal = 62D7C7DF48064D1A8B13468D /* RCTWebSocket.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 3C86DF461ADF2C930047B81A;
 			remoteInfo = RCTWebSocket;
 		};
-		2CAB32BCF4F74720A656C629 /* PBXContainerItemProxy */ = {
+		3DCB845B0BE24905B7396EF5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 5D057527313744F7A94EF68E /* RCTLinking.xcodeproj */;
+			containerPortal = CD2E13564187469F9BF40743 /* RCTLinking.xcodeproj */;
 			proxyType = 1;
-			remoteGlobalIDString = CEF4A00F578A4B5A923F335D;
+			remoteGlobalIDString = 3BC7CAABE7F4444DBF347712;
 			remoteInfo = RCTLinking;
 		};
-		718E5B0C384143FC8CF87603 /* PBXContainerItemProxy */ = {
+		09906E471D024593BD44C51D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 5D057527313744F7A94EF68E /* RCTLinking.xcodeproj */;
+			containerPortal = CD2E13564187469F9BF40743 /* RCTLinking.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 134814201AA4EA6300B7C361;
 			remoteInfo = RCTLinking;
 		};
-		0915A4BAA7444B01BD581B47 /* PBXContainerItemProxy */ = {
+		A94BC7A1C5F4481FB923A2A4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 5FC4D815F8084A9B8D7CFA94 /* RCTNetwork.xcodeproj */;
+			containerPortal = F1F31928415543AD9B70884C /* RCTNetwork.xcodeproj */;
 			proxyType = 1;
-			remoteGlobalIDString = E891452223214EFDB4D832C3;
+			remoteGlobalIDString = 523DB60953474C5F85C39C8A;
 			remoteInfo = RCTNetwork;
 		};
-		427F2F57269F40D7AC21AE6D /* PBXContainerItemProxy */ = {
+		929E234F7AEA4D5CB3F4FA9D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 5FC4D815F8084A9B8D7CFA94 /* RCTNetwork.xcodeproj */;
+			containerPortal = F1F31928415543AD9B70884C /* RCTNetwork.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 58B511DB1A9E6C8500147676;
 			remoteInfo = RCTNetwork;
 		};
-		183B800F57574D3992972D76 /* PBXContainerItemProxy */ = {
+		141C79D2BF6A48E098B4F6D3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = F1A6094908DC41C1A13BE6E6 /* RCTSettings.xcodeproj */;
+			containerPortal = 1FC90994BB9C4E26B4690514 /* RCTSettings.xcodeproj */;
 			proxyType = 1;
-			remoteGlobalIDString = D31F656E0C4F44D3A1CE5F64;
+			remoteGlobalIDString = A378DCF570CC4C46A714AE4F;
 			remoteInfo = RCTSettings;
 		};
-		8B758344F05F44778F052309 /* PBXContainerItemProxy */ = {
+		6239AF62627247ACA47F58F7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = F1A6094908DC41C1A13BE6E6 /* RCTSettings.xcodeproj */;
+			containerPortal = 1FC90994BB9C4E26B4690514 /* RCTSettings.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 134814201AA4EA6300B7C361;
 			remoteInfo = RCTSettings;
 		};
-		842628DC7E494198ADC721BB /* PBXContainerItemProxy */ = {
+		4580143CC5F841789A9C5EF9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 66EC659CFBAF433F8ACA76D8 /* RCTVibration.xcodeproj */;
+			containerPortal = 093FEAB6D3A94D48B0F0253E /* RCTVibration.xcodeproj */;
 			proxyType = 1;
-			remoteGlobalIDString = 7ED53936168041438C60A6BC;
+			remoteGlobalIDString = C6C3286384744FD8A2405EEE;
 			remoteInfo = RCTVibration;
 		};
-		A690D3E4408F4E5DACCD5E17 /* PBXContainerItemProxy */ = {
+		48544E17AF0944589362B112 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 66EC659CFBAF433F8ACA76D8 /* RCTVibration.xcodeproj */;
+			containerPortal = 093FEAB6D3A94D48B0F0253E /* RCTVibration.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 832C81801AAF6DEF007FA2F7;
 			remoteInfo = RCTVibration;
 		};
-		BF49BC485E394C76A843FF50 /* PBXContainerItemProxy */ = {
+		D7316B8D23E84EBAADAEC6AF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = D03FDDAEC40B4EC29104B2E4 /* RCTCameraRoll.xcodeproj */;
+			containerPortal = 756C6A08A7894E06ADE8FD0F /* RCTCameraRoll.xcodeproj */;
 			proxyType = 1;
-			remoteGlobalIDString = 59D427DD6D244CBE8E650DBE;
+			remoteGlobalIDString = 5EA30A436C2948C48944ED8A;
 			remoteInfo = RCTCameraRoll;
 		};
-		88725C57E2CE461CA4A9DFD3 /* PBXContainerItemProxy */ = {
+		6F49667A06B646179C2EFA4D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = D03FDDAEC40B4EC29104B2E4 /* RCTCameraRoll.xcodeproj */;
+			containerPortal = 756C6A08A7894E06ADE8FD0F /* RCTCameraRoll.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 58B5115D1A9E6B3D00147676;
 			remoteInfo = RCTCameraRoll;
 		};
-		2EDD100319C14AB09C9C0B5C /* PBXContainerItemProxy */ = {
+		E28CE15E1CE44AF1B486E506 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 1300F5CC4AF748B190246657 /* ART.xcodeproj */;
+			containerPortal = D916BAA30A86423294CAE90C /* ART.xcodeproj */;
 			proxyType = 1;
-			remoteGlobalIDString = 9EAF4616667E4D5E946ACDC3;
+			remoteGlobalIDString = E3F81227A6024FDD9A839347;
 			remoteInfo = ART;
 		};
-		7CAF460658244A2A8936F781 /* PBXContainerItemProxy */ = {
+		84330495BD1F444F864FFBDC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 1300F5CC4AF748B190246657 /* ART.xcodeproj */;
+			containerPortal = D916BAA30A86423294CAE90C /* ART.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 0CF68AC11AF0540F00FF9E5C;
 			remoteInfo = ART;
@@ -279,81 +279,81 @@
 		48500A971E2FF55B009B6610 /* ElectrodeReactNative.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ElectrodeReactNative.m; sourceTree = "<group>"; };
 		968333D51E54E3470031C565 /* ElectrodeBridgeDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ElectrodeBridgeDelegate.h; sourceTree = "<group>"; };
 		968333D61E54E3470031C565 /* ElectrodeBridgeDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ElectrodeBridgeDelegate.m; sourceTree = "<group>"; };
-		922AB0516B794DE199B9C2FA /* BirthYear.swift */ = {isa = PBXFileReference; name = "BirthYear.swift"; path = "APIs/BirthYear.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; fileRef = 922AB0516B794DE199B9C2FA; basename = BirthYear.swift; target = undefined; uuid = 95FA7029C262409882F17FFF; settings = {ATTRIBUTES = (Public, ); }; };
-		89444EF457C44E4BA8568BF4 /* Movie.swift */ = {isa = PBXFileReference; name = "Movie.swift"; path = "APIs/Movie.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; fileRef = 89444EF457C44E4BA8568BF4; basename = Movie.swift; target = undefined; uuid = 675152A6B90D48F6B5E5423C; settings = {ATTRIBUTES = (Public, ); }; };
-		3D9F065F09BA497C9D19A8F4 /* MoviesAPI.swift */ = {isa = PBXFileReference; name = "MoviesAPI.swift"; path = "APIs/MoviesAPI.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; fileRef = 3D9F065F09BA497C9D19A8F4; basename = MoviesAPI.swift; target = undefined; uuid = 11CDB21C18AD48418FD47233; settings = {ATTRIBUTES = (Public, ); }; };
-		4B2040C7A12F48B99AFDB78E /* MoviesRequests.swift */ = {isa = PBXFileReference; name = "MoviesRequests.swift"; path = "APIs/MoviesRequests.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; fileRef = 4B2040C7A12F48B99AFDB78E; basename = MoviesRequests.swift; target = undefined; uuid = 205CE59DB2054B0F9A002AB0; settings = {ATTRIBUTES = (Public, ); }; };
-		3A87EEFE9D02499B88560CB1 /* Person.swift */ = {isa = PBXFileReference; name = "Person.swift"; path = "APIs/Person.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; fileRef = 3A87EEFE9D02499B88560CB1; basename = Person.swift; target = undefined; uuid = 164210A9789C4649A3528D7C; settings = {ATTRIBUTES = (Public, ); }; };
-		746E0A02ADE6412EB6410CDB /* Synopsis.swift */ = {isa = PBXFileReference; name = "Synopsis.swift"; path = "APIs/Synopsis.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; fileRef = 746E0A02ADE6412EB6410CDB; basename = Synopsis.swift; target = undefined; uuid = 5796ABC351204FA28783A1D0; settings = {ATTRIBUTES = (Public, ); }; };
-		C524D9876CE64F81867DFFA7 /* React.xcodeproj */ = {isa = PBXFileReference; name = "React.xcodeproj"; path = "ReactNative/React/React.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		342ACF96D6004DC3BA3ECB4A /* libReact.a */ = {isa = PBXFileReference; name = "libReact.a"; path = "libReact.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
-		A4064CFB9A0A4EBB8FC79DAA /* RCTActionSheet.xcodeproj */ = {isa = PBXFileReference; name = "RCTActionSheet.xcodeproj"; path = "ReactNative/ActionSheetIOS/RCTActionSheet.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		B8377F0EC1644AD087327E76 /* libRCTActionSheet.a */ = {isa = PBXFileReference; name = "libRCTActionSheet.a"; path = "libRCTActionSheet.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
-		CD75E435684348F39C854F37 /* RCTImage.xcodeproj */ = {isa = PBXFileReference; name = "RCTImage.xcodeproj"; path = "ReactNative/Image/RCTImage.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		756CCFE460A74914B31F152F /* libRCTImage.a */ = {isa = PBXFileReference; name = "libRCTImage.a"; path = "libRCTImage.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
-		EBA9F2845C5648DBB47A488A /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; name = "RCTAnimation.xcodeproj"; path = "ReactNative/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		A00A5B08C01A4E9FAB6AC128 /* libRCTAnimation.a */ = {isa = PBXFileReference; name = "libRCTAnimation.a"; path = "libRCTAnimation.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
-		5E99B0891E684A61ACF345FA /* RCTText.xcodeproj */ = {isa = PBXFileReference; name = "RCTText.xcodeproj"; path = "ReactNative/Text/RCTText.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		2D31630C788847C795184181 /* libRCTText.a */ = {isa = PBXFileReference; name = "libRCTText.a"; path = "libRCTText.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
-		7DFEB507D6D84D2CB01B428D /* RCTWebSocket.xcodeproj */ = {isa = PBXFileReference; name = "RCTWebSocket.xcodeproj"; path = "ReactNative/WebSocket/RCTWebSocket.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		DA8CB8DF5660447DB08588B9 /* libRCTWebSocket.a */ = {isa = PBXFileReference; name = "libRCTWebSocket.a"; path = "libRCTWebSocket.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
-		5D057527313744F7A94EF68E /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; name = "RCTLinking.xcodeproj"; path = "ReactNative/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		D587F64962B54B42BCE87221 /* libRCTLinking.a */ = {isa = PBXFileReference; name = "libRCTLinking.a"; path = "libRCTLinking.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
-		5FC4D815F8084A9B8D7CFA94 /* RCTNetwork.xcodeproj */ = {isa = PBXFileReference; name = "RCTNetwork.xcodeproj"; path = "ReactNative/Network/RCTNetwork.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		29279E8AB8A34CADBF2E12E5 /* libRCTNetwork.a */ = {isa = PBXFileReference; name = "libRCTNetwork.a"; path = "libRCTNetwork.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
-		F1A6094908DC41C1A13BE6E6 /* RCTSettings.xcodeproj */ = {isa = PBXFileReference; name = "RCTSettings.xcodeproj"; path = "ReactNative/Settings/RCTSettings.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		879203F5F2D04719A2E77912 /* libRCTSettings.a */ = {isa = PBXFileReference; name = "libRCTSettings.a"; path = "libRCTSettings.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
-		66EC659CFBAF433F8ACA76D8 /* RCTVibration.xcodeproj */ = {isa = PBXFileReference; name = "RCTVibration.xcodeproj"; path = "ReactNative/Vibration/RCTVibration.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		57C87EFEFAC746178BA5AD09 /* libRCTVibration.a */ = {isa = PBXFileReference; name = "libRCTVibration.a"; path = "libRCTVibration.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
-		D03FDDAEC40B4EC29104B2E4 /* RCTCameraRoll.xcodeproj */ = {isa = PBXFileReference; name = "RCTCameraRoll.xcodeproj"; path = "ReactNative/CameraRoll/RCTCameraRoll.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		8750E888785C4AC5B682995C /* libRCTCameraRoll.a */ = {isa = PBXFileReference; name = "libRCTCameraRoll.a"; path = "libRCTCameraRoll.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
-		1300F5CC4AF748B190246657 /* ART.xcodeproj */ = {isa = PBXFileReference; name = "ART.xcodeproj"; path = "ReactNative/ART/ART.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		EC0521DEC3C240BCBBAAABEF /* libART.a */ = {isa = PBXFileReference; name = "libART.a"; path = "libART.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
-		2A5956E2AADA44929787B251 /* JavaScriptCore.framework */ = {isa = PBXFileReference; name = "JavaScriptCore.framework"; path = "/System/Library/Frameworks/JavaScriptCore.framework"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.framework; explicitFileType = undefined; includeInIndex = 0; };
-		0A36683066BC490889DF4393 /* ElectrodeObject.swift */ = {isa = PBXFileReference; name = "ElectrodeObject.swift"; path = "ElectrodeReactNativeBridge/ElectrodeObject.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
-		F8673ED2F04D47958AE2E8DC /* Bridgeable.swift */ = {isa = PBXFileReference; name = "Bridgeable.swift"; path = "ElectrodeReactNativeBridge/Bridgeable.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
-		ED899B5E7CDA465C8D654D54 /* ElectrodeRequestHandlerProcessor.swift */ = {isa = PBXFileReference; name = "ElectrodeRequestHandlerProcessor.swift"; path = "ElectrodeReactNativeBridge/ElectrodeRequestHandlerProcessor.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
-		72926F73F12148E48BF3E8FC /* ElectrodeRequestProcessor.swift */ = {isa = PBXFileReference; name = "ElectrodeRequestProcessor.swift"; path = "ElectrodeReactNativeBridge/ElectrodeRequestProcessor.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
-		E165BC6B41C9411CA0E180AC /* ElectrodeUtilities.swift */ = {isa = PBXFileReference; name = "ElectrodeUtilities.swift"; path = "ElectrodeReactNativeBridge/ElectrodeUtilities.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
-		D0C66D0AE0F04E7183ECEE4C /* EventListenerProcessor.swift */ = {isa = PBXFileReference; name = "EventListenerProcessor.swift"; path = "ElectrodeReactNativeBridge/EventListenerProcessor.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
-		AF3B8C73DB8341DF84D68A61 /* EventProcessor.swift */ = {isa = PBXFileReference; name = "EventProcessor.swift"; path = "ElectrodeReactNativeBridge/EventProcessor.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
-		F09E853E565444288CD1964C /* Processor.swift */ = {isa = PBXFileReference; name = "Processor.swift"; path = "ElectrodeReactNativeBridge/Processor.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
-		D537440A144B4B878288603C /* None.swift */ = {isa = PBXFileReference; name = "None.swift"; path = "ElectrodeReactNativeBridge/None.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
-		821B84A2A482485A97E9283E /* ElectrodeBridgeEvent.m */ = {isa = PBXFileReference; name = "ElectrodeBridgeEvent.m"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeEvent.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
-		F7BA40A42A084F4FA3F273A6 /* ElectrodeBridgeFailureMessage.m */ = {isa = PBXFileReference; name = "ElectrodeBridgeFailureMessage.m"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeFailureMessage.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
-		454B74BB01D04911BC46DE7C /* ElectrodeBridgeHolder.m */ = {isa = PBXFileReference; name = "ElectrodeBridgeHolder.m"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeHolder.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
-		FA3D9732CAC64FF9BF4DA10E /* ElectrodeBridgeMessage.m */ = {isa = PBXFileReference; name = "ElectrodeBridgeMessage.m"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeMessage.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
-		94A12E1EC03C405990498784 /* ElectrodeBridgeProtocols.m */ = {isa = PBXFileReference; name = "ElectrodeBridgeProtocols.m"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeProtocols.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
-		4D6C8ACFDF684F6B9670237B /* ElectrodeBridgeRequest.m */ = {isa = PBXFileReference; name = "ElectrodeBridgeRequest.m"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeRequest.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
-		7A78C56A2BD94F8D9670B207 /* ElectrodeBridgeResponse.m */ = {isa = PBXFileReference; name = "ElectrodeBridgeResponse.m"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeResponse.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
-		F9AB3F8332E943B5B5C6070B /* ElectrodeBridgeTransaction.m */ = {isa = PBXFileReference; name = "ElectrodeBridgeTransaction.m"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeTransaction.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
-		98B9046C45844779B41D5151 /* ElectrodeBridgeTransceiver.m */ = {isa = PBXFileReference; name = "ElectrodeBridgeTransceiver.m"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeTransceiver.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
-		0DB5A3306FA945308A2CE6F4 /* ElectrodeEventDispatcher.m */ = {isa = PBXFileReference; name = "ElectrodeEventDispatcher.m"; path = "ElectrodeReactNativeBridge/ElectrodeEventDispatcher.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
-		B56DA748483D47E5B2820C4F /* ElectrodeEventRegistrar.m */ = {isa = PBXFileReference; name = "ElectrodeEventRegistrar.m"; path = "ElectrodeReactNativeBridge/ElectrodeEventRegistrar.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
-		1283577C4EFC4094840520AF /* ElectrodeRequestDispatcher.m */ = {isa = PBXFileReference; name = "ElectrodeRequestDispatcher.m"; path = "ElectrodeReactNativeBridge/ElectrodeRequestDispatcher.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
-		2A981CC9CF3C4C419884A133 /* ElectrodeRequestRegistrar.m */ = {isa = PBXFileReference; name = "ElectrodeRequestRegistrar.m"; path = "ElectrodeReactNativeBridge/ElectrodeRequestRegistrar.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
-		6EA3D4EC06B64B1DB8064458 /* ElectrodeLogger.m */ = {isa = PBXFileReference; name = "ElectrodeLogger.m"; path = "ElectrodeReactNativeBridge/ElectrodeLogger.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
-		6E52B1E80A394F31A798B099 /* ElectrodeBridgeEvent.h */ = {isa = PBXFileReference; name = "ElectrodeBridgeEvent.h"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeEvent.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
-		B4E57F46A5764F04BD3B4F69 /* ElectrodeBridgeFailureMessage.h */ = {isa = PBXFileReference; name = "ElectrodeBridgeFailureMessage.h"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeFailureMessage.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
-		1288768B5F864D9CA8352858 /* ElectrodeBridgeHolder.h */ = {isa = PBXFileReference; name = "ElectrodeBridgeHolder.h"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeHolder.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
-		A0A4B741955942139F174160 /* ElectrodeBridgeMessage.h */ = {isa = PBXFileReference; name = "ElectrodeBridgeMessage.h"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeMessage.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
-		2AF0643E2004494590BC19B2 /* ElectrodeBridgeProtocols.h */ = {isa = PBXFileReference; name = "ElectrodeBridgeProtocols.h"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeProtocols.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
-		544D80E6740C4A4FA51E6260 /* ElectrodeBridgeRequest.h */ = {isa = PBXFileReference; name = "ElectrodeBridgeRequest.h"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeRequest.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
-		F3FC08E34E024FBDB01030E7 /* ElectrodeBridgeTransaction.h */ = {isa = PBXFileReference; name = "ElectrodeBridgeTransaction.h"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeTransaction.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
-		9442118C673445808FD8FB2F /* ElectrodeBridgeTransceiver.h */ = {isa = PBXFileReference; name = "ElectrodeBridgeTransceiver.h"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeTransceiver.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
-		47C408392DAC4AF08E05C347 /* ElectrodeBridgeTransceiver_Internal.h */ = {isa = PBXFileReference; name = "ElectrodeBridgeTransceiver_Internal.h"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeTransceiver_Internal.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
-		BAE20E8B32804BAF8040B9C6 /* ElectrodeEventDispatcher.h */ = {isa = PBXFileReference; name = "ElectrodeEventDispatcher.h"; path = "ElectrodeReactNativeBridge/ElectrodeEventDispatcher.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
-		A4190F10A88342CE9336B5D6 /* ElectrodeEventRegistrar.h */ = {isa = PBXFileReference; name = "ElectrodeEventRegistrar.h"; path = "ElectrodeReactNativeBridge/ElectrodeEventRegistrar.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
-		A1D0EBB0C58F4B87817F92CA /* ElectrodeRequestDispatcher.h */ = {isa = PBXFileReference; name = "ElectrodeRequestDispatcher.h"; path = "ElectrodeReactNativeBridge/ElectrodeRequestDispatcher.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
-		4C40D7317CA742C58FE043BA /* ElectrodeRequestRegistrar.h */ = {isa = PBXFileReference; name = "ElectrodeRequestRegistrar.h"; path = "ElectrodeReactNativeBridge/ElectrodeRequestRegistrar.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
-		DAD2D24668D7419994AEA019 /* ElectrodeReactNativeBridge.h */ = {isa = PBXFileReference; name = "ElectrodeReactNativeBridge.h"; path = "ElectrodeReactNativeBridge/ElectrodeReactNativeBridge.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
-		7F54A0B8AF294B0DBB75439B /* ElectrodeBridgeResponse.h */ = {isa = PBXFileReference; name = "ElectrodeBridgeResponse.h"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeResponse.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
-		17DB6581B3DE48BF8E550663 /* ElectrodeLogger.h */ = {isa = PBXFileReference; name = "ElectrodeLogger.h"; path = "ElectrodeReactNativeBridge/ElectrodeLogger.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
-		3A57738B93AF4C989CEC135B /* RequestHandlerConfig.swift */ = {isa = PBXFileReference; name = "RequestHandlerConfig.swift"; path = "APIImpls/RequestHandlerConfig.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
-		3E23073932764A4494D0A022 /* RequestHandlerProvider.swift */ = {isa = PBXFileReference; name = "RequestHandlerProvider.swift"; path = "APIImpls/RequestHandlerProvider.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
-		84419EE64FA5431CBA6CF718 /* MoviesApiController.swift */ = {isa = PBXFileReference; name = "MoviesApiController.swift"; path = "APIImpls/MoviesApiController.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
-		FA9BDC4A11AC4923A4C3A3A5 /* MoviesApiRequestHandlerDelegate.swift */ = {isa = PBXFileReference; name = "MoviesApiRequestHandlerDelegate.swift"; path = "APIImpls/MoviesApiRequestHandlerDelegate.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
-		E8F860445AE44DCC8BF853D2 /* MoviesApiRequestHandlerProvider.swift */ = {isa = PBXFileReference; name = "MoviesApiRequestHandlerProvider.swift"; path = "APIImpls/MoviesApiRequestHandlerProvider.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
+		13B10AEDF1C742A89D8FFAE0 /* BirthYear.swift */ = {isa = PBXFileReference; name = "BirthYear.swift"; path = "APIs/BirthYear.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; fileRef = 13B10AEDF1C742A89D8FFAE0; basename = BirthYear.swift; target = undefined; uuid = 2E5D54881DF34A2C83D98DED; settings = {ATTRIBUTES = (Public, ); }; };
+		F008A3DD55B1439E9629003C /* Movie.swift */ = {isa = PBXFileReference; name = "Movie.swift"; path = "APIs/Movie.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; fileRef = F008A3DD55B1439E9629003C; basename = Movie.swift; target = undefined; uuid = 65D73A592D9B4307A22D6235; settings = {ATTRIBUTES = (Public, ); }; };
+		51D1A8D89BE0424181B26C1C /* MoviesAPI.swift */ = {isa = PBXFileReference; name = "MoviesAPI.swift"; path = "APIs/MoviesAPI.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; fileRef = 51D1A8D89BE0424181B26C1C; basename = MoviesAPI.swift; target = undefined; uuid = EDCAB009C0FD4523BA5A8820; settings = {ATTRIBUTES = (Public, ); }; };
+		8EB7520044374421B02CD5B9 /* MoviesRequests.swift */ = {isa = PBXFileReference; name = "MoviesRequests.swift"; path = "APIs/MoviesRequests.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; fileRef = 8EB7520044374421B02CD5B9; basename = MoviesRequests.swift; target = undefined; uuid = C1F53B09F3124B9D86911E8D; settings = {ATTRIBUTES = (Public, ); }; };
+		B035902C85D642CB913025E0 /* Person.swift */ = {isa = PBXFileReference; name = "Person.swift"; path = "APIs/Person.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; fileRef = B035902C85D642CB913025E0; basename = Person.swift; target = undefined; uuid = 6667F5FA0F684D2EBBEBB230; settings = {ATTRIBUTES = (Public, ); }; };
+		014CE5E2222F4AED975FC696 /* Synopsis.swift */ = {isa = PBXFileReference; name = "Synopsis.swift"; path = "APIs/Synopsis.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; fileRef = 014CE5E2222F4AED975FC696; basename = Synopsis.swift; target = undefined; uuid = 56FE4D76E8D54FA9BD71DAB7; settings = {ATTRIBUTES = (Public, ); }; };
+		1B74240B2FED4DAF85225D8A /* React.xcodeproj */ = {isa = PBXFileReference; name = "React.xcodeproj"; path = "ReactNative/React/React.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		4530D0C4E2354B75AA715F09 /* libReact.a */ = {isa = PBXFileReference; name = "libReact.a"; path = "libReact.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
+		F29154365FDD475B946E5302 /* RCTActionSheet.xcodeproj */ = {isa = PBXFileReference; name = "RCTActionSheet.xcodeproj"; path = "ReactNative/ActionSheetIOS/RCTActionSheet.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		8659CA6AA91F4125AB8F7B6B /* libRCTActionSheet.a */ = {isa = PBXFileReference; name = "libRCTActionSheet.a"; path = "libRCTActionSheet.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
+		2BBBBA557F2D447BA790EC99 /* RCTImage.xcodeproj */ = {isa = PBXFileReference; name = "RCTImage.xcodeproj"; path = "ReactNative/Image/RCTImage.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		675DD353DA434F3887E3F07E /* libRCTImage.a */ = {isa = PBXFileReference; name = "libRCTImage.a"; path = "libRCTImage.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
+		E0B63C72661C4141BAD93506 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; name = "RCTAnimation.xcodeproj"; path = "ReactNative/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		F285AF6B832D4DF1B0FE570D /* libRCTAnimation.a */ = {isa = PBXFileReference; name = "libRCTAnimation.a"; path = "libRCTAnimation.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
+		1F6809096DE14F03B961AF47 /* RCTText.xcodeproj */ = {isa = PBXFileReference; name = "RCTText.xcodeproj"; path = "ReactNative/Text/RCTText.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		695896FB4B024D6D8574AAA4 /* libRCTText.a */ = {isa = PBXFileReference; name = "libRCTText.a"; path = "libRCTText.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
+		62D7C7DF48064D1A8B13468D /* RCTWebSocket.xcodeproj */ = {isa = PBXFileReference; name = "RCTWebSocket.xcodeproj"; path = "ReactNative/WebSocket/RCTWebSocket.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		DDA5EAEB810649F09F05CBBC /* libRCTWebSocket.a */ = {isa = PBXFileReference; name = "libRCTWebSocket.a"; path = "libRCTWebSocket.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
+		CD2E13564187469F9BF40743 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; name = "RCTLinking.xcodeproj"; path = "ReactNative/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		06CC3837B38545D5B8700231 /* libRCTLinking.a */ = {isa = PBXFileReference; name = "libRCTLinking.a"; path = "libRCTLinking.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
+		F1F31928415543AD9B70884C /* RCTNetwork.xcodeproj */ = {isa = PBXFileReference; name = "RCTNetwork.xcodeproj"; path = "ReactNative/Network/RCTNetwork.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		79B0B5EC498741B7A2CEB13C /* libRCTNetwork.a */ = {isa = PBXFileReference; name = "libRCTNetwork.a"; path = "libRCTNetwork.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
+		1FC90994BB9C4E26B4690514 /* RCTSettings.xcodeproj */ = {isa = PBXFileReference; name = "RCTSettings.xcodeproj"; path = "ReactNative/Settings/RCTSettings.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		20A0C4D4891C45ED8153BE83 /* libRCTSettings.a */ = {isa = PBXFileReference; name = "libRCTSettings.a"; path = "libRCTSettings.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
+		093FEAB6D3A94D48B0F0253E /* RCTVibration.xcodeproj */ = {isa = PBXFileReference; name = "RCTVibration.xcodeproj"; path = "ReactNative/Vibration/RCTVibration.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		4DF73984DD4641139953D2BE /* libRCTVibration.a */ = {isa = PBXFileReference; name = "libRCTVibration.a"; path = "libRCTVibration.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
+		756C6A08A7894E06ADE8FD0F /* RCTCameraRoll.xcodeproj */ = {isa = PBXFileReference; name = "RCTCameraRoll.xcodeproj"; path = "ReactNative/CameraRoll/RCTCameraRoll.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		EDA16051889D48A297C2FC05 /* libRCTCameraRoll.a */ = {isa = PBXFileReference; name = "libRCTCameraRoll.a"; path = "libRCTCameraRoll.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
+		D916BAA30A86423294CAE90C /* ART.xcodeproj */ = {isa = PBXFileReference; name = "ART.xcodeproj"; path = "ReactNative/ART/ART.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		81914CD829AE40F2B1C19EF3 /* libART.a */ = {isa = PBXFileReference; name = "libART.a"; path = "libART.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
+		F9ECB7A5F13444D2AFB8F28B /* JavaScriptCore.framework */ = {isa = PBXFileReference; name = "JavaScriptCore.framework"; path = "/System/Library/Frameworks/JavaScriptCore.framework"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.framework; explicitFileType = undefined; includeInIndex = 0; };
+		3C8DCB96FFB44F22BA880A89 /* ElectrodeObject.swift */ = {isa = PBXFileReference; name = "ElectrodeObject.swift"; path = "ElectrodeReactNativeBridge/ElectrodeObject.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
+		D0E1F8DD5FA04A9B923C2CD7 /* Bridgeable.swift */ = {isa = PBXFileReference; name = "Bridgeable.swift"; path = "ElectrodeReactNativeBridge/Bridgeable.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
+		5085D58461F343F387419197 /* ElectrodeRequestHandlerProcessor.swift */ = {isa = PBXFileReference; name = "ElectrodeRequestHandlerProcessor.swift"; path = "ElectrodeReactNativeBridge/ElectrodeRequestHandlerProcessor.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
+		8CB845D93BBF447E82BCABA5 /* ElectrodeRequestProcessor.swift */ = {isa = PBXFileReference; name = "ElectrodeRequestProcessor.swift"; path = "ElectrodeReactNativeBridge/ElectrodeRequestProcessor.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
+		C56F3299C2A046BAA4E6602C /* ElectrodeUtilities.swift */ = {isa = PBXFileReference; name = "ElectrodeUtilities.swift"; path = "ElectrodeReactNativeBridge/ElectrodeUtilities.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
+		6F33C74A7288445AB49578DA /* EventListenerProcessor.swift */ = {isa = PBXFileReference; name = "EventListenerProcessor.swift"; path = "ElectrodeReactNativeBridge/EventListenerProcessor.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
+		7B816B2FEBBA45F0AB210566 /* EventProcessor.swift */ = {isa = PBXFileReference; name = "EventProcessor.swift"; path = "ElectrodeReactNativeBridge/EventProcessor.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
+		49D007763A434C2C86B8E9EB /* Processor.swift */ = {isa = PBXFileReference; name = "Processor.swift"; path = "ElectrodeReactNativeBridge/Processor.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
+		C23E7C2BDEDD46A9BC9CBB91 /* None.swift */ = {isa = PBXFileReference; name = "None.swift"; path = "ElectrodeReactNativeBridge/None.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
+		FD9500C534864B2F82D2F37A /* ElectrodeBridgeEvent.m */ = {isa = PBXFileReference; name = "ElectrodeBridgeEvent.m"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeEvent.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		982BEE6587D24E9BB3D26D3A /* ElectrodeBridgeFailureMessage.m */ = {isa = PBXFileReference; name = "ElectrodeBridgeFailureMessage.m"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeFailureMessage.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		D6C52BD44FD34335B6C09A0A /* ElectrodeBridgeHolder.m */ = {isa = PBXFileReference; name = "ElectrodeBridgeHolder.m"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeHolder.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		64D4D954FF6A48E3A963D7B3 /* ElectrodeBridgeMessage.m */ = {isa = PBXFileReference; name = "ElectrodeBridgeMessage.m"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeMessage.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		8D3B569F92CF4E13B44C8F06 /* ElectrodeBridgeProtocols.m */ = {isa = PBXFileReference; name = "ElectrodeBridgeProtocols.m"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeProtocols.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		058AC462661445CAAD000E54 /* ElectrodeBridgeRequest.m */ = {isa = PBXFileReference; name = "ElectrodeBridgeRequest.m"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeRequest.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		3117C44ABF77458DB6EF587D /* ElectrodeBridgeResponse.m */ = {isa = PBXFileReference; name = "ElectrodeBridgeResponse.m"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeResponse.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		0C3DB500F91242868D053568 /* ElectrodeBridgeTransaction.m */ = {isa = PBXFileReference; name = "ElectrodeBridgeTransaction.m"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeTransaction.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		AC604D6C094D4278A7E55079 /* ElectrodeBridgeTransceiver.m */ = {isa = PBXFileReference; name = "ElectrodeBridgeTransceiver.m"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeTransceiver.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		DB9A4863CB4A4584832617BE /* ElectrodeEventDispatcher.m */ = {isa = PBXFileReference; name = "ElectrodeEventDispatcher.m"; path = "ElectrodeReactNativeBridge/ElectrodeEventDispatcher.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		928134793E4E4EF8A6B5FC6E /* ElectrodeEventRegistrar.m */ = {isa = PBXFileReference; name = "ElectrodeEventRegistrar.m"; path = "ElectrodeReactNativeBridge/ElectrodeEventRegistrar.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		95A00CBC1C484252B2F211B6 /* ElectrodeRequestDispatcher.m */ = {isa = PBXFileReference; name = "ElectrodeRequestDispatcher.m"; path = "ElectrodeReactNativeBridge/ElectrodeRequestDispatcher.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		91D43B65FD464155BE3C8A4E /* ElectrodeRequestRegistrar.m */ = {isa = PBXFileReference; name = "ElectrodeRequestRegistrar.m"; path = "ElectrodeReactNativeBridge/ElectrodeRequestRegistrar.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		B6EF756CCC1949F69CEFC27C /* ElectrodeLogger.m */ = {isa = PBXFileReference; name = "ElectrodeLogger.m"; path = "ElectrodeReactNativeBridge/ElectrodeLogger.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		BCA323016FCE4EF8B4A64C3E /* ElectrodeBridgeEvent.h */ = {isa = PBXFileReference; name = "ElectrodeBridgeEvent.h"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeEvent.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		D3FC3FC2F01B4468AE582A26 /* ElectrodeBridgeFailureMessage.h */ = {isa = PBXFileReference; name = "ElectrodeBridgeFailureMessage.h"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeFailureMessage.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		4534DD8F036246958656447B /* ElectrodeBridgeHolder.h */ = {isa = PBXFileReference; name = "ElectrodeBridgeHolder.h"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeHolder.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		B7E82C42D9AF4AEDBE2A9665 /* ElectrodeBridgeMessage.h */ = {isa = PBXFileReference; name = "ElectrodeBridgeMessage.h"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeMessage.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		F222C0CDC0C04D1EABFA4FC2 /* ElectrodeBridgeProtocols.h */ = {isa = PBXFileReference; name = "ElectrodeBridgeProtocols.h"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeProtocols.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		AF03853308A340CE8DF58A45 /* ElectrodeBridgeRequest.h */ = {isa = PBXFileReference; name = "ElectrodeBridgeRequest.h"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeRequest.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		58CC99F571AA4324AB296D3A /* ElectrodeBridgeTransaction.h */ = {isa = PBXFileReference; name = "ElectrodeBridgeTransaction.h"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeTransaction.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		E88B3B8AB16744069F71E4B7 /* ElectrodeBridgeTransceiver.h */ = {isa = PBXFileReference; name = "ElectrodeBridgeTransceiver.h"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeTransceiver.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		6E6CE102096D4D42BA4B7249 /* ElectrodeBridgeTransceiver_Internal.h */ = {isa = PBXFileReference; name = "ElectrodeBridgeTransceiver_Internal.h"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeTransceiver_Internal.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		025B3B66AC294FA69EB38FD1 /* ElectrodeEventDispatcher.h */ = {isa = PBXFileReference; name = "ElectrodeEventDispatcher.h"; path = "ElectrodeReactNativeBridge/ElectrodeEventDispatcher.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		3AB594DD6347402E9EAF1A7D /* ElectrodeEventRegistrar.h */ = {isa = PBXFileReference; name = "ElectrodeEventRegistrar.h"; path = "ElectrodeReactNativeBridge/ElectrodeEventRegistrar.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		D999DACBBA4C436A98DA1651 /* ElectrodeRequestDispatcher.h */ = {isa = PBXFileReference; name = "ElectrodeRequestDispatcher.h"; path = "ElectrodeReactNativeBridge/ElectrodeRequestDispatcher.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		6A9267DEB21E4C20971E4EBE /* ElectrodeRequestRegistrar.h */ = {isa = PBXFileReference; name = "ElectrodeRequestRegistrar.h"; path = "ElectrodeReactNativeBridge/ElectrodeRequestRegistrar.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		227C4CB93C7849A09DF5A0B5 /* ElectrodeReactNativeBridge.h */ = {isa = PBXFileReference; name = "ElectrodeReactNativeBridge.h"; path = "ElectrodeReactNativeBridge/ElectrodeReactNativeBridge.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		3CB72912321B418B94D904C1 /* ElectrodeBridgeResponse.h */ = {isa = PBXFileReference; name = "ElectrodeBridgeResponse.h"; path = "ElectrodeReactNativeBridge/ElectrodeBridgeResponse.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		AA96309E76764F4699FCC9AC /* ElectrodeLogger.h */ = {isa = PBXFileReference; name = "ElectrodeLogger.h"; path = "ElectrodeReactNativeBridge/ElectrodeLogger.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		D6B4D9E10D54495DAE63FD07 /* RequestHandlerConfig.swift */ = {isa = PBXFileReference; name = "RequestHandlerConfig.swift"; path = "APIImpls/RequestHandlerConfig.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
+		FDF4B79503FC4C1CA75FDEF2 /* RequestHandlerProvider.swift */ = {isa = PBXFileReference; name = "RequestHandlerProvider.swift"; path = "APIImpls/RequestHandlerProvider.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
+		24BAF44817164401BD4F9261 /* MoviesApiController.swift */ = {isa = PBXFileReference; name = "MoviesApiController.swift"; path = "APIImpls/MoviesApiController.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
+		9991E74604B946DA913DD416 /* MoviesApiRequestHandlerDelegate.swift */ = {isa = PBXFileReference; name = "MoviesApiRequestHandlerDelegate.swift"; path = "APIImpls/MoviesApiRequestHandlerDelegate.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
+		5B6BB3A45FE04A9889730931 /* MoviesApiRequestHandlerProvider.swift */ = {isa = PBXFileReference; name = "MoviesApiRequestHandlerProvider.swift"; path = "APIImpls/MoviesApiRequestHandlerProvider.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -361,19 +361,19 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1D29B26C1DF14F00904D7AC7 /* libReact.a in Frameworks */,
-				F38D5A88B53245EC8602899B /* libRCTActionSheet.a in Frameworks */,
-				9EFE1764FF904EABA3C3C567 /* libRCTImage.a in Frameworks */,
-				1DFD252BC2674C6695E497A7 /* libRCTAnimation.a in Frameworks */,
-				D18E55B006A74C8E93F222DD /* libRCTText.a in Frameworks */,
-				731C7D69EC664CB0AB9E26D0 /* libRCTWebSocket.a in Frameworks */,
-				CEF4A00F578A4B5A923F335D /* libRCTLinking.a in Frameworks */,
-				E891452223214EFDB4D832C3 /* libRCTNetwork.a in Frameworks */,
-				D31F656E0C4F44D3A1CE5F64 /* libRCTSettings.a in Frameworks */,
-				7ED53936168041438C60A6BC /* libRCTVibration.a in Frameworks */,
-				59D427DD6D244CBE8E650DBE /* libRCTCameraRoll.a in Frameworks */,
-				9EAF4616667E4D5E946ACDC3 /* libART.a in Frameworks */,
-				C3CBC753A1FB4911A4DB720B /* JavaScriptCore.framework in Frameworks */,
+				91A62DCA98F04190A9BD81AF /* libReact.a in Frameworks */,
+				422E0ED3434F41059ADC4BE3 /* libRCTActionSheet.a in Frameworks */,
+				209BD438A04A4CBE867D770E /* libRCTImage.a in Frameworks */,
+				A6B5CA0431E2452994315E57 /* libRCTAnimation.a in Frameworks */,
+				77895A0769F44EAE88975765 /* libRCTText.a in Frameworks */,
+				C93A5A05069D4A5583611AD8 /* libRCTWebSocket.a in Frameworks */,
+				3BC7CAABE7F4444DBF347712 /* libRCTLinking.a in Frameworks */,
+				523DB60953474C5F85C39C8A /* libRCTNetwork.a in Frameworks */,
+				A378DCF570CC4C46A714AE4F /* libRCTSettings.a in Frameworks */,
+				C6C3286384744FD8A2405EEE /* libRCTVibration.a in Frameworks */,
+				5EA30A436C2948C48944ED8A /* libRCTCameraRoll.a in Frameworks */,
+				E3F81227A6024FDD9A839347 /* libART.a in Frameworks */,
+				3403260EAACA4995B4560D4B /* JavaScriptCore.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -391,18 +391,18 @@
 		226325CE1E80594F00CD0B10 /* ReactNative */ = {
 			isa = PBXGroup;
 			children = (
-				C524D9876CE64F81867DFFA7 /* React.xcodeproj */,
-				A4064CFB9A0A4EBB8FC79DAA /* RCTActionSheet.xcodeproj */,
-				CD75E435684348F39C854F37 /* RCTImage.xcodeproj */,
-				EBA9F2845C5648DBB47A488A /* RCTAnimation.xcodeproj */,
-				5E99B0891E684A61ACF345FA /* RCTText.xcodeproj */,
-				7DFEB507D6D84D2CB01B428D /* RCTWebSocket.xcodeproj */,
-				5D057527313744F7A94EF68E /* RCTLinking.xcodeproj */,
-				5FC4D815F8084A9B8D7CFA94 /* RCTNetwork.xcodeproj */,
-				F1A6094908DC41C1A13BE6E6 /* RCTSettings.xcodeproj */,
-				66EC659CFBAF433F8ACA76D8 /* RCTVibration.xcodeproj */,
-				D03FDDAEC40B4EC29104B2E4 /* RCTCameraRoll.xcodeproj */,
-				1300F5CC4AF748B190246657 /* ART.xcodeproj */,
+				1B74240B2FED4DAF85225D8A /* React.xcodeproj */,
+				F29154365FDD475B946E5302 /* RCTActionSheet.xcodeproj */,
+				2BBBBA557F2D447BA790EC99 /* RCTImage.xcodeproj */,
+				E0B63C72661C4141BAD93506 /* RCTAnimation.xcodeproj */,
+				1F6809096DE14F03B961AF47 /* RCTText.xcodeproj */,
+				62D7C7DF48064D1A8B13468D /* RCTWebSocket.xcodeproj */,
+				CD2E13564187469F9BF40743 /* RCTLinking.xcodeproj */,
+				F1F31928415543AD9B70884C /* RCTNetwork.xcodeproj */,
+				1FC90994BB9C4E26B4690514 /* RCTSettings.xcodeproj */,
+				093FEAB6D3A94D48B0F0253E /* RCTVibration.xcodeproj */,
+				756C6A08A7894E06ADE8FD0F /* RCTCameraRoll.xcodeproj */,
+				D916BAA30A86423294CAE90C /* ART.xcodeproj */,
 			);
 			name = ReactNative;
 			sourceTree = "<group>";
@@ -410,12 +410,12 @@
 		22C096A91EA0893F00E1486A /* APIs */ = {
 			isa = PBXGroup;
 			children = (
-				922AB0516B794DE199B9C2FA /* BirthYear.swift */,
-				89444EF457C44E4BA8568BF4 /* Movie.swift */,
-				3D9F065F09BA497C9D19A8F4 /* MoviesAPI.swift */,
-				4B2040C7A12F48B99AFDB78E /* MoviesRequests.swift */,
-				3A87EEFE9D02499B88560CB1 /* Person.swift */,
-				746E0A02ADE6412EB6410CDB /* Synopsis.swift */,
+				13B10AEDF1C742A89D8FFAE0 /* BirthYear.swift */,
+				F008A3DD55B1439E9629003C /* Movie.swift */,
+				51D1A8D89BE0424181B26C1C /* MoviesAPI.swift */,
+				8EB7520044374421B02CD5B9 /* MoviesRequests.swift */,
+				B035902C85D642CB913025E0 /* Person.swift */,
+				014CE5E2222F4AED975FC696 /* Synopsis.swift */,
 			);
 			name = APIs;
 			sourceTree = "<group>";
@@ -423,45 +423,45 @@
 		22FD4D1E1E96ECBB00FC81DB /* ElectrodeReactNativeBridge */ = {
 			isa = PBXGroup;
 			children = (
-				0A36683066BC490889DF4393 /* ElectrodeObject.swift */,
-				F8673ED2F04D47958AE2E8DC /* Bridgeable.swift */,
-				ED899B5E7CDA465C8D654D54 /* ElectrodeRequestHandlerProcessor.swift */,
-				72926F73F12148E48BF3E8FC /* ElectrodeRequestProcessor.swift */,
-				E165BC6B41C9411CA0E180AC /* ElectrodeUtilities.swift */,
-				D0C66D0AE0F04E7183ECEE4C /* EventListenerProcessor.swift */,
-				AF3B8C73DB8341DF84D68A61 /* EventProcessor.swift */,
-				F09E853E565444288CD1964C /* Processor.swift */,
-				D537440A144B4B878288603C /* None.swift */,
-				821B84A2A482485A97E9283E /* ElectrodeBridgeEvent.m */,
-				F7BA40A42A084F4FA3F273A6 /* ElectrodeBridgeFailureMessage.m */,
-				454B74BB01D04911BC46DE7C /* ElectrodeBridgeHolder.m */,
-				FA3D9732CAC64FF9BF4DA10E /* ElectrodeBridgeMessage.m */,
-				94A12E1EC03C405990498784 /* ElectrodeBridgeProtocols.m */,
-				4D6C8ACFDF684F6B9670237B /* ElectrodeBridgeRequest.m */,
-				7A78C56A2BD94F8D9670B207 /* ElectrodeBridgeResponse.m */,
-				F9AB3F8332E943B5B5C6070B /* ElectrodeBridgeTransaction.m */,
-				98B9046C45844779B41D5151 /* ElectrodeBridgeTransceiver.m */,
-				0DB5A3306FA945308A2CE6F4 /* ElectrodeEventDispatcher.m */,
-				B56DA748483D47E5B2820C4F /* ElectrodeEventRegistrar.m */,
-				1283577C4EFC4094840520AF /* ElectrodeRequestDispatcher.m */,
-				2A981CC9CF3C4C419884A133 /* ElectrodeRequestRegistrar.m */,
-				6EA3D4EC06B64B1DB8064458 /* ElectrodeLogger.m */,
-				6E52B1E80A394F31A798B099 /* ElectrodeBridgeEvent.h */,
-				B4E57F46A5764F04BD3B4F69 /* ElectrodeBridgeFailureMessage.h */,
-				1288768B5F864D9CA8352858 /* ElectrodeBridgeHolder.h */,
-				A0A4B741955942139F174160 /* ElectrodeBridgeMessage.h */,
-				2AF0643E2004494590BC19B2 /* ElectrodeBridgeProtocols.h */,
-				544D80E6740C4A4FA51E6260 /* ElectrodeBridgeRequest.h */,
-				F3FC08E34E024FBDB01030E7 /* ElectrodeBridgeTransaction.h */,
-				9442118C673445808FD8FB2F /* ElectrodeBridgeTransceiver.h */,
-				47C408392DAC4AF08E05C347 /* ElectrodeBridgeTransceiver_Internal.h */,
-				BAE20E8B32804BAF8040B9C6 /* ElectrodeEventDispatcher.h */,
-				A4190F10A88342CE9336B5D6 /* ElectrodeEventRegistrar.h */,
-				A1D0EBB0C58F4B87817F92CA /* ElectrodeRequestDispatcher.h */,
-				4C40D7317CA742C58FE043BA /* ElectrodeRequestRegistrar.h */,
-				DAD2D24668D7419994AEA019 /* ElectrodeReactNativeBridge.h */,
-				7F54A0B8AF294B0DBB75439B /* ElectrodeBridgeResponse.h */,
-				17DB6581B3DE48BF8E550663 /* ElectrodeLogger.h */,
+				3C8DCB96FFB44F22BA880A89 /* ElectrodeObject.swift */,
+				D0E1F8DD5FA04A9B923C2CD7 /* Bridgeable.swift */,
+				5085D58461F343F387419197 /* ElectrodeRequestHandlerProcessor.swift */,
+				8CB845D93BBF447E82BCABA5 /* ElectrodeRequestProcessor.swift */,
+				C56F3299C2A046BAA4E6602C /* ElectrodeUtilities.swift */,
+				6F33C74A7288445AB49578DA /* EventListenerProcessor.swift */,
+				7B816B2FEBBA45F0AB210566 /* EventProcessor.swift */,
+				49D007763A434C2C86B8E9EB /* Processor.swift */,
+				C23E7C2BDEDD46A9BC9CBB91 /* None.swift */,
+				FD9500C534864B2F82D2F37A /* ElectrodeBridgeEvent.m */,
+				982BEE6587D24E9BB3D26D3A /* ElectrodeBridgeFailureMessage.m */,
+				D6C52BD44FD34335B6C09A0A /* ElectrodeBridgeHolder.m */,
+				64D4D954FF6A48E3A963D7B3 /* ElectrodeBridgeMessage.m */,
+				8D3B569F92CF4E13B44C8F06 /* ElectrodeBridgeProtocols.m */,
+				058AC462661445CAAD000E54 /* ElectrodeBridgeRequest.m */,
+				3117C44ABF77458DB6EF587D /* ElectrodeBridgeResponse.m */,
+				0C3DB500F91242868D053568 /* ElectrodeBridgeTransaction.m */,
+				AC604D6C094D4278A7E55079 /* ElectrodeBridgeTransceiver.m */,
+				DB9A4863CB4A4584832617BE /* ElectrodeEventDispatcher.m */,
+				928134793E4E4EF8A6B5FC6E /* ElectrodeEventRegistrar.m */,
+				95A00CBC1C484252B2F211B6 /* ElectrodeRequestDispatcher.m */,
+				91D43B65FD464155BE3C8A4E /* ElectrodeRequestRegistrar.m */,
+				B6EF756CCC1949F69CEFC27C /* ElectrodeLogger.m */,
+				BCA323016FCE4EF8B4A64C3E /* ElectrodeBridgeEvent.h */,
+				D3FC3FC2F01B4468AE582A26 /* ElectrodeBridgeFailureMessage.h */,
+				4534DD8F036246958656447B /* ElectrodeBridgeHolder.h */,
+				B7E82C42D9AF4AEDBE2A9665 /* ElectrodeBridgeMessage.h */,
+				F222C0CDC0C04D1EABFA4FC2 /* ElectrodeBridgeProtocols.h */,
+				AF03853308A340CE8DF58A45 /* ElectrodeBridgeRequest.h */,
+				58CC99F571AA4324AB296D3A /* ElectrodeBridgeTransaction.h */,
+				E88B3B8AB16744069F71E4B7 /* ElectrodeBridgeTransceiver.h */,
+				6E6CE102096D4D42BA4B7249 /* ElectrodeBridgeTransceiver_Internal.h */,
+				025B3B66AC294FA69EB38FD1 /* ElectrodeEventDispatcher.h */,
+				3AB594DD6347402E9EAF1A7D /* ElectrodeEventRegistrar.h */,
+				D999DACBBA4C436A98DA1651 /* ElectrodeRequestDispatcher.h */,
+				6A9267DEB21E4C20971E4EBE /* ElectrodeRequestRegistrar.h */,
+				227C4CB93C7849A09DF5A0B5 /* ElectrodeReactNativeBridge.h */,
+				3CB72912321B418B94D904C1 /* ElectrodeBridgeResponse.h */,
+				AA96309E76764F4699FCC9AC /* ElectrodeLogger.h */,
 			);
 			name = ElectrodeReactNativeBridge;
 			sourceTree = "<group>";
@@ -527,7 +527,7 @@
 		48500AA71E2FFA14009B6610 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				2A5956E2AADA44929787B251 /* JavaScriptCore.framework */,
+				F9ECB7A5F13444D2AFB8F28B /* JavaScriptCore.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -535,11 +535,11 @@
 		7F1C6B771FAD343A00F68360 /* APIImpls */ = {
 			isa = PBXGroup;
 			children = (
-				3A57738B93AF4C989CEC135B /* RequestHandlerConfig.swift */,
-				3E23073932764A4494D0A022 /* RequestHandlerProvider.swift */,
-				84419EE64FA5431CBA6CF718 /* MoviesApiController.swift */,
-				FA9BDC4A11AC4923A4C3A3A5 /* MoviesApiRequestHandlerDelegate.swift */,
-				E8F860445AE44DCC8BF853D2 /* MoviesApiRequestHandlerProvider.swift */,
+				D6B4D9E10D54495DAE63FD07 /* RequestHandlerConfig.swift */,
+				FDF4B79503FC4C1CA75FDEF2 /* RequestHandlerProvider.swift */,
+				24BAF44817164401BD4F9261 /* MoviesApiController.swift */,
+				9991E74604B946DA913DD416 /* MoviesApiRequestHandlerDelegate.swift */,
+				5B6BB3A45FE04A9889730931 /* MoviesApiRequestHandlerProvider.swift */,
 			);
 			name = APIImpls;
 			sourceTree = "<group>";
@@ -551,109 +551,109 @@
 			path = MiniApp;
 			sourceTree = "<group>";
 		};
-		33E31D23B9784F6385E105CB /* Products */ = {
+		B30D2DC48EC34B0293AAC8FC /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				342ACF96D6004DC3BA3ECB4A /* libReact.a */,
+				4530D0C4E2354B75AA715F09 /* libReact.a */,
 			);
 			name = Products;
 			path = undefined;
 			sourceTree = "<group>";
 		};
-		9303A283A6E84B52899CD575 /* Products */ = {
+		B0CEDF1D04024753AFDC4CDB /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				B8377F0EC1644AD087327E76 /* libRCTActionSheet.a */,
+				8659CA6AA91F4125AB8F7B6B /* libRCTActionSheet.a */,
 			);
 			name = Products;
 			path = undefined;
 			sourceTree = "<group>";
 		};
-		CED86B66C64047F7807C7B21 /* Products */ = {
+		7778AC85518F4006A18A5E67 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				756CCFE460A74914B31F152F /* libRCTImage.a */,
+				675DD353DA434F3887E3F07E /* libRCTImage.a */,
 			);
 			name = Products;
 			path = undefined;
 			sourceTree = "<group>";
 		};
-		479DE006C87743418E07B9CF /* Products */ = {
+		F2793D44606D4AA1A446039D /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				A00A5B08C01A4E9FAB6AC128 /* libRCTAnimation.a */,
+				F285AF6B832D4DF1B0FE570D /* libRCTAnimation.a */,
 			);
 			name = Products;
 			path = undefined;
 			sourceTree = "<group>";
 		};
-		DF43F9C24C084DBA9CEE7226 /* Products */ = {
+		669098FDDC424D58A67C05A3 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				2D31630C788847C795184181 /* libRCTText.a */,
+				695896FB4B024D6D8574AAA4 /* libRCTText.a */,
 			);
 			name = Products;
 			path = undefined;
 			sourceTree = "<group>";
 		};
-		6A1EA6428DCF44F59A553FFD /* Products */ = {
+		7EB2738043374DD9B6AEA1A5 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				DA8CB8DF5660447DB08588B9 /* libRCTWebSocket.a */,
+				DDA5EAEB810649F09F05CBBC /* libRCTWebSocket.a */,
 			);
 			name = Products;
 			path = undefined;
 			sourceTree = "<group>";
 		};
-		54847B062FE34A459356DA6C /* Products */ = {
+		63498D91E8C44B5D958CF01A /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				D587F64962B54B42BCE87221 /* libRCTLinking.a */,
+				06CC3837B38545D5B8700231 /* libRCTLinking.a */,
 			);
 			name = Products;
 			path = undefined;
 			sourceTree = "<group>";
 		};
-		D1001014244A49AB93970801 /* Products */ = {
+		CFA1C6AF4CB240EBACBBAAC4 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				29279E8AB8A34CADBF2E12E5 /* libRCTNetwork.a */,
+				79B0B5EC498741B7A2CEB13C /* libRCTNetwork.a */,
 			);
 			name = Products;
 			path = undefined;
 			sourceTree = "<group>";
 		};
-		3F36D741DC144FA79924D7A1 /* Products */ = {
+		E31C4065632A4A7ABCCE3C99 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				879203F5F2D04719A2E77912 /* libRCTSettings.a */,
+				20A0C4D4891C45ED8153BE83 /* libRCTSettings.a */,
 			);
 			name = Products;
 			path = undefined;
 			sourceTree = "<group>";
 		};
-		57D43446B6574165893E550C /* Products */ = {
+		2AAC1A50B1A546E482E2A598 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				57C87EFEFAC746178BA5AD09 /* libRCTVibration.a */,
+				4DF73984DD4641139953D2BE /* libRCTVibration.a */,
 			);
 			name = Products;
 			path = undefined;
 			sourceTree = "<group>";
 		};
-		34ED9413504E4F0CB9DE8644 /* Products */ = {
+		AEF38B71879A4D2C9AE12D2A /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				8750E888785C4AC5B682995C /* libRCTCameraRoll.a */,
+				EDA16051889D48A297C2FC05 /* libRCTCameraRoll.a */,
 			);
 			name = Products;
 			path = undefined;
 			sourceTree = "<group>";
 		};
-		7C89599B9E6645C0B741DB8F /* Products */ = {
+		AB468BECC56A49D6B0D39421 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				EC0521DEC3C240BCBBAAABEF /* libART.a */,
+				81914CD829AE40F2B1C19EF3 /* libART.a */,
 			);
 			name = Products;
 			path = undefined;
@@ -670,28 +670,28 @@
 				968333D71E54E3470031C565 /* ElectrodeBridgeDelegate.h in Headers */,
 				30F8CDEE1E67946E00413247 /* ElectrodeReactNative_Internal.h in Headers */,
 				48500A981E2FF55B009B6610 /* ElectrodeReactNative.h in Headers */,
-				95FA7029C262409882F17FFF /* BirthYear.swift in Headers */,
-				675152A6B90D48F6B5E5423C /* Movie.swift in Headers */,
-				11CDB21C18AD48418FD47233 /* MoviesAPI.swift in Headers */,
-				205CE59DB2054B0F9A002AB0 /* MoviesRequests.swift in Headers */,
-				164210A9789C4649A3528D7C /* Person.swift in Headers */,
-				5796ABC351204FA28783A1D0 /* Synopsis.swift in Headers */,
-				C23EAF2CB1474B0E8DDF2DF8 /* ElectrodeBridgeEvent.h in Headers */,
-				FE1E25388CFA4579A4B74323 /* ElectrodeBridgeFailureMessage.h in Headers */,
-				87498F35A38A4C4D9957A267 /* ElectrodeBridgeHolder.h in Headers */,
-				A65961AC242F402FA33C1870 /* ElectrodeBridgeMessage.h in Headers */,
-				17D981AAAAF2409D8220271B /* ElectrodeBridgeProtocols.h in Headers */,
-				D874B8FCBD2741AE9757177B /* ElectrodeBridgeRequest.h in Headers */,
-				6E8CE40513D0426E9AF4CC73 /* ElectrodeBridgeTransaction.h in Headers */,
-				2C412BD40F424C09B8420E20 /* ElectrodeBridgeTransceiver.h in Headers */,
-				EC98153D553345FEB1392FFE /* ElectrodeBridgeTransceiver_Internal.h in Headers */,
-				332138ACE45B40C4BE902653 /* ElectrodeEventDispatcher.h in Headers */,
-				1F42260A5273410DA41E0822 /* ElectrodeEventRegistrar.h in Headers */,
-				FC6180DC037142A88A353178 /* ElectrodeRequestDispatcher.h in Headers */,
-				B122825FE1BE4B94BF69A882 /* ElectrodeRequestRegistrar.h in Headers */,
-				6C68C376F7B84ECF898737B2 /* ElectrodeReactNativeBridge.h in Headers */,
-				FCA3F3A6EF6B488F9D07BABC /* ElectrodeBridgeResponse.h in Headers */,
-				A267DB259E6E45118C7EA2CE /* ElectrodeLogger.h in Headers */,
+				2E5D54881DF34A2C83D98DED /* BirthYear.swift in Headers */,
+				65D73A592D9B4307A22D6235 /* Movie.swift in Headers */,
+				EDCAB009C0FD4523BA5A8820 /* MoviesAPI.swift in Headers */,
+				C1F53B09F3124B9D86911E8D /* MoviesRequests.swift in Headers */,
+				6667F5FA0F684D2EBBEBB230 /* Person.swift in Headers */,
+				56FE4D76E8D54FA9BD71DAB7 /* Synopsis.swift in Headers */,
+				6920D1139E0548A39AFCAE46 /* ElectrodeBridgeEvent.h in Headers */,
+				ED3B37211CC240E68A8B15BE /* ElectrodeBridgeFailureMessage.h in Headers */,
+				034E83165FFD410EAED42C80 /* ElectrodeBridgeHolder.h in Headers */,
+				491EA01390A544F3844E90FF /* ElectrodeBridgeMessage.h in Headers */,
+				272CB7ADBB554DC8A3019E45 /* ElectrodeBridgeProtocols.h in Headers */,
+				E829ECCBB295434CAFBA27B3 /* ElectrodeBridgeRequest.h in Headers */,
+				D54E2BD324064BD58C2F5247 /* ElectrodeBridgeTransaction.h in Headers */,
+				73189C98E92C4370B00A1BBC /* ElectrodeBridgeTransceiver.h in Headers */,
+				B332553A8D3648CD96E96F97 /* ElectrodeBridgeTransceiver_Internal.h in Headers */,
+				4CAE95209C894F15B6F94B3E /* ElectrodeEventDispatcher.h in Headers */,
+				3BB484FF8855407E988C0D87 /* ElectrodeEventRegistrar.h in Headers */,
+				9C85E44439D04BB18B38DB0B /* ElectrodeRequestDispatcher.h in Headers */,
+				86377534357B4D16A184D56C /* ElectrodeRequestRegistrar.h in Headers */,
+				FF533697BBF84834A2FE3AAB /* ElectrodeReactNativeBridge.h in Headers */,
+				1E2FDB1E92DF4CA081F9A207 /* ElectrodeBridgeResponse.h in Headers */,
+				E5AAD8A1E3F74E4A90A7CD82 /* ElectrodeLogger.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -710,18 +710,18 @@
 			buildRules = (
 			);
 			dependencies = (
-				3F48AB4D6AA846D9BF0E5133 /* PBXTargetDependency */,
-				19550F21BED74D229BCB062D /* PBXTargetDependency */,
-				F4723BEE5DD94B55ACD1F594 /* PBXTargetDependency */,
-				A09C47804BE8419F95C7840A /* PBXTargetDependency */,
-				308291E992354B46A810870F /* PBXTargetDependency */,
-				2DB0C8266AE84234896120EE /* PBXTargetDependency */,
-				7D6832B6FB1644B3B12735D1 /* PBXTargetDependency */,
-				4BA2828001D64A20A73B355B /* PBXTargetDependency */,
-				D86D44989CE944C7964CF6B1 /* PBXTargetDependency */,
-				F507A4E0F8AD4FE9A58CA7CF /* PBXTargetDependency */,
-				2BDB65C0D72A4C6681B1F9FB /* PBXTargetDependency */,
-				9CAD3FD3ACC5479986BC11FA /* PBXTargetDependency */,
+				2FDAA86E4CE249AE9A4A4DF9 /* PBXTargetDependency */,
+				2227219C8E3947F496BEDB65 /* PBXTargetDependency */,
+				539DFD41EA454C5497668FDD /* PBXTargetDependency */,
+				71CF099645AF4AC59F0C5886 /* PBXTargetDependency */,
+				941E8025A03A4571A19324B3 /* PBXTargetDependency */,
+				FD3CCF0C4B67484480BF756D /* PBXTargetDependency */,
+				EC92F6E3BF144F3EB47ACC0E /* PBXTargetDependency */,
+				0FB3CBC3AC934A919F9C9730 /* PBXTargetDependency */,
+				9572C8679B2045F39B65EF3A /* PBXTargetDependency */,
+				544E2506573C470CBCC7C5DD /* PBXTargetDependency */,
+				16B513B37179407E858EB988 /* PBXTargetDependency */,
+				D511D9F8EA22474CA6CA6617 /* PBXTargetDependency */,
 			);
 			name = ElectrodeApiImpl;
 			productName = ElectrodeApiImpl;
@@ -783,140 +783,140 @@
 			);
 			projectReferences = (
 				{
-					ProjectRef = C524D9876CE64F81867DFFA7 /* React.xcodeproj */;
-					ProductGroup = 33E31D23B9784F6385E105CB /* Products */;
+					ProjectRef = 1B74240B2FED4DAF85225D8A /* React.xcodeproj */;
+					ProductGroup = B30D2DC48EC34B0293AAC8FC /* Products */;
 				},
 				{
-					ProjectRef = A4064CFB9A0A4EBB8FC79DAA /* RCTActionSheet.xcodeproj */;
-					ProductGroup = 9303A283A6E84B52899CD575 /* Products */;
+					ProjectRef = F29154365FDD475B946E5302 /* RCTActionSheet.xcodeproj */;
+					ProductGroup = B0CEDF1D04024753AFDC4CDB /* Products */;
 				},
 				{
-					ProjectRef = CD75E435684348F39C854F37 /* RCTImage.xcodeproj */;
-					ProductGroup = CED86B66C64047F7807C7B21 /* Products */;
+					ProjectRef = 2BBBBA557F2D447BA790EC99 /* RCTImage.xcodeproj */;
+					ProductGroup = 7778AC85518F4006A18A5E67 /* Products */;
 				},
 				{
-					ProjectRef = EBA9F2845C5648DBB47A488A /* RCTAnimation.xcodeproj */;
-					ProductGroup = 479DE006C87743418E07B9CF /* Products */;
+					ProjectRef = E0B63C72661C4141BAD93506 /* RCTAnimation.xcodeproj */;
+					ProductGroup = F2793D44606D4AA1A446039D /* Products */;
 				},
 				{
-					ProjectRef = 5E99B0891E684A61ACF345FA /* RCTText.xcodeproj */;
-					ProductGroup = DF43F9C24C084DBA9CEE7226 /* Products */;
+					ProjectRef = 1F6809096DE14F03B961AF47 /* RCTText.xcodeproj */;
+					ProductGroup = 669098FDDC424D58A67C05A3 /* Products */;
 				},
 				{
-					ProjectRef = 7DFEB507D6D84D2CB01B428D /* RCTWebSocket.xcodeproj */;
-					ProductGroup = 6A1EA6428DCF44F59A553FFD /* Products */;
+					ProjectRef = 62D7C7DF48064D1A8B13468D /* RCTWebSocket.xcodeproj */;
+					ProductGroup = 7EB2738043374DD9B6AEA1A5 /* Products */;
 				},
 				{
-					ProjectRef = 5D057527313744F7A94EF68E /* RCTLinking.xcodeproj */;
-					ProductGroup = 54847B062FE34A459356DA6C /* Products */;
+					ProjectRef = CD2E13564187469F9BF40743 /* RCTLinking.xcodeproj */;
+					ProductGroup = 63498D91E8C44B5D958CF01A /* Products */;
 				},
 				{
-					ProjectRef = 5FC4D815F8084A9B8D7CFA94 /* RCTNetwork.xcodeproj */;
-					ProductGroup = D1001014244A49AB93970801 /* Products */;
+					ProjectRef = F1F31928415543AD9B70884C /* RCTNetwork.xcodeproj */;
+					ProductGroup = CFA1C6AF4CB240EBACBBAAC4 /* Products */;
 				},
 				{
-					ProjectRef = F1A6094908DC41C1A13BE6E6 /* RCTSettings.xcodeproj */;
-					ProductGroup = 3F36D741DC144FA79924D7A1 /* Products */;
+					ProjectRef = 1FC90994BB9C4E26B4690514 /* RCTSettings.xcodeproj */;
+					ProductGroup = E31C4065632A4A7ABCCE3C99 /* Products */;
 				},
 				{
-					ProjectRef = 66EC659CFBAF433F8ACA76D8 /* RCTVibration.xcodeproj */;
-					ProductGroup = 57D43446B6574165893E550C /* Products */;
+					ProjectRef = 093FEAB6D3A94D48B0F0253E /* RCTVibration.xcodeproj */;
+					ProductGroup = 2AAC1A50B1A546E482E2A598 /* Products */;
 				},
 				{
-					ProjectRef = D03FDDAEC40B4EC29104B2E4 /* RCTCameraRoll.xcodeproj */;
-					ProductGroup = 34ED9413504E4F0CB9DE8644 /* Products */;
+					ProjectRef = 756C6A08A7894E06ADE8FD0F /* RCTCameraRoll.xcodeproj */;
+					ProductGroup = AEF38B71879A4D2C9AE12D2A /* Products */;
 				},
 				{
-					ProjectRef = 1300F5CC4AF748B190246657 /* ART.xcodeproj */;
-					ProductGroup = 7C89599B9E6645C0B741DB8F /* Products */;
+					ProjectRef = D916BAA30A86423294CAE90C /* ART.xcodeproj */;
+					ProductGroup = AB468BECC56A49D6B0D39421 /* Products */;
 				},
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		342ACF96D6004DC3BA3ECB4A /* libReact.a */ = {
+		4530D0C4E2354B75AA715F09 /* libReact.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
 			path = libReact.a;
-			remoteRef = 9B00B06B0ABD47B4B1DAB48D /* PBXContainerItemProxy */;
+			remoteRef = B0151E15752A45759B41A30B /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		B8377F0EC1644AD087327E76 /* libRCTActionSheet.a */ = {
+		8659CA6AA91F4125AB8F7B6B /* libRCTActionSheet.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
 			path = libRCTActionSheet.a;
-			remoteRef = 94AD3FA22C9E428BAC291CB7 /* PBXContainerItemProxy */;
+			remoteRef = 21B0C6B3E4A54CA486DFFD1B /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		756CCFE460A74914B31F152F /* libRCTImage.a */ = {
+		675DD353DA434F3887E3F07E /* libRCTImage.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
 			path = libRCTImage.a;
-			remoteRef = 34224277956349EDAF2976D5 /* PBXContainerItemProxy */;
+			remoteRef = 8D6A7438F39C40BE9CBD03DD /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		A00A5B08C01A4E9FAB6AC128 /* libRCTAnimation.a */ = {
+		F285AF6B832D4DF1B0FE570D /* libRCTAnimation.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
 			path = libRCTAnimation.a;
-			remoteRef = E4581D952885429A91ED69C6 /* PBXContainerItemProxy */;
+			remoteRef = 28D98B1892CB427094C30EB6 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		2D31630C788847C795184181 /* libRCTText.a */ = {
+		695896FB4B024D6D8574AAA4 /* libRCTText.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
 			path = libRCTText.a;
-			remoteRef = 7A1280F8D847461DA2F65956 /* PBXContainerItemProxy */;
+			remoteRef = D8EE690E111A4B0A87AA865B /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		DA8CB8DF5660447DB08588B9 /* libRCTWebSocket.a */ = {
+		DDA5EAEB810649F09F05CBBC /* libRCTWebSocket.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
 			path = libRCTWebSocket.a;
-			remoteRef = F679EA0410A045B59A3D1975 /* PBXContainerItemProxy */;
+			remoteRef = 9FC62972570848F2A85BE1E4 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		D587F64962B54B42BCE87221 /* libRCTLinking.a */ = {
+		06CC3837B38545D5B8700231 /* libRCTLinking.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
 			path = libRCTLinking.a;
-			remoteRef = 718E5B0C384143FC8CF87603 /* PBXContainerItemProxy */;
+			remoteRef = 09906E471D024593BD44C51D /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		29279E8AB8A34CADBF2E12E5 /* libRCTNetwork.a */ = {
+		79B0B5EC498741B7A2CEB13C /* libRCTNetwork.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
 			path = libRCTNetwork.a;
-			remoteRef = 427F2F57269F40D7AC21AE6D /* PBXContainerItemProxy */;
+			remoteRef = 929E234F7AEA4D5CB3F4FA9D /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		879203F5F2D04719A2E77912 /* libRCTSettings.a */ = {
+		20A0C4D4891C45ED8153BE83 /* libRCTSettings.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
 			path = libRCTSettings.a;
-			remoteRef = 8B758344F05F44778F052309 /* PBXContainerItemProxy */;
+			remoteRef = 6239AF62627247ACA47F58F7 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		57C87EFEFAC746178BA5AD09 /* libRCTVibration.a */ = {
+		4DF73984DD4641139953D2BE /* libRCTVibration.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
 			path = libRCTVibration.a;
-			remoteRef = A690D3E4408F4E5DACCD5E17 /* PBXContainerItemProxy */;
+			remoteRef = 48544E17AF0944589362B112 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		8750E888785C4AC5B682995C /* libRCTCameraRoll.a */ = {
+		EDA16051889D48A297C2FC05 /* libRCTCameraRoll.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
 			path = libRCTCameraRoll.a;
-			remoteRef = 88725C57E2CE461CA4A9DFD3 /* PBXContainerItemProxy */;
+			remoteRef = 6F49667A06B646179C2EFA4D /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		EC0521DEC3C240BCBBAAABEF /* libART.a */ = {
+		81914CD829AE40F2B1C19EF3 /* libART.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
 			path = libART.a;
-			remoteRef = 7CAF460658244A2A8936F781 /* PBXContainerItemProxy */;
+			remoteRef = 84330495BD1F444F864FFBDC /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -945,40 +945,40 @@
 			files = (
 				48500A991E2FF55B009B6610 /* ElectrodeReactNative.m in Sources */,
 				968333D81E54E3470031C565 /* ElectrodeBridgeDelegate.m in Sources */,
-				9FFFB709FA934199B8371C61 /* BirthYear.swift in Sources */,
-				B564A86FC75846948872FAE3 /* Movie.swift in Sources */,
-				77C865A1071F4320A4015BCC /* MoviesAPI.swift in Sources */,
-				FA670D7560914A589B0FCE2B /* MoviesRequests.swift in Sources */,
-				C636FC82FEF4421CAB6CC086 /* Person.swift in Sources */,
-				FCCC88BA9B40441881CB2CCA /* Synopsis.swift in Sources */,
-				BBC1A7AF1CEB451A93DAD2CD /* ElectrodeObject.swift in Sources */,
-				C13F2C3D2330409F994D2E31 /* Bridgeable.swift in Sources */,
-				FA96F01717664CA7B932C20E /* ElectrodeRequestHandlerProcessor.swift in Sources */,
-				0D26150FE4EA4A85AEF975B9 /* ElectrodeRequestProcessor.swift in Sources */,
-				AA3F41E300FA4F49B95DBFF0 /* ElectrodeUtilities.swift in Sources */,
-				C9CF3234AB2341AFB4649A98 /* EventListenerProcessor.swift in Sources */,
-				F002B5EFD5CD4332B6DE381C /* EventProcessor.swift in Sources */,
-				9553CFA0BC434CCD92FC69BF /* Processor.swift in Sources */,
-				F3CC2B941C034C539C37FC3F /* None.swift in Sources */,
-				B9CF8B6DE246400F84005064 /* ElectrodeBridgeEvent.m in Sources */,
-				851B536347604511B6E3A1DF /* ElectrodeBridgeFailureMessage.m in Sources */,
-				353D6A2F14A94507BA484DC3 /* ElectrodeBridgeHolder.m in Sources */,
-				C6E475A6A4FC4EC6ABD6FD63 /* ElectrodeBridgeMessage.m in Sources */,
-				F7916C8A50AC42D1B1CBE6CE /* ElectrodeBridgeProtocols.m in Sources */,
-				F0497EFD088C48959542CF8B /* ElectrodeBridgeRequest.m in Sources */,
-				06FB3ABAEE7F49D2AB29D060 /* ElectrodeBridgeResponse.m in Sources */,
-				8C3AE94331BE4A128AC95ABE /* ElectrodeBridgeTransaction.m in Sources */,
-				A24494D32E82492DB19F7214 /* ElectrodeBridgeTransceiver.m in Sources */,
-				20212A28174C4E66A6C09EB5 /* ElectrodeEventDispatcher.m in Sources */,
-				A9758458F8DD48B79CE51A95 /* ElectrodeEventRegistrar.m in Sources */,
-				B3E66CBC1EF846A59559F7B6 /* ElectrodeRequestDispatcher.m in Sources */,
-				0584D37782D44684B94DAB8E /* ElectrodeRequestRegistrar.m in Sources */,
-				628998D472D7457DB8E3C0EC /* ElectrodeLogger.m in Sources */,
-				A9C41B75D74C4481A3DCA8E8 /* RequestHandlerConfig.swift in Sources */,
-				8508E94F74C74474A7E2DE2F /* RequestHandlerProvider.swift in Sources */,
-				15401B3EFC2B40A683BA6AF9 /* MoviesApiController.swift in Sources */,
-				2F53C92653994F51A6CCC6C4 /* MoviesApiRequestHandlerDelegate.swift in Sources */,
-				7B5B02311BA442F4B33714E3 /* MoviesApiRequestHandlerProvider.swift in Sources */,
+				BA97D74343BA490382F059E3 /* BirthYear.swift in Sources */,
+				0FB692E011474519B2FCF855 /* Movie.swift in Sources */,
+				7D4E5A2E68FD41259E7C5D43 /* MoviesAPI.swift in Sources */,
+				C59360F3F535408BBABA4517 /* MoviesRequests.swift in Sources */,
+				9AF196F7CBEE404098257C65 /* Person.swift in Sources */,
+				8562544B4A09418CB51D7D60 /* Synopsis.swift in Sources */,
+				D357DFB910AB4F3C8CCAE049 /* ElectrodeObject.swift in Sources */,
+				29B05768E2CB46EE8E8D97ED /* Bridgeable.swift in Sources */,
+				A21D7C2770F243F2B6CEB19D /* ElectrodeRequestHandlerProcessor.swift in Sources */,
+				CEA3E8ECC8694C549F50D2A5 /* ElectrodeRequestProcessor.swift in Sources */,
+				A240144532924676A6211059 /* ElectrodeUtilities.swift in Sources */,
+				CD55DCEABDA7429A998FBAFC /* EventListenerProcessor.swift in Sources */,
+				280FB03914EB468FBB853D9E /* EventProcessor.swift in Sources */,
+				3A460D3484E1456191A39C83 /* Processor.swift in Sources */,
+				6FF96C47C6E5442093FEAD63 /* None.swift in Sources */,
+				159B1DE3D12B4CBAB910D579 /* ElectrodeBridgeEvent.m in Sources */,
+				9BF86B1A55824858A9232819 /* ElectrodeBridgeFailureMessage.m in Sources */,
+				0603AA7A10CA4479ADAA3682 /* ElectrodeBridgeHolder.m in Sources */,
+				C8F68C30B4A043E78A068664 /* ElectrodeBridgeMessage.m in Sources */,
+				55815C5C070843EA87B45305 /* ElectrodeBridgeProtocols.m in Sources */,
+				EAE7142CBE8F4D71A3DB73D1 /* ElectrodeBridgeRequest.m in Sources */,
+				1D51194FAD2B44679E42D615 /* ElectrodeBridgeResponse.m in Sources */,
+				526403837DA34F4993170BF8 /* ElectrodeBridgeTransaction.m in Sources */,
+				CF5C601A7EEF462D87145919 /* ElectrodeBridgeTransceiver.m in Sources */,
+				795ACC6907DB4258B9FDECBA /* ElectrodeEventDispatcher.m in Sources */,
+				C6C44602E4DB49CA9FC47D1E /* ElectrodeEventRegistrar.m in Sources */,
+				C8F1718893D94907B16552C9 /* ElectrodeRequestDispatcher.m in Sources */,
+				7462F357C17A4A0885F84703 /* ElectrodeRequestRegistrar.m in Sources */,
+				0653AF9860FC42A5B7DA1354 /* ElectrodeLogger.m in Sources */,
+				8CFD80B054854A91AAC3D36E /* RequestHandlerConfig.swift in Sources */,
+				732A58B500C54BF1820AEB1F /* RequestHandlerProvider.swift in Sources */,
+				FE216A0EB8FA4CDF856C5356 /* MoviesApiController.swift in Sources */,
+				53486FBBB3EB4325BDAF00BA /* MoviesApiRequestHandlerDelegate.swift in Sources */,
+				A51D611E410C4CED8DCA55B6 /* MoviesApiRequestHandlerProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1000,65 +1000,65 @@
 			target = 485009E21E2FF23B009B6610 /* ElectrodeApiImpl */;
 			targetProxy = 485009EE1E2FF23C009B6610 /* PBXContainerItemProxy */;
 		};
-		3F48AB4D6AA846D9BF0E5133 /* PBXTargetDependency */ = {
+		2FDAA86E4CE249AE9A4A4DF9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = React;
-			targetProxy = EE1DBF2392A94B8FAE9EA52D /* PBXContainerItemProxy */;
+			targetProxy = 121F726F8740469088E0ABEB /* PBXContainerItemProxy */;
 		};
-		19550F21BED74D229BCB062D /* PBXTargetDependency */ = {
+		2227219C8E3947F496BEDB65 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = RCTActionSheet;
-			targetProxy = 20625B9C7B0A424880FCE5F3 /* PBXContainerItemProxy */;
+			targetProxy = 68375611FBB84BD78ACA4D0E /* PBXContainerItemProxy */;
 		};
-		F4723BEE5DD94B55ACD1F594 /* PBXTargetDependency */ = {
+		539DFD41EA454C5497668FDD /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = RCTImage;
-			targetProxy = DD7EADE1A0B746708E9E462F /* PBXContainerItemProxy */;
+			targetProxy = 004C372D30524488B9FF6FFF /* PBXContainerItemProxy */;
 		};
-		A09C47804BE8419F95C7840A /* PBXTargetDependency */ = {
+		71CF099645AF4AC59F0C5886 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = RCTAnimation;
-			targetProxy = 03774759791944ACB1CCBC5B /* PBXContainerItemProxy */;
+			targetProxy = 5446D4C3FD8B48C78C8CA8EF /* PBXContainerItemProxy */;
 		};
-		308291E992354B46A810870F /* PBXTargetDependency */ = {
+		941E8025A03A4571A19324B3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = RCTText;
-			targetProxy = 93884F884A6B48AD9DAAC0BB /* PBXContainerItemProxy */;
+			targetProxy = FD0C94CB12304ADB8D3F7E9C /* PBXContainerItemProxy */;
 		};
-		2DB0C8266AE84234896120EE /* PBXTargetDependency */ = {
+		FD3CCF0C4B67484480BF756D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = RCTWebSocket;
-			targetProxy = CFAA3CEB493843B895C79274 /* PBXContainerItemProxy */;
+			targetProxy = 31F1CCDBAADF4266B7774D72 /* PBXContainerItemProxy */;
 		};
-		7D6832B6FB1644B3B12735D1 /* PBXTargetDependency */ = {
+		EC92F6E3BF144F3EB47ACC0E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = RCTLinking;
-			targetProxy = 2CAB32BCF4F74720A656C629 /* PBXContainerItemProxy */;
+			targetProxy = 3DCB845B0BE24905B7396EF5 /* PBXContainerItemProxy */;
 		};
-		4BA2828001D64A20A73B355B /* PBXTargetDependency */ = {
+		0FB3CBC3AC934A919F9C9730 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = RCTNetwork;
-			targetProxy = 0915A4BAA7444B01BD581B47 /* PBXContainerItemProxy */;
+			targetProxy = A94BC7A1C5F4481FB923A2A4 /* PBXContainerItemProxy */;
 		};
-		D86D44989CE944C7964CF6B1 /* PBXTargetDependency */ = {
+		9572C8679B2045F39B65EF3A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = RCTSettings;
-			targetProxy = 183B800F57574D3992972D76 /* PBXContainerItemProxy */;
+			targetProxy = 141C79D2BF6A48E098B4F6D3 /* PBXContainerItemProxy */;
 		};
-		F507A4E0F8AD4FE9A58CA7CF /* PBXTargetDependency */ = {
+		544E2506573C470CBCC7C5DD /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = RCTVibration;
-			targetProxy = 842628DC7E494198ADC721BB /* PBXContainerItemProxy */;
+			targetProxy = 4580143CC5F841789A9C5EF9 /* PBXContainerItemProxy */;
 		};
-		2BDB65C0D72A4C6681B1F9FB /* PBXTargetDependency */ = {
+		16B513B37179407E858EB988 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = RCTCameraRoll;
-			targetProxy = BF49BC485E394C76A843FF50 /* PBXContainerItemProxy */;
+			targetProxy = D7316B8D23E84EBAADAEC6AF /* PBXContainerItemProxy */;
 		};
-		9CAD3FD3ACC5479986BC11FA /* PBXTargetDependency */ = {
+		D511D9F8EA22474CA6CA6617 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = ART;
-			targetProxy = 2EDD100319C14AB09C9C0B5C /* PBXContainerItemProxy */;
+			targetProxy = E28CE15E1CE44AF1B486E506 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/system-tests/fixtures/api-impl-native/ReactNativeErnmovieApiImplNative/yarn.lock
+++ b/system-tests/fixtures/api-impl-native/ReactNativeErnmovieApiImplNative/yarn.lock
@@ -10,17 +10,17 @@
     "@babel/highlight" "^7.0.0"
 
 "@babel/core@^7.0.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.6.0.tgz#9b00f73554edd67bebc86df8303ef678be3d7b48"
-  integrity sha512-FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.6.4.tgz#6ebd9fe00925f6c3e177bb726a188b5f578088ff"
+  integrity sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==
   dependencies:
     "@babel/code-frame" "^7.5.5"
-    "@babel/generator" "^7.6.0"
-    "@babel/helpers" "^7.6.0"
-    "@babel/parser" "^7.6.0"
+    "@babel/generator" "^7.6.4"
+    "@babel/helpers" "^7.6.2"
+    "@babel/parser" "^7.6.4"
     "@babel/template" "^7.6.0"
-    "@babel/traverse" "^7.6.0"
-    "@babel/types" "^7.6.0"
+    "@babel/traverse" "^7.6.3"
+    "@babel/types" "^7.6.3"
     convert-source-map "^1.1.0"
     debug "^4.1.0"
     json5 "^2.1.0"
@@ -29,16 +29,15 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.0.0", "@babel/generator@^7.6.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.6.0.tgz#e2c21efbfd3293ad819a2359b448f002bfdfda56"
-  integrity sha512-Ms8Mo7YBdMMn1BYuNtKuP/z0TgEIhbcyB8HVR6PPNYp4P61lMsABiS4A3VG1qznjXVCf3r+fVHhm4efTYVsySA==
+"@babel/generator@^7.0.0", "@babel/generator@^7.6.3", "@babel/generator@^7.6.4":
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.6.4.tgz#a4f8437287bf9671b07f483b76e3bb731bc97671"
+  integrity sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==
   dependencies:
-    "@babel/types" "^7.6.0"
+    "@babel/types" "^7.6.3"
     jsesc "^2.5.1"
     lodash "^4.17.13"
     source-map "^0.5.0"
-    trim-right "^1.0.1"
 
 "@babel/helper-annotate-as-pure@^7.0.0":
   version "7.0.0"
@@ -215,13 +214,13 @@
     "@babel/traverse" "^7.1.0"
     "@babel/types" "^7.2.0"
 
-"@babel/helpers@^7.6.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.6.0.tgz#21961d16c6a3c3ab597325c34c465c0887d31c6e"
-  integrity sha512-W9kao7OBleOjfXtFGgArGRX6eCP0UEcA2ZWEWNkJdRZnHhW4eEbeswbG3EwaRsnQUAEGWYgMq1HsIXuNNNy2eQ==
+"@babel/helpers@^7.6.2":
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.6.2.tgz#681ffe489ea4dcc55f23ce469e58e59c1c045153"
+  integrity sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==
   dependencies:
     "@babel/template" "^7.6.0"
-    "@babel/traverse" "^7.6.0"
+    "@babel/traverse" "^7.6.2"
     "@babel/types" "^7.6.0"
 
 "@babel/highlight@^7.0.0":
@@ -233,10 +232,10 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.6.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.0.tgz#3e05d0647432a8326cb28d0de03895ae5a57f39b"
-  integrity sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==
+"@babel/parser@^7.0.0", "@babel/parser@^7.6.0", "@babel/parser@^7.6.3", "@babel/parser@^7.6.4":
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.4.tgz#cb9b36a7482110282d5cb6dd424ec9262b473d81"
+  integrity sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==
 
 "@babel/plugin-external-helpers@^7.0.0":
   version "7.2.0"
@@ -270,9 +269,9 @@
     "@babel/plugin-syntax-nullish-coalescing-operator" "^7.2.0"
 
 "@babel/plugin-proposal-object-rest-spread@^7.0.0":
-  version "7.5.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz#61939744f71ba76a3ae46b5eea18a54c16d22e58"
-  integrity sha512-F2DxJJSQ7f64FyTVl5cw/9MWn6naXGdk3Q3UhDbFEEHv+EilCPoeRD3Zh/Utx1CJz4uyKlQ4uH+bJPbEhMV7Zw==
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz#8ffccc8f3a6545e9f78988b6bf4fe881b88e8096"
+  integrity sha512-LDBXlmADCsMZV1Y9OQwMc0MyGZ8Ta/zlD9N67BfQT8uYwkRswiu2hU6nJKrjrt/58aH/vqfQlR/9yId/7A2gWw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
@@ -387,9 +386,9 @@
     "@babel/helper-plugin-utils" "^7.0.0"
 
 "@babel/plugin-transform-block-scoping@^7.0.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.0.tgz#c49e21228c4bbd4068a35667e6d951c75439b1dc"
-  integrity sha512-tIt4E23+kw6TgL/edACZwP1OUKrjOTyMrFMLoT5IOFrfMRabCgekjqFd5o6PaAMildBu46oFkekIdMuGkkPEpA==
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.3.tgz#6e854e51fbbaa84351b15d4ddafe342f3a5d542a"
+  integrity sha512-7hvrg75dubcO3ZI2rjYTzUrEuh1E9IyDEhhB6qfcooxhDA33xx2MasuLVgdxzcP6R/lipAC6n9ub9maNW6RKdw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     lodash "^4.17.13"
@@ -431,9 +430,9 @@
     "@babel/helper-plugin-utils" "^7.0.0"
 
 "@babel/plugin-transform-flow-strip-types@^7.0.0":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.4.4.tgz#d267a081f49a8705fc9146de0768c6b58dccd8f7"
-  integrity sha512-WyVedfeEIILYEaWGAUWzVNyqG4sfsNooMhXWsu/YzOvVGcsnPb5PguysjJqI3t3qiaYj0BR8T2f5njdjTGe44Q==
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.6.3.tgz#8110f153e7360cfd5996eee68706cfad92d85256"
+  integrity sha512-l0ETkyEofkqFJ9LS6HChNIKtVJw2ylKbhYMlJ5C6df+ldxxaLIyXY4yOdDQQspfFpV8/vDiaWoJlvflstlYNxg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-flow" "^7.2.0"
@@ -540,9 +539,9 @@
     regenerator-transform "^0.14.0"
 
 "@babel/plugin-transform-runtime@^7.0.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.0.tgz#85a3cce402b28586138e368fce20ab3019b9713e"
-  integrity sha512-Da8tMf7uClzwUm/pnJ1S93m/aRXmoYNDD7TkHua8xBDdaAs54uZpTWvEt6NGwmoVMb9mZbntfTqmG2oSzN/7Vg==
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.2.tgz#2669f67c1fae0ae8d8bf696e4263ad52cb98b6f8"
+  integrity sha512-cqULw/QB4yl73cS5Y0TZlQSjDvNkzDbu0FurTZyHlJpWE5T3PCMdnyV+xXoH1opr1ldyHODe3QAX3OMAii5NxA==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"
@@ -557,9 +556,9 @@
     "@babel/helper-plugin-utils" "^7.0.0"
 
 "@babel/plugin-transform-spread@^7.0.0":
-  version "7.2.2"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz#3103a9abe22f742b6d406ecd3cd49b774919b406"
-  integrity sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.6.2.tgz#fc77cf798b24b10c46e1b51b1b88c2bf661bb8dd"
+  integrity sha512-DpSvPFryKdK1x+EDJYCy28nmAaIMdxmhot62jAXF/o99iA33Zj2Lmcp3vDmz+MUh0LNYVPvfj5iC3feb3/+PFg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
@@ -580,27 +579,27 @@
     "@babel/helper-plugin-utils" "^7.0.0"
 
 "@babel/plugin-transform-typescript@^7.0.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.6.0.tgz#48d78405f1aa856ebeea7288a48a19ed8da377a6"
-  integrity sha512-yzw7EopOOr6saONZ3KA3lpizKnWRTe+rfBqg4AmQbSow7ik7fqmzrfIqt053osLwLE2AaTqGinLM2tl6+M/uog==
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.6.3.tgz#dddb50cf3b8b2ef70b22e5326e9a91f05a1db13b"
+  integrity sha512-aiWINBrPMSC3xTXRNM/dfmyYuPNKY/aexYqBgh0HBI5Y+WO5oRAqW/oROYeYHrF4Zw12r9rK4fMk/ZlAmqx/FQ==
   dependencies:
     "@babel/helper-create-class-features-plugin" "^7.6.0"
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-typescript" "^7.2.0"
 
 "@babel/plugin-transform-unicode-regex@^7.0.0":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz#ab4634bb4f14d36728bf5978322b35587787970f"
-  integrity sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.6.2.tgz#b692aad888a7e8d8b1b214be6b9dc03d5031f698"
+  integrity sha512-orZI6cWlR3nk2YmYdb0gImrgCUwb5cBUwjf6Ks6dvNVvXERkwtJWOQaEOjPiu0Gu1Tq6Yq/hruCZZOOi9F34Dw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-regex" "^7.4.4"
-    regexpu-core "^4.5.4"
+    regexpu-core "^4.6.0"
 
 "@babel/register@^7.0.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.6.0.tgz#76b6f466714680f4becafd45beeb2a7b87431abf"
-  integrity sha512-78BomdN8el+x/nkup9KwtjJXuptW5oXMFmP11WoM2VJBjxrKv4grC3qjpLL8RGGUYUGsm57xnjYFM2uom+jWUQ==
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.6.2.tgz#25765a922202cb06f8bdac5a3b1e70cd6bf3dd45"
+  integrity sha512-xgZk2LRZvt6i2SAUWxc7ellk4+OYRgS3Zpsnr13nMS1Qo25w21Uu8o6vTOAqNaxiqrnv30KTYzh9YWY2k21CeQ==
   dependencies:
     find-cache-dir "^2.0.0"
     lodash "^4.17.13"
@@ -609,9 +608,9 @@
     source-map-support "^0.5.9"
 
 "@babel/runtime@^7.0.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.0.tgz#4fc1d642a9fd0299754e8b5de62c631cf5568205"
-  integrity sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.3.tgz#935122c74c73d2240cafd32ddb5fc2a6cd35cf1f"
+  integrity sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==
   dependencies:
     regenerator-runtime "^0.13.2"
 
@@ -624,25 +623,25 @@
     "@babel/parser" "^7.6.0"
     "@babel/types" "^7.6.0"
 
-"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.4.4", "@babel/traverse@^7.5.5", "@babel/traverse@^7.6.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.6.0.tgz#389391d510f79be7ce2ddd6717be66d3fed4b516"
-  integrity sha512-93t52SaOBgml/xY74lsmt7xOR4ufYvhb5c5qiM6lu4J/dWGMAfAh6eKw4PjLes6DI6nQgearoxnFJk60YchpvQ==
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.4.4", "@babel/traverse@^7.5.5", "@babel/traverse@^7.6.2", "@babel/traverse@^7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.6.3.tgz#66d7dba146b086703c0fb10dd588b7364cec47f9"
+  integrity sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==
   dependencies:
     "@babel/code-frame" "^7.5.5"
-    "@babel/generator" "^7.6.0"
+    "@babel/generator" "^7.6.3"
     "@babel/helper-function-name" "^7.1.0"
     "@babel/helper-split-export-declaration" "^7.4.4"
-    "@babel/parser" "^7.6.0"
-    "@babel/types" "^7.6.0"
+    "@babel/parser" "^7.6.3"
+    "@babel/types" "^7.6.3"
     debug "^4.1.0"
     globals "^11.1.0"
     lodash "^4.17.13"
 
-"@babel/types@^7.0.0", "@babel/types@^7.2.0", "@babel/types@^7.3.0", "@babel/types@^7.4.4", "@babel/types@^7.5.5", "@babel/types@^7.6.0":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.6.1.tgz#53abf3308add3ac2a2884d539151c57c4b3ac648"
-  integrity sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==
+"@babel/types@^7.0.0", "@babel/types@^7.2.0", "@babel/types@^7.3.0", "@babel/types@^7.4.4", "@babel/types@^7.5.5", "@babel/types@^7.6.0", "@babel/types@^7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.6.3.tgz#3f07d96f854f98e2fbd45c64b0cb942d11e8ba09"
+  integrity sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.13"
@@ -657,19 +656,19 @@
     minimist "^1.2.0"
 
 "@hapi/address@2.x.x":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.1.tgz#61395b5ed94c4cb19c2dc4c85969cff3d40d583f"
-  integrity sha512-DYuHzu978pP1XW1GD3HGvLnAFjbQTIgc2+V153FGkbS2pgo9haigCdwBnUDrbhaOkgiJlbZvoEqDrcxSLHpiWA==
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.2.tgz#1c794cd6dbf2354d1eb1ef10e0303f573e1c7222"
+  integrity sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q==
 
 "@hapi/bourne@1.x.x":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@hapi/bourne/-/bourne-1.3.2.tgz#0a7095adea067243ce3283e1b56b8a8f453b242a"
   integrity sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==
 
-"@hapi/hoek@8.x.x":
-  version "8.2.4"
-  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.2.4.tgz#684a14f4ca35d46f44abc87dfc696e5e4fe8a020"
-  integrity sha512-Ze5SDNt325yZvNO7s5C4fXDscjJ6dcqLFXJQ/M7dZRQCewuDj2iDUuBi6jLQt+APbW9RjjVEvLr35FXuOEqjow==
+"@hapi/hoek@8.x.x", "@hapi/hoek@^8.3.0":
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.3.2.tgz#91e7188edebc5d876f0b91a860f555ff06f0782b"
+  integrity sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA==
 
 "@hapi/joi@^15.0.3":
   version "15.1.1"
@@ -682,11 +681,11 @@
     "@hapi/topo" "3.x.x"
 
 "@hapi/topo@3.x.x":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-3.1.3.tgz#c7a02e0d936596d29f184e6d7fdc07e8b5efce11"
-  integrity sha512-JmS9/vQK6dcUYn7wc2YZTqzIKubAQcJKu2KCKAru6es482U5RT5fP1EXCPtlXpiK7PR0On/kpQKI4fRKkzpZBQ==
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-3.1.6.tgz#68d935fa3eae7fdd5ab0d7f953f3205d8b2bfc29"
+  integrity sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==
   dependencies:
-    "@hapi/hoek" "8.x.x"
+    "@hapi/hoek" "^8.3.0"
 
 "@jest/console@^24.9.0":
   version "24.9.0"
@@ -835,9 +834,9 @@
   integrity sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==
 
 "@types/yargs@^13.0.0":
-  version "13.0.2"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.2.tgz#a64674fc0149574ecd90ba746e932b5a5f7b3653"
-  integrity sha512-lwwgizwk/bIIU+3ELORkyuOgDjCh7zuWDFqRtPPhhVgq9N1F7CvLNKg1TX4f2duwtKQ0p044Au9r1PLIXHrIzQ==
+  version "13.0.3"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.3.tgz#76482af3981d4412d65371a318f992d33464a380"
+  integrity sha512-K8/LfZq2duW33XW/tFwEAfnZlqIfVsoyRB3kfXdPXYhl0nfM8mmh7GS0jg7WrX2Dgq/0Ha/pR1PaR+BvmWwjiQ==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -1066,9 +1065,9 @@ babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
   integrity sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==
 
 babel-preset-fbjs@^3.1.2, babel-preset-fbjs@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-fbjs/-/babel-preset-fbjs-3.2.0.tgz#c0e6347d3e0379ed84b3c2434d3467567aa05297"
-  integrity sha512-5Jo+JeWiVz2wHUUyAlvb/sSYnXNig9r+HqGAOSfh5Fzxp7SnAaR/tEGRJ1ZX7C77kfk82658w6R5Z+uPATTD9g==
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-fbjs/-/babel-preset-fbjs-3.3.0.tgz#a6024764ea86c8e06a22d794ca8b69534d263541"
+  integrity sha512-7QTLTCd2gwB2qGoi5epSULMHugSVgpcVt5YAeiFO9ABLrutDQzKfGwzxgZHLpugq8qMdg/DhRZDZ5CLKxBkEbw==
   dependencies:
     "@babel/plugin-proposal-class-properties" "^7.0.0"
     "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
@@ -1129,9 +1128,9 @@ basic-auth@~2.0.0:
     safe-buffer "5.1.2"
 
 big-integer@^1.6.7:
-  version "1.6.45"
-  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.45.tgz#1bf2fa1271bfd20d4c52c3d6c6f08cab8d91c77e"
-  integrity sha512-nmb9E7oEtVJ7SmSCH/DeJobXyuRmaofkpoQSimMFu3HKJ5MADtM825SPLhDuWhZ6TElLAQtgJbQmBZuHIRlZoA==
+  version "1.6.47"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.47.tgz#e1e9320e26c4cc81f64fbf4b3bb20e025bf18e2d"
+  integrity sha512-9t9f7X3as2XGX8b52GqG6ox0GvIdM86LyIXASJnDCFhYNgt+A+MByQZ3W2PyMRZjEvG5f8TEbSPfEotVuMJnQg==
 
 bplist-creator@0.0.7:
   version "0.0.7"
@@ -1172,9 +1171,9 @@ braces@^2.3.1:
     to-regex "^3.0.1"
 
 bser@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.0.tgz#65fc784bf7f87c009b973c12db6546902fa9c7b5"
-  integrity sha512-8zsjWrQkkBoLK6uxASk1nJ2SKv97ltiGDo6A3wA0/yRPz+CwmEyDo0hUrhIuukG2JHpAl3bvFIixw2/3Hi0DOg==
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
+  integrity sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==
   dependencies:
     node-int64 "^0.4.0"
 
@@ -1264,9 +1263,9 @@ chardet@^0.4.0:
   integrity sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=
 
 chownr@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.2.tgz#a18f1e0b269c8a6a5d3c86eb298beb14c3dd7bf6"
-  integrity sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.3.tgz#42d837d5239688d55f303003a508230fa6727142"
+  integrity sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==
 
 ci-info@^2.0.0:
   version "2.0.0"
@@ -1359,9 +1358,9 @@ colorette@^1.0.7:
   integrity sha512-6S062WDQUXi6hOfkO/sBPVwE5ASXY4G2+b4atvhJfSsuUUhIaUKlkjLe9692Ipyt5/a+IPF5aVTu3V5gvXq5cg==
 
 commander@^2.19.0:
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
-  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 commander@~2.13.0:
   version "2.13.0"
@@ -1446,9 +1445,9 @@ core-js@^1.0.0:
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
 core-js@^2.2.2, core-js@^2.4.1:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
-  integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
+  version "2.6.10"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.10.tgz#8a5b8391f8cc7013da703411ce5b585706300d7f"
+  integrity sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==
 
 core-util-is@~1.0.0:
   version "1.0.2"
@@ -1624,16 +1623,16 @@ encoding@^0.1.11:
     iconv-lite "~0.4.13"
 
 end-of-stream@^1.1.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
-  integrity sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
+  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
 
 envinfo@^7.1.0:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.3.1.tgz#892e42f7bf858b3446d9414ad240dbaf8da52f09"
-  integrity sha512-GvXiDTqLYrORVSCuJCsWHPXF5BFvoWMQA9xX4YVjPT1jyS3aZEHUBwjzxU/6LTPF9ReHgVEbX7IEN5UvSXHw/A==
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.4.0.tgz#bef4ece9e717423aaf0c3584651430b735ad6630"
+  integrity sha512-FdDfnWnCVjxTTpWE3d6Jgh5JDIA3Cw7LCgpM/pI7kK1ORkjaqI2r6NqQ+ln2j0dfpgxY00AWieSvtkiZQKIItA==
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.2"
@@ -1994,9 +1993,9 @@ get-value@^2.0.3, get-value@^2.0.6:
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
 glob@^7.1.1, glob@^7.1.3:
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
-  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.5.tgz#6714c69bee20f3c3e64c4dd905553e532b40cdc0"
+  integrity sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -2080,9 +2079,9 @@ hermesvm@^0.1.0:
   integrity sha512-EosSDeUqTTGvlc9vQiy5Y/9GBlucEyo6lYuxg/FnukHCD/CP3NYeDAGV54TyZ19FgSqMEoPgOH9cyxvv8epQ1g==
 
 hosted-git-info@^2.1.4:
-  version "2.8.4"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.4.tgz#44119abaf4bc64692a16ace34700fed9c03e2546"
-  integrity sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.5.tgz#759cfcf2c4d156ade59b0b2dfabddc42a6b9c70c"
+  integrity sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==
 
 http-errors@~1.7.2:
   version "1.7.3"
@@ -2103,9 +2102,9 @@ iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
     safer-buffer ">= 2.1.2 < 3"
 
 ignore-walk@^3.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.2.tgz#99d83a246c196ea5c93ef9315ad7b0819c35069b"
-  integrity sha512-EXyErtpHbn75ZTsOADsfx6J/FPo6/5cjev46PXrcTpd8z3BoRkXgYu9/JVqrI7tusjmwCZutGeRJeU0Wo1e4Cw==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
+  integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
   dependencies:
     minimatch "^3.0.4"
 
@@ -2472,9 +2471,9 @@ json-stable-stringify@^1.0.1:
     jsonify "~0.0.0"
 
 json5@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
-  integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.1.tgz#81b6cb04e9ba496f1c7005d07b4368a2638f90b6"
+  integrity sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==
   dependencies:
     minimist "^1.2.0"
 
@@ -2938,9 +2937,9 @@ mime-db@1.40.0:
   integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
 
 "mime-db@>= 1.40.0 < 2":
-  version "1.41.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.41.0.tgz#9110408e1f6aa1b34aef51f2c9df3caddf46b6a0"
-  integrity sha512-B5gxBI+2K431XW8C2rcc/lhppbuji67nf9v39eH8pkWoZDxnAL0PxdpH32KYRScniF8qDHBDlI+ipgg5WrCUYw==
+  version "1.42.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.42.0.tgz#3e252907b4c7adb906597b4b65636272cf9e7bac"
+  integrity sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==
 
 mime-db@~1.23.0:
   version "1.23.0"
@@ -3005,20 +3004,20 @@ minimist@^1.1.1, minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
-minipass@^2.2.1, minipass@^2.6.0, minipass@^2.6.4:
-  version "2.6.5"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.6.5.tgz#1c245f9f2897f70fd4a219066261ce6c29f80b18"
-  integrity sha512-ewSKOPFH9blOLXx0YSE+mbrNMBFPS+11a2b03QZ+P4LVrUHW/GAlqeYC7DBknDyMWkHzrzTpDhUvy7MUxqyrPA==
+minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
+  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
   dependencies:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
 minizlib@^1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.2.tgz#6f0ccc82fa53e1bf2ff145f220d2da9fa6e3a166"
-  integrity sha512-hR3At21uSrsjjDTWrbu0IMLTpnkpv8IIMFDFaoz43Tmu4LkmAXfH44vNNzpTnf+OAQQCHrb91y/wc2J4x5XgSQ==
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
+  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
   dependencies:
-    minipass "^2.2.1"
+    minipass "^2.9.0"
 
 mixin-deep@^1.2.0:
   version "1.3.2"
@@ -3188,9 +3187,9 @@ npm-bundled@^1.0.1:
   integrity sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==
 
 npm-packlist@^1.1.6:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.4.tgz#866224233850ac534b63d1a6e76050092b5d2f44"
-  integrity sha512-zTLo8UcVYtDU3gdeaFu2Xu0n0EvelfHDGuqtNIn5RO7yQj4H1TqNdBc/yZjxnWA0PVB8D3Woyp0i5B43JwQ6Vw==
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.6.tgz#53ba3ed11f8523079f1457376dd379ee4ea42ff4"
+  integrity sha512-u65uQdb+qwtGvEJh/DgQgW1Xg7sqeNbmxYyrvlNznaVTjV3E5P6F/EFjM+BVHXl7JJlsdG8A64M0XI8FI/IOlg==
   dependencies:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
@@ -3598,9 +3597,9 @@ react-devtools-core@^3.6.1:
     ws "^3.3.1"
 
 react-is@^16.8.1, react-is@^16.8.4:
-  version "16.9.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
-  integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
+  version "16.11.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.11.0.tgz#b85dfecd48ad1ce469ff558a882ca8e8313928fa"
+  integrity sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw==
 
 react-native-electrode-bridge@1.5.x:
   version "1.5.19"
@@ -3729,7 +3728,7 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
-regexpu-core@^4.5.4:
+regexpu-core@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.6.0.tgz#2037c18b327cfce8a6fea2a4ec441f2432afb8b6"
   integrity sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==
@@ -3742,9 +3741,9 @@ regexpu-core@^4.5.4:
     unicode-match-property-value-ecmascript "^1.1.0"
 
 regjsgen@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.5.0.tgz#a7634dc08f89209c2049adda3525711fb97265dd"
-  integrity sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.5.1.tgz#48f0bf1a5ea205196929c0d9798b42d1ed98443c"
+  integrity sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==
 
 regjsparser@^0.6.0:
   version "0.6.0"
@@ -4247,13 +4246,13 @@ symbol-observable@1.0.1:
   integrity sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=
 
 tar@^4:
-  version "4.4.11"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.11.tgz#7ac09801445a3cf74445ed27499136b5240ffb73"
-  integrity sha512-iI4zh3ktLJKaDNZKZc+fUONiQrSn9HkCFzamtb7k8FFmVilHVob7QsLX/VySAW8lAviMzMbFw4QtFb4errwgYA==
+  version "4.4.13"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
+  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
   dependencies:
     chownr "^1.1.1"
     fs-minipass "^1.2.5"
-    minipass "^2.6.4"
+    minipass "^2.8.6"
     minizlib "^1.2.1"
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
@@ -4336,11 +4335,6 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
-
-trim-right@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
-  integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
 type-fest@^0.7.1:
   version "0.7.1"
@@ -4602,9 +4596,9 @@ yallist@^2.1.2:
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
 yallist@^3.0.0, yallist@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
-  integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yargs-parser@^11.1.1:
   version "11.1.1"


### PR DESCRIPTION
The PR introduces a way for the user to pass the compile Options.

For a plugin such as https://github.com/react-native-community/react-native-webview, where it specifically need JAVA 8 constructs. Also verified it's standard with core `react native` project 

```
java:25: error: incompatible types: List<RNCWebViewManager> cannot be converted to List<ViewManager>
15:39:07     return Collections.singletonList(new RNCWebViewManager());
```