### PR TITLE
Avoid unnecessary modifications to test fixtures

### DIFF
--- a/system-tests/fixtures/api/complex-api/package.json
+++ b/system-tests/fixtures/api/complex-api/package.json
@@ -1,5 +1,5 @@
 {
-  "author": "blemair",
+  "author": "generated",
   "dependencies": {
     "react-native-electrode-bridge": "1.5.x"
   },

--- a/system-tests/fixtures/api/test-api/package.json
+++ b/system-tests/fixtures/api/test-api/package.json
@@ -1,5 +1,5 @@
 {
-  "author": "blemair",
+  "author": "generated",
   "dependencies": {
     "react-native-electrode-bridge": "1.5.x"
   },

--- a/system-tests/regen-fixtures.js
+++ b/system-tests/regen-fixtures.js
@@ -102,9 +102,9 @@ function regenComplexApiFixture() {
   shell.rm('-rf', pathsToFixtures['complex-api'])
   shell.cd(rootApiFixturesPath)
   shell.exec(
-    `ern create-api ${f.complexApiName} -p ${f.complexApiPkgName}  --schemaPath ${
+    `ern create-api ${f.complexApiName} -p ${f.complexApiPkgName} --schemaPath ${
       f.pathToComplexApiSchema
-    } --skipNpmCheck`
+    } -u "generated" --skipNpmCheck`
   )
 }
 
@@ -115,7 +115,7 @@ function regenTestApiFixture() {
   shell.exec(
     `ern create-api ${f.testApiName} -p ${f.testApiPkgName} --schemaPath ${
       f.pathToTestApiSchema
-    } --skipNpmCheck`
+    } -u "generated" --skipNpmCheck`
   )
 }
 

--- a/system-tests/tests/create-api-base-fixture.js
+++ b/system-tests/tests/create-api-base-fixture.js
@@ -7,7 +7,6 @@ const f = require('../fixtures/constants')
 const excludeFilter = [
   'ElectrodeApiImpl.xcodeproj',
   'project.pbxproj',
-  'package.json',
   '.DS_Store',
   'index.android.bundle',
   'index.android.bundle.meta',
@@ -19,7 +18,7 @@ const excludeFilter = [
   '.yarn-integrity'
 ].map(s => `**/${s}`).join(',')
 
-run(`create-api ${f.testApiName} -p ${f.testApiPkgName} --skipNpmCheck`)
+run(`create-api ${f.testApiName} -p ${f.testApiPkgName} -u "generated" --skipNpmCheck`)
 
 const fixtureApiPath = f.pathToBaseApiFixture
 const generatedApiPath = path.join(process.cwd(), f.testApiPkgName)

--- a/system-tests/tests/create-api-complex-fixture.js
+++ b/system-tests/tests/create-api-complex-fixture.js
@@ -7,7 +7,6 @@ const f = require('../fixtures/constants')
 const excludeFilter = [
   'ElectrodeApiImpl.xcodeproj',
   'project.pbxproj',
-  'package.json',
   '.DS_Store',
   'index.android.bundle',
   'index.android.bundle.meta',
@@ -19,7 +18,7 @@ const excludeFilter = [
   '.yarn-integrity'
 ].map(s => `**/${s}`).join(',')
 
-run(`create-api ${f.complexApiName} -p ${f.complexApiPkgName} --schemaPath ${f.pathToComplexApiSchema} --skipNpmCheck`)
+run(`create-api ${f.complexApiName} -p ${f.complexApiPkgName} --schemaPath ${f.pathToComplexApiSchema} -u "generated" --skipNpmCheck`)
 
 const fixtureApiPath = f.pathToComplexApiFixture
 const generatedApiPath = path.join(process.cwd(), f.complexApiPkgName)


### PR DESCRIPTION
No longer take the machine-local user name and modify the `author` field in the test fixtures on regeneration.