### PR TITLE
Fix an issue with ern start command

### DIFF
--- a/ern-orchestrator/package.json
+++ b/ern-orchestrator/package.json
@@ -5,10 +5,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "homepage": "http://www.electrode.io",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/electrode-io/electrode-native.git"
-  },
+  "repository": "https://github.com/electrode-io/electrode-native.git",
   "bugs": {
     "url": "https://github.com/electrode-io/electrode-native/issues"
   },
@@ -71,7 +68,7 @@
     "fs-extra": "^8.1.0",
     "fs-readdir-recursive": "^1.1.0",
     "got": "^9.6.0",
-    "kax":"^2.0.1",
+    "kax": "^2.0.1",
     "lodash": "^4.17.14",
     "ncp": "^2.0.0",
     "semver": "^5.5.0",


### PR DESCRIPTION
Fix an issue with `start` command causing multiple instances of native modules to be used.

Problem is due to the fact that all linked miniapps directories are copied over to their location in the composite directory, including their node_modules directory, containing all the native modules being used by the miniapp.

The `start` command was already excluding a few native modules directories from being copied to the composite (react-native / react-native-electrode-bridge) but was not excluding any other native modules.

This PR make sure that all native modules used in the composite, are not copied over along with the miniapp directory, so that they are only kept in the top level composite node_modules directory. 

For example, assuming we are using `start` command for two miniapps, both of them linked and miniappA is using `react-native-svg` as shown in the following node_modules structure: 

```
miniappA
└── node_modules
    ├── lodash
    └── react-native-svg
```

Using `start` command ends ups with the following composite structure

```
composite
├── miniappA
│   └── node_modules
│       ├── lodash
│       └── react-native-svg
├── miniappB
│   └── node_modules
│       └── foo
└── node_modules
    └── react-native-svg
````

where `react-native-svg` is not deduped.

with this PR, `react-native-svg` will be excluded from the copy over to the composite, resulting in the following structure:

```
composite
├── miniappA
│   └── node_modules
│       └── lodash
├── miniappB
│   └── node_modules
│       └── foo
└── node_modules
    └── react-native-svg
```` 

this fixes issues with multiple instances of the native module being instanciated. 

PR opened directly to `v0.38` branch (unusual) because of some heavy refactoring in `start` source file on master, and need a quick patch release of `0.38.8` with this fix. 
Will port similar fix to master in a separate PR.