### PR TITLE
Improve error message

### DIFF
--- a/ern-core/src/utils.ts
+++ b/ern-core/src/utils.ts
@@ -446,7 +446,7 @@ export async function getCommitShaOfGitBranchOrTag(
   }
   const result = await gitCli().listRemote([p.basePath, p.version])
   if (!result || result === '') {
-    throw new Error(`${p.version} branch or tag not found`)
+    throw new Error(`${p.version} branch or tag not found in ${p.basePath}`)
   }
   return result.substring(0, gitShaLength)
 }


### PR DESCRIPTION
Improve error message logged by `getCommitShaOfGitBranchOrTag` function in case the branch/tag does not exist in the target repository.

from:

```
✖ An error occurred: foo branch or tag not found
```

to:

```
✖ An error occurred: foo branch or tag not found in git+ssh://git@github.com/bar/miniapp.git
```

This makes it clear as to which repository is concerned, in case the function is used in a loop for multiple different repositories (as in the case of `regen-container` command).