### PR TITLE
Fix missing source map output for local containers

### DIFF
--- a/ern-orchestrator/src/container.ts
+++ b/ern-orchestrator/src/container.ts
@@ -58,6 +58,7 @@ export async function runLocalContainerGen(
         jsMainModuleName,
         outDir,
         plugins: nativeDependencies,
+        sourceMapOutput,
         targetPlatform: platform,
       })
     )


### PR DESCRIPTION
Quick fix in `runLocalContainerGen` to forward `sourceMapOutput` parameter to `generateContainer` (was missing)