### PR TITLE
Use fs-extra ensureDir

### DIFF
--- a/ern-api-impl-gen/package.json
+++ b/ern-api-impl-gen/package.json
@@ -55,6 +55,7 @@
     "chalk": "^2.4.1",
     "ern-api-gen": "1000.0.0",
     "ern-core": "1000.0.0",
+    "fs-extra": "^8.1.0",
     "lodash": "^4.17.14",
     "mustache": "^2.3.1",
     "semver": "5.5.0",

--- a/ern-api-impl-gen/src/generators/android/ApiImplAndroidGenerator.ts
+++ b/ern-api-impl-gen/src/generators/android/ApiImplAndroidGenerator.ts
@@ -9,7 +9,7 @@ import {
   PluginConfig,
   android,
 } from 'ern-core'
-import fs from 'fs'
+import fs from 'fs-extra'
 import path from 'path'
 import readDir from 'fs-readdir-recursive'
 import { ApiImplGeneratable } from '../../ApiImplGeneratable'
@@ -38,9 +38,8 @@ export default class ApiImplAndroidGenerator implements ApiImplGeneratable {
       SRC_MAIN_JAVA_DIR,
       API_IMPL_PACKAGE
     )
-    if (!fs.existsSync(outputDir)) {
-      shell.mkdir('-p', outputDir)
-    }
+
+    fs.ensureDirSync(outputDir)
 
     const resourceDir = path.join(
       Platform.currentPlatformVersionPath,
@@ -92,9 +91,8 @@ export default class ApiImplAndroidGenerator implements ApiImplGeneratable {
       log.debug(
         `Creating out directory(${outputDirectory}) for android and copying container hull to it.`
       )
-      if (!fs.existsSync(outputDirectory)) {
-        shell.mkdir(outputDirectory)
-      }
+
+      fs.ensureDirSync(outputDirectory)
 
       fileUtils.chmodr(READ_WRITE_EXECUTE, outputDirectory)
       shell.cp(
@@ -155,9 +153,9 @@ export default class ApiImplAndroidGenerator implements ApiImplGeneratable {
       SRC_MAIN_JAVA_DIR,
       '*'
     )
-    if (!fs.existsSync(pluginOutputDirectory)) {
-      shell.mkdir('-p', pluginOutputDirectory)
-    }
+
+    fs.ensureDirSync(pluginOutputDirectory)
+
     log.debug(
       `Copying code from ${pluginSrcDirectory} to ${pluginOutputDirectory}`
     )

--- a/ern-api-impl-gen/src/generators/ios/ApiImplIosGenerator.ts
+++ b/ern-api-impl-gen/src/generators/ios/ApiImplIosGenerator.ts
@@ -7,7 +7,7 @@ import {
   log,
 } from 'ern-core'
 import { ApiImplGeneratable } from '../../ApiImplGeneratable'
-import fs from 'fs'
+import fs from 'fs-extra'
 import path from 'path'
 import xcode from 'xcode-ern'
 import readDir from 'fs-readdir-recursive'
@@ -182,9 +182,8 @@ export default class ApiImplIosGenerator implements ApiImplGeneratable {
     const requestHandlerConfigFile = 'RequestHandlerConfig.swift'
     const requestHandlerProviderFile = 'RequestHandlerProvider.swift'
 
-    if (!shell.test('-e', outputDir)) {
-      shell.mkdir(outputDir)
-    }
+    fs.ensureDirSync(outputDir)
+
     shell.cp(path.join(resourceDir, requestHandlerConfigFile), outputDir)
     shell.cp(path.join(resourceDir, requestHandlerProviderFile), outputDir)
 

--- a/ern-api-impl-gen/src/generators/js/ApiImplJsGenerator.ts
+++ b/ern-api-impl-gen/src/generators/js/ApiImplJsGenerator.ts
@@ -1,6 +1,6 @@
 import { ApiImplGeneratable } from '../../ApiImplGeneratable'
 import { PackagePath, shell, mustacheUtils, Platform, log } from 'ern-core'
-import fs from 'fs'
+import fs from 'fs-extra'
 import path from 'path'
 
 export default class ApiImplJsGenerator implements ApiImplGeneratable {
@@ -35,9 +35,7 @@ export default class ApiImplJsGenerator implements ApiImplGeneratable {
     try {
       const outputDirectory = path.join(paths.outDirectory, 'js')
       log.debug(`Creating out directory(${outputDirectory}) for JS.`)
-      if (!fs.existsSync(outputDirectory)) {
-        shell.mkdir(outputDirectory)
-      }
+      await fs.ensureDir(outputDirectory)
       const mustacheFile = path.join(
         Platform.currentPlatformVersionPath,
         'ern-api-impl-gen/resources/js/apiimpl.mustache'

--- a/ern-cauldron-api/package.json
+++ b/ern-cauldron-api/package.json
@@ -53,6 +53,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@hapi/joi": "^15.0.1",
+    "fs-extra": "^8.1.0",
     "lodash": "^4.17.14",
     "semver": "^5.5.0",
     "ern-core": "1000.0.0",

--- a/ern-cauldron-api/src/BaseGit.ts
+++ b/ern-cauldron-api/src/BaseGit.ts
@@ -1,6 +1,6 @@
-import fs from 'fs'
+import fs from 'fs-extra'
 import path from 'path'
-import { log, shell, gitCli, fileUtils } from 'ern-core'
+import { log, gitCli, fileUtils } from 'ern-core'
 import { ITransactional } from './types'
 
 const GIT_REMOTE_NAME = 'upstream'
@@ -24,9 +24,7 @@ export default class BaseGit implements ITransactional {
     branch?: string
   }) {
     this.fsPath = cauldronPath
-    if (!fs.existsSync(this.fsPath)) {
-      shell.mkdir('-p', this.fsPath)
-    }
+    fs.ensureDirSync(this.fsPath)
     this.repository = repository
     this.branch = branch
     this.git = gitCli(this.fsPath)

--- a/ern-cauldron-api/src/EphemeralFileStore.ts
+++ b/ern-cauldron-api/src/EphemeralFileStore.ts
@@ -1,4 +1,4 @@
-import fs from 'fs'
+import fs from 'fs-extra'
 import path from 'path'
 import { ICauldronFileStore } from './types'
 import { createTmpDir } from 'ern-core'
@@ -29,10 +29,8 @@ export default class EphemeralFileStore implements ICauldronFileStore {
   ) {
     const pathToFile = path.join(this.storePath, identifier)
     const pathToDir = path.dirname(pathToFile)
-    if (!fs.existsSync(pathToDir)) {
-      shell.mkdir('-p', pathToDir)
-    }
-    fs.writeFileSync(pathToFile, content, 'utf8')
+    await fs.ensureDir(pathToDir)
+    await fs.writeFile(pathToFile, content, 'utf8')
     if (fileMode) {
       shell.chmod(fileMode, pathToFile)
     }

--- a/ern-cauldron-api/src/GitFileStore.ts
+++ b/ern-cauldron-api/src/GitFileStore.ts
@@ -1,5 +1,5 @@
 import BaseGit from './BaseGit'
-import fs from 'fs'
+import fs from 'fs-extra'
 import path from 'path'
 import { log, shell, fileUtils } from 'ern-core'
 import { ICauldronFileStore } from './types'
@@ -31,10 +31,7 @@ export default class GitFileStore extends BaseGit
   ) {
     await this.sync()
     const storeDirectoryPath = path.resolve(this.fsPath, path.dirname(filePath))
-    if (!fs.existsSync(storeDirectoryPath)) {
-      log.debug(`Creating directory ${storeDirectoryPath}`)
-      shell.mkdir('-p', storeDirectoryPath)
-    }
+    await fs.ensureDir(storeDirectoryPath)
     const pathToFile = path.resolve(storeDirectoryPath, path.basename(filePath))
     await fileUtils.writeFile(pathToFile, content, { flag: 'w' })
     if (fileMode) {

--- a/ern-container-gen-android/package.json
+++ b/ern-container-gen-android/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "ern-container-gen": "1000.0.0",
     "ern-core": "1000.0.0",
+    "fs-extra": "^8.1.0",
     "decompress-zip": "^0.3.1",
     "lodash": "^4.17.14",
     "fs-readdir-recursive": "^1.1.0",

--- a/ern-container-gen-ios/package.json
+++ b/ern-container-gen-ios/package.json
@@ -56,6 +56,7 @@
   "dependencies": {
     "ern-container-gen": "1000.0.0",
     "ern-core": "1000.0.0",
+    "fs-extra": "^8.1.0",
     "xcode-ern": "^1.0.12",
     "lodash": "^4.17.14",
     "fs-readdir-recursive": "^1.1.0"

--- a/ern-container-gen/package.json
+++ b/ern-container-gen/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "ern-core": "1000.0.0",
     "ern-composite-gen": "1000.0.0",
+    "fs-extra": "^8.1.0",
     "fs-readdir-recursive": "^1.1.0",
     "mustache": "^2.3.1",
     "semver": "^5.5.0",

--- a/ern-container-gen/src/generateContainer.ts
+++ b/ern-container-gen/src/generateContainer.ts
@@ -5,7 +5,7 @@ import { copyRnConfigAssets } from './copyRnConfigAssets'
 import { addContainerMetadata } from './addContainerMetadata'
 import { ContainerGeneratorConfig, ContainerGenResult } from './types'
 import { kax, shell, BundlingResult } from 'ern-core'
-import fs from 'fs'
+import fs from 'fs-extra'
 import path from 'path'
 import _ from 'lodash'
 
@@ -23,11 +23,8 @@ export async function generateContainer(
     postCopyRnpmAssets?: ContainerGeneratorAction
   } = {}
 ): Promise<ContainerGenResult> {
-  if (!fs.existsSync(config.outDir)) {
-    shell.mkdir('-p', config.outDir)
-  } else {
-    shell.rm('-rf', path.join(config.outDir, '{.*,*}'))
-  }
+  fs.ensureDirSync(config.outDir)
+  shell.rm('-rf', path.join(config.outDir, '{.*,*}'))
 
   config.plugins = sortDependenciesByName(config.plugins)
 

--- a/ern-container-gen/src/reactNativeBundleIos.ts
+++ b/ern-container-gen/src/reactNativeBundleIos.ts
@@ -1,5 +1,5 @@
 import { BundlingResult, reactnative, shell } from 'ern-core'
-import fs from 'fs'
+import fs from 'fs-extra'
 import path from 'path'
 
 export async function reactNativeBundleIos({
@@ -37,9 +37,7 @@ export async function reactNativeBundleIos({
     )
   }
 
-  if (!fs.existsSync(miniAppOutPath)) {
-    shell.mkdir('-p', miniAppOutPath)
-  }
+  await fs.ensureDir(miniAppOutPath)
 
   shell.pushd(cwd)
 

--- a/ern-core/src/ErnBinaryStore.ts
+++ b/ern-core/src/ErnBinaryStore.ts
@@ -2,7 +2,7 @@ import { BinaryStore } from './BinaryStore'
 import { AppVersionDescriptor } from './descriptors'
 import createTmpDir from './createTmpDir'
 import shell from './shell'
-import fs from 'fs'
+import fs from 'fs-extra'
 import path from 'path'
 import archiver from 'archiver'
 import DecompressZip = require('decompress-zip')
@@ -75,8 +75,8 @@ export class ErnBinaryStore implements BinaryStore {
     const pathToZippedBinary = await this.getZippedBinary(descriptor, {
       flavor,
     })
-    if (outDir && !fs.existsSync(outDir)) {
-      shell.mkdir('-p', outDir)
+    if (outDir) {
+      await fs.ensureDir(outDir)
     }
     return this.unzipBinary(descriptor, pathToZippedBinary, { flavor, outDir })
   }

--- a/ern-core/src/FsCache.ts
+++ b/ern-core/src/FsCache.ts
@@ -1,4 +1,4 @@
-import fs from 'fs'
+import fs from 'fs-extra'
 import path from 'path'
 import { readJSON, writeJSON, writeJSONSync } from './fileUtil'
 import shell from './shell'
@@ -108,9 +108,7 @@ export class FsCache<T> {
     this.maxCacheSize = maxCacheSize
     this.addObjectToCacheDirectory = addObjectToCacheDirectory
     this.objectToId = objectToId
-    if (!fs.existsSync(rootCachePath)) {
-      shell.mkdir(rootCachePath)
-    }
+    fs.ensureDirSync(rootCachePath)
     if (!fs.existsSync(this.cacheManifestPath)) {
       writeJSONSync(this.cacheManifestPath, { entries: [], size: 0 })
     }

--- a/ern-core/src/GitManifest.ts
+++ b/ern-core/src/GitManifest.ts
@@ -2,7 +2,7 @@ import { PackagePath } from './PackagePath'
 import shell from './shell'
 import { gitCli } from './gitCli'
 import _ from 'lodash'
-import fs from 'fs'
+import fs from 'fs-extra'
 import path from 'path'
 import semver from 'semver'
 import Platform from './Platform'
@@ -28,9 +28,7 @@ export default class GitManifest {
       remote: 'origin',
     }
   ) {
-    if (!fs.existsSync(repoLocalPath)) {
-      shell.mkdir('-p', repoLocalPath)
-    }
+    fs.ensureDirSync(repoLocalPath)
     this.git = gitCli(repoLocalPath)
     this.remote = remote
     this.branch = branch

--- a/ern-core/src/createTmpDir.ts
+++ b/ern-core/src/createTmpDir.ts
@@ -1,12 +1,11 @@
 import tmp from 'tmp'
 import config from './config'
-import shell from './shell'
-import fs from 'fs'
+import fs from 'fs-extra'
 
 export default function(): string {
   const tmpDir = config.get('tmp-dir')
-  if (tmpDir && !fs.existsSync(tmpDir)) {
-    shell.mkdir('-p', tmpDir)
+  if (tmpDir) {
+    fs.ensureDirSync(tmpDir)
   }
   const retainTmpDir = config.get('retain-tmp-dir', false)
   return tmp.dirSync({

--- a/ern-core/src/handleCopyDirective.ts
+++ b/ern-core/src/handleCopyDirective.ts
@@ -1,4 +1,4 @@
-import fs from 'fs'
+import fs from 'fs-extra'
 import shell from './shell'
 import path from 'path'
 
@@ -10,9 +10,7 @@ export default function handleCopyDirective(
   for (const cp of arr) {
     const sourcePath = path.join(sourceRoot, cp.source)
     const destPath = path.join(destRoot, cp.dest)
-    if (!fs.existsSync(destPath)) {
-      shell.mkdir('-p', destPath)
-    }
+    fs.ensureDirSync(destPath)
     shell.cp('-R', sourcePath, destPath)
   }
 }

--- a/ern-core/src/unzip.ts
+++ b/ern-core/src/unzip.ts
@@ -1,12 +1,10 @@
-import fs from 'fs'
+import fs from 'fs-extra'
 import path from 'path'
 import shell from 'shelljs'
 import yauzl from 'yauzl'
 
 export async function unzip(zippedData: Buffer, destPath: string) {
-  if (!fs.existsSync(destPath)) {
-    shell.mkdir('-p', destPath)
-  }
+  await fs.ensureDir(destPath)
   return new Promise((resolve, reject) => {
     yauzl.fromBuffer(zippedData, { lazyEntries: true }, (err, zipfile) => {
       if (err) {

--- a/ern-local-cli/package.json
+++ b/ern-local-cli/package.json
@@ -71,6 +71,7 @@
     "ern-runner-gen-android": "1000.0.0",
     "ern-runner-gen-ios": "1000.0.0",
     "fast-levenshtein": "^2.0.6",
+    "fs-extra": "^8.1.0",
     "fs-readdir-recursive": "^1.1.0",
     "got": "^9.6.0",
     "inquirer": "^3.0.6",


### PR DESCRIPTION
Replace blocks following such pattern 

```javascript
if (!fs.existsSync(dir)) {	
  shell.mkdir('-p', dir)
}
```

with a single call to [fs-extra](https://github.com/jprichardson/node-fs-extra) more concise [ensureDir](https://github.com/jprichardson/node-fs-extra/blob/HEAD/docs/ensureDir.md) call.

```javascript
fs.ensureDirSync(dir)
```

Using synchronous version `ensureDirSync` in synchronous functions and asynchronous version `ensureDir` in asynchronous functions.