### PR TITLE
Add guard clause to generateComposite

### DIFF
--- a/ern-composite-gen/src/generateComposite.ts
+++ b/ern-composite-gen/src/generateComposite.ts
@@ -27,6 +27,15 @@ import uuidv4 from 'uuid/v4'
 export async function generateComposite(config: CompositeGeneratorConfig) {
   log.debug(`generateComposite config : ${JSON.stringify(config, null, 2)}`)
 
+  if (
+    config.miniApps.length === 0 &&
+    (config.jsApiImplDependencies || []).length === 0
+  ) {
+    throw new Error(
+      `At least one MiniApp or JS API implementation is needed to generate a composite`
+    )
+  }
+
   return config.baseComposite
     ? generateCompositeFromBase(
         config.miniApps,

--- a/ern-composite-gen/test/compositegen-test.ts
+++ b/ern-composite-gen/test/compositegen-test.ts
@@ -345,6 +345,20 @@ describe('ern-container-gen utils.js', () => {
       )
     })
 
+    it('should throw an exception if called with no miniapp or js api impl', async () => {
+      yarnCliStub.install.callsFake(() =>
+        createCompositeNodeModulesReactNativePackageJson(tmpOutDir, '0.56.0')
+      )
+      const miniApps = []
+      assert(
+        await doesThrow(generateComposite, null, {
+          miniApps,
+          outDir: tmpOutDir,
+          pathToYarnLock: pathToSampleYarnLock,
+        })
+      )
+    })
+
     it('should call yarn install prior to calling yarn add or yarn upgrade for each MiniApp', async () => {
       // One new, one same, one upgrade
       yarnCliStub.install.callsFake(() =>


### PR DESCRIPTION
Add a guard clause to `generateComposite` function to make sure that at least one MiniApp or JS API implementation is provided to the function.

Closes https://github.com/electrode-io/electrode-native/issues/1396

While this PR guarantees that any command that generates a composite during its execution, will fail with a clear enough error message, all the involved commands should ideally fail before reaching this guard clause with an even clearer error message related to the command being ran.


