### PR TITLE
Fix writePackageJson formatting

### DIFF
--- a/ern-core/src/packageJsonFileUtils.ts
+++ b/ern-core/src/packageJsonFileUtils.ts
@@ -27,7 +27,7 @@ export const readPackageJsonSync = (p: string): any =>
  * @param content Content of package.json as an object
  */
 export const writePackageJson = (p: string, content: any): Promise<void> =>
-  fs.writeJson(getPathToPackageJson(p), content)
+  fs.writeJson(getPathToPackageJson(p), content, { spaces: 2 })
 
 /**
  * Synchronously writes a package.json file to a given directory and
@@ -36,7 +36,7 @@ export const writePackageJson = (p: string, content: any): Promise<void> =>
  * @param content Content of package.json as an object
  */
 export const writePackageJsonSync = (p: string, content: any): void =>
-  fs.writeJsonSync(getPathToPackageJson(p), content)
+  fs.writeJsonSync(getPathToPackageJson(p), content, { spaces: 2 })
 
 /**
  * Given a directory holding a package.json file, return the full path


### PR DESCRIPTION
Fix a regression introduced in https://github.com/electrode-io/electrode-native/pull/1409 in `writePackageJson` and `writePackageJsonSync` functions.

Instead of calling our custom `fileUtils` helper, [we switched to using fs-extra](https://github.com/electrode-io/electrode-native/pull/1409/files#diff-782006eabb7ea51c10f5e550f380b257L29-L39) to write the json file. 

Problem is that our custom helper functions were internally passing the appropriate formatting options to `JSON.stringify`, and forgot about that when switching to fs-extra. 

System test fixtures of https://github.com/electrode-io/electrode-native/pull/1414 have been regenerated to fix the issue.