### PR TITLE
Disable logging during unit tests run

### DIFF
--- a/ern-core/test/mocha-root-level-hooks.ts
+++ b/ern-core/test/mocha-root-level-hooks.ts
@@ -1,0 +1,40 @@
+//
+// This file contains any Mocha root level hooks
+// which should be run for any test cases regardless
+// of the file they live in.
+
+import shell from '../src/shell'
+import log from '../src/log'
+import { LogLevel } from '../src/coloredLog'
+import kax from '../src/kax'
+import { KaxRenderer, KaxTask } from 'kax'
+
+class KaxNullRenderer implements KaxRenderer {
+  public renderWarning(msg: string) {
+    // noop
+  }
+  public renderInfo(msg: string) {
+    // noop
+  }
+  public renderError(msg: string) {
+    // noop
+  }
+  public renderRaw(msg: string) {
+    // noop
+  }
+  public renderTask<T>(msg: string, task: KaxTask<T>) {
+    // noop
+  }
+}
+
+//
+// Before any test suite is run
+before(() => {
+  // Disable shell commands logging
+  shell.config.verbose = false
+  shell.config.silent = true
+  // Disable base logging (log.)
+  log.setLogLevel(LogLevel.Off)
+  // Disable kax logging (kax.)
+  kax.renderer = new KaxNullRenderer()
+})

--- a/ern-util-dev/bin/ern-mocha.js
+++ b/ern-util-dev/bin/ern-mocha.js
@@ -12,6 +12,7 @@ if (!require('fs').existsSync(require('path').join(process.cwd(), 'test'))) {
 console.log(`running tests in ${testCwd}`)
 process.argv.push('-r', 'ts-node/register')
 process.argv.push('-r', 'tsconfig-paths/register')
+process.argv.push('--file', '../ern-core/test/mocha-root-level-hooks.ts')
 if (process.env.ENV_AZURE_PIPELINE) {
   // Create `node_modules/mocha` in current module directory
   // and copy top level `node_modules/mocha/package.json` to


### PR DESCRIPTION
Unit tests run output can get very messy in the terminal, because logging is still happening at default levels, which causes test result outcome to be intertwined with all of the logging done by the unit of code under test.

This PR disable all the various loggers used in the code base, before running any test suite. This is achieved through a mocha global (root level) `before` hook that is loaded prior to running a module test suite and disable `shell`/`log` and `kax` loggers.

Extract of test run with messy output prior to this PR :

```
 installPlatform
      ✓ should throw if the platform version is not available
/private/var/folders/mp/sgcm53dd33b348tm65vwc6_8kv5xkh/T/tmp-15382WpYr0Wvvmy6Q/ern_home/versions/3.0.0 /Users/blemair/Code/electrode-native/ern-core
/Users/blemair/Code/electrode-native/ern-core
      ✓ should create complete directory hierarchy
/private/var/folders/mp/sgcm53dd33b348tm65vwc6_8kv5xkh/T/tmp-15382QuIi1H2yvh4d/ern_home/versions/3.0.0 /Users/blemair/Code/electrode-native/ern-core
/Users/blemair/Code/electrode-native/ern-core
      ✓ should use yarn add to install platform if yarn is installed
/private/var/folders/mp/sgcm53dd33b348tm65vwc6_8kv5xkh/T/tmp-15382NZkQVDh0otQ3/ern_home/versions/3.0.0 /Users/blemair/Code/electrode-native/ern-core
/Users/blemair/Code/electrode-native/ern-core
      ✓ should use npm install to install platform if yarn is not installed
      ✓ should throw something went wrong during install
      ✓ should remove the version directory if something went wrong during install
    uninstallPlatform
⚠ Version 3.0.0 of ern platform is not installed
⚠ Version 3.0.0 of ern platform is not installed
✖ Version 3.0.0 is currently activated. Cannot uninstall
      ✓ should not do anything if the platform version is the current one
```

Same extract post change :

```
installPlatform
      ✓ should throw if the platform version is not available
      ✓ should create complete directory hierarchy
      ✓ should use yarn add to install platform if yarn is installed
      ✓ should use npm install to install platform if yarn is not installed
      ✓ should throw something went wrong during install
      ✓ should remove the version directory if something went wrong during install
      ✓ should not do anything if the platform version is the current one
```

This change applies to unit tests of all modules BUT `ern-api-gen`, which is using a complete different way to do logging, and should be cleaned up through a different PR.