### PR TITLE
Bump typescript

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
   "editor.tabSize": 2,
   "editor.formatOnSave": true,
   "npm.enableScriptExplorer": true,
-  "typescript.implementationsCodeLens.enabled": true
+  "typescript.implementationsCodeLens.enabled": true,
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/ern-cauldron-api/src/CauldronHelper.ts
+++ b/ern-cauldron-api/src/CauldronHelper.ts
@@ -918,11 +918,7 @@ export class CauldronHelper {
     let updatedEntriesArr
 
     if (codePushEntries) {
-      if (
-        codePushConfig &&
-        codePushConfig.entriesLimit &&
-        codePushEntries.length >= codePushConfig.entriesLimit
-      ) {
+      if (codePushEntries.length >= codePushConfig?.entriesLimit) {
         nbEntriesToDrop =
           codePushEntries.length - codePushConfig.entriesLimit + 1
       }
@@ -1066,7 +1062,7 @@ export class CauldronHelper {
 
   public async getStartCommandConfig(
     descriptor?: AnyAppDescriptor
-  ): Promise<CauldronStartCommandConfig | void> {
+  ): Promise<CauldronStartCommandConfig | undefined> {
     return this.getConfigForKey('start', descriptor)
   }
 
@@ -1232,12 +1228,12 @@ export class CauldronHelper {
     descriptor: AppVersionDescriptor
   ): Promise<PackagePath[]> {
     const result: PackagePath[] = []
-    const miniAppsBranches = (await this.cauldron.getContainerMiniAppsBranches(
-      descriptor
-    )).map(p => PackagePath.fromString(p))
-    const miniApps = (await this.cauldron.getContainerMiniApps(descriptor)).map(
-      p => PackagePath.fromString(p)
-    )
+    const miniAppsBranches = (
+      await this.cauldron.getContainerMiniAppsBranches(descriptor)
+    ).map(p => PackagePath.fromString(p))
+    const miniApps = (
+      await this.cauldron.getContainerMiniApps(descriptor)
+    ).map(p => PackagePath.fromString(p))
     for (const miniAppBranch of miniAppsBranches) {
       const latestCommitSha = await coreUtils.getCommitShaOfGitBranchOrTag(
         miniAppBranch
@@ -1259,12 +1255,12 @@ export class CauldronHelper {
     descriptor: AppVersionDescriptor
   ) {
     const result: PackagePath[] = []
-    const jsApiImplsBranches = (await this.cauldron.getContainerJsApiImplsBranches(
-      descriptor
-    )).map(p => PackagePath.fromString(p))
-    const jsApiImpls = (await this.cauldron.getContainerJsApiImpls(
-      descriptor
-    )).map(p => PackagePath.fromString(p))
+    const jsApiImplsBranches = (
+      await this.cauldron.getContainerJsApiImplsBranches(descriptor)
+    ).map(p => PackagePath.fromString(p))
+    const jsApiImpls = (
+      await this.cauldron.getContainerJsApiImpls(descriptor)
+    ).map(p => PackagePath.fromString(p))
     for (const jsApiImplBranch of jsApiImplsBranches) {
       const latestCommitSha = await coreUtils.getCommitShaOfGitBranchOrTag(
         jsApiImplBranch

--- a/ern-composite-gen/src/Composite.ts
+++ b/ern-composite-gen/src/Composite.ts
@@ -45,7 +45,7 @@ export class Composite {
   }
 
   public getJsApiImpls(): PackagePath[] {
-    return this.config.jsApiImplDependencies || []
+    return this.config.jsApiImplDependencies ?? []
   }
 
   public getMiniApps(): BaseMiniApp[] {
@@ -74,12 +74,11 @@ export class Composite {
         continue
       }
       const pluginConfig = await manifest.getPluginConfig(dependency)
-      if (pluginConfig) {
-        if (platform === 'android' && pluginConfig.android) {
-          result.push(dependency)
-        } else if (platform === 'ios' && pluginConfig.ios) {
-          result.push(dependency)
-        }
+
+      if (platform === 'android' && pluginConfig?.android) {
+        result.push(dependency)
+      } else if (platform === 'ios' && pluginConfig?.ios) {
+        result.push(dependency)
       }
     }
     return result

--- a/ern-composite-gen/src/generateComposite.ts
+++ b/ern-composite-gen/src/generateComposite.ts
@@ -309,7 +309,7 @@ async function addBabelrcRoots({ outDir }: { outDir: string }) {
       const depPackageJson = await readPackageJson(
         path.join(compositeNodeModulesPath, dependency)
       )
-      if (depPackageJson.ern && depPackageJson.ern.useBabelRc === true) {
+      if (depPackageJson.ern?.useBabelRc === true) {
         babelRcRootsRe.push(new RegExp(`node_modules\/${dependency}(?!.+\/)`))
         babelRcRootsPaths.push(`./node_modules/${dependency}`)
       }
@@ -433,7 +433,7 @@ async function getCompositeMetroVersion({
   if (await fs.pathExists(pathToMetroNodeModuleDir)) {
     metroPackageJson = await readPackageJson(pathToMetroNodeModuleDir)
   }
-  return metroPackageJson ? metroPackageJson.version : '0.0.0'
+  return metroPackageJson?.version ?? '0.0.0'
 }
 
 async function patchMetro51({ outDir }: { outDir: string }) {

--- a/ern-container-gen-ios/src/IosGenerator.ts
+++ b/ern-container-gen-ios/src/IosGenerator.ts
@@ -180,14 +180,12 @@ export default class IosGenerator implements ContainerGenerator {
       }
       if (!pluginConfig.ios) {
         log.warn(
-          `${
-            plugin.basePath
-          } does not have any injection configuration for ios platform`
+          `${plugin.basePath} does not have any injection configuration for ios platform`
         )
         continue
       }
       const iOSPluginHook = pluginConfig.ios.pluginHook
-      if (iOSPluginHook && iOSPluginHook.name) {
+      if (iOSPluginHook?.name) {
         if (!pluginConfig.path) {
           throw new Error('No plugin config path was set. Cannot proceed.')
         }

--- a/ern-container-gen/src/copyRnpmAssets.ts
+++ b/ern-container-gen/src/copyRnpmAssets.ts
@@ -24,7 +24,7 @@ export function copyRnpmAssets(
 
   for (const miniAppPath of miniAppPaths) {
     const packageJson = readPackageJsonSync(miniAppPath)
-    if (packageJson.rnpm && packageJson.rnpm.assets) {
+    if (packageJson.rnpm?.assets) {
       for (const assetDirectoryName of packageJson.rnpm.assets) {
         const source = path.join(assetDirectoryName, '*')
         const dest = getAssetsPath(platform, assetDirectoryName)

--- a/ern-container-gen/src/populateApiImplMustacheView.ts
+++ b/ern-container-gen/src/populateApiImplMustacheView.ts
@@ -17,7 +17,7 @@ export function populateApiImplMustacheView(
 ) {
   const packageJson = readPackageJsonSync(apiImplPluginPath)
   const containerGenConfig = packageJson.ern.containerGen
-  if (containerGenConfig && containerGenConfig.apiNames) {
+  if (containerGenConfig?.apiNames) {
     mustacheView.apiImplementations = mustacheView.apiImplementations
       ? mustacheView.apiImplementations
       : []
@@ -43,9 +43,7 @@ export function populateApiImplMustacheView(
     }
   } else {
     log.warn(
-      `!!!!! containerGen entry not valid for api implementation, skipping api-impl code gen in container for ${
-        packageJson.name
-      } !!!!`
+      `!!!!! containerGen entry not valid for api implementation, skipping api-impl code gen in container for ${packageJson.name} !!!!`
     )
   }
 }

--- a/ern-container-gen/src/reactNativeBundleAndroid.ts
+++ b/ern-container-gen/src/reactNativeBundleAndroid.ts
@@ -15,10 +15,10 @@ export async function reactNativeBundleAndroid({
   sourceMapOutput?: string
   cwd?: string
 }): Promise<BundlingResult> {
-  cwd = cwd || process.cwd()
+  cwd = cwd ?? process.cwd()
   const libSrcMainPath = path.join(outDir, 'lib', 'src', 'main')
   bundleOutput =
-    bundleOutput || path.join(libSrcMainPath, 'assets', 'index.android.bundle')
+    bundleOutput ?? path.join(libSrcMainPath, 'assets', 'index.android.bundle')
   const assetsDest = path.join(libSrcMainPath, 'res')
   // Cleanup everything from 'res' directory but 'devassist'
   if (fs.existsSync(assetsDest)) {

--- a/ern-container-gen/src/reactNativeBundleIos.ts
+++ b/ern-container-gen/src/reactNativeBundleIos.ts
@@ -22,7 +22,7 @@ export async function reactNativeBundleIos({
     'Libraries',
     'MiniApp'
   )
-  bundleOutput = bundleOutput || path.join(miniAppOutPath, 'MiniApp.jsbundle')
+  bundleOutput = bundleOutput ?? path.join(miniAppOutPath, 'MiniApp.jsbundle')
   const assetsDest = miniAppOutPath
   if (fs.existsSync(assetsDest)) {
     shell.rm('-rf', path.join(assetsDest, '{.*,*}'))

--- a/ern-core/src/BaseMiniApp.ts
+++ b/ern-core/src/BaseMiniApp.ts
@@ -42,9 +42,7 @@ in the package.json of ${packageJson.name} MiniApp
 =================================================================`)
     } else if (!packageJson.ern) {
       throw new Error(
-        tagOneLine`No ern section found in ${
-          packageJson.name
-        } package.json. Are you sure this is a MiniApp ?`
+        tagOneLine`No ern section found in ${packageJson.name} package.json. Are you sure this is a MiniApp ?`
       )
     }
 
@@ -53,14 +51,11 @@ in the package.json of ${packageJson.name} MiniApp
   }
 
   get name(): string {
-    if (this.packageJson.ern) {
-      if (this.packageJson.ern.miniAppName) {
-        return this.packageJson.ern.miniAppName
-      } else if (this.packageJson.ern.moduleName) {
-        return this.packageJson.ern.moduleName
-      }
-    }
-    return this.getUnscopedModuleName(this.packageJson.name)
+    return (
+      this.packageJson.ern?.miniAppName ??
+      this.packageJson.ern?.moduleName ??
+      this.getUnscopedModuleName(this.packageJson.name)
+    )
   }
 
   public getUnscopedModuleName(moduleName: string): string {
@@ -92,9 +87,7 @@ in the package.json of ${packageJson.name} MiniApp
   }
 
   get platformVersion(): string {
-    return this.packageJson.ern
-      ? this.packageJson.ern.version
-      : this.packageJson.ernPlatformVersion
+    return this.packageJson.ern?.version ?? this.packageJson.ernPlatformVersion
   }
 
   get packageDescriptor(): string {

--- a/ern-core/src/BundleStoreSdk.ts
+++ b/ern-core/src/BundleStoreSdk.ts
@@ -18,7 +18,7 @@ export class BundleStoreSdk {
       })
       return res.body.accessKey
     } catch (err) {
-      throw new Error(err.response ? err.response.text : err.message)
+      throw new Error(err.response?.text ?? err.message)
     }
   }
 
@@ -35,7 +35,7 @@ export class BundleStoreSdk {
       })
       return res.body.id
     } catch (err) {
-      throw new Error(err.response ? err.response.text : err.message)
+      throw new Error(err.response?.text ?? err.message)
     }
   }
 
@@ -50,7 +50,7 @@ export class BundleStoreSdk {
       })
       return storeId
     } catch (err) {
-      throw new Error(err.response ? err.response.text : err.message)
+      throw new Error(err.response?.text ?? err.message)
     }
   }
 
@@ -85,7 +85,7 @@ export class BundleStoreSdk {
       )
       return JSON.parse(res.body).id
     } catch (err) {
-      throw new Error(err.response ? err.response.text : err.message)
+      throw new Error(err.response?.text ?? err.message)
     }
   }
 
@@ -99,7 +99,7 @@ export class BundleStoreSdk {
         body: form,
       })
     } catch (err) {
-      throw new Error(err.response ? err.response.text : err.message)
+      throw new Error(err.response?.text ?? err.message)
     }
   }
 
@@ -112,7 +112,7 @@ export class BundleStoreSdk {
       })
       return res.body
     } catch (err) {
-      throw new Error(err.response ? err.response.text : err.message)
+      throw new Error(err.response?.text ?? err.message)
     }
   }
 }

--- a/ern-core/src/ErnBinaryStore.ts
+++ b/ern-core/src/ErnBinaryStore.ts
@@ -39,7 +39,7 @@ export class ErnBinaryStore implements BinaryStore {
       form.append('file', binaryRs)
       await got.post(this.config.url, { ...this.gotCommonOpts, body: form })
     } catch (err) {
-      throw new Error(err.response ? err.response.text : err.message)
+      throw new Error(err.response?.text ?? err.message)
     }
   }
 
@@ -57,7 +57,7 @@ export class ErnBinaryStore implements BinaryStore {
         ...this.gotCommonOpts,
       })
     } catch (err) {
-      throw new Error(err.response ? err.response.text : err.message)
+      throw new Error(err.response?.text ?? err.message)
     }
   }
 
@@ -98,7 +98,7 @@ export class ErnBinaryStore implements BinaryStore {
       if (err.response && err.response.statusCode === 404) {
         return false
       }
-      throw new Error(err.response ? err.response.text : err.message)
+      throw new Error(err.response?.text ?? err.message)
     }
   }
 

--- a/ern-core/src/Manifest.ts
+++ b/ern-core/src/Manifest.ts
@@ -609,9 +609,7 @@ export class Manifest {
     )
     if (!pluginConfigPath) {
       throw new Error(
-        `There is no configuration for ${
-          plugin.basePath
-        } plugin in Manifest matching platform version ${platformVersion}`
+        `There is no configuration for ${plugin.basePath} plugin in Manifest matching platform version ${platformVersion}`
       )
     }
 
@@ -625,9 +623,7 @@ export class Manifest {
 
     // Add default value (convention) for Android subsection for missing fields
     if (result.android) {
-      if (result.android.root === undefined) {
-        result.android.root = 'android'
-      }
+      result.android.root = result.android.root ?? 'android'
 
       const matchedFiles = shell.find(pluginConfigPath).filter(file => {
         return file.match(/\.java$/)
@@ -649,9 +645,7 @@ export class Manifest {
     }
 
     if (result.ios) {
-      if (result.ios.root === undefined) {
-        result.ios.root = 'ios'
-      }
+      result.ios.root = result.ios.root ?? 'ios'
 
       const matchedHeaderFiles = shell.find(pluginConfigPath).filter(file => {
         return file.match(/\.h$/)
@@ -698,7 +692,7 @@ export class Manifest {
     plugin: PackagePath,
     projectName: string = 'ElectrodeContainer',
     platformVersion: string = Platform.currentVersion
-  ): Promise<PluginConfig | void> {
+  ): Promise<PluginConfig | undefined> {
     await this.initOverrideManifest()
     let result
     if (await isDependencyApi(plugin.basePath)) {
@@ -722,9 +716,7 @@ export class Manifest {
       )
     } else {
       log.warn(
-        `Unsupported plugin. No configuration found in manifest for ${
-          plugin.basePath
-        }.`
+        `Unsupported plugin. No configuration found in manifest for ${plugin.basePath}.`
       )
       return
       /*throw new Error(

--- a/ern-core/src/ModuleFactory.ts
+++ b/ern-core/src/ModuleFactory.ts
@@ -76,7 +76,7 @@ export class ModuleFactory<T> {
 
   private async refreshCacheFor(p: PackagePath) {
     const packageJson = await readPackageJson(this.packageCachePath)
-    return packageJson.dependencies && packageJson.dependencies[p.basePath]
+    return packageJson.dependencies?.[p.basePath]
       ? this.upgradeCachedPackage(p)
       : this.addPackageToCache(p)
   }

--- a/ern-core/src/SourceMapStoreSdk.ts
+++ b/ern-core/src/SourceMapStoreSdk.ts
@@ -32,13 +32,11 @@ export class SourceMapStoreSdk {
     try {
       const form = this.createSourceMapForm(sourceMapPath)
       await got.post(
-        `http://${this.host}/sourcemaps/codepush/${descriptor.name}/${
-          descriptor.platform
-        }/${descriptor.version}/${deploymentName}/${label}`,
+        `http://${this.host}/sourcemaps/codepush/${descriptor.name}/${descriptor.platform}/${descriptor.version}/${deploymentName}/${label}`,
         { ...this.gotCommonOpts, body: form }
       )
     } catch (err) {
-      throw new Error(err.response ? err.response.text : err.message)
+      throw new Error(err.response?.text ?? err.message)
     }
   }
 
@@ -59,15 +57,11 @@ export class SourceMapStoreSdk {
   }) {
     try {
       await got.post(
-        `http://${this.host}/sourcemaps/codepush/copy/${descriptor.name}/${
-          descriptor.platform
-        }/${
-          descriptor.version
-        }/${deploymentName}/${label}/${toVersion}/${toDeploymentName}/${toLabel}`,
+        `http://${this.host}/sourcemaps/codepush/copy/${descriptor.name}/${descriptor.platform}/${descriptor.version}/${deploymentName}/${label}/${toVersion}/${toDeploymentName}/${toLabel}`,
         this.gotCommonOpts
       )
     } catch (err) {
-      throw new Error(err.response ? err.response.text : err.message)
+      throw new Error(err.response?.text ?? err.message)
     }
   }
 
@@ -83,13 +77,11 @@ export class SourceMapStoreSdk {
     try {
       const form = this.createSourceMapForm(sourceMapPath)
       await got.post(
-        `http://${this.host}/sourcemaps/container/${descriptor.name}/${
-          descriptor.platform
-        }/${descriptor.version}/${containerVersion}`,
+        `http://${this.host}/sourcemaps/container/${descriptor.name}/${descriptor.platform}/${descriptor.version}/${containerVersion}`,
         { ...this.gotCommonOpts, body: form }
       )
     } catch (err) {
-      throw new Error(err.response ? err.response.text : err.message)
+      throw new Error(err.response?.text ?? err.message)
     }
   }
 }

--- a/ern-core/src/YarnLockParser.ts
+++ b/ern-core/src/YarnLockParser.ts
@@ -57,13 +57,13 @@ export class YarnLockParser {
           .filter(k => k === pkg.fullPath)
           .map(k => ({
             pkgPath: PackagePath.fromString(k),
-            version: this.parsed.object[k] && this.parsed.object[k].version,
+            version: this.parsed.object[k]?.version,
           }))
       : Object.keys(this.parsed.object)
           .filter(k => k.startsWith(`${pkg.basePath}@`))
           .map(k => ({
             pkgPath: PackagePath.fromString(k),
-            version: this.parsed.object[k] && this.parsed.object[k].version,
+            version: this.parsed.object[k]?.version,
           }))
   }
 
@@ -86,7 +86,7 @@ export class YarnLockParser {
       )
       .map(([k, v]: [string, any]) => ({
         pkgPath: PackagePath.fromString(k),
-        version: this.parsed.object[k] && this.parsed.object[k].version,
+        version: this.parsed.object[k]?.version,
       }))
   }
 

--- a/ern-core/src/isPackagePublished.ts
+++ b/ern-core/src/isPackagePublished.ts
@@ -9,7 +9,7 @@ export async function isPackagePublished(
       field: 'versions 2> /dev/null',
       json: true,
     })
-    if (result && result.type === `inspect`) {
+    if (result?.type === `inspect`) {
       return true
     }
   } catch (e) {

--- a/ern-core/src/nativeDependenciesLookup.ts
+++ b/ern-core/src/nativeDependenciesLookup.ts
@@ -21,7 +21,7 @@ export function filterDirectories(directories: string[]): string[] {
 }
 
 export function getUnprefixedVersion(version: string): string {
-  return version && version.startsWith('v') ? version.slice(1) : version
+  return version?.startsWith('v') ? version.slice(1) : version
 }
 
 export interface NativeDependency {
@@ -159,10 +159,8 @@ function packagePathFrom(
 
 export async function getNativeDependencyPath(dir: string, d: PackagePath) {
   const dependencies = await findNativeDependencies(dir)
-  const dependency: NativeDependency | void = dependencies.all.find(x =>
+  const dependency: NativeDependency | undefined = dependencies.all.find(x =>
     x.packagePath.same(d, { ignoreVersion: true })
   )
-  if (dependency) {
-    return dependency.path
-  }
+  return dependency?.path
 }

--- a/ern-core/src/utils.ts
+++ b/ern-core/src/utils.ts
@@ -38,18 +38,16 @@ export async function isPublishedToNpm(
     log.debug(e)
     return false
   }
-  if (publishedVersionsInfo) {
-    const publishedVersions: string[] = publishedVersionsInfo.data
-    const type: string = publishedVersionsInfo.type
-    if (type && type === 'inspect') {
-      const pkgVersion = PackagePath.fromString(pkg.toString()).version
-      if (publishedVersions && pkgVersion) {
-        return publishedVersions.includes(pkgVersion)
-      } else {
-        return true
-      }
-    }
+
+  const publishedVersions: string[] = publishedVersionsInfo?.data
+  const type: string = publishedVersionsInfo?.type
+  if (type === 'inspect') {
+    const pkgVersion = PackagePath.fromString(pkg.toString()).version
+    return publishedVersions && pkgVersion
+      ? publishedVersions.includes(pkgVersion)
+      : true
   }
+
   return false
 }
 
@@ -163,11 +161,11 @@ export async function isDependencyApi(
     field: 'ern 2> /dev/null',
     json: true,
   })
-  if (depInfo && depInfo.type === 'error') {
+  if (depInfo?.type === 'error') {
     throw new Error(`Cannot find ${dependencyName} in npm registry`)
   }
 
-  return depInfo.data && ModuleType.API === depInfo.data.moduleType
+  return ModuleType.API === depInfo.data?.moduleType
 }
 
 /**
@@ -202,11 +200,11 @@ export async function isDependencyApiImpl(
     field: 'ern 2> /dev/null',
     json: true,
   })
-  if (depInfo && depInfo.type === 'error') {
+  if (depInfo?.type === 'error') {
     throw new Error(`Cannot find ${dependencyName} in npm registry`)
   }
 
-  return depInfo.data && modulesTypes.indexOf(depInfo.data.moduleType) > -1
+  return modulesTypes.indexOf(depInfo.data?.moduleType) > -1
 }
 
 export async function isDependencyJsApiImpl(
@@ -230,9 +228,7 @@ export async function isDependencyPathApiImpl(
     : [ModuleType.NATIVE_API_IMPL, ModuleType.JS_API_IMPL]
 
   const packageJson = await readPackageJson(dependencyPath)
-  return (
-    packageJson.ern && modulesTypes.indexOf(packageJson.ern.moduleType) > -1
-  )
+  return modulesTypes.indexOf(packageJson.ern?.moduleType) > -1
 }
 
 export async function isDependencyPathJsApiImpl(

--- a/ern-orchestrator/src/Ensure.ts
+++ b/ern-orchestrator/src/Ensure.ts
@@ -251,9 +251,7 @@ export default class Ensure {
         ))
       ) {
         throw new Error(
-          `${
-            dependency.basePath
-          } does not exists in ${napDescriptor}.\n${extraErrorMessage}`
+          `${dependency.basePath} does not exists in ${napDescriptor}.\n${extraErrorMessage}`
         )
       }
     }
@@ -343,7 +341,7 @@ export default class Ensure {
         miniApps,
         dependency
       )
-      if (miniAppsUsingDependency && miniAppsUsingDependency.length > 0) {
+      if (miniAppsUsingDependency?.length > 0) {
         let errorMessage = ''
         errorMessage += 'The following MiniApp(s) are using this dependency\n'
         for (const miniApp of miniAppsUsingDependency) {
@@ -518,9 +516,7 @@ export default class Ensure {
             throw new Error(`Missing version for ${dependency}`)
           } else if (!semver.valid(dependency.version)) {
             throw new Error(
-              `Unsupported version ${dependency.version} for ${
-                dependency.basePath
-              }`
+              `Unsupported version ${dependency.version} for ${dependency.basePath}`
             )
           }
         } else if (!dependency.version) {

--- a/ern-orchestrator/src/codepush.ts
+++ b/ern-orchestrator/src/codepush.ts
@@ -227,9 +227,7 @@ export async function performCodePushPromote(
             const sdk = new SourceMapStoreSdk(sourcemapStoreConfig.url)
             await kax
               .task(
-                `Copying source map in source map store [${
-                  sourcemapStoreConfig.url
-                }]`
+                `Copying source map in source map store [${sourcemapStoreConfig.url}]`
               )
               .run(
                 sdk.copyCodePushSourceMap({
@@ -296,8 +294,7 @@ export async function performCodePushOtaUpdate(
     const compositeGenConfig = await cauldron.getCompositeGeneratorConfig(
       napDescriptor
     )
-    baseComposite =
-      baseComposite || (compositeGenConfig && compositeGenConfig.baseComposite)
+    baseComposite = baseComposite ?? compositeGenConfig?.baseComposite
     await cauldron.beginTransaction()
     const codePushPlugin = _.find(
       plugins,
@@ -422,14 +419,10 @@ export async function performCodePushOtaUpdate(
 
     if (platform === 'android') {
       const conf = await cauldron.getContainerGeneratorConfig(napDescriptor)
-      const isHermesEnabled =
-        conf &&
-        conf.androidConfig &&
-        conf.androidConfig.jsEngine &&
-        conf.androidConfig.jsEngine === 'hermes'
+      const isHermesEnabled = conf?.androidConfig?.jsEngine === 'hermes'
       if (isHermesEnabled) {
         const hermesVersion =
-          conf.androidConfig.hermesVersion || android.DEFAULT_HERMES_VERSION
+          conf.androidConfig.hermesVersion ?? android.DEFAULT_HERMES_VERSION
         const hermesCli = await kax
           .task(`Installing hermes-engine@${hermesVersion}`)
           .run(HermesCli.fromVersion(hermesVersion))
@@ -504,9 +497,7 @@ export async function performCodePushOtaUpdate(
           const sdk = new SourceMapStoreSdk(sourcemapStoreConfig.url)
           await kax
             .task(
-              `Uploading source map to source map store [${
-                sourcemapStoreConfig.url
-              }]`
+              `Uploading source map to source map store [${sourcemapStoreConfig.url}]`
             )
             .run(
               sdk.uploadCodePushSourceMap({
@@ -604,15 +595,12 @@ export function removeZeroPatchDigit({
 export async function getCodePushAppName(
   napDescriptor: AppVersionDescriptor
 ): Promise<string> {
-  let result = napDescriptor.name
   const cauldron = await getActiveCauldron()
   const codePushConfig = await cauldron.getCodePushConfig(napDescriptor)
-  if (codePushConfig && codePushConfig.appName) {
-    result = codePushConfig.appName
-  } else {
-    result = `${napDescriptor.name}${
+  return (
+    codePushConfig?.appName ??
+    `${napDescriptor.name}${
       napDescriptor.platform === 'ios' ? 'Ios' : 'Android'
     }`
-  }
-  return result
+  )
 }

--- a/ern-orchestrator/src/runContainerPipeline.ts
+++ b/ern-orchestrator/src/runContainerPipeline.ts
@@ -31,20 +31,14 @@ export async function runContainerPipeline({
       pipelineEltType = 'transformer'
     } else {
       log.error(
-        `[${curIdx}/${
-          pipeline.length
-        }] Skipping non transformer/publisher pipeline element ${
-          pipelineElt.name
-        }`
+        `[${curIdx}/${pipeline.length}] Skipping non transformer/publisher pipeline element ${pipelineElt.name}`
       )
       continue
     }
 
     if (pipelineElt.disabled) {
       log.info(
-        `[${curIdx}/${pipeline.length}] Skipping ${
-          pipelineElt.name
-        } ${pipelineEltType} [disabled]`
+        `[${curIdx}/${pipeline.length}] Skipping ${pipelineElt.name} ${pipelineEltType} [disabled]`
       )
       continue
     }
@@ -63,9 +57,7 @@ export async function runContainerPipeline({
     }
     await kax
       .task(
-        `[${curIdx}/${pipeline.length}] Running Container ${pipelineEltType} ${
-          pipelineEltPackage.basePath
-        }`
+        `[${curIdx}/${pipeline.length}] Running Container ${pipelineEltType} ${pipelineEltPackage.basePath}`
       )
       .run(
         isPublisher(pipelineEltPackage)

--- a/ern-orchestrator/src/runContainerPipelineForDescriptor.ts
+++ b/ern-orchestrator/src/runContainerPipelineForDescriptor.ts
@@ -25,7 +25,7 @@ export async function runContainerPipelineForDescriptor({
     .task('Getting pipeline configuration from Cauldron')
     .run(cauldron.getContainerGeneratorConfig(descriptor))
 
-  const pipeline = containerGenConfig && containerGenConfig.pipeline
+  const pipeline = containerGenConfig?.pipeline
   if (!pipeline) {
     log.warn(`No pipeline configuration found for ${descriptor}`)
   } else {

--- a/ern-orchestrator/src/runMiniApp.ts
+++ b/ern-orchestrator/src/runMiniApp.ts
@@ -57,7 +57,7 @@ export async function runMiniApp(
     port?: string
   } = {}
 ) {
-  cwd = cwd || process.cwd()
+  cwd = cwd ?? process.cwd()
 
   let napDescriptor: AppVersionDescriptor | void
 
@@ -113,9 +113,7 @@ export async function runMiniApp(
         `This command is being run from the ${miniapp.name} MiniApp directory.`
       )
       log.info(
-        `All extra MiniApps will be included in the Runner container along with ${
-          miniapp.name
-        }`
+        `All extra MiniApps will be included in the Runner container along with ${miniapp.name}`
       )
       if (!mainMiniAppName) {
         log.info(`${miniapp.name} will be set as the main MiniApp`)
@@ -215,7 +213,7 @@ export async function runMiniApp(
 
   const runnerGeneratorConfig: RunnerGeneratorConfig = {
     extra: {
-      androidConfig: (extra && extra.androidConfig) || {},
+      androidConfig: extra?.androidConfig ?? {},
       containerGenWorkingDir: Platform.containerGenDirectory,
     },
     mainMiniAppName: entryMiniAppName,

--- a/ern-orchestrator/src/start.ts
+++ b/ern-orchestrator/src/start.ts
@@ -80,9 +80,8 @@ export default async function start({
     const compositeGenConfig = await cauldron.getCompositeGeneratorConfig(
       descriptor
     )
-    baseComposite =
-      baseComposite || (compositeGenConfig && compositeGenConfig.baseComposite)
-    resolutions = compositeGenConfig && compositeGenConfig.resolutions
+    baseComposite = baseComposite || compositeGenConfig?.baseComposite
+    resolutions = compositeGenConfig?.resolutions
   }
 
   // Because this command can only be stoped through `CTRL+C` (or killing the process)
@@ -170,14 +169,11 @@ export default async function start({
       const binaryStore = new ErnBinaryStore(binaryStoreConfig)
       if (await binaryStore.hasBinary(descriptor, { flavor })) {
         if (descriptor.platform === 'android') {
-          if (
-            cauldronStartCommandConfig &&
-            cauldronStartCommandConfig.android
-          ) {
+          if (cauldronStartCommandConfig?.android) {
             packageName =
-              packageName || cauldronStartCommandConfig.android.packageName
+              packageName ?? cauldronStartCommandConfig.android.packageName
             activityName =
-              activityName || cauldronStartCommandConfig.android.activityName
+              activityName ?? cauldronStartCommandConfig.android.activityName
           }
           if (!packageName) {
             throw new Error(
@@ -196,8 +192,8 @@ export default async function start({
             packageName,
           })
         } else if (descriptor.platform === 'ios') {
-          if (cauldronStartCommandConfig && cauldronStartCommandConfig.ios) {
-            bundleId = bundleId || cauldronStartCommandConfig.ios.bundleId
+          if (cauldronStartCommandConfig?.ios) {
+            bundleId = bundleId ?? cauldronStartCommandConfig.ios.bundleId
           }
           if (!bundleId) {
             throw new Error(

--- a/ern-orchestrator/src/syncCauldronContainer.ts
+++ b/ern-orchestrator/src/syncCauldronContainer.ts
@@ -75,7 +75,7 @@ export async function syncCauldronContainer(
     const compositeGenConfig = await cauldron.getCompositeGeneratorConfig(
       descriptor
     )
-    const baseComposite = compositeGenConfig && compositeGenConfig.baseComposite
+    const baseComposite = compositeGenConfig?.baseComposite
 
     const compositeDir = createTmpDir()
 
@@ -96,7 +96,7 @@ export async function syncCauldronContainer(
     )
 
     // Generate Container from Cauldron
-    sourceMapOutput = sourceMapOutput || path.join(createTmpDir(), 'index.map')
+    sourceMapOutput = sourceMapOutput ?? path.join(createTmpDir(), 'index.map')
     await kax.task('Generating Container from Cauldron').run(
       runCauldronContainerGen(descriptor, composite, {
         outDir,
@@ -140,9 +140,7 @@ export async function syncCauldronContainer(
         const sdk = new SourceMapStoreSdk(sourcemapStoreConfig.url)
         await kax
           .task(
-            `Uploading source map to source map store [${
-              sourcemapStoreConfig.url
-            }]`
+            `Uploading source map to source map store [${sourcemapStoreConfig.url}]`
           )
           .run(
             sdk.uploadContainerSourceMap({

--- a/ern-runner-gen-android/src/AndroidRunnerGenerator.ts
+++ b/ern-runner-gen-android/src/AndroidRunnerGenerator.ts
@@ -75,13 +75,7 @@ function getPackageFilePath(config: RunnerGeneratorConfig): string {
 }
 
 function isOldRunner(config: RunnerGeneratorConfig): boolean {
-  const oldRunner =
-    config.extra &&
-    config.extra.androidConfig &&
-    config.extra.androidConfig.isOldRunner
-      ? true
-      : false
-  return oldRunner
+  return !!config.extra?.androidConfig?.isOldRunner
 }
 
 // Given a string returns the same string with its first letter capitalized
@@ -93,9 +87,7 @@ function configureMustacheView(
   config: RunnerGeneratorConfig,
   mustacheView: any
 ) {
-  const versions = android.resolveAndroidVersions(
-    config.extra && config.extra.androidConfig
-  )
+  const versions = android.resolveAndroidVersions(config.extra?.androidConfig)
   mustacheView = Object.assign(mustacheView, versions)
 
   mustacheView.isReactNativeDevSupportEnabled =
@@ -108,17 +100,10 @@ function configureMustacheView(
   mustacheView.pascalCaseMiniAppName = pascalCase(config.mainMiniAppName)
   mustacheView.lowerCaseMiniAppName = config.mainMiniAppName.toLowerCase()
   mustacheView.artifactId =
-    config.extra &&
-    config.extra.androidConfig &&
-    config.extra.androidConfig.artifactId
-      ? config.extra.androidConfig.artifactId
-      : `runner-ern-container-${config.mainMiniAppName.toLowerCase()}`
+    config.extra?.androidConfig?.artifactId ??
+    `runner-ern-container-${config.mainMiniAppName.toLowerCase()}`
   mustacheView.groupId =
-    config.extra &&
-    config.extra.androidConfig &&
-    config.extra.androidConfig.groupId
-      ? config.extra.androidConfig.groupId
-      : 'com.walmartlabs.ern'
+    config.extra?.androidConfig?.groupId ?? 'com.walmartlabs.ern'
   mustacheView.isOldRunner = isOldRunner(config)
   injectReactNativeVersionKeysInObject(mustacheView, config.reactNativeVersion)
   return mustacheView

--- a/ern-runner-gen-ios/src/IosRunnerGenerator.ts
+++ b/ern-runner-gen-ios/src/IosRunnerGenerator.ts
@@ -64,9 +64,9 @@ export default class IosRunerGenerator implements RunnerGenerator {
         config.reactNativeDevSupportEnabled === true ? 'YES' : 'NO',
       miniAppName: config.mainMiniAppName,
       packagerHost:
-        config.reactNativePackagerHost || defaultReactNativePackagerHost,
+        config.reactNativePackagerHost ?? defaultReactNativePackagerHost,
       packagerPort:
-        config.reactNativePackagerPort || defaultReactNativePackagerPort,
+        config.reactNativePackagerPort ?? defaultReactNativePackagerPort,
       pascalCaseMiniAppName: pascalCase(config.mainMiniAppName),
       pathToElectrodeContainerXcodeProj,
     }

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "shelljs": "^0.8.3"
   },
   "devDependencies": {
-    "@types/chai": "^4.1.7",
-    "@types/mocha": "^5.2.6",
+    "@types/chai": "^4.2.6",
+    "@types/mocha": "^5.2.7",
     "@yarnpkg/lockfile": "^1.1.0",
     "chai": "^4.2.0",
     "colors": "^1.3.3",
@@ -56,17 +56,17 @@
     "nock": "^11.7.0",
     "npm": "^6.9.0",
     "nyc": "14.0.0",
-    "prettier": "1.17.0",
-    "pretty-quick": "^1.10.0",
+    "prettier": "1.19.1",
+    "pretty-quick": "^2.0.1",
     "rimraf": "^2.6.3",
     "sinon": "7.3.2",
     "source-map-support": "^0.5.12",
-    "ts-node": "^8.2.0",
-    "tsconfig-paths": "^3.8.0",
-    "tslint": "^5.17.0",
+    "ts-node": "^8.5.4",
+    "tsconfig-paths": "^3.9.0",
+    "tslint": "^5.20.1",
     "tslint-config-prettier": "^1.18.0",
     "tslint-no-unused-expression-chai": "^0.1.4",
-    "typescript": "^3.5.1"
+    "typescript": "^3.7.3"
   },
   "engines": {
     "node": ">=6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1530,10 +1530,10 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@types/chai@^4.1.7":
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.2.tgz#6b825013863d04868c15624ec8b7fdced88a47c6"
-  integrity sha512-8V2aCcPM3WLuJvJpF6N60uUvdZb7NHjpjQlLk1QmZbTP4XZET/FX0c3TJ3K7qt4L98FS1Pifa8BVofTVuJFWVA==
+"@types/chai@^4.2.6":
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.6.tgz#a55625d151d9c7c7a0a95920632131d66480bce9"
+  integrity sha512-HF8faEUA4JurIm+68VaA2KedtZf5LYdXpQEAbIAN79DwWQbO82BNTksZgCH3UMqbZHXex9C6TrBfg7OUInRISQ==
 
 "@types/events@*":
   version "3.0.0"
@@ -1554,12 +1554,12 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/minimatch@*":
+"@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
-"@types/mocha@^5.2.6":
+"@types/mocha@^5.2.7":
   version "5.2.7"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.7.tgz#315d570ccb56c53452ff8638738df60726d5b6ea"
   integrity sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
@@ -1916,6 +1916,11 @@ array-differ@^2.0.3:
   resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-2.1.0.tgz#4b9c1c3f14b906757082925769e8ab904f4801b1"
   integrity sha512-KbUpJgx909ZscOc/7CLATBFam7P1Z1QRQInvgT0UztM9Q72aGKCunKASAl7WNW0tnPmPyEMeMhdsfWhfmW037w==
 
+array-differ@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-3.0.0.tgz#3cbb3d0f316810eafcc47624734237d6aee4ae6b"
+  integrity sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==
+
 array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
@@ -1938,6 +1943,11 @@ array-union@^1.0.2:
   dependencies:
     array-uniq "^1.0.1"
 
+array-union@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
+  integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
 array-uniq@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
@@ -1952,6 +1962,11 @@ arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
+
+arrify@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
+  integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
 
 asap@^2.0.0:
   version "2.0.6"
@@ -3028,6 +3043,15 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cross-spawn@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
+  integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
 crypt@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
@@ -3190,11 +3214,6 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
-
-deepmerge@^2.0.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
-  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
 
 default-require-extensions@^2.0.0:
   version "2.0.0"
@@ -3578,19 +3597,6 @@ execa@^0.7.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-execa@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
-  integrity sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=
-  dependencies:
-    cross-spawn "^5.0.1"
-    get-stream "^3.0.0"
-    is-stream "^1.1.0"
-    npm-run-path "^2.0.0"
-    p-finally "^1.0.0"
-    signal-exit "^3.0.0"
-    strip-eof "^1.0.0"
-
 execa@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
@@ -3603,6 +3609,21 @@ execa@^1.0.0:
     p-finally "^1.0.0"
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
+
+execa@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-2.1.0.tgz#e5d3ecd837d2a60ec50f3da78fd39767747bbe99"
+  integrity sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==
+  dependencies:
+    cross-spawn "^7.0.0"
+    get-stream "^5.0.0"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^3.0.0"
+    onetime "^5.1.0"
+    p-finally "^2.0.0"
+    signal-exit "^3.0.2"
+    strip-final-newline "^2.0.0"
 
 exif-parser@^0.1.12:
   version "0.1.12"
@@ -3825,7 +3846,7 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
-find-up@^4.0.0:
+find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
@@ -4095,7 +4116,7 @@ get-stream@^4.0.0, get-stream@^4.1.0:
   dependencies:
     pump "^3.0.0"
 
-get-stream@^5.1.0:
+get-stream@^5.0.0, get-stream@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
   integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
@@ -4552,15 +4573,15 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
-ignore@^3.3.7:
-  version "3.3.10"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
-  integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
-
 ignore@^4.0.3:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+ignore@^5.1.4:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
+  integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
 
 import-fresh@^2.0.0:
   version "2.0.0"
@@ -4983,6 +5004,11 @@ is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
+
+is-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
+  integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
 
 is-symbol@^1.0.2:
   version "1.0.2"
@@ -5953,6 +5979,11 @@ merge-source-map@^1.1.0:
   dependencies:
     source-map "^0.6.1"
 
+merge-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
+  integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+
 merge2@^1.2.3:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.4.tgz#c9269589e6885a60cf80605d9522d4b67ca646e3"
@@ -6009,7 +6040,7 @@ mimic-fn@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
-mimic-fn@^2.0.0:
+mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
@@ -6188,7 +6219,7 @@ move-concurrently@^1.0.1:
     rimraf "^2.5.4"
     run-queue "^1.0.3"
 
-mri@^1.1.0:
+mri@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.4.tgz#7cb1dd1b9b40905f1fac053abe25b6720f44744a"
   integrity sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==
@@ -6216,6 +6247,17 @@ multimatch@^3.0.0:
     array-differ "^2.0.3"
     array-union "^1.0.2"
     arrify "^1.0.1"
+    minimatch "^3.0.4"
+
+multimatch@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-4.0.0.tgz#8c3c0f6e3e8449ada0af3dd29efb491a375191b3"
+  integrity sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==
+  dependencies:
+    "@types/minimatch" "^3.0.3"
+    array-differ "^3.0.0"
+    array-union "^2.1.0"
+    arrify "^2.0.1"
     minimatch "^3.0.4"
 
 mustache@^2.3.1:
@@ -6562,6 +6604,13 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
+npm-run-path@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-3.1.0.tgz#7f91be317f6a466efed3c9f2980ad8a4ee8b0fa5"
+  integrity sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==
+  dependencies:
+    path-key "^3.0.0"
+
 npm-user-validate@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/npm-user-validate/-/npm-user-validate-1.0.0.tgz#8ceca0f5cea04d4e93519ef72d0557a75122e951"
@@ -6823,6 +6872,13 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+onetime@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.0.tgz#fff0f3c91617fe62bb50189636e99ac8a6df7be5"
+  integrity sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
+  dependencies:
+    mimic-fn "^2.1.0"
+
 opener@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
@@ -6913,6 +6969,11 @@ p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
+
+p-finally@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-2.0.1.tgz#bd6fcaa9c559a096b680806f4d657b3f0f240561"
+  integrity sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==
 
 p-is-promise@^2.0.0:
   version "2.1.0"
@@ -7215,6 +7276,11 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
+path-key@^3.0.0, path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
 path-loader@^1.0.2:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/path-loader/-/path-loader-1.0.10.tgz#dd3d1bd54cb6f2e6423af2ad334a41cc0bce4cf6"
@@ -7389,22 +7455,22 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-prettier@1.17.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.0.tgz#53b303676eed22cc14a9f0cec09b477b3026c008"
-  integrity sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==
+prettier@1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
-pretty-quick@^1.10.0:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/pretty-quick/-/pretty-quick-1.11.1.tgz#462ffa2b93d24c05b7a0c3a001e08601a0c55ee4"
-  integrity sha512-kSXCkcETfak7EQXz6WOkCeCqpbC4GIzrN/vaneTGMP/fAtD8NerA9bPhCUqHAks1geo7biZNl5uEMPceeneLuA==
+pretty-quick@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pretty-quick/-/pretty-quick-2.0.1.tgz#417ee605ade98ecc686e72f63b5d28a2c35b43e9"
+  integrity sha512-y7bJt77XadjUr+P1uKqZxFWLddvj3SKY6EU4BuQtMxmmEFSMpbN132pUWdSG1g1mtUfO0noBvn7wBf0BVeomHg==
   dependencies:
-    chalk "^2.3.0"
-    execa "^0.8.0"
-    find-up "^2.1.0"
-    ignore "^3.3.7"
-    mri "^1.1.0"
-    multimatch "^3.0.0"
+    chalk "^2.4.2"
+    execa "^2.1.0"
+    find-up "^4.1.0"
+    ignore "^5.1.4"
+    mri "^1.1.4"
+    multimatch "^4.0.0"
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -8165,10 +8231,22 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 shell-quote@^1.4.3:
   version "1.7.2"
@@ -8623,6 +8701,11 @@ strip-eof@^1.0.0:
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
   integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
 
+strip-final-newline@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
+  integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
+
 strip-indent@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
@@ -9019,10 +9102,10 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-ts-node@^8.2.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.3.0.tgz#e4059618411371924a1fb5f3b125915f324efb57"
-  integrity sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==
+ts-node@^8.5.4:
+  version "8.5.4"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.5.4.tgz#a152add11fa19c221d0b48962c210cf467262ab2"
+  integrity sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==
   dependencies:
     arg "^4.1.0"
     diff "^4.0.1"
@@ -9030,13 +9113,12 @@ ts-node@^8.2.0:
     source-map-support "^0.5.6"
     yn "^3.0.0"
 
-tsconfig-paths@^3.8.0:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.8.0.tgz#4e34202d5b41958f269cf56b01ed95b853d59f72"
-  integrity sha512-zZEYFo4sjORK8W58ENkRn9s+HmQFkkwydDG7My5s/fnfr2YYCaiyXe/HBUcIgU8epEKOXwiahOO+KZYjiXlWyQ==
+tsconfig-paths@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"
+  integrity sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==
   dependencies:
     "@types/json5" "^0.0.29"
-    deepmerge "^2.0.1"
     json5 "^1.0.1"
     minimist "^1.2.0"
     strip-bom "^3.0.0"
@@ -9058,10 +9140,10 @@ tslint-no-unused-expression-chai@^0.1.4:
   dependencies:
     tsutils "^3.0.0"
 
-tslint@^5.17.0:
-  version "5.20.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.20.0.tgz#fac93bfa79568a5a24e7be9cdde5e02b02d00ec1"
-  integrity sha512-2vqIvkMHbnx8acMogAERQ/IuINOq6DFqgF8/VDvhEkBqQh/x6SP0Y+OHnKth9/ZcHQSroOZwUQSN18v8KKF0/g==
+tslint@^5.20.1:
+  version "5.20.1"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.20.1.tgz#e401e8aeda0152bc44dd07e614034f3f80c67b7d"
+  integrity sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     builtin-modules "^1.1.1"
@@ -9135,10 +9217,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.5.1:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.2.tgz#105b0f1934119dde543ac8eb71af3a91009efe54"
-  integrity sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==
+typescript@^3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
+  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
 
 uglify-js@^3.1.4:
   version "3.6.0"
@@ -9418,6 +9500,13 @@ which@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.1.tgz#f1cf94d07a8e571b6ff006aeb91d0300c47ef0a4"
   integrity sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==
+  dependencies:
+    isexe "^2.0.0"
+
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 


### PR DESCRIPTION
Bump TypeScript to `3.7.3` version (latest), along with bumping all TypeScript associated dev dependencies to their latest, for proper [TypeScript 3.7](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html) support.

Please note that the only dev dependency to get a major bump is `pretty-quick`, going from `1.x` to `2.x`. [Only breaking change in 2.x](https://github.com/azz/pretty-quick/releases/tag/v2.0.0) is a strong requirement on Node 8, which is already our minimal Node version requirement, so no issue there.

This PR also contains an update to the vscode workspace settings to use the version of TypeScript installed in the workspace, rather than the one shipped in vscode. This is achieved through [typescript.tsdk](https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-the-workspace-version-of-typescript) setting. This is needed because current stable release of vscode (October 2019) is still shipping with TypeScript 3.6 (next vscode release will ship with 3.7).

Finally, this PR contains some code refactoring, to make some statements less verbose, using new language constructs introduced in TypeScript 3.7, respectively [Optional Chaining](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#optional-chaining) and [Nullish Coalescing](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#nullish-coalescing). Did a quick pass through the code base, probably missed a lot of LOC where these constructs could be used, but will convert any other we notice, over time.


