### PR TITLE
Fix system tests

### DIFF
--- a/system-tests/tests/misc.js
+++ b/system-tests/tests/misc.js
@@ -92,8 +92,8 @@ run(`create-container --miniapps file:${miniAppPath} ${f.movieListMiniAppPgkName
 run(`create-container --miniapps file:${miniAppPath} ${f.movieListMiniAppPgkName}@${f.movieListMiniAppPkgVersion} -p ios`)
 
 // transform-container / publish-coontainer should be successful
-run (`ern transform-container --containerPath ${defaultAndroidContainerGenPath} --platform android --transformer dummy`)
-run (`ern publish-container --containerPath ${defaultAndroidContainerGenPath} --platform android --publisher dummy`)
+run (`transform-container --containerPath ${defaultAndroidContainerGenPath} --platform android --transformer dummy`)
+run (`publish-container --containerPath ${defaultAndroidContainerGenPath} --platform android --publisher dummy`)
 
 // Del miniapp
 run(`cauldron del miniapps ${f.movieListMiniAppPgkName} -d ${androidNativeApplicationDescriptor}`)


### PR DESCRIPTION
Fix [system tests failure](https://dev.azure.com/ElectrodeNative/Electrode%20Native/_build/results?buildId=1632&view=logs&s=a91c8f70-7e8a-583d-a65c-db3cf7ee37c6&j=0b89bb54-e3f1-5753-4a6d-bc059c79df46) on running `transform-container` command.

Due to command to run improperly formatted as :

```
$ ern ern transform-container [...]
```

This remained unnoticed because it wasn't failing prior to https://github.com/electrode-io/electrode-native/pull/1370 which bumped `yargs` library version to latest (from a quite old one). Seems like more recent versions of yargs are less forgiving when it comes to invalid command syntax ;)