### PR TITLE
Replace curl with got for binary store

### DIFF
--- a/ern-core/src/BinaryStore.ts
+++ b/ern-core/src/BinaryStore.ts
@@ -1,11 +1,8 @@
 import { AppVersionDescriptor } from './descriptors'
 
 export interface BinaryStore {
-  addBinary(
-    descriptor: AppVersionDescriptor,
-    binary: any
-  ): Promise<string | Buffer>
-  removeBinary(descriptor: AppVersionDescriptor): Promise<string | Buffer>
+  addBinary(descriptor: AppVersionDescriptor, binary: any): Promise<void>
+  removeBinary(descriptor: AppVersionDescriptor): Promise<void>
   getBinary(descriptor: AppVersionDescriptor, options: any): Promise<string>
-  hasBinary(descriptor: AppVersionDescriptor): Promise<string | Buffer>
+  hasBinary(descriptor: AppVersionDescriptor): Promise<boolean>
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "mocha": "^6.1.4",
     "mocha-junit-reporter": "^1.23.0",
     "mock-fs": "^4.9.0",
+    "nock": "^11.7.0",
     "npm": "^6.9.0",
     "nyc": "14.0.0",
     "prettier": "1.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2146,7 +2146,7 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chai@^4.2.0:
+chai@^4.1.2, chai@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
   integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
@@ -5998,6 +5998,18 @@ nise@^1.4.10:
     lolex "^4.1.0"
     path-to-regexp "^1.7.0"
 
+nock@^11.7.0:
+  version "11.7.0"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-11.7.0.tgz#5eaae8b8a55c0dfc014d05692c8cf3d31d61a342"
+  integrity sha512-7c1jhHew74C33OBeRYyQENT+YXQiejpwIrEjinh6dRurBae+Ei4QjeUaPlkptIF0ZacEiVCnw8dWaxqepkiihg==
+  dependencies:
+    chai "^4.1.2"
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.13"
+    mkdirp "^0.5.0"
+    propagate "^2.0.0"
+
 node-environment-flags@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/node-environment-flags/-/node-environment-flags-1.0.5.tgz#fa930275f5bf5dae188d6192b24b4c8bbac3d76a"
@@ -7118,6 +7130,11 @@ promzard@^0.3.0:
   integrity sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=
   dependencies:
     read "1"
+
+propagate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
+  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 proto-list@~1.2.1:
   version "1.2.4"


### PR DESCRIPTION
Use [got](https://github.com/sindresorhus/got) to issue HTTP requests to the Binary Store server, rather than running `curl` commands. [got](https://github.com/sindresorhus/got) is being used for the Bundle and SourceMap store clients, only the Binary store was relying on `curl` making it less cross-platform (windows does not have `curl` pre installed). 

Add a dev dependency on [nock](https://github.com/nock/nock) to improve unit tests of binary store (will also be used to improve unit tests of other pieces of code making HTTP requests)