### PR TITLE
Add proxy support to binary store client

### DIFF
--- a/docs/cli/platform/config/del.md
+++ b/docs/cli/platform/config/del.md
@@ -16,6 +16,7 @@
 
 **Whitelisted properties**
 
+- `binaryStoreProxy`
 - `bundleStoreProxy`
 - `codePushAccessKey`
 - `codePushCustomHeaders`

--- a/docs/cli/platform/config/get.md
+++ b/docs/cli/platform/config/get.md
@@ -16,6 +16,7 @@
 
 **Whitelisted properties**
 
+- `binaryStoreProxy`
 - `bundleStoreProxy`
 - `codePushAccessKey`
 - `codePushCustomHeaders`

--- a/docs/cli/platform/config/set.md
+++ b/docs/cli/platform/config/set.md
@@ -73,6 +73,11 @@ HTTP/HTTPS proxy to use to connect to the source map store server.
 Should be the full url to the proxy, including the port. For example `http://10.0.0.0:9089`.  
 **default** : no proxy
 
+- `binaryStoreProxy` [string]  
+HTTP/HTTPS proxy to use to connect to the binary store server.  
+Should be the full url to the proxy, including the port. For example `http://10.0.0.0:9089`.  
+**default** : no proxy
+
 #### Remarks
  
 * In case a value already exists in the configuration for a given key, this command will not fail and will overwrite the existing value.

--- a/ern-orchestrator/src/constants.ts
+++ b/ern-orchestrator/src/constants.ts
@@ -71,4 +71,9 @@ export const availableUserConfigKeys = [
     name: 'sourceMapStoreProxy',
     values: ['string'],
   },
+  {
+    desc: 'HTTP/HTTPS proxy to use to connect to the binary store server',
+    name: 'binaryStoreProxy',
+    values: ['string'],
+  },
 ]


### PR DESCRIPTION
Make binary store http client on par with bundle and source map store clients by adding configurable proxy support to it.