### PR TITLE
Fix file mode of api-impl generated directories

### DIFF
--- a/ern-api-impl-gen/src/ApiImpl.ts
+++ b/ern-api-impl-gen/src/ApiImpl.ts
@@ -96,7 +96,7 @@ async function createOutputDirectory(
     log.info(
       `Deleting the existing directory and recreating a new one in ${outputDirectoryPath}`
     )
-    fileUtils.chmodr('777', outputDirectoryPath)
+    fileUtils.chmodr('755', outputDirectoryPath)
     shell.rm('-Rf', outputDirectoryPath)
   } else {
     log.debug(`creating output dir: ${outputDirectoryPath}`)

--- a/ern-api-impl-gen/src/generators/android/ApiImplAndroidGenerator.ts
+++ b/ern-api-impl-gen/src/generators/android/ApiImplAndroidGenerator.ts
@@ -15,8 +15,6 @@ import readDir from 'fs-readdir-recursive'
 import { ApiImplGeneratable } from '../../ApiImplGeneratable'
 
 export const ROOT_DIR = shell.pwd()
-const READ_EXECUTE = '555'
-const READ_WRITE_EXECUTE = '777'
 const SRC_MAIN_JAVA_DIR = path.normalize('src/main/java')
 const API_IMPL_PACKAGE = path.normalize('com/ern/api/impl')
 
@@ -94,7 +92,7 @@ export default class ApiImplAndroidGenerator implements ApiImplGeneratable {
 
       fs.ensureDirSync(outputDirectory)
 
-      fileUtils.chmodr(READ_WRITE_EXECUTE, outputDirectory)
+      fileUtils.chmodr('755', outputDirectory)
       shell.cp(
         '-Rf',
         path.join(paths.apiImplHull, 'android/{.*,*}'),
@@ -160,21 +158,6 @@ export default class ApiImplAndroidGenerator implements ApiImplGeneratable {
       `Copying code from ${pluginSrcDirectory} to ${pluginOutputDirectory}`
     )
     shell.cp('-Rf', pluginSrcDirectory, pluginOutputDirectory)
-  }
-
-  public async updateFilePermissions(
-    srcOutputDirectory: string,
-    editableFiles: string[]
-  ) {
-    log.debug('Updating file permissions')
-    const files = shell
-      .find(srcOutputDirectory)
-      .filter(file => file.endsWith('.java'))
-    for (const file of files) {
-      editableFiles.includes(file)
-        ? fileUtils.chmodr(READ_WRITE_EXECUTE, file)
-        : fileUtils.chmodr(READ_EXECUTE, file)
-    }
   }
 
   public updateBuildGradle(


### PR DESCRIPTION
This fixes the file mode of some directories generated by `ern-api-impl-gen`.

The default umask on macOS (and most Linux distributions) is `022`, there should be no need to give _group and world_ the executable bit on those directories. Generated directories will now have the default `755` instead of `777`.

It also removes an unused and unnecessary method related to file permissions.