### PR TITLE
Rename some methods of ErnConfig class

### DIFF
--- a/ern-cauldron-api/src/CauldronRepositories.ts
+++ b/ern-cauldron-api/src/CauldronRepositories.ts
@@ -23,9 +23,9 @@ https://[token]@[repourl]`)
       }
     }
 
-    const cauldronRepositories = config.getValue('cauldronRepositories', {})
+    const cauldronRepositories = config.get('cauldronRepositories', {})
     cauldronRepositories[alias] = url
-    config.setValue('cauldronRepositories', cauldronRepositories)
+    config.set('cauldronRepositories', cauldronRepositories)
     if (activate) {
       this.activate({ alias })
     }
@@ -33,25 +33,25 @@ https://[token]@[repourl]`)
   }
 
   public doesExist({ alias }: { alias: string }) {
-    const cauldronRepositories = config.getValue('cauldronRepositories', {})
+    const cauldronRepositories = config.get('cauldronRepositories', {})
     return cauldronRepositories[alias] !== undefined
   }
 
   public remove({ alias }: { alias: string }): CauldronRepository {
     this.throwIfAliasDoesNotExist({ alias })
-    const cauldronRepositories = config.getValue('cauldronRepositories')
+    const cauldronRepositories = config.get('cauldronRepositories')
     const result = { alias, url: cauldronRepositories[alias] }
     delete cauldronRepositories[alias]
-    config.setValue('cauldronRepositories', cauldronRepositories)
-    const cauldronRepoInUse = config.getValue('cauldronRepoInUse')
+    config.set('cauldronRepositories', cauldronRepositories)
+    const cauldronRepoInUse = config.get('cauldronRepoInUse')
     if (cauldronRepoInUse === alias) {
-      config.setValue('cauldronRepoInUse', null)
+      config.set('cauldronRepoInUse', null)
     }
     return result
   }
 
   public list(): CauldronRepository[] {
-    const repositories = config.getValue('cauldronRepositories', {})
+    const repositories = config.get('cauldronRepositories', {})
     return repositories
       ? Object.keys(repositories).map(alias => ({
           alias,
@@ -61,9 +61,9 @@ https://[token]@[repourl]`)
   }
 
   public get current(): CauldronRepository | void {
-    const alias = config.getValue('cauldronRepoInUse')
+    const alias = config.get('cauldronRepoInUse')
     if (alias) {
-      const repositories = config.getValue('cauldronRepositories', {})
+      const repositories = config.get('cauldronRepositories', {})
       const url = repositories[alias]
       if (url) {
         return {
@@ -83,7 +83,7 @@ https://[token]@[repourl]`)
   }
 
   private updateCauldronRepoInUse({ alias }: { alias?: string } = {}) {
-    config.setValue('cauldronRepoInUse', alias)
+    config.set('cauldronRepoInUse', alias)
     shell.rm('-rf', Platform.cauldronDirectory)
   }
 

--- a/ern-cauldron-api/src/getActiveCauldron.ts
+++ b/ern-cauldron-api/src/getActiveCauldron.ts
@@ -23,10 +23,10 @@ export default async function getActiveCauldron({
   localRepoPath?: string
   throwIfNoActiveCauldron?: boolean
 } = {}): Promise<CauldronHelper> {
-  const repoInUse = config.getValue('cauldronRepoInUse')
+  const repoInUse = config.get('cauldronRepoInUse')
   ignoreRequiredErnVersionMismatch =
     ignoreRequiredErnVersionMismatch ||
-    config.getValue('ignore-required-ern-version') ||
+    config.get('ignore-required-ern-version') ||
     process.env.ERN_IGNORE_REQUIRED_ERN_VERSION
   if (!repoInUse && throwIfNoActiveCauldron) {
     throw new Error('No active Cauldron')
@@ -35,7 +35,7 @@ export default async function getActiveCauldron({
   try {
     if (repoInUse && repoInUse !== currentCauldronRepoInUse) {
       kaxTask = kax.task(`Connecting to the Cauldron`)
-      const cauldronRepositories = config.getValue('cauldronRepositories')
+      const cauldronRepositories = config.get('cauldronRepositories')
       const cauldronRepoUrl = cauldronRepositories[repoInUse]
       const cauldronRepoBranchReResult = /#(.+)$/.exec(cauldronRepoUrl)
       const cauldronRepoUrlWithoutBranch = cauldronRepoUrl.replace(/#(.+)$/, '')

--- a/ern-core/src/BundleStoreEngine.ts
+++ b/ern-core/src/BundleStoreEngine.ts
@@ -39,11 +39,11 @@ export class BundleStoreEngine {
     sourceMapPath: string
   }): Promise<string> {
     const res = await this.sdk.uploadBundle({
-      accessKey: config.getValue('bundlestore-accesskey'),
+      accessKey: config.get('bundlestore-accesskey'),
       bundlePath,
       platform,
       sourceMapPath,
-      store: config.getValue('bundlestore-id'),
+      store: config.get('bundlestore-id'),
     })
     await this.uploadAssets()
     ipc.server.stop()
@@ -119,11 +119,11 @@ export class BundleStoreEngine {
     await Promise.all([pBundle, pSourceMap])
 
     const res = await this.sdk.uploadBundle({
-      accessKey: config.getValue('bundlestore-accesskey'),
+      accessKey: config.get('bundlestore-accesskey'),
       bundlePath,
       platform: 'android',
       sourceMapPath,
-      store: config.getValue('bundlestore-id'),
+      store: config.get('bundlestore-id'),
     })
     streamBundle.close()
     streamSourceMap.close()

--- a/ern-core/src/Manifest.ts
+++ b/ern-core/src/Manifest.ts
@@ -411,7 +411,7 @@ export class Manifest {
     //   "searchValue": "github.com",
     //   "replaceValue": "new.github.com"
     // }
-    const overrideManifestUrlModifier = config.getValue(
+    const overrideManifestUrlModifier = config.get(
       'overrideManifestUrlModifier'
     )
     if (overrideManifestUrlModifier) {

--- a/ern-core/src/MiniApp.ts
+++ b/ern-core/src/MiniApp.ts
@@ -52,7 +52,7 @@ export class MiniApp extends BaseMiniApp {
   public static async fromPackagePath(packagePath: PackagePath) {
     let fsPackagePath
     if (
-      config.getValue('package-cache-enabled', true) &&
+      config.get('package-cache-enabled', true) &&
       !packagePath.isFilePath &&
       !(await utils.isGitBranch(packagePath))
     ) {
@@ -518,7 +518,7 @@ with "ern" : { "version" : "${this.packageJson.ernPlatformVersion}" } instead`)
   }
 
   public async link() {
-    const miniAppsLinks = config.getValue('miniAppsLinks', {})
+    const miniAppsLinks = config.get('miniAppsLinks', {})
     const previousLinkPath = miniAppsLinks[this.packageJson.name]
     if (previousLinkPath && previousLinkPath !== this.path) {
       log.warn(
@@ -532,7 +532,7 @@ with "ern" : { "version" : "${this.packageJson.ernPlatformVersion}" } instead`)
       )
     }
     miniAppsLinks[this.packageJson.name] = this.path
-    config.setValue('miniAppsLinks', miniAppsLinks)
+    config.set('miniAppsLinks', miniAppsLinks)
     log.info(
       `${this.packageJson.name} link created [${this.packageJson.name} => ${
         this.path
@@ -541,10 +541,10 @@ with "ern" : { "version" : "${this.packageJson.ernPlatformVersion}" } instead`)
   }
 
   public async unlink() {
-    const miniAppsLinks = config.getValue('miniAppsLinks', {})
+    const miniAppsLinks = config.get('miniAppsLinks', {})
     if (miniAppsLinks[this.packageJson.name]) {
       delete miniAppsLinks[this.packageJson.name]
-      config.setValue('miniAppsLinks', miniAppsLinks)
+      config.set('miniAppsLinks', miniAppsLinks)
       log.info(`${this.packageJson.name} link was removed`)
     } else {
       return log.warn(`No link exists for ${this.packageJson.name}`)

--- a/ern-core/src/Platform.ts
+++ b/ern-core/src/Platform.ts
@@ -68,7 +68,7 @@ export default class Platform {
   }
 
   static get currentVersion(): string {
-    return config.getValue('platformVersion', '1000.0.0')
+    return config.get('platformVersion', '1000.0.0')
   }
 
   public static isPlatformVersionAvailable(version: string) {
@@ -169,7 +169,7 @@ export default class Platform {
       this.installPlatform(version)
     }
 
-    config.setValue('platformVersion', version)
+    config.set('platformVersion', version)
     log.info(`ern v${version} is now activated.`)
   }
 

--- a/ern-core/src/android.ts
+++ b/ern-core/src/android.ts
@@ -185,9 +185,7 @@ export async function runAndroid({
 
 export async function askUserToSelectAvdEmulator(): Promise<string> {
   const avdImageNames = await getAndroidAvds()
-  const deviceConfig = ernConfig.getValue(
-    deviceConfigUtil.ANDROID_DEVICE_CONFIG
-  )
+  const deviceConfig = ernConfig.get(deviceConfigUtil.ANDROID_DEVICE_CONFIG)
   // Check if user has set the usePreviousEmulator flag to true
   if (avdImageNames && deviceConfig) {
     if (deviceConfig.usePreviousDevice) {
@@ -214,7 +212,7 @@ export async function askUserToSelectAvdEmulator(): Promise<string> {
   // Update the device Config
   if (deviceConfig) {
     deviceConfig.deviceId = avdImageName
-    ernConfig.setValue(deviceConfigUtil.ANDROID_DEVICE_CONFIG, deviceConfig)
+    ernConfig.set(deviceConfigUtil.ANDROID_DEVICE_CONFIG, deviceConfig)
   }
   return `${avdImageName}`
 }

--- a/ern-core/src/config.ts
+++ b/ern-core/src/config.ts
@@ -19,32 +19,28 @@ export class ErnConfig {
       : ERN_RC_GLOBAL_FILE_PATH
   }
 
-  public getValue(key: string, defaultValue?: any): any {
+  public get(key: string, defaultValue?: any): any {
     return this.obj[key] !== undefined ? this.obj[key] : defaultValue
   }
 
-  public setValue(key: string, value: any) {
+  public set(key: string, value: any) {
     const c = this.obj
     c[key] = value
-    this.writeConfig(c)
+    this.persist(c)
   }
 
-  public writeConfig(obj: any) {
-    fs.writeFileSync(this.ernRcFilePath, JSON.stringify(obj, null, 2))
-  }
-
-  public deleteConfig(key: string): boolean {
+  public del(key: string): boolean {
     const c = this.obj
     if (key && c.hasOwnProperty(key)) {
       delete c[key]
-      this.writeConfig(c)
+      this.persist(c)
       return true
     }
     return false
   }
 
-  public getAllConfig(): any {
-    return this.obj
+  public persist(obj: any) {
+    fs.writeFileSync(this.ernRcFilePath, JSON.stringify(obj, null, 2))
   }
 }
 

--- a/ern-core/src/createProxyAgent.ts
+++ b/ern-core/src/createProxyAgent.ts
@@ -27,7 +27,7 @@ export function createProxyAgentFromUrl(proxyUrl: url.URL): http.Agent {
 export function createProxyAgentFromErnConfig(
   configKey: string
 ): http.Agent | undefined {
-  const proxyUrl = config.getValue(configKey)
+  const proxyUrl = config.get(configKey)
   if (proxyUrl) {
     return createProxyAgentFromUrl(new url.URL(proxyUrl))
   }

--- a/ern-core/src/createTmpDir.ts
+++ b/ern-core/src/createTmpDir.ts
@@ -4,11 +4,11 @@ import shell from './shell'
 import fs from 'fs'
 
 export default function(): string {
-  const tmpDir = config.getValue('tmp-dir')
+  const tmpDir = config.get('tmp-dir')
   if (tmpDir && !fs.existsSync(tmpDir)) {
     shell.mkdir('-p', tmpDir)
   }
-  const retainTmpDir = config.getValue('retain-tmp-dir', false)
+  const retainTmpDir = config.get('retain-tmp-dir', false)
   return tmp.dirSync({
     dir: tmpDir,
     unsafeCleanup: !retainTmpDir,

--- a/ern-core/src/deviceConfig.ts
+++ b/ern-core/src/deviceConfig.ts
@@ -9,9 +9,9 @@ export function updateDeviceConfig(
 ) {
   const key = platform === 'ios' ? IOS_DEVICE_CONFIG : ANDROID_DEVICE_CONFIG
 
-  const deviceConfig = config.getValue(key, {
+  const deviceConfig = config.get(key, {
     deviceId: '',
   })
   deviceConfig.usePreviousDevice = usePreviousDevice
-  config.setValue(key, deviceConfig)
+  config.set(key, deviceConfig)
 }

--- a/ern-core/src/getCodePushInitConfig.ts
+++ b/ern-core/src/getCodePushInitConfig.ts
@@ -15,10 +15,10 @@ export function getCodePushInitConfig(): CodePushInitConfig {
     )
   } else {
     codePushInitConfig = {
-      accessKey: config.getValue('codePushAccessKey'),
-      customHeaders: config.getValue('codePushCustomHeaders'),
-      customServerUrl: config.getValue('codePushCustomServerUrl'),
-      proxy: config.getValue('codePushProxy'),
+      accessKey: config.get('codePushAccessKey'),
+      customHeaders: config.get('codePushCustomHeaders'),
+      customServerUrl: config.get('codePushCustomServerUrl'),
+      proxy: config.get('codePushProxy'),
     }
   }
   return codePushInitConfig

--- a/ern-core/src/ios.ts
+++ b/ern-core/src/ios.ts
@@ -62,10 +62,7 @@ export async function askUserToSelectAniPhoneSimulator() {
   }))
 
   // Check if user has set the usePreviousEmulator flag to true
-  const deviceConfig = ernConfig.getValue(
-    deviceConfigUtil.IOS_DEVICE_CONFIG,
-    {}
-  )
+  const deviceConfig = ernConfig.get(deviceConfigUtil.IOS_DEVICE_CONFIG, {})
   if (choices && deviceConfig) {
     if (deviceConfig.usePreviousDevice) {
       // Get the name of previously used simulator
@@ -95,7 +92,7 @@ export async function askUserToSelectAniPhoneSimulator() {
 
   // Update the emulatorConfig
   deviceConfig.deviceId = selectedDevice.udid
-  ernConfig.setValue(deviceConfigUtil.IOS_DEVICE_CONFIG, deviceConfig)
+  ernConfig.set(deviceConfigUtil.IOS_DEVICE_CONFIG, deviceConfig)
 
   return selectedDevice
 }

--- a/ern-core/src/packageCache.ts
+++ b/ern-core/src/packageCache.ts
@@ -25,7 +25,7 @@ export const packageCache = new FsCache<PackagePath>({
       shell.popd()
     }
   },
-  maxCacheSize: config.getValue('max-package-cache-size'),
+  maxCacheSize: config.get('max-package-cache-size'),
   objectToId: (obj: PackagePath) => obj.fullPath,
   rootCachePath: Platform.packagesCacheDirectory,
 })

--- a/ern-core/test/Platform-test.ts
+++ b/ern-core/test/Platform-test.ts
@@ -153,7 +153,7 @@ describe('Platform', () => {
 
   describe('currentPlatformVersionPath', () => {
     it('should return the correct platform version path', () => {
-      sandbox.stub(config, 'getValue').callsFake(key => {
+      sandbox.stub(config, 'get').callsFake(key => {
         if (key === 'platformVersion') {
           return '3.0.0'
         }
@@ -166,7 +166,7 @@ describe('Platform', () => {
 
   describe('currentVersion', () => {
     it('should return the current version', () => {
-      sandbox.stub(config, 'getValue').callsFake(key => {
+      sandbox.stub(config, 'get').callsFake(key => {
         if (key === 'platformVersion') {
           return '3.0.0'
         }
@@ -268,7 +268,7 @@ describe('Platform', () => {
 
   describe('uninstallPlatform', () => {
     it('should not do anything if the platform version is not installed', () => {
-      sandbox.stub(config, 'getValue').callsFake(key => {
+      sandbox.stub(config, 'get').callsFake(key => {
         if (key === 'platformVersion') {
           return '3.0.0'
         }
@@ -281,7 +281,7 @@ describe('Platform', () => {
         '-p',
         path.join(path.join(ernHomePath, 'versions', '3.0.0', 'node_modules'))
       )
-      sandbox.stub(config, 'getValue').callsFake(key => {
+      sandbox.stub(config, 'get').callsFake(key => {
         if (key === 'platformVersion') {
           return '3.0.0'
         }
@@ -294,7 +294,7 @@ describe('Platform', () => {
         '-p',
         path.join(path.join(ernHomePath, 'versions', '3.0.0', 'node_modules'))
       )
-      sandbox.stub(config, 'getValue').callsFake(key => {
+      sandbox.stub(config, 'get').callsFake(key => {
         if (key === 'platformVersion') {
           return '2.0.0'
         }

--- a/ern-core/test/android-test.ts
+++ b/ern-core/test/android-test.ts
@@ -12,14 +12,14 @@ import * as fixtures from './fixtures/common'
 const readFile = Prom.promisify(fs.readFile)
 const sandbox = sinon.createSandbox()
 
-let ernConfigGetValueStub
+let ernConfigGetStub
 let execpStub
 
 describe('android.js', () => {
   beforeEach(() => {
     beforeTest()
 
-    ernConfigGetValueStub = sandbox.stub(ernConfig, 'getValue')
+    ernConfigGetStub = sandbox.stub(ernConfig, 'get')
 
     // class in test stubs
     execpStub = sandbox.stub(childProcess, 'execp')
@@ -87,7 +87,7 @@ describe('android.js', () => {
       const inquirerStub = sinon.stub(inquirer, 'prompt').resolves({
         avdImageName: fixtures.oneAvd,
       })
-      ernConfigGetValueStub.returns(config)
+      ernConfigGetStub.returns(config)
       const result = await android.askUserToSelectAvdEmulator()
       inquirerStub.restore()
       expect(result).to.be.equal(fixtures.oneAvd)
@@ -102,7 +102,7 @@ describe('android.js', () => {
       const inquirerStub = sinon.stub(inquirer, 'prompt').resolves({
         avdImageName: fixtures.oneAvd,
       })
-      ernConfigGetValueStub.returns(config)
+      ernConfigGetStub.returns(config)
       const result = await android.askUserToSelectAvdEmulator()
       inquirerStub.restore()
       expect(result).to.be.equal(fixtures.oneAvd)
@@ -114,7 +114,7 @@ describe('android.js', () => {
       const inquirerStub = sinon.stub(inquirer, 'prompt').resolves({
         avdImageName: fixtures.oneAvd,
       })
-      ernConfigGetValueStub.returns(config)
+      ernConfigGetStub.returns(config)
       const result = await android.askUserToSelectAvdEmulator()
       inquirerStub.restore()
       expect(result).to.be.equal(fixtures.oneAvd)
@@ -126,7 +126,7 @@ describe('android.js', () => {
       const inquirerStub = sinon.stub(inquirer, 'prompt').resolves({
         avdImageName: fixtures.oneAvd,
       })
-      ernConfigGetValueStub.returns(config)
+      ernConfigGetStub.returns(config)
       const result = await android.askUserToSelectAvdEmulator()
       inquirerStub.restore()
       expect(result).to.be.equal(fixtures.oneAvd)
@@ -138,7 +138,7 @@ describe('android.js', () => {
         deviceId: fixtures.oneAvd,
         usePreviousDevice: true,
       }
-      ernConfigGetValueStub.returns(config)
+      ernConfigGetStub.returns(config)
       expect(await android.askUserToSelectAvdEmulator()).to.be.equal(
         fixtures.oneAvd
       )

--- a/ern-core/test/ios-test.js
+++ b/ern-core/test/ios-test.js
@@ -23,7 +23,7 @@ const sandbox = sinon.createSandbox()
 let getDevicesStub
 let getKnownDevicesStub
 let getComputerNameStub
-let ernConfigGetValueStub
+let ernConfigGetStub
 
 function resolveGetDevices(fixtures) {
   getDevicesStub.resolves(fixtures)
@@ -35,7 +35,7 @@ describe('ios utils', () => {
     getDevicesStub = sandbox.stub(simctl, 'getDevices')
     getKnownDevicesStub = sandbox.stub(ios, 'getKnownDevices')
     getComputerNameStub = sandbox.stub(ios, 'getComputerName')
-    ernConfigGetValueStub = sandbox.stub(ernConfig, 'getValue')
+    ernConfigGetStub = sandbox.stub(ernConfig, 'get')
     let ernConfigStub
   })
 
@@ -119,7 +119,7 @@ describe('ios utils', () => {
         usePreviousDevice: false,
         deviceId: fixtures.oneUdid,
       }
-      ernConfigGetValueStub.returns(config)
+      ernConfigGetStub.returns(config)
       const inquirerIosStub = sinon.stub(inquirer, 'prompt').resolves({
         selectedDevice: {
           name: 'iPhone 5s',
@@ -142,7 +142,7 @@ describe('ios utils', () => {
         usePreviousDevice: true,
         deviceId: 'SimulatorNotPresent',
       }
-      ernConfigGetValueStub.returns(config)
+      ernConfigGetStub.returns(config)
       const inquirerIosStub = sinon.stub(inquirer, 'prompt').resolves({
         selectedDevice: {
           name: 'iPhone 5s',
@@ -165,7 +165,7 @@ describe('ios utils', () => {
         usePreviousDevice: true,
         deviceId: fixtures.oneUdid,
       }
-      ernConfigGetValueStub.returns(config)
+      ernConfigGetStub.returns(config)
       const result = await ios.askUserToSelectAniPhoneSimulator()
       expect(result.udid).to.eql(fixtures.oneUdid)
     })

--- a/ern-local-cli/src/commands/bundlestore/create.ts
+++ b/ern-local-cli/src/commands/bundlestore/create.ts
@@ -26,8 +26,8 @@ export const commandHandler = async ({ store }: { store: string }) => {
   const sdk = new BundleStoreSdk(bundleStoreUrl)
   const accessKey = await sdk.createStore({ store })
 
-  config.setValue('bundlestore-id', store)
-  config.setValue('bundlestore-accesskey', accessKey)
+  config.set('bundlestore-id', store)
+  config.set('bundlestore-accesskey', accessKey)
 
   log.info(`Store ${store} was successfuly created`)
   log.info(`AccessKey : ${accessKey}`)

--- a/ern-local-cli/src/commands/bundlestore/delete.ts
+++ b/ern-local-cli/src/commands/bundlestore/delete.ts
@@ -27,9 +27,9 @@ export const commandHandler = async ({ accessKey }: { accessKey: string }) => {
 
   const storeId = await sdk.deleteStoreByAccessKey({ accessKey })
 
-  if (storeId === config.getValue('bundlestore-id')) {
-    config.setValue('bundlestore-id', undefined)
-    config.setValue('bundlestore-accesskey', undefined)
+  if (storeId === config.get('bundlestore-id')) {
+    config.set('bundlestore-id', undefined)
+    config.set('bundlestore-accesskey', undefined)
   }
 
   log.info(`Deleted store ${storeId}`)

--- a/ern-local-cli/src/commands/bundlestore/use.ts
+++ b/ern-local-cli/src/commands/bundlestore/use.ts
@@ -26,8 +26,8 @@ export const commandHandler = async ({ accessKey }: { accessKey: string }) => {
   const sdk = new BundleStoreSdk(bundleStoreUrl)
 
   const store = await sdk.getStoreByAccessKey({ accessKey })
-  config.setValue('bundlestore-id', store)
-  config.setValue('bundlestore-accesskey', accessKey)
+  config.set('bundlestore-id', store)
+  config.set('bundlestore-accesskey', accessKey)
 
   log.info(`Now using store ${store}`)
 }

--- a/ern-local-cli/src/commands/platform/config/del.ts
+++ b/ern-local-cli/src/commands/platform/config/del.ts
@@ -20,7 +20,7 @@ export const commandHandler = async ({ key }: { key: string }) => {
     },
   })
 
-  if (ernConfig.deleteConfig(key)) {
+  if (ernConfig.del(key)) {
     log.info(`Successfully deleted ${key} from config`)
   } else {
     log.warn(`${key} was not found in config`)

--- a/ern-local-cli/src/commands/platform/config/get.ts
+++ b/ern-local-cli/src/commands/platform/config/get.ts
@@ -19,8 +19,8 @@ export const commandHandler = async ({ key }: { key: string }) => {
       key,
     },
   })
-  if (ernConfig.getValue(key)) {
-    log.info(`Configuration value for ${key} is ${ernConfig.getValue(key)}`)
+  if (ernConfig.get(key)) {
+    log.info(`Configuration value for ${key} is ${ernConfig.get(key)}`)
   } else {
     log.warn(`${key} was not found in config`)
   }

--- a/ern-local-cli/src/commands/platform/config/list.ts
+++ b/ern-local-cli/src/commands/platform/config/list.ts
@@ -11,7 +11,7 @@ export const builder = (argv: Argv) => {
 
 export const commandHandler = async () => {
   // TODO: Add tabular view
-  log.info(JSON.stringify(ernConfig.getAllConfig(), null, 2))
+  log.info(JSON.stringify(ernConfig.obj, null, 2))
 }
 
 export const handler = tryCatchWrap(commandHandler)

--- a/ern-local-cli/src/commands/platform/config/set.ts
+++ b/ern-local-cli/src/commands/platform/config/set.ts
@@ -33,8 +33,8 @@ export const commandHandler = async ({
   } else {
     valueToset = value === 'true' ? true : value === 'false' ? false : value
   }
-  ernConfig.setValue(key, valueToset)
-  log.info(`Successfully set ${key} value to ${ernConfig.getValue(key)}`)
+  ernConfig.set(key, valueToset)
+  log.info(`Successfully set ${key} value to ${ernConfig.get(key)}`)
 }
 
 export const handler = tryCatchWrap(commandHandler)

--- a/ern-local-cli/src/index.ts
+++ b/ern-local-cli/src/index.ts
@@ -43,8 +43,8 @@ function showBanner() {
 }
 
 function showInfo() {
-  const currentCauldronRepo = config.getValue('cauldronRepoInUse') || '-NONE-'
-  const bundleStoreId = config.getValue('bundlestore-id')
+  const currentCauldronRepo = config.get('cauldronRepoInUse') || '-NONE-'
+  const bundleStoreId = config.get('bundlestore-id')
   const l = bundleStoreId ? chalk.cyan(` [BundleStore: ${bundleStoreId}]`) : ''
   console.log(
     chalk.cyan(`[v${Platform.currentVersion}]`) +
@@ -56,8 +56,8 @@ function showInfo() {
 
 function showVersion() {
   // get electrode-native local-cli version
-  if (config.getValue('platformVersion')) {
-    log.info(`ern-local-cli : ${config.getValue('platformVersion')}`)
+  if (config.get('platformVersion')) {
+    log.info(`ern-local-cli : ${config.get('platformVersion')}`)
   }
   // get electrode-native global-cli version
   const packageInfo = JSON.parse(
@@ -155,7 +155,7 @@ const logLevelStringToEnum = level => {
     ? LogLevel.Off
     : process.env.ERN_LOG_LEVEL
     ? logLevelStringToEnum(process.env.ERN_LOG_LEVEL)
-    : logLevelStringToEnum(config.getValue('logLevel', 'info'))
+    : logLevelStringToEnum(config.get('logLevel', 'info'))
 
   log.setLogLevel(logLevel)
   shell.config.fatal = true
@@ -172,7 +172,7 @@ const logLevelStringToEnum = level => {
       : new KaxAdvancedRenderer(kaxRendererConfig)
 
   if (!hasJsonOpt) {
-    if (config.getValue('showBanner', true)) {
+    if (config.get('showBanner', true)) {
       showBanner()
     }
     showInfo()

--- a/ern-orchestrator/src/Ensure.ts
+++ b/ern-orchestrator/src/Ensure.ts
@@ -572,7 +572,7 @@ export default class Ensure {
   }
 
   public static bundleStoreAccessKeyIsSet(extraErrorMessage: string = '') {
-    if (!config.getValue('bundlestore-accesskey')) {
+    if (!config.get('bundlestore-accesskey')) {
       throw new Error(
         `bundlestore-accesskey is not set in configuration\n${extraErrorMessage}`
       )

--- a/ern-orchestrator/src/start.ts
+++ b/ern-orchestrator/src/start.ts
@@ -103,7 +103,7 @@ export default async function start({
     })
   )
 
-  const miniAppsLinksObj = ernConfig.getValue('miniAppsLinks', {})
+  const miniAppsLinksObj = ernConfig.get('miniAppsLinks', {})
   const linkedMiniAppsPackageNames = Object.keys(miniAppsLinksObj).filter(p =>
     fs.existsSync(miniAppsLinksObj[p])
   )

--- a/ern-orchestrator/test/start-test.ts
+++ b/ern-orchestrator/test/start-test.ts
@@ -87,7 +87,7 @@ describe('start', () => {
     sandbox
       .stub(core.ErnBinaryStore.prototype, 'hasBinary')
       .resolves(hasBinaryReturn)
-    const configStub = sandbox.stub(core.config, 'getValue')
+    const configStub = sandbox.stub(core.config, 'get')
     configStub.withArgs('tmp-dir').returns(undefined)
     configStub.withArgs('miniAppsLinks').returns(configMiniAppsLinks)
   }


### PR DESCRIPTION
Quick refactoring, only renaming some methods because current method names are making my eyes bleed. 

Keep them short and consistent :

`getValue` => `get`
`setValue` => `set`
`deleteConfig` => `del`