### PR TITLE
Add missing mocha hooks to nyc command invocation

### DIFF
--- a/ern-util-dev/bin/ern-nyc.js
+++ b/ern-util-dev/bin/ern-nyc.js
@@ -23,6 +23,8 @@ process.argv.push(
   'tsconfig-paths/register',
   '-r',
   'ts-node/register',
+  '--file',
+  '../ern-core/test/mocha-root-level-hooks.ts',
   '--full-trace',
   '--bail',
   'test/*-test.{ts,js}'


### PR DESCRIPTION
Follow up to https://github.com/electrode-io/electrode-native/pull/1401 

Forgot to add mocha hooks registration when using `nyc` command (for coverage), so the unit tests run with coverage were still showing polluted log output.