### PR TITLE
Exclude json files from being packaged to bundle assets directory

### DIFF
--- a/ern-composite-gen/src/generateComposite.ts
+++ b/ern-composite-gen/src/generateComposite.ts
@@ -625,6 +625,39 @@ module.exports = {
       // Ignore android directories
       /.*\\/app\\/build\\/.*/,
     ]),
+    assetExts: [
+      // Image formats
+      "bmp",
+      "gif",
+      "jpg",
+      "jpeg",
+      "png",
+      "psd",
+      "svg",
+      "webp", 
+      // Video formats
+      "m4v",
+      "mov",
+      "mp4",
+      "mpeg",
+      "mpg",
+      "webm", 
+      // Audio formats
+      "aac",
+      "aiff",
+      "caf",
+      "m4a",
+      "mp3",
+      "wav", 
+      // Document formats
+      "html",
+      "pdf",
+      // Font formats
+      "otf",
+      "ttf", 
+      // Archives (virtual files)
+      "zip"
+    ]
   },
   transformer: {
     getTransformOptions: async () => ({


### PR DESCRIPTION
We noticed that `.json` files are being written to target `assets` directory when using `react-native bundle` command on composite.

This behavior was noticed starting from RN60 upgrade, and is linked to this commit in Metro https://github.com/facebook/metro/commit/dcb41e39f0df6ae1e0b3dfeff9ef5a69128830d5#diff-235a3e5d21175615e1cc254dd8b17eb2 that added `.json` to default assets list to be copied over.

Looks like the problem was experienced by some other users and reported. Imported `.json` files are backed into the JS bundle and therefore shouldn't have to be copied separately because they are not loaded dynamically at runtime (at the difference of images for example). For now the fix is just to override `assetExts` in the `metro.config.js` of the composite, by using all the same asset extensions, but excluding `json` files.

This problem is causing big issues internally, so this fix will be released immediately in `0.38.9` patch release.