### PR TITLE
Ensure CocoaPods is installed if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - NPM >= 3.0
 - Android Studio (for Android apps)
 - Xcode >= 10 (for iOS apps)
+- CocoaPods (for iOS apps using a version of React Native >= 0.60)
 
 ### Install
 
@@ -113,3 +114,5 @@ Thank you.
 [platform use]: https://native.electrode.io/cli-commands/platform/use
 
 [Electrode Native Case Study]: https://www.walmartlabs.com/case-studies/electrode-native
+
+[CocoaPods]: https://cocoapods.org

--- a/ern-core/src/MiniApp.ts
+++ b/ern-core/src/MiniApp.ts
@@ -153,6 +153,16 @@ export class MiniApp extends BaseMiniApp {
       throw e
     }
 
+    if (
+      process.platform === 'darwin' &&
+      semver.gte(reactNativeVersion, '0.60.0') &&
+      !Platform.isCocoaPodsInstalled()
+    ) {
+      throw new Error(`pod command not found.
+CocoaPods is required starting from React Native 0.60 version.
+You can find instructions to install CocoaPods @ https://cocoapods.org`)
+    }
+
     await kax
       .task(
         `Creating ${miniAppName} project using react-native v${reactNativeVersion}`

--- a/ern-core/src/Platform.ts
+++ b/ern-core/src/Platform.ts
@@ -194,4 +194,13 @@ export default class Platform {
       return false
     }
   }
+
+  public static isCocoaPodsInstalled() {
+    try {
+      execSync('pod --version 1>/dev/null 2>/dev/null')
+      return true
+    } catch (e) {
+      return false
+    }
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/electrode-io/electrode-native/issues/1394

CocoaPods is a requisite for iOS RN applications, starting with React Native 0.60.

Even though Electrode Native does not need CocoaPods even with React Native 0.60, due to a different way to retrieve native modules, the fact that `create-miniapp` command relies on `react-native init` command under the hood (which has a health check for CocoaPods availability) causes the command to stall if CocoaPods is not installed.

This PR fixes the issue with `create-miniapp` command, by throwing a clear error message if CocoaPods is not installed on the machine running the command (and iff machine is a Mac and RN version >= 0.60).

While there is no need as of now to update other commands such as `run-ios` with this new guard, because as mentioned, CocoaPods is not required for Electrode Native -even for running MiniApps using RN 0.60- we will have to make sure that this guard clause is properly propagated to all commands for RN 0.61 support, as Electrode Native will HAVE to rely on CocoPods starting from this RN version.