### PR TITLE
Join string literal path segments

### DIFF
--- a/ern-api-impl-gen/src/ApiImpl.ts
+++ b/ern-api-impl-gen/src/ApiImpl.ts
@@ -125,9 +125,7 @@ async function createNodePackage(
     shell.cp(
       path.join(
         Platform.currentPlatformVersionPath,
-        'ern-api-impl-gen',
-        'resources',
-        'gitignore'
+        'ern-api-impl-gen/resources/gitignore'
       ),
       path.join(outputDirectoryPath, '.gitignore')
     )

--- a/ern-api-impl-gen/src/generators/ApiImplGen.ts
+++ b/ern-api-impl-gen/src/generators/ApiImplGen.ts
@@ -47,8 +47,7 @@ export default class ApiImplGen {
     const reactNativeElectrodeBridge: any = await readPackageJson(
       path.join(
         paths.outDirectory,
-        'node_modules',
-        'react-native-electrode-bridge'
+        'node_modules/react-native-electrode-bridge'
       )
     )
 

--- a/ern-api-impl-gen/src/generators/android/ApiImplAndroidGenerator.ts
+++ b/ern-api-impl-gen/src/generators/android/ApiImplAndroidGenerator.ts
@@ -17,8 +17,8 @@ import { ApiImplGeneratable } from '../../ApiImplGeneratable'
 export const ROOT_DIR = shell.pwd()
 const READ_EXECUTE = '555'
 const READ_WRITE_EXECUTE = '777'
-const SRC_MAIN_JAVA_DIR = path.join('src', 'main', 'java')
-const API_IMPL_PACKAGE = path.join('com', 'ern', 'api', 'impl')
+const SRC_MAIN_JAVA_DIR = path.normalize('src/main/java')
+const API_IMPL_PACKAGE = path.normalize('com/ern/api/impl')
 
 export default class ApiImplAndroidGenerator implements ApiImplGeneratable {
   public static getMustacheFileNamesMap(resourceDir, apiName) {
@@ -34,8 +34,7 @@ export default class ApiImplAndroidGenerator implements ApiImplGeneratable {
   public static createImplDirectoryAndCopyCommonClasses(paths) {
     const outputDir = path.join(
       paths.outDirectory,
-      'android',
-      'lib',
+      'android/lib',
       SRC_MAIN_JAVA_DIR,
       API_IMPL_PACKAGE
     )
@@ -45,9 +44,7 @@ export default class ApiImplAndroidGenerator implements ApiImplGeneratable {
 
     const resourceDir = path.join(
       Platform.currentPlatformVersionPath,
-      'ern-api-impl-gen',
-      'resources',
-      'android'
+      'ern-api-impl-gen/resources/android'
     )
     shell.cp(path.join(resourceDir, 'RequestHandlerConfig.java'), outputDir)
     shell.cp(path.join(resourceDir, 'RequestHandlerProvider.java'), outputDir)
@@ -102,7 +99,7 @@ export default class ApiImplAndroidGenerator implements ApiImplGeneratable {
       fileUtils.chmodr(READ_WRITE_EXECUTE, outputDirectory)
       shell.cp(
         '-Rf',
-        path.join(paths.apiImplHull, 'android', '{.*,*}'),
+        path.join(paths.apiImplHull, 'android/{.*,*}'),
         outputDirectory
       )
 
@@ -194,14 +191,14 @@ export default class ApiImplAndroidGenerator implements ApiImplGeneratable {
     mustacheView.reactNativeVersion = reactNativeVersion
     mustacheView = Object.assign(mustacheView, versions)
     mustacheUtils.mustacheRenderToOutputFileUsingTemplateFile(
-      path.join(paths.apiImplHull, 'android', 'build.gradle'),
+      path.join(paths.apiImplHull, 'android/build.gradle'),
       mustacheView,
       path.join(outputDirectory, 'build.gradle')
     )
     return mustacheUtils.mustacheRenderToOutputFileUsingTemplateFile(
-      path.join(paths.apiImplHull, 'android', 'lib', 'build.gradle'),
+      path.join(paths.apiImplHull, 'android/lib/build.gradle'),
       mustacheView,
-      path.join(outputDirectory, 'lib', 'build.gradle')
+      path.join(outputDirectory, 'lib/build.gradle')
     )
   }
 
@@ -215,18 +212,10 @@ export default class ApiImplAndroidGenerator implements ApiImplGeneratable {
     return mustacheUtils.mustacheRenderToOutputFileUsingTemplateFile(
       path.join(
         paths.apiImplHull,
-        'android',
-        'gradle',
-        'wrapper',
-        'gradle-wrapper.properties'
+        'android/gradle/wrapper/gradle-wrapper.properties'
       ),
       mustacheView,
-      path.join(
-        outputDirectory,
-        'gradle',
-        'wrapper',
-        'gradle-wrapper.properties'
-      )
+      path.join(outputDirectory, 'gradle/wrapper/gradle-wrapper.properties')
     )
   }
 

--- a/ern-api-impl-gen/src/generators/ios/ApiImplIosGenerator.ts
+++ b/ern-api-impl-gen/src/generators/ios/ApiImplIosGenerator.ts
@@ -53,7 +53,7 @@ export default class ApiImplIosGenerator implements ApiImplGeneratable {
     try {
       const pathSpec = {
         outputDir: path.join(paths.outDirectory, 'ios'),
-        projectHullDir: path.join(paths.apiImplHull, 'ios', '{.*,*}'),
+        projectHullDir: path.join(paths.apiImplHull, 'ios/{.*,*}'),
         rootDir: ROOT_DIR,
       }
 
@@ -171,9 +171,7 @@ export default class ApiImplIosGenerator implements ApiImplGeneratable {
   ) {
     const resourceDir = path.join(
       Platform.currentPlatformVersionPath,
-      'ern-api-impl-gen',
-      'resources',
-      'ios'
+      'ern-api-impl-gen/resources/ios'
     )
     const outputDir = path.join(
       pathSpec.outputDir,

--- a/ern-api-impl-gen/src/generators/js/ApiImplJsGenerator.ts
+++ b/ern-api-impl-gen/src/generators/js/ApiImplJsGenerator.ts
@@ -40,10 +40,7 @@ export default class ApiImplJsGenerator implements ApiImplGeneratable {
       }
       const mustacheFile = path.join(
         Platform.currentPlatformVersionPath,
-        'ern-api-impl-gen',
-        'resources',
-        'js',
-        'apiimpl.mustache'
+        'ern-api-impl-gen/resources/js/apiimpl.mustache'
       )
 
       for (const api of apis) {
@@ -57,10 +54,7 @@ export default class ApiImplJsGenerator implements ApiImplGeneratable {
 
       const indexMustacheFile = path.join(
         Platform.currentPlatformVersionPath,
-        'ern-api-impl-gen',
-        'resources',
-        'js',
-        'index.mustache'
+        'ern-api-impl-gen/resources/js/index.mustache'
       )
       const apisMustacheView = {
         apis,

--- a/ern-cauldron-api/test/CauldronApi-test.ts
+++ b/ern-cauldron-api/test/CauldronApi-test.ts
@@ -32,7 +32,7 @@ const codePushNewEntryFixture: CauldronCodePushEntry = {
 let documentStore
 let fileStore
 
-const fixtureFileStorePath = path.join(__dirname, 'fixtures', 'filestore')
+const fixtureFileStorePath = path.join(__dirname, 'fixtures/filestore')
 
 function cauldronApi({
   cauldronDocument,
@@ -65,14 +65,14 @@ describe('CauldronApi.js', () => {
       sandbox.stub(utils, 'isGitBranch').resolves(true)
       const fixture = JSON.parse(
         fs
-          .readFileSync(path.join(__dirname, 'fixtures', 'cauldron-0.0.0.json'))
+          .readFileSync(path.join(__dirname, 'fixtures/cauldron-0.0.0.json'))
           .toString()
       )
       const api = cauldronApi({ cauldronDocument: fixture })
       await api.upgradeCauldronSchema()
       const expectedCauldronDoc = JSON.parse(
         fs
-          .readFileSync(path.join(__dirname, 'fixtures', 'cauldron-3.0.0.json'))
+          .readFileSync(path.join(__dirname, 'fixtures/cauldron-3.0.0.json'))
           .toString()
       )
       const cauldronDoc = await api.getCauldron()
@@ -734,7 +734,7 @@ describe('CauldronApi.js', () => {
         storePath: fixtureFileStorePath,
       }).getConfig(AppVersionDescriptor.fromString('test:android:17.7.0'))
       const config = fs.readFileSync(
-        path.join(fixtureFileStorePath, 'config', 'test-android-17.7.0.json')
+        path.join(fixtureFileStorePath, 'config/test-android-17.7.0.json')
       )
       expect(configObj).eql(JSON.parse(config.toString()))
     })
@@ -755,7 +755,7 @@ describe('CauldronApi.js', () => {
         storePath: fixtureFileStorePath,
       }).getConfig(AppPlatformDescriptor.fromString('test:android'))
       const config = fs.readFileSync(
-        path.join(fixtureFileStorePath, 'config', 'test-android.json')
+        path.join(fixtureFileStorePath, 'config/test-android.json')
       )
       expect(configObj).eql(JSON.parse(config.toString()))
     })
@@ -776,7 +776,7 @@ describe('CauldronApi.js', () => {
         storePath: fixtureFileStorePath,
       }).getConfig(AppNameDescriptor.fromString('test'))
       const config = fs.readFileSync(
-        path.join(fixtureFileStorePath, 'config', 'test.json')
+        path.join(fixtureFileStorePath, 'config/test.json')
       )
       expect(configObj).eql(JSON.parse(config.toString()))
     })

--- a/ern-cauldron-api/test/CauldronHelper-test.ts
+++ b/ern-cauldron-api/test/CauldronHelper-test.ts
@@ -1274,7 +1274,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper({ cauldronDocument: fixture })
       await cauldronHelper.addFile({
         cauldronFilePath: 'path/in/cauldron/testfile.ext',
-        localFilePath: path.resolve(__dirname, 'fixtures', 'testfile.ext'),
+        localFilePath: path.resolve(__dirname, 'fixtures/testfile.ext'),
       })
       const hasAddedFile = await fileStore.hasFile(
         'path/in/cauldron/testfile.ext'
@@ -1290,7 +1290,7 @@ describe('CauldronHelper.js', () => {
       assert(
         doesThrow(cauldronHelper.updateFile, cauldronHelper, {
           cauldronFilePath: 'path/in/cauldron/testfile.ext',
-          localFilePath: path.resolve(__dirname, 'fixtures', 'testfile.ext'),
+          localFilePath: path.resolve(__dirname, 'fixtures/testfile.ext'),
         })
       )
     })
@@ -1300,11 +1300,11 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper({ cauldronDocument: fixture })
       await cauldronHelper.addFile({
         cauldronFilePath: 'path/in/cauldron/testfile.ext',
-        localFilePath: path.resolve(__dirname, 'fixtures', 'testfile.ext'),
+        localFilePath: path.resolve(__dirname, 'fixtures/testfile.ext'),
       })
       await cauldronHelper.updateFile({
         cauldronFilePath: 'path/in/cauldron/testfile.ext',
-        localFilePath: path.resolve(__dirname, 'fixtures', 'testfile.ext'),
+        localFilePath: path.resolve(__dirname, 'fixtures/testfile.ext'),
       })
       const hasAddedFile = await fileStore.hasFile(
         'path/in/cauldron/testfile.ext'
@@ -1320,7 +1320,7 @@ describe('CauldronHelper.js', () => {
       assert(
         doesThrow(cauldronHelper.removeFile, cauldronHelper, {
           cauldronFilePath: 'path/in/cauldron/testfile.ext',
-          localFilePath: path.resolve(__dirname, 'fixtures', 'testfile.ext'),
+          localFilePath: path.resolve(__dirname, 'fixtures/testfile.ext'),
         })
       )
     })
@@ -1330,7 +1330,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper({ cauldronDocument: fixture })
       await cauldronHelper.addFile({
         cauldronFilePath: 'path/in/cauldron/testfile.ext',
-        localFilePath: path.resolve(__dirname, 'fixtures', 'testfile.ext'),
+        localFilePath: path.resolve(__dirname, 'fixtures/testfile.ext'),
       })
       await cauldronHelper.removeFile({
         cauldronFilePath: 'path/in/cauldron/testfile.ext',
@@ -1355,7 +1355,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper({ cauldronDocument: fixture })
       await cauldronHelper.addFile({
         cauldronFilePath: 'path/in/cauldron/testfile.ext',
-        localFilePath: path.resolve(__dirname, 'fixtures', 'testfile.ext'),
+        localFilePath: path.resolve(__dirname, 'fixtures/testfile.ext'),
       })
       const hasFile = await cauldronHelper.hasFile({
         cauldronFilePath: 'path/in/cauldron/testfile.ext',
@@ -1380,7 +1380,7 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper({ cauldronDocument: fixture })
       await cauldronHelper.addFile({
         cauldronFilePath: 'path/in/cauldron/testfile.ext',
-        localFilePath: path.resolve(__dirname, 'fixtures', 'testfile.ext'),
+        localFilePath: path.resolve(__dirname, 'fixtures/testfile.ext'),
       })
       const fileContent = await cauldronHelper.getFile({
         cauldronFilePath: 'path/in/cauldron/testfile.ext',
@@ -1424,7 +1424,7 @@ describe('CauldronHelper.js', () => {
         'bundleContent'
       )
       const bundledAdded = await fileStore.hasFile(
-        path.join('bundles', 'test-android-17.7.0.zip')
+        path.join('bundles/test-android-17.7.0.zip')
       )
       expect(bundledAdded).true
     })
@@ -2736,7 +2736,7 @@ describe('CauldronHelper.js', () => {
       const storeTmpDir = createTmpDir()
       shell.mkdir('-p', path.join(storeTmpDir, 'config'))
       fs.writeFileSync(
-        path.join(storeTmpDir, 'config', 'test-android-17.7.0.json'),
+        path.join(storeTmpDir, 'config/test-android-17.7.0.json'),
         JSON.stringify({ detachContainerVersionFromRoot: true })
       )
       const cauldronHelper = createCauldronHelper({
@@ -3192,13 +3192,11 @@ describe('CauldronHelper.js', () => {
       })
       const pathToSourceConfig = path.join(
         fileStoreTmpDir,
-        'config',
-        'test-android-17.7.0.json'
+        'config/test-android-17.7.0.json'
       )
       const pathToTargetConfig = path.join(
         fileStoreTmpDir,
-        'config',
-        'test-android-20.0.0.json'
+        'config/test-android-20.0.0.json'
       )
       const hasCreatedConfig = fs.existsSync(pathToTargetConfig)
       expect(hasCreatedConfig).true
@@ -3230,13 +3228,11 @@ describe('CauldronHelper.js', () => {
       })
       const pathToSourceConfig = path.join(
         fileStoreTmpDir,
-        'config',
-        'test-android-17.7.0.json'
+        'config/test-android-17.7.0.json'
       )
       const pathToTargetConfig = path.join(
         fileStoreTmpDir,
-        'config',
-        'test-android-20.0.0.json'
+        'config/test-android-20.0.0.json'
       )
       const hasCreatedConfig = fs.existsSync(pathToTargetConfig)
       expect(hasCreatedConfig).false

--- a/ern-cauldron-api/test/upgrade-scripts-test.ts
+++ b/ern-cauldron-api/test/upgrade-scripts-test.ts
@@ -30,14 +30,14 @@ describe('cauldron upgrade scripts', () => {
     const script = scripts.find(s => s.from === '0.0.0' && s.to === '1.0.0')
     const fixture = JSON.parse(
       fs
-        .readFileSync(path.join(__dirname, 'fixtures', 'cauldron-0.0.0.json'))
+        .readFileSync(path.join(__dirname, 'fixtures/cauldron-0.0.0.json'))
         .toString()
     )
     const cauldronApi = createCauldronApi(fixture)
     await script!.upgrade(cauldronApi)
     const expectedCauldronDoc = JSON.parse(
       fs
-        .readFileSync(path.join(__dirname, 'fixtures', 'cauldron-1.0.0.json'))
+        .readFileSync(path.join(__dirname, 'fixtures/cauldron-1.0.0.json'))
         .toString()
     )
     const cauldronDoc = await cauldronApi.getCauldron()
@@ -48,14 +48,14 @@ describe('cauldron upgrade scripts', () => {
     const script = scripts.find(s => s.from === '1.0.0' && s.to === '2.0.0')
     const fixture = JSON.parse(
       fs
-        .readFileSync(path.join(__dirname, 'fixtures', 'cauldron-1.0.0.json'))
+        .readFileSync(path.join(__dirname, 'fixtures/cauldron-1.0.0.json'))
         .toString()
     )
     const cauldronApi = createCauldronApi(fixture)
     await script!.upgrade(cauldronApi)
     const expectedCauldronDoc = JSON.parse(
       fs
-        .readFileSync(path.join(__dirname, 'fixtures', 'cauldron-2.0.0.json'))
+        .readFileSync(path.join(__dirname, 'fixtures/cauldron-2.0.0.json'))
         .toString()
     )
     const cauldronDoc = await cauldronApi.getCauldron()
@@ -66,14 +66,14 @@ describe('cauldron upgrade scripts', () => {
     const script = scripts.find(s => s.from === '2.0.0' && s.to === '3.0.0')
     const fixture = JSON.parse(
       fs
-        .readFileSync(path.join(__dirname, 'fixtures', 'cauldron-2.0.0.json'))
+        .readFileSync(path.join(__dirname, 'fixtures/cauldron-2.0.0.json'))
         .toString()
     )
     const cauldronApi = createCauldronApi(fixture)
     await script!.upgrade(cauldronApi)
     const expectedCauldronDoc = JSON.parse(
       fs
-        .readFileSync(path.join(__dirname, 'fixtures', 'cauldron-3.0.0.json'))
+        .readFileSync(path.join(__dirname, 'fixtures/cauldron-3.0.0.json'))
         .toString()
     )
     const cauldronDoc = await cauldronApi.getCauldron()

--- a/ern-composite-gen/src/generateComposite.ts
+++ b/ern-composite-gen/src/generateComposite.ts
@@ -334,30 +334,21 @@ async function addBabelrcRoots({ outDir }: { outDir: string }) {
       // https://github.com/facebook/metro/blob/v0.50.0/packages/metro/src/reactNativeTransformer.js#L120
       pathToFileToPatch = path.join(
         compositeNodeModulesPath,
-        'metro',
-        'src',
-        'reactNativeTransformer.js'
+        'metro/src/reactNativeTransformer.js'
       )
     } else {
       // For versions of metro >= 0.51.0, we are patching the index.js file
       // https://github.com/facebook/metro/blob/v0.51.0/packages/metro-react-native-babel-transformer/src/index.js#L120
       const pathInCommunityCli = path.join(
         compositeNodeModulesPath,
-        '@react-native-community',
-        'cli',
-        'node_modules',
-        'metro-react-native-babel-transformer',
-        'src',
-        'index.js'
+        '@react-native-community/cli/node_modules/metro-react-native-babel-transformer/src/index.js'
       )
       if (fs.existsSync(pathInCommunityCli)) {
         pathToFileToPatch = pathInCommunityCli
       } else {
         pathToFileToPatch = path.join(
           compositeNodeModulesPath,
-          'metro-react-native-babel-transformer',
-          'src',
-          'index.js'
+          'metro-react-native-babel-transformer/src/index.js'
         )
       }
     }
@@ -446,9 +437,7 @@ async function patchMetro51({ outDir }: { outDir: string }) {
   if (metroVersion === '0.51.1') {
     const pathToFileToPatch = path.join(
       compositeNodeModulesPath,
-      'metro-resolver',
-      'src',
-      'resolve.js'
+      'metro-resolver/src/resolve.js'
     )
     const stringToReplace = `const assetNames = resolveAsset(dirPath, fileNameHint, platform);`
     const replacementString = `let assetNames;

--- a/ern-container-gen-android/src/AndroidGenerator.ts
+++ b/ern-container-gen-android/src/AndroidGenerator.ts
@@ -92,7 +92,7 @@ export default class AndroidGenerator implements ContainerGenerator {
     let mustacheView: any = {
       customPermissions: [],
       customRepos: [],
-      permissions: []
+      permissions: [],
     }
     injectReactNativeVersionKeysInObject(
       mustacheView,
@@ -184,32 +184,21 @@ export default class AndroidGenerator implements ContainerGenerator {
         if (await coreUtils.isDependencyPathNativeApiImpl(pluginSourcePath)) {
           // Special handling for native api implementation as we don't
           // want to copy the API and bridge code (part of native api implementations projects)
-          const relPathToApiImplSource = path.join(
-            'lib',
-            'src',
-            'main',
-            'java',
-            'com',
-            'ern'
+          const relPathToApiImplSource = path.normalize(
+            'lib/src/main/java/com/ern'
           )
           const absPathToCopyPluginSourceTo = path.join(
             config.outDir,
-            'lib',
-            'src',
-            'main',
-            'java',
-            'com'
+            'lib/src/main/java/com'
           )
           shell.cp('-R', relPathToApiImplSource, absPathToCopyPluginSourceTo)
         } else {
           const relPathToPluginSource = pluginConfig.android.moduleName
-            ? path.join(pluginConfig.android.moduleName, 'src', 'main', 'java')
-            : path.join('src', 'main', 'java')
+            ? path.join(pluginConfig.android.moduleName, 'src/main/java')
+            : path.join('src/main/java')
           const absPathToCopyPluginSourceTo = path.join(
             config.outDir,
-            'lib',
-            'src',
-            'main'
+            'lib/src/main'
           )
           shell.cp('-R', relPathToPluginSource, absPathToCopyPluginSourceTo)
         }
@@ -305,15 +294,13 @@ export default class AndroidGenerator implements ContainerGenerator {
       config.outDir,
       f => !f.endsWith('.jar') && !f.endsWith('.aar') && !f.endsWith('.git')
     )
-    const pathLibSrcMain = path.join('lib', 'src', 'main')
-    const pathLibSrcMainJniLibs = path.join('lib', 'src', 'main', 'jniLibs')
-    const pathLibSrcMainAssets = path.join('lib', 'src', 'main', 'assets')
-    const pathLibSrcMainJavaCom = path.join(pathLibSrcMain, 'java', 'com')
+    const pathLibSrcMain = path.normalize('lib/src/main')
+    const pathLibSrcMainJniLibs = path.normalize('lib/src/main/jniLibs')
+    const pathLibSrcMainAssets = path.normalize('lib/src/main/assets')
+    const pathLibSrcMainJavaCom = path.join(pathLibSrcMain, 'java/com')
     const pathLibSrcMainJavaComWalmartlabsErnContainer = path.join(
       pathLibSrcMainJavaCom,
-      'walmartlabs',
-      'ern',
-      'container'
+      'walmartlabs/ern/container'
     )
     for (const file of files) {
       if (
@@ -570,15 +557,7 @@ export default class AndroidGenerator implements ContainerGenerator {
         )
         const pathToCopyPluginConfigHookTo = path.join(
           outDir,
-          'lib',
-          'src',
-          'main',
-          'java',
-          'com',
-          'walmartlabs',
-          'ern',
-          'container',
-          'plugins'
+          'lib/src/main/java/com/walmartlabs/ern/container/plugins'
         )
         shell.cp(pathToPluginConfigHook, pathToCopyPluginConfigHookTo)
       }

--- a/ern-container-gen/src/reactNativeBundleIos.ts
+++ b/ern-container-gen/src/reactNativeBundleIos.ts
@@ -32,7 +32,7 @@ export async function reactNativeBundleIos({
     // which will lead to issues when building the iOS Container
     // if the assets directory is missing
     fs.writeFileSync(
-      path.join(assetsDest, 'assets', 'README.md'),
+      path.join(assetsDest, 'assets/README.md'),
       'React Native bundled assets will be stored in this directory'
     )
   }

--- a/ern-container-gen/test/copyRnpmAssets-test.ts
+++ b/ern-container-gen/test/copyRnpmAssets-test.ts
@@ -8,8 +8,7 @@ describe('copyRnpmAssets', () => {
   it('should not copy anything to output directory if the MiniApp package.json does not declare any rnpm assets [android]', () => {
     const miniAppPath = path.join(
       __dirname,
-      'fixtures',
-      'MiniAppWithoutRnpmAssets'
+      'fixtures/MiniAppWithoutRnpmAssets'
     )
     const outDir = createTmpDir()
     copyRnpmAssets(
@@ -32,8 +31,7 @@ describe('copyRnpmAssets', () => {
   it('should not copy anything to output directory if the MiniApp package.json does not declare any rnpm assets [ios]', () => {
     const miniAppPath = path.join(
       __dirname,
-      'fixtures',
-      'MiniAppWithoutRnpmAssets'
+      'fixtures/MiniAppWithoutRnpmAssets'
     )
     const outDir = createTmpDir()
     copyRnpmAssets(
@@ -54,11 +52,7 @@ describe('copyRnpmAssets', () => {
   })
 
   it('should copy assets to output directory if the MiniApp package.json declares rnpm assets [android]', () => {
-    const miniAppPath = path.join(
-      __dirname,
-      'fixtures',
-      'MiniAppWithRnpmAssets'
-    )
+    const miniAppPath = path.join(__dirname, 'fixtures/MiniAppWithRnpmAssets')
     const outDir = createTmpDir()
     copyRnpmAssets(
       [
@@ -84,11 +78,7 @@ describe('copyRnpmAssets', () => {
   })
 
   it('should copy assets to output directory if the MiniApp package.json declares rnpm assets [ios]', () => {
-    const miniAppPath = path.join(
-      __dirname,
-      'fixtures',
-      'MiniAppWithRnpmAssets'
-    )
+    const miniAppPath = path.join(__dirname, 'fixtures/MiniAppWithRnpmAssets')
     const outDir = createTmpDir()
     copyRnpmAssets(
       [

--- a/ern-container-gen/test/getContainerMetadata-test.ts
+++ b/ern-container-gen/test/getContainerMetadata-test.ts
@@ -14,8 +14,7 @@ describe('getContainerMetadata', () => {
   it('should return the container metadata object if path contains a container metadata file', async () => {
     const containerFixturePath = path.join(
       __dirname,
-      'fixtures',
-      'ContainerWithMetadata'
+      'fixtures/ContainerWithMetadata'
     )
     const result = await getContainerMetadata(containerFixturePath)
     const expectedResult = JSON.parse(

--- a/ern-container-gen/test/inferContainerPlatform-test.ts
+++ b/ern-container-gen/test/inferContainerPlatform-test.ts
@@ -10,14 +10,14 @@ describe('inferContainerPlatform', () => {
 
   it('should return android if the container is an android one', () => {
     const result = inferContainerPlatform(
-      path.resolve('..', 'system-tests', 'fixtures', 'android-container')
+      path.resolve('../system-tests/fixtures/android-container')
     )
     expect(result).eql('android')
   })
 
   it('should return android if the container is an ios one', () => {
     const result = inferContainerPlatform(
-      path.resolve('..', 'system-tests', 'fixtures', 'ios-container')
+      path.resolve('../system-tests/fixtures/ios-container')
     )
     expect(result).eql('ios')
   })

--- a/ern-core/src/MiniApp.ts
+++ b/ern-core/src/MiniApp.ts
@@ -111,7 +111,7 @@ export class MiniApp extends BaseMiniApp {
       template?: string
     } = {}
   ) {
-    if (fs.existsSync(path.join('node_modules', 'react-native'))) {
+    if (fs.existsSync(path.join('node_modules/react-native'))) {
       throw new Error(
         'It seems like there is already a react native app in this directory. Use another directory.'
       )

--- a/ern-core/src/clients.ts
+++ b/ern-core/src/clients.ts
@@ -11,16 +11,12 @@ export const reactnative = new ReactNativeCli(
 function getInternalBinaryPath(binaryName: string): string {
   const pathWhenInstalledWithYarn = path.resolve(
     __dirname,
-    '..',
-    'node_modules',
-    '.bin',
+    '../node_modules/.bin',
     binaryName
   )
   const pathWhenInstalledWithNpm = path.resolve(
     __dirname,
-    '..',
-    '..',
-    '.bin',
+    '../../.bin',
     binaryName
   )
   if (fs.existsSync(pathWhenInstalledWithYarn)) {

--- a/ern-core/src/getDefaultMavenLocalDirectory.ts
+++ b/ern-core/src/getDefaultMavenLocalDirectory.ts
@@ -2,6 +2,6 @@ import os from 'os'
 import path from 'path'
 
 export function getDefaultMavenLocalDirectory() {
-  const pathToRepository = path.join(os.homedir(), '.m2', 'repository')
+  const pathToRepository = path.join(os.homedir(), '.m2/repository')
   return `file://${pathToRepository}`
 }

--- a/ern-core/src/iosUtil.ts
+++ b/ern-core/src/iosUtil.ts
@@ -119,7 +119,7 @@ export async function fillProjectHull(
               log.debug(
                 `Handling copy directive: Falling back to old directory structure for API(Backward compatibility)`
               )
-              copy.source = path.join('IOS', 'IOS', 'Classes', 'SwaggersAPIs')
+              copy.source = path.normalize('IOS/IOS/Classes/SwaggersAPIs')
             }
           }
           handleCopyDirective(
@@ -181,12 +181,8 @@ export async function fillProjectHull(
                   log.debug(
                     `Source Copy: Falling back to old directory structure for API(Backward compatibility)`
                   )
-                  source.from = path.join(
-                    'IOS',
-                    'IOS',
-                    'Classes',
-                    'SwaggersAPIs',
-                    '*.swift'
+                  source.from = path.normalize(
+                    'IOS/IOS/Classes/SwaggersAPIs/*.swift'
                   )
                 }
                 const relativeSourcePath = path.dirname(source.from)
@@ -227,12 +223,8 @@ export async function fillProjectHull(
                   log.debug(
                     `Header Copy: Falling back to old directory structure for API(Backward compatibility)`
                   )
-                  header.from = path.join(
-                    'IOS',
-                    'IOS',
-                    'Classes',
-                    'SwaggersAPIs',
-                    '*.swift'
+                  header.from = path.normalize(
+                    'IOS/IOS/Classes/SwaggersAPIs/*.swift'
                   )
                 }
                 const relativeHeaderPath = path.dirname(header.from)
@@ -363,7 +355,7 @@ function switchToOldDirectoryStructure(
   tail: string
 ): boolean {
   // This is to check if the api referenced during container generation is created using the old or new directory structure to help keep the backward compatibility.
-  const pathToSwaggersAPIs = path.join('IOS', 'IOS', 'Classes', 'SwaggersAPIs')
+  const pathToSwaggersAPIs = path.normalize('IOS/IOS/Classes/SwaggersAPIs')
   if (
     path.dirname(tail) === `IOS` &&
     fs.existsSync(path.join(pluginSourcePath, path.dirname(pathToSwaggersAPIs)))

--- a/ern-core/test/AndroidPluginConfigGenerator-test.ts
+++ b/ern-core/test/AndroidPluginConfigGenerator-test.ts
@@ -5,9 +5,7 @@ import { expect } from 'chai'
 describe('AndroidPluginConfigGenerator', () => {
   const fixutresPath = path.join(
     __dirname,
-    'fixtures',
-    'PluginConfigGenerator',
-    'android'
+    'fixtures/PluginConfigGenerator/android'
   )
 
   const dependenciesFixturePath = path.join(fixutresPath, 'dependencies')

--- a/ern-core/test/ErnBinaryStore-test.ts
+++ b/ern-core/test/ErnBinaryStore-test.ts
@@ -33,9 +33,7 @@ describe('ErnBinaryStore', () => {
   const createBinaryStore = () => new ErnBinaryStore({ url: binaryStoreUrl })
   const fakeBinaryApkPath = path.join(
     __dirname,
-    'fixtures',
-    'ErnBinaryStore',
-    'fakebinary.apk'
+    'fixtures/ErnBinaryStore/fakebinary.apk'
   )
 
   describe('addBinary', () => {

--- a/ern-core/test/ModuleFactory-test.ts
+++ b/ern-core/test/ModuleFactory-test.ts
@@ -11,7 +11,7 @@ import { YarnCli } from '../src/YarnCli'
 describe('ModuleFactory', () => {
   const PACKAGE_PREFIX = 'package-prefix-'
   const PACKAGE_CACHE_PATH = path.join(__dirname, 'ModuleFactoryCache')
-  const FIXTURES_PATH = path.join(__dirname, 'fixtures', 'ModuleFactory')
+  const FIXTURES_PATH = path.join(__dirname, 'fixtures/ModuleFactory')
 
   const sandbox = sinon.createSandbox()
 
@@ -176,8 +176,7 @@ describe('ModuleFactory', () => {
       )
       const localPathToModuleInCache = path.join(
         PACKAGE_CACHE_PATH,
-        'node_modules',
-        'package-prefix-foo-package'
+        'node_modules/package-prefix-foo-package'
       )
       sandbox.assert.calledWith(instantiateModuleStub, localPathToModuleInCache)
     })

--- a/ern-core/test/Platform-test.ts
+++ b/ern-core/test/Platform-test.ts
@@ -134,13 +134,13 @@ describe('Platform', () => {
   describe('getContainerGenOutDirectory', () => {
     it('should return the correct path for android', () => {
       expect(Platform.getContainerGenOutDirectory('android')).eql(
-        path.join(ernHomePath, 'containergen', 'out', 'android')
+        path.join(ernHomePath, 'containergen/out/android')
       )
     })
 
     it('should return the correct path for ios', () => {
       expect(Platform.getContainerGenOutDirectory('ios')).eql(
-        path.join(ernHomePath, 'containergen', 'out', 'ios')
+        path.join(ernHomePath, 'containergen/out/ios')
       )
     })
   })
@@ -159,7 +159,7 @@ describe('Platform', () => {
         }
       })
       expect(Platform.currentPlatformVersionPath).eql(
-        path.join(ernHomePath, 'versions', '3.0.0', 'node_modules')
+        path.join(ernHomePath, 'versions/3.0.0/node_modules')
       )
     })
   })
@@ -188,7 +188,7 @@ describe('Platform', () => {
   describe('getRootPlatformVersionPath', () => {
     it('should return the correct root platform version path', () => {
       expect(Platform.getRootPlatformVersionPath('3.0.0')).eql(
-        path.join(ernHomePath, 'versions', '3.0.0')
+        path.join(ernHomePath, 'versions/3.0.0')
       )
     })
   })
@@ -196,13 +196,13 @@ describe('Platform', () => {
   describe('getPlatformVersionPath', () => {
     it('should return the correct platform version path for version 1000.0.0', () => {
       expect(Platform.getPlatformVersionPath('1000.0.0')).eql(
-        path.join(ernHomePath, 'versions', '1000.0.0')
+        path.join(ernHomePath, 'versions/1000.0.0')
       )
     })
 
     it('should return the correct platform version path for a version different from 1000.0.0', () => {
       expect(Platform.getPlatformVersionPath('3.0.0')).eql(
-        path.join(ernHomePath, 'versions', '3.0.0', 'node_modules')
+        path.join(ernHomePath, 'versions/3.0.0/node_modules')
       )
     })
   })
@@ -221,9 +221,7 @@ describe('Platform', () => {
     it('should create complete directory hierarchy', () => {
       Platform.installPlatform('3.0.0')
       expect(
-        fs.existsSync(
-          path.join(ernHomePath, 'versions', '3.0.0', 'node_modules')
-        )
+        fs.existsSync(path.join(ernHomePath, 'versions/3.0.0/node_modules'))
       ).true
     })
 
@@ -259,9 +257,7 @@ describe('Platform', () => {
         // noop
       }
       expect(
-        fs.existsSync(
-          path.join(ernHomePath, 'versions', '3.0.0', 'node_modules')
-        )
+        fs.existsSync(path.join(ernHomePath, 'versions/3.0.0/node_modules'))
       ).false
     })
   })
@@ -279,7 +275,7 @@ describe('Platform', () => {
     it('should not do anything if the platform version is the current one', () => {
       shell.mkdir(
         '-p',
-        path.join(path.join(ernHomePath, 'versions', '3.0.0', 'node_modules'))
+        path.join(path.join(ernHomePath, 'versions/3.0.0/node_modules'))
       )
       sandbox.stub(config, 'get').callsFake(key => {
         if (key === 'platformVersion') {
@@ -292,7 +288,7 @@ describe('Platform', () => {
     it('should remove the version directory', () => {
       shell.mkdir(
         '-p',
-        path.join(path.join(ernHomePath, 'versions', '3.0.0', 'node_modules'))
+        path.join(path.join(ernHomePath, 'versions/3.0.0/node_modules'))
       )
       sandbox.stub(config, 'get').callsFake(key => {
         if (key === 'platformVersion') {
@@ -300,7 +296,7 @@ describe('Platform', () => {
         }
       })
       Platform.uninstallPlatform('3.0.0')
-      expect(fs.existsSync(path.join(ernHomePath, 'versions', '3.0.0'))).false
+      expect(fs.existsSync(path.join(ernHomePath, 'versions/3.0.0'))).false
     })
   })
 

--- a/ern-orchestrator/test/Ensure-test.js
+++ b/ern-orchestrator/test/Ensure-test.js
@@ -209,7 +209,7 @@ describe('Ensure.js', () => {
   describe('dependencyIsOrphaned', async () => {
     it('should throw if dependency is not orphaned', async () => {
       cauldronHelperStub.getYarnLock.resolves(
-        fs.readFileSync(path.join(__dirname, 'fixtures', 'sample.yarn.lock'))
+        fs.readFileSync(path.join(__dirname, 'fixtures/sample.yarn.lock'))
       )
       assert(
         await doesThrow(
@@ -223,7 +223,7 @@ describe('Ensure.js', () => {
 
     it('should not throw if dependency is orphaned [not in lock file]', async () => {
       cauldronHelperStub.getYarnLock.resolves(
-        fs.readFileSync(path.join(__dirname, 'fixtures', 'sample.yarn.lock'))
+        fs.readFileSync(path.join(__dirname, 'fixtures/sample.yarn.lock'))
       )
       assert(
         await doesNotThrow(
@@ -237,7 +237,7 @@ describe('Ensure.js', () => {
 
     it('should not throw if dependency is orphaned [in lock file]', async () => {
       cauldronHelperStub.getYarnLock.resolves(
-        fs.readFileSync(path.join(__dirname, 'fixtures', 'sample.yarn.lock'))
+        fs.readFileSync(path.join(__dirname, 'fixtures/sample.yarn.lock'))
       )
       assert(
         await doesNotThrow(

--- a/ern-orchestrator/test/codepush-test.ts
+++ b/ern-orchestrator/test/codepush-test.ts
@@ -34,12 +34,7 @@ let cauldronDoc
 
 const cauldronApiFixtureFileStorePath = path.join(
   __dirname,
-  '..',
-  '..',
-  'ern-cauldron-api',
-  'test',
-  'fixtures',
-  'filestore'
+  '../../ern-cauldron-api/test/fixtures/filestore'
 )
 
 function createCauldronApi(cauldronDocument) {

--- a/ern-orchestrator/test/getBinaryStoreFromCauldron-test.ts
+++ b/ern-orchestrator/test/getBinaryStoreFromCauldron-test.ts
@@ -16,12 +16,7 @@ const sandbox = sinon.createSandbox()
 
 const cauldronApiFixtureFileStorePath = path.join(
   __dirname,
-  '..',
-  '..',
-  'ern-cauldron-api',
-  'test',
-  'fixtures',
-  'filestore'
+  '../../ern-cauldron-api/test/fixtures/filestore'
 )
 
 function createCauldronApi(cauldronDocument) {

--- a/ern-orchestrator/test/utils-test.js
+++ b/ern-orchestrator/test/utils-test.js
@@ -269,7 +269,7 @@ describe('utils.js', () => {
     it('should return parsed json if value is a json file', async () => {
       expect(
         await parseJsonFromStringOrFile(
-          path.resolve(__dirname, 'fixtures', 'dummy.json')
+          path.resolve(__dirname, 'fixtures/dummy.json')
         )
       ).eql({
         key: 'value',

--- a/ern-runner-gen-android/test/regen-fixtures.ts
+++ b/ern-runner-gen-android/test/regen-fixtures.ts
@@ -6,8 +6,7 @@ import { getRunnerGeneratorForPlatform } from 'ern-orchestrator'
 const pathToTestFixtures = path.join(__dirname, 'fixtures')
 const pathToGeneratedFixtures = path.join(
   __dirname,
-  'generated',
-  'simple-android-runner'
+  'generated/simple-android-runner'
 )
 logHeader('Regenerating Android Runner Fixture')
 getRunnerGeneratorForPlatform('android')

--- a/ern-runner-gen-ios/src/IosRunnerGenerator.ts
+++ b/ern-runner-gen-ios/src/IosRunnerGenerator.ts
@@ -22,8 +22,8 @@ export default class IosRunerGenerator implements RunnerGenerator {
 
     shell.cp('-R', path.join(runnerHullPath, '*'), config.outDir)
     const filesToMustache = [
-      path.join(config.outDir, 'ErnRunner', 'RunnerConfig.m'),
-      path.join(config.outDir, 'ErnRunner.xcodeproj', 'project.pbxproj'),
+      path.join(config.outDir, 'ErnRunner/RunnerConfig.m'),
+      path.join(config.outDir, 'ErnRunner.xcodeproj/project.pbxproj'),
     ]
 
     for (const file of filesToMustache) {
@@ -45,7 +45,7 @@ export default class IosRunerGenerator implements RunnerGenerator {
       'ErnRunner/RunnerConfig.m'
     )
     shell.cp(
-      path.join(runnerHullPath, 'ErnRunner', 'RunnerConfig.m'),
+      path.join(runnerHullPath, 'ErnRunner/RunnerConfig.m'),
       pathToRunnerConfig
     )
     await mustacheUtils.mustacheRenderToOutputFileUsingTemplateFile(
@@ -57,7 +57,7 @@ export default class IosRunerGenerator implements RunnerGenerator {
 
   public createMustacheView({ config }: { config: RunnerGeneratorConfig }) {
     const pathToElectrodeContainerXcodeProj = replaceHomePathWithTidle(
-      path.join(config.extra.containerGenWorkingDir, 'out', 'ios')
+      path.join(config.extra.containerGenWorkingDir, 'out/ios')
     )
     const mustacheView = {
       isReactNativeDevSupportEnabled:

--- a/ern-runner-gen-ios/test/IosRunnerGenerator-test.ts
+++ b/ern-runner-gen-ios/test/IosRunnerGenerator-test.ts
@@ -9,13 +9,11 @@ import { getRunnerGeneratorForPlatform } from 'ern-orchestrator'
 describe('IosRunnerGenerator', () => {
   const simpleIosRunnerTestGeneratedPath = path.join(
     __dirname,
-    'generated',
-    'simple-ios-runner'
+    'generated/simple-ios-runner'
   )
   const simpleIosRunnerFixturePath = path.join(
     __dirname,
-    'fixtures',
-    'simple-ios-runner'
+    'fixtures/simple-ios-runner'
   )
 
   before(function() {

--- a/ern-runner-gen-ios/test/regen-fixtures.ts
+++ b/ern-runner-gen-ios/test/regen-fixtures.ts
@@ -6,8 +6,7 @@ import { getRunnerGeneratorForPlatform } from 'ern-orchestrator'
 const pathToTestFixtures = path.join(__dirname, 'fixtures')
 const pathToGeneratedFixtures = path.join(
   __dirname,
-  'generated',
-  'simple-ios-runner'
+  'generated/simple-ios-runner'
 )
 logHeader('Regenerating iOS Runner Fixture')
 getRunnerGeneratorForPlatform('ios')

--- a/ern-util-dev/src/index.js
+++ b/ern-util-dev/src/index.js
@@ -10,14 +10,7 @@ const sandbox = sinon.createSandbox()
 const jsdiff = require('diff')
 require('colors')
 
-const CLI = path.resolve(
-  __dirname,
-  '..',
-  '..',
-  'ern-local-cli',
-  'src',
-  'index.dev.js'
-)
+const CLI = path.resolve(__dirname, '../../ern-local-cli/src/index.dev.js')
 
 /**
  * Sets up an environment for tests.

--- a/system-tests/tests/misc.js
+++ b/system-tests/tests/misc.js
@@ -22,7 +22,7 @@ const ERN_RC_GLOBAL_FILE_PATH = path.join(ERN_ROOT_PATH, '.ernrc')
 const ernConfigObj = fs.existsSync(ERN_RC_GLOBAL_FILE_PATH)
 ? JSON.parse(fs.readFileSync(ERN_RC_GLOBAL_FILE_PATH, 'utf-8'))
 : {}
-const defaultAndroidContainerGenPath = path.join(ERN_ROOT_PATH, 'containergen', 'out', 'android')
+const defaultAndroidContainerGenPath = path.join(ERN_ROOT_PATH, 'containergen/out/android')
 
 process.env['SYSTEM_TESTS'] = 'true'
 process.on('SIGINT', () => afterAll())

--- a/system-tests/utils/runErnCommand.js
+++ b/system-tests/utils/runErnCommand.js
@@ -3,11 +3,7 @@ const path = require('path')
 
 const pathToIndexProd = path.resolve(
   __dirname,
-  '..',
-  '..',
-  'ern-local-cli',
-  'dist',
-  'index'
+  '../../ern-local-cli/dist/index'
 )
 
 const ern = `node ${pathToIndexProd}`


### PR DESCRIPTION
Quick refactoring to make paths more compact / readable, by joining string literal path segments, where applicable. For joins that end up as a single string, replace `path.join` with `path.normalize`, given that there is nothing left to join.