### PR TITLE
Fix formatting of generated api schema

### DIFF
--- a/ern-api-gen/src/generateProject.ts
+++ b/ern-api-gen/src/generateProject.ts
@@ -105,51 +105,53 @@ export async function generateInitialSchema({
 }) {
   return apiSchemaPath && fs.existsSync(apiSchemaPath)
     ? fileUtils.readFile(apiSchemaPath)
-    : `
-  {
-    "swagger": "2.0",
-    "info": {
-      "description": "Walmart Item Module",
-      "title": "WalmartItem",
-      "contact": {
-        "name": "ERN Mobile Platform Team"
-      }
-    },
-    "paths": {
-      "/items": {
-        "get": {
-          "tags": [
+    : `{
+  "swagger": "2.0",
+  "info": {
+    "description": "Walmart Item Module",
+    "title": "WalmartItem",
+    "contact": {
+      "name": "ERN Mobile Platform Team"
+    }
+  },
+  "paths": {
+    "/items": {
+      "get": {
+        "tags": [
           "WalmartItem"
-          ],
-          "description": "Returns all items from the system that the user has access to",
-          "operationId": "findItems",
-          "parameters": [{
+        ],
+        "description": "Returns all items from the system that the user has access to",
+        "operationId": "findItems",
+        "parameters": [
+          {
             "name": "limit",
             "in": "query",
             "description": "maximum number of results to return",
             "required": false,
             "type": "integer",
             "format": "int32"
-          }],
-          "responses": {
-            "200": {
-              "description": "Item response",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/Item"
-                }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Item response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Item"
               }
             }
           }
-        },
-        "post": {
-          "tags": [
+        }
+      },
+      "post": {
+        "tags": [
           "WalmartItem"
-          ],
-          "description": "Creates a Item in the store.",
-          "operationId": "addItem",
-          "parameters": [{
+        ],
+        "description": "Creates a Item in the store.",
+        "operationId": "addItem",
+        "parameters": [
+          {
             "name": "item",
             "in": "body",
             "description": "Item to add",
@@ -157,55 +159,58 @@ export async function generateInitialSchema({
             "schema": {
               "$ref": "#/definitions/Item"
             }
-          }],
-          "responses": {
-            "200": {
-              "schema": {
-                "type": "boolean"
-              }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "boolean"
             }
           }
         }
-      },
-      "event/itemAdded": {
-        "event": {
-          "tags": [
+      }
+    },
+    "event/itemAdded": {
+      "event": {
+        "tags": [
           "WalmartItem"
-          ],
-          "operationId": "itemAdded",
-          "parameters": [{
+        ],
+        "operationId": "itemAdded",
+        "parameters": [
+          {
             "name": "itemId",
             "in": "path",
             "description": "Event to notify new item added",
             "required": true,
             "type": "string"
-          }]
-        }
+          }
+        ]
       }
-    },
-    "definitions": {
-      "Item": {
-        "type": "object",
-        "required": [
+    }
+  },
+  "definitions": {
+    "Item": {
+      "type": "object",
+      "required": [
         "name",
         "id"
-        ],
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "name": {
-            "type": "string"
-          },
-          "desc": {
-            "type": "string"
-          }
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "desc": {
+          "type": "string"
         }
       }
     }
   }
-  `
+}
+`
 }
 
 export function generateFlowConfig(): string {

--- a/system-tests/fixtures/api/ComplexApi/schema.json
+++ b/system-tests/fixtures/api/ComplexApi/schema.json
@@ -1,116 +1,122 @@
 {
-	"swagger": "2.0",
-	"info": {
-		"description": "Test schema to demonstrate ComplexAPI ",
-		"title": "Complex Api"
-	},
-	"produces": [
-		"application/json"
-	],
-	"paths": {
-		"/testArrayOfStrings": {
-			"post": {
-				"tags": [
-					"SystemTests"
-				],
-				"operationId": "testArrayOfStrings",
-				"parameters": [{
-					"name": "key",
-					"in": "body",
-					"description": "keys to get setting",
-					"required": true,
-					"schema": {
-						"type": "array",
-						"items": {
-							"type": "string"
-						}
-					}
-				}],
-				"responses": {
+  "swagger": "2.0",
+  "info": {
+    "description": "Test schema to demonstrate ComplexAPI ",
+    "title": "Complex Api"
+  },
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/testArrayOfStrings": {
+      "post": {
+        "tags": [
+          "SystemTests"
+        ],
+        "operationId": "testArrayOfStrings",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "body",
+            "description": "keys to get setting",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
           "200": {
             "schema": {
-							"type": "array",
-							"description": "response as an array of Objects",
-							"items": {
-								"$ref": "#/definitions/ERNObject"
-							}
+              "type": "array",
+              "description": "response as an array of Objects",
+              "items": {
+                "$ref": "#/definitions/ERNObject"
+              }
             }
           }
         }
-			}
-		},
-		"/testMultiArgs": {
-			"post": {
-				"tags": [
-						"SystemTests"
-					],
-					"description": "This is a test for multiple arguments.",
-					"operationId": "testMultiArgs",
-					"parameters": [{
-						"name": "key1",
-						"in": "path",
-						"description": "first argument",
-						"required": true,
-						"type": "string"
-		},
-		{
-			"name": "key2",
-			"in": "path",
-			"description": "second argument",
-			"required": true,
-			"type": "integer"
-		}],
-			"responses": {
-				"200": {
-					"description": "set location response",
-					"schema": {
-						"type": "string"
-				}
-			}
-		}
-	}
-},
-"event/testEvent": {
-	"event": {
-		"tags": [
-			"SysteTestEvent"
-		],
-		"operationId": "testEvent",
-		"parameters": [{
-			"name": "buttonId",
-			"in": "path",
-			"description": "id of the button clicked",
-			"required": true,
-				"type": "string"
-		}]
-	}
-}
-	},
-	"definitions": {
-		"NavBarButton": {
-			"properties": {
-				"name": {
-					"type": "string",
-					"description": "Name of button"
-		},
-			"identifier": {
-				"type": "string",
-				"description": "Id of the button"
-		},
-			"showIcon": {
-				"type": "boolean",
-				"description": "Set to true for showing icon"
-		}
-	},
-		"required": [
-			"name",
-			"identifier"
-	]
-},
+      }
+    },
+    "/testMultiArgs": {
+      "post": {
+        "tags": [
+          "SystemTests"
+        ],
+        "description": "This is a test for multiple arguments.",
+        "operationId": "testMultiArgs",
+        "parameters": [
+          {
+            "name": "key1",
+            "in": "path",
+            "description": "first argument",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "key2",
+            "in": "path",
+            "description": "second argument",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "set location response",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "event/testEvent": {
+      "event": {
+        "tags": [
+          "SysteTestEvent"
+        ],
+        "operationId": "testEvent",
+        "parameters": [
+          {
+            "name": "buttonId",
+            "in": "path",
+            "description": "id of the button clicked",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "NavBarButton": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of button"
+        },
+        "identifier": {
+          "type": "string",
+          "description": "Id of the button"
+        },
+        "showIcon": {
+          "type": "boolean",
+          "description": "Set to true for showing icon"
+        }
+      },
+      "required": [
+        "name",
+        "identifier"
+      ]
+    },
     "ERNObject": {
       "type": "object",
       "properties": {
-				"name": {
+        "name": {
           "type": "string"
         },
         "value": {
@@ -133,30 +139,30 @@
           "type": "number",
           "format": "long"
         },
-				"leftButton":{
-					"$ref": "#/definitions/NavBarButton"
-				},
-				"rightButtons": {
-					"type": "array",
-						"items": {
-							"$ref": "#/definitions/NavBarButton"
-										 },
-										 "description": "Right button properties"
-				},
-				"isGuestUser": {
-					"type": "boolean",
-					"description": "specify if user is a guest",
-					"default": false
-				},
-				"mergeType": {
-					"type": "integer",
-					"description": "specify merge type"
-				}
+        "leftButton": {
+          "$ref": "#/definitions/NavBarButton"
+        },
+        "rightButtons": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NavBarButton"
+          },
+          "description": "Right button properties"
+        },
+        "isGuestUser": {
+          "type": "boolean",
+          "description": "specify if user is a guest",
+          "default": false
+        },
+        "mergeType": {
+          "type": "integer",
+          "description": "specify merge type"
+        }
       },
-			"required": [
+      "required": [
         "name",
         "version"
       ]
     }
-	}
+  }
 }

--- a/system-tests/fixtures/api/TestApi/schema.json
+++ b/system-tests/fixtures/api/TestApi/schema.json
@@ -1,48 +1,50 @@
-
-  {
-    "swagger": "2.0",
-    "info": {
-      "description": "Walmart Item Module",
-      "title": "WalmartItem",
-      "contact": {
-        "name": "ERN Mobile Platform Team"
-      }
-    },
-    "paths": {
-      "/items": {
-        "get": {
-          "tags": [
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "Walmart Item Module",
+    "title": "WalmartItem",
+    "contact": {
+      "name": "ERN Mobile Platform Team"
+    }
+  },
+  "paths": {
+    "/items": {
+      "get": {
+        "tags": [
           "WalmartItem"
-          ],
-          "description": "Returns all items from the system that the user has access to",
-          "operationId": "findItems",
-          "parameters": [{
+        ],
+        "description": "Returns all items from the system that the user has access to",
+        "operationId": "findItems",
+        "parameters": [
+          {
             "name": "limit",
             "in": "query",
             "description": "maximum number of results to return",
             "required": false,
             "type": "integer",
             "format": "int32"
-          }],
-          "responses": {
-            "200": {
-              "description": "Item response",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/Item"
-                }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Item response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Item"
               }
             }
           }
-        },
-        "post": {
-          "tags": [
+        }
+      },
+      "post": {
+        "tags": [
           "WalmartItem"
-          ],
-          "description": "Creates a Item in the store.",
-          "operationId": "addItem",
-          "parameters": [{
+        ],
+        "description": "Creates a Item in the store.",
+        "operationId": "addItem",
+        "parameters": [
+          {
             "name": "item",
             "in": "body",
             "description": "Item to add",
@@ -50,52 +52,54 @@
             "schema": {
               "$ref": "#/definitions/Item"
             }
-          }],
-          "responses": {
-            "200": {
-              "schema": {
-                "type": "boolean"
-              }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "boolean"
             }
           }
         }
-      },
-      "event/itemAdded": {
-        "event": {
-          "tags": [
+      }
+    },
+    "event/itemAdded": {
+      "event": {
+        "tags": [
           "WalmartItem"
-          ],
-          "operationId": "itemAdded",
-          "parameters": [{
+        ],
+        "operationId": "itemAdded",
+        "parameters": [
+          {
             "name": "itemId",
             "in": "path",
             "description": "Event to notify new item added",
             "required": true,
             "type": "string"
-          }]
-        }
+          }
+        ]
       }
-    },
-    "definitions": {
-      "Item": {
-        "type": "object",
-        "required": [
+    }
+  },
+  "definitions": {
+    "Item": {
+      "type": "object",
+      "required": [
         "name",
         "id"
-        ],
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "name": {
-            "type": "string"
-          },
-          "desc": {
-            "type": "string"
-          }
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "desc": {
+          "type": "string"
         }
       }
     }
   }
-  
+}

--- a/system-tests/fixtures/api/complexapi-schema.json
+++ b/system-tests/fixtures/api/complexapi-schema.json
@@ -1,116 +1,122 @@
 {
-	"swagger": "2.0",
-	"info": {
-		"description": "Test schema to demonstrate ComplexAPI ",
-		"title": "Complex Api"
-	},
-	"produces": [
-		"application/json"
-	],
-	"paths": {
-		"/testArrayOfStrings": {
-			"post": {
-				"tags": [
-					"SystemTests"
-				],
-				"operationId": "testArrayOfStrings",
-				"parameters": [{
-					"name": "key",
-					"in": "body",
-					"description": "keys to get setting",
-					"required": true,
-					"schema": {
-						"type": "array",
-						"items": {
-							"type": "string"
-						}
-					}
-				}],
-				"responses": {
+  "swagger": "2.0",
+  "info": {
+    "description": "Test schema to demonstrate ComplexAPI ",
+    "title": "Complex Api"
+  },
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/testArrayOfStrings": {
+      "post": {
+        "tags": [
+          "SystemTests"
+        ],
+        "operationId": "testArrayOfStrings",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "body",
+            "description": "keys to get setting",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
           "200": {
             "schema": {
-							"type": "array",
-							"description": "response as an array of Objects",
-							"items": {
-								"$ref": "#/definitions/ERNObject"
-							}
+              "type": "array",
+              "description": "response as an array of Objects",
+              "items": {
+                "$ref": "#/definitions/ERNObject"
+              }
             }
           }
         }
-			}
-		},
-		"/testMultiArgs": {
-			"post": {
-				"tags": [
-						"SystemTests"
-					],
-					"description": "This is a test for multiple arguments.",
-					"operationId": "testMultiArgs",
-					"parameters": [{
-						"name": "key1",
-						"in": "path",
-						"description": "first argument",
-						"required": true,
-						"type": "string"
-		},
-		{
-			"name": "key2",
-			"in": "path",
-			"description": "second argument",
-			"required": true,
-			"type": "integer"
-		}],
-			"responses": {
-				"200": {
-					"description": "set location response",
-					"schema": {
-						"type": "string"
-				}
-			}
-		}
-	}
-},
-"event/testEvent": {
-	"event": {
-		"tags": [
-			"SysteTestEvent"
-		],
-		"operationId": "testEvent",
-		"parameters": [{
-			"name": "buttonId",
-			"in": "path",
-			"description": "id of the button clicked",
-			"required": true,
-				"type": "string"
-		}]
-	}
-}
-	},
-	"definitions": {
-		"NavBarButton": {
-			"properties": {
-				"name": {
-					"type": "string",
-					"description": "Name of button"
-		},
-			"identifier": {
-				"type": "string",
-				"description": "Id of the button"
-		},
-			"showIcon": {
-				"type": "boolean",
-				"description": "Set to true for showing icon"
-		}
-	},
-		"required": [
-			"name",
-			"identifier"
-	]
-},
+      }
+    },
+    "/testMultiArgs": {
+      "post": {
+        "tags": [
+          "SystemTests"
+        ],
+        "description": "This is a test for multiple arguments.",
+        "operationId": "testMultiArgs",
+        "parameters": [
+          {
+            "name": "key1",
+            "in": "path",
+            "description": "first argument",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "key2",
+            "in": "path",
+            "description": "second argument",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "set location response",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "event/testEvent": {
+      "event": {
+        "tags": [
+          "SysteTestEvent"
+        ],
+        "operationId": "testEvent",
+        "parameters": [
+          {
+            "name": "buttonId",
+            "in": "path",
+            "description": "id of the button clicked",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "NavBarButton": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of button"
+        },
+        "identifier": {
+          "type": "string",
+          "description": "Id of the button"
+        },
+        "showIcon": {
+          "type": "boolean",
+          "description": "Set to true for showing icon"
+        }
+      },
+      "required": [
+        "name",
+        "identifier"
+      ]
+    },
     "ERNObject": {
       "type": "object",
       "properties": {
-				"name": {
+        "name": {
           "type": "string"
         },
         "value": {
@@ -133,30 +139,30 @@
           "type": "number",
           "format": "long"
         },
-				"leftButton":{
-					"$ref": "#/definitions/NavBarButton"
-				},
-				"rightButtons": {
-					"type": "array",
-						"items": {
-							"$ref": "#/definitions/NavBarButton"
-										 },
-										 "description": "Right button properties"
-				},
-				"isGuestUser": {
-					"type": "boolean",
-					"description": "specify if user is a guest",
-					"default": false
-				},
-				"mergeType": {
-					"type": "integer",
-					"description": "specify merge type"
-				}
+        "leftButton": {
+          "$ref": "#/definitions/NavBarButton"
+        },
+        "rightButtons": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NavBarButton"
+          },
+          "description": "Right button properties"
+        },
+        "isGuestUser": {
+          "type": "boolean",
+          "description": "specify if user is a guest",
+          "default": false
+        },
+        "mergeType": {
+          "type": "integer",
+          "description": "specify merge type"
+        }
       },
-			"required": [
+      "required": [
         "name",
         "version"
       ]
     }
-	}
+  }
 }

--- a/system-tests/fixtures/api/testapi-schema.json
+++ b/system-tests/fixtures/api/testapi-schema.json
@@ -1,48 +1,50 @@
-
-  {
-    "swagger": "2.0",
-    "info": {
-      "description": "Walmart Item Module",
-      "title": "WalmartItem",
-      "contact": {
-        "name": "ERN Mobile Platform Team"
-      }
-    },
-    "paths": {
-      "/items": {
-        "get": {
-          "tags": [
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "Walmart Item Module",
+    "title": "WalmartItem",
+    "contact": {
+      "name": "ERN Mobile Platform Team"
+    }
+  },
+  "paths": {
+    "/items": {
+      "get": {
+        "tags": [
           "WalmartItem"
-          ],
-          "description": "Returns all items from the system that the user has access to",
-          "operationId": "findItems",
-          "parameters": [{
+        ],
+        "description": "Returns all items from the system that the user has access to",
+        "operationId": "findItems",
+        "parameters": [
+          {
             "name": "limit",
             "in": "query",
             "description": "maximum number of results to return",
             "required": false,
             "type": "integer",
             "format": "int32"
-          }],
-          "responses": {
-            "200": {
-              "description": "Item response",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/Item"
-                }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Item response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Item"
               }
             }
           }
-        },
-        "post": {
-          "tags": [
+        }
+      },
+      "post": {
+        "tags": [
           "WalmartItem"
-          ],
-          "description": "Creates a Item in the store.",
-          "operationId": "addItem",
-          "parameters": [{
+        ],
+        "description": "Creates a Item in the store.",
+        "operationId": "addItem",
+        "parameters": [
+          {
             "name": "item",
             "in": "body",
             "description": "Item to add",
@@ -50,52 +52,54 @@
             "schema": {
               "$ref": "#/definitions/Item"
             }
-          }],
-          "responses": {
-            "200": {
-              "schema": {
-                "type": "boolean"
-              }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "boolean"
             }
           }
         }
-      },
-      "event/itemAdded": {
-        "event": {
-          "tags": [
+      }
+    },
+    "event/itemAdded": {
+      "event": {
+        "tags": [
           "WalmartItem"
-          ],
-          "operationId": "itemAdded",
-          "parameters": [{
+        ],
+        "operationId": "itemAdded",
+        "parameters": [
+          {
             "name": "itemId",
             "in": "path",
             "description": "Event to notify new item added",
             "required": true,
             "type": "string"
-          }]
-        }
+          }
+        ]
       }
-    },
-    "definitions": {
-      "Item": {
-        "type": "object",
-        "required": [
+    }
+  },
+  "definitions": {
+    "Item": {
+      "type": "object",
+      "required": [
         "name",
         "id"
-        ],
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "name": {
-            "type": "string"
-          },
-          "desc": {
-            "type": "string"
-          }
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "desc": {
+          "type": "string"
         }
       }
     }
   }
-  
+}


### PR DESCRIPTION
The entire generated `schema.json` file was one indentation level off, had a leading empty line, and whitespace errors on the last line. This fixes it.