### PR TITLE
fix(ern-api-gen): patch bad object ref, improve error messaging, patch $ref bugs

### DIFF
--- a/ern-api-gen/src/DefaultCodegen.ts
+++ b/ern-api-gen/src/DefaultCodegen.ts
@@ -1278,7 +1278,7 @@ export default class DefaultCodegen {
           }
           if (
             parent == null &&
-            (interfaceModel != null && interfaceModel instanceof ModelImpl) &&
+            interfaceModel != null && interfaceModel instanceof ModelImpl &&
             interfaceModel.getDiscriminator() != null
           ) {
             parent = _interface
@@ -1333,13 +1333,13 @@ export default class DefaultCodegen {
       let child = composed.getChild()
       if (
         child != null &&
-        (child != null && child instanceof RefModel) &&
+        child != null && child instanceof RefModel &&
         allDefinitions != null
       ) {
         const childRef = child.getSimpleRef()
         child = (allDefinitions as any).get(childRef)
       }
-      if (child != null && (child != null && child instanceof ModelImpl)) {
+      if (child != null && child != null && child instanceof ModelImpl) {
         this.addProperties(properties, required, child, allDefinitions)
         if (this.supportsInheritance) {
           this.addProperties(allProperties, allRequired, child, allDefinitions)
@@ -1372,7 +1372,9 @@ export default class DefaultCodegen {
   }
 
   public addAdditionPropertiesToCodeGenModel(codegenModel, swaggerModel) {
-    const mapProperty = new MapProperty(swaggerModel.getAdditionalProperties())
+    const swaggerAdditionalProperties = swaggerModel.getAdditionalProperties()
+    const mapProperty = new MapProperty()
+    mapProperty.setAdditionalProperties(swaggerAdditionalProperties)
     this.addParentContainer(codegenModel, codegenModel.name, mapProperty)
   }
 
@@ -1738,7 +1740,7 @@ export default class DefaultCodegen {
     } else if (swagger != null && isNotEmptySet(swagger.getConsumes())) {
       consumes = swagger.getConsumes()
       log.debug(
-        `No consumes defined in operation. 
+        `No consumes defined in operation.
 Using global consumes (${swagger.getConsumes()}) for ${op.operationId}`
       )
     }
@@ -1773,7 +1775,7 @@ Using global consumes (${swagger.getConsumes()}) for ${op.operationId}`
     ) {
       produces = swagger.getProduces()
       log.debug(
-        `No produces defined in operation. 
+        `No produces defined in operation.
 Using global produces (${swagger.getProduces()}) for ${op.operationId}`
       )
     }
@@ -2874,9 +2876,7 @@ Renamed to auto-generated operationId: ${operationId}`
       this.__supportingFiles.push(supportingFile)
     } else {
       log.info(
-        `Skipped overwriting ${
-          supportingFile.destinationFilename
-        } as the file already exists in folder`
+        `Skipped overwriting ${supportingFile.destinationFilename} as the file already exists in folder`
       )
     }
   }

--- a/ern-api-gen/src/DefaultGenerator.ts
+++ b/ern-api-gen/src/DefaultGenerator.ts
@@ -318,9 +318,12 @@ export default class DefaultGenerator extends AbstractGenerator {
           } catch (e) {
             rethrow(
               e,
-              "Could not process model '" +
-                name +
-                "'.Please make sure that your schema is correct!",
+              [
+                `Could not process model '${name}'`,
+                'Please make sure that your schema is correct!',
+                `Failed with error message: ${(e && e.message) ||
+                  'unknown error'}`,
+              ].join('\n'),
               e
             )
           }

--- a/ern-api-gen/src/languages/JavascriptClientCodegen.ts
+++ b/ern-api-gen/src/languages/JavascriptClientCodegen.ts
@@ -49,7 +49,7 @@ export default class JavascriptClientCodegen extends DefaultCodegen {
       let removedChildEnum = false
       for (const parentModelCodegenPropery of parentModelCodegenProperties) {
         if (parentModelCodegenPropery.isEnum) {
-          for (let i = codegenProperties.length; i--; ) {
+          for (let i = codegenProperties.length; i--;) {
             const codegenProperty = codegenProperties[i]
             if (
               codegenProperty.isEnum &&
@@ -350,7 +350,7 @@ export default class JavascriptClientCodegen extends DefaultCodegen {
         JavascriptClientCodegen.PROJECT_NAME
       )
     ) {
-      ;(this as any).setProjectName(
+      ; (this as any).setProjectName(
         this.__additionalProperties.get(JavascriptClientCodegen.PROJECT_NAME)
       )
     }
@@ -359,7 +359,7 @@ export default class JavascriptClientCodegen extends DefaultCodegen {
         JavascriptClientCodegen.MODULE_NAME
       )
     ) {
-      ;(this as any).setModuleName(
+      ; (this as any).setModuleName(
         this.__additionalProperties.get(JavascriptClientCodegen.MODULE_NAME)
       )
     }
@@ -368,7 +368,7 @@ export default class JavascriptClientCodegen extends DefaultCodegen {
         JavascriptClientCodegen.PROJECT_DESCRIPTION
       )
     ) {
-      ;(this as any).setProjectDescription(
+      ; (this as any).setProjectDescription(
         this.__additionalProperties.get(
           JavascriptClientCodegen.PROJECT_DESCRIPTION
         )
@@ -379,7 +379,7 @@ export default class JavascriptClientCodegen extends DefaultCodegen {
         JavascriptClientCodegen.PROJECT_VERSION
       )
     ) {
-      ;(this as any).setProjectVersion(
+      ; (this as any).setProjectVersion(
         this.__additionalProperties.get(JavascriptClientCodegen.PROJECT_VERSION)
       )
     }
@@ -388,7 +388,7 @@ export default class JavascriptClientCodegen extends DefaultCodegen {
         JavascriptClientCodegen.PROJECT_LICENSE_NAME
       )
     ) {
-      ;(this as any).setProjectLicenseName(
+      ; (this as any).setProjectLicenseName(
         this.__additionalProperties.get(
           JavascriptClientCodegen.PROJECT_LICENSE_NAME
         )
@@ -399,21 +399,21 @@ export default class JavascriptClientCodegen extends DefaultCodegen {
         CodegenConstants.LOCAL_VARIABLE_PREFIX
       )
     ) {
-      ;(this as any).setLocalVariablePrefix(
+      ; (this as any).setLocalVariablePrefix(
         this.__additionalProperties.get(CodegenConstants.LOCAL_VARIABLE_PREFIX)
       )
     }
     if (
       this.__additionalProperties.containsKey(CodegenConstants.SOURCE_FOLDER)
     ) {
-      ;(this as any).setSourceFolder(
+      ; (this as any).setSourceFolder(
         this.__additionalProperties.get(CodegenConstants.SOURCE_FOLDER)
       )
     }
     if (
       this.__additionalProperties.containsKey(CodegenConstants.INVOKER_PACKAGE)
     ) {
-      ;(this as any).setInvokerPackage(
+      ; (this as any).setInvokerPackage(
         this.__additionalProperties.get(CodegenConstants.INVOKER_PACKAGE)
       )
     }
@@ -442,7 +442,7 @@ export default class JavascriptClientCodegen extends DefaultCodegen {
         JavascriptClientCodegen.EMIT_MODEL_METHODS
       )
     ) {
-      ;(this as any).setEmitModelMethods(
+      ; (this as any).setEmitModelMethods(
         parseBoolean(
           this.__additionalProperties.get(
             JavascriptClientCodegen.EMIT_MODEL_METHODS
@@ -455,7 +455,7 @@ export default class JavascriptClientCodegen extends DefaultCodegen {
         JavascriptClientCodegen.EMIT_JS_DOC
       )
     ) {
-      ;(this as any).setEmitJSDoc(
+      ; (this as any).setEmitJSDoc(
         parseBoolean(
           this.__additionalProperties.get(JavascriptClientCodegen.EMIT_JS_DOC)
         )
@@ -483,8 +483,8 @@ export default class JavascriptClientCodegen extends DefaultCodegen {
           JavascriptClientCodegen.PROJECT_LICENSE_NAME
         ) == null
       ) {
-        if (info.getLicense() != null) {
-          const license = info.getLicense()
+        const license = info.getLicense()
+        if (license && license.getName()) {
           this.__additionalProperties.put(
             JavascriptClientCodegen.PROJECT_LICENSE_NAME,
             this.sanitizeName(license.getName())

--- a/ern-api-gen/src/models/factory.ts
+++ b/ern-api-gen/src/models/factory.ts
@@ -105,6 +105,22 @@ export function factory(prop, parent?: any) {
       return prop
     }
   }
+  if (!prop || !Object.keys(prop).length) {
+    let debugAssistText = ''
+    if (parent && parent.getParent && parent.getParent()) {
+      debugAssistText = `{ ${Object.keys(parent.getParent()).join(', ')} } `
+    }
+    throw new Error(
+      [
+        'Empty property or key-less object detected.',
+        debugAssistText
+          ? `Try inspecting schema with shape: ${debugAssistText}`
+          : '',
+      ]
+        .filter(Boolean)
+        .join('\n')
+    )
+  }
   const PropertyClz = resolve(prop)
   if (!PropertyClz) {
     throw new Error(`Can not resolve property for ${prop}`)

--- a/ern-api-gen/src/models/properties/ObjectPropertyBase.ts
+++ b/ern-api-gen/src/models/properties/ObjectPropertyBase.ts
@@ -6,7 +6,7 @@ import { has } from '../../java/beanUtils'
 
 function objectToPropertyMap(obj) {
   return newHashMap(
-    ...Object.keys(obj).map(key => [key, factory(obj[key], this)])
+    ...Object.keys(obj).map(key => [key, factory(obj[key], obj)])
   )
 }
 

--- a/ern-api-gen/src/models/properties/ObjectPropertyBase.ts
+++ b/ern-api-gen/src/models/properties/ObjectPropertyBase.ts
@@ -39,7 +39,9 @@ export class ObjectPropertyBase extends Property {
     if (!properties) {
       this._additionalProperties = null
     }
-    if (properties.type) {
+    // @todo the ref support here is only dangerously supported
+    // { $ref: '#/definition/ModelName }
+    if (properties.type || properties.$ref || properties.genericRef) {
       this._additionalProperties = factory(properties)
     } else {
       this._additionalProperties = objectToPropertyMap(properties)

--- a/ern-api-gen/test/api-test.js
+++ b/ern-api-gen/test/api-test.js
@@ -8,8 +8,9 @@ import CodegenConfigurator from '../src/config/CodegenConfigurator'
 import Langs from '../src/cmd/Langs'
 import fs from 'fs'
 import { log } from 'ern-core'
+import { expect } from 'chai'
 
-describe('api schemas', function() {
+describe('api schemas', async function() {
   this.timeout(50000)
 
   const { compare, runBefore, cwd, runAfter } = ernUtilDev(__dirname, true)
@@ -26,47 +27,23 @@ describe('api schemas', function() {
     })
   }
 
-  const generateObj = function(config) {
-    const thens = []
-    const f = async function() {
-      const outputDir = cwd(config.outputDir)
-      const tmpFile = new File(outputDir)
-      if (tmpFile.exists()) {
-        shell.rm('-rf', tmpFile)
-      }
-
-      tmpFile.mkdirs()
-      config.inputSpec = path.join(__dirname, 'fixtures', config.inputSpec)
-      config.outputDir = outputDir
-      config.bridgeVersion = '1.0.0'
-      config.apiPackage = 'com.ern.test'
-      const cc = new CodegenConfigurator(config)
-
-      const opts = await cc.toClientOptInput()
-      const d = new DefaultGenerator().opts(opts)
-      try {
-        d.generate()
-        for (const [success] of thens) {
-          await success()
-        }
-      } catch (e) {
-        log.trace(e)
-        if (!thens || thens.length == 0) throw e
-        for (const [s, fail] of thens) {
-          if (fail) {
-            fail(e)
-          } else {
-            throw e
-          }
-        }
-      }
-    }
-    f.then = (...args) => {
-      thens.push(args)
-      return f
+  const generateObj = async function(config) {
+    const outputDir = cwd(config.outputDir)
+    const tmpFile = new File(outputDir)
+    if (tmpFile.exists()) {
+      shell.rm('-rf', tmpFile)
     }
 
-    return f
+    tmpFile.mkdirs()
+    config.inputSpec = path.join(__dirname, 'fixtures', config.inputSpec)
+    config.outputDir = outputDir
+    config.bridgeVersion = '1.0.0'
+    config.apiPackage = 'com.ern.test'
+    const cc = new CodegenConfigurator(config)
+
+    const opts = await cc.toClientOptInput()
+    const d = new DefaultGenerator().opts(opts)
+    return d.generate()
   }
 
   function npm(command, dir) {
@@ -78,20 +55,40 @@ describe('api schemas', function() {
     }
   }
 
-  const specs = fs.readdirSync(path.join(__dirname, 'fixtures', 'apis'))
+  const specs = fs
+    .readdirSync(path.join(__dirname, 'fixtures', 'apis'))
+    .filter(basename => !basename.match(/invalid/))
+  const invalidSpecsByName = {
+    emptyProperty: 'empty-property.json',
+  }
   const langs = Langs.langs()
   for (const lang of langs) {
     describe(lang, function() {
       for (const inputSpec of specs) {
-        it(
-          `apis should generate '${inputSpec}' for '${lang}'`,
-          generateObj({
+        it(`apis should generate '${inputSpec}' for '${lang}'`, async () => {
+          const api = await generateObj({
             inputSpec: `apis/${inputSpec}`,
             lang,
             outputDir: `apis/${inputSpec.replace(/\./, '_')}/${lang}`,
           })
-        )
+          expect(api).to.have.length.greaterThan(0)
+        })
       }
+      // manually exec invalid api expecations
+      it(`apis shouldn't generate 'empty-property' for '${lang}'`, () =>
+        generateObj({
+          inputSpec: `apis/invalid/${invalidSpecsByName.emptyProperty}`,
+          lang,
+          outputDir: `apis/invalid/${invalidSpecsByName.emptyProperty.replace(
+            /\./,
+            '_'
+          )}/${lang}`,
+        })
+          .then(api => expect(api).to.not.exist)
+          .catch(err => {
+            expect(err.message.match(/Empty/))
+            expect(err.message.match(/Try inspecting/))
+          }))
     })
   }
   /* it(`should generate 'analytics.json' for 'ES6ERN'`, generateObj({

--- a/ern-api-gen/test/fixtures/apis/invalid/empty-property.json
+++ b/ern-api-gen/test/fixtures/apis/invalid/empty-property.json
@@ -1,0 +1,40 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "TestApiDescription",
+    "version": "0.16.1",
+    "title": "TestApi"
+  },
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/testCall": {
+      "post": {
+        "tags": [
+          "TestApiCall"
+        ],
+        "operationId": "testCall",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "'#/definitions/TestResponse"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "TestResponse": {
+      "type": "object",
+      "properties": {
+        "errors": {
+          "type": "array",
+          "items": {}
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# problem

on generating an api, i encountered this:

```
$ ern regen-api
[v0.38.7] [Cauldron: -NONE-]
✔ Syncing https://github.com/electrode-io/electrode-native-manifest.git Manifest 1s
? Would you like to bump the plugin version from [react-native-walmartsmartlist-api@1.8
✔ Syncing https://github.com/electrode-io/electrode-native-manifest.git Manifest 1s
✖ An error occurred: Could not resolve type undefined undefined
```

as you can see, the error message is invalid and not actionable.

additionally,

- regen-api was attempting to set an undefined value if license was omitted
- regen-api was _not_ setting `additionalProperties` appropriately
- regen-api was not handling $refs in additionalProperties

# solution

- fix the invalid `parent` reference passed into the function stack that induces the reported error
- enhance the error messaging to direct the user more closely to his/her failing code
- test it.
- set `additionalProperties`
- do not set an undefined license value
- permit $ref processing in additionalProperties

# discussion

- now the user gets meaningful, actionable information on error:

![image](https://user-images.githubusercontent.com/1003261/71702634-7d0b1500-2d85-11ea-84a7-9ba33011fa01.png)

- the regen-fixtures-check may need some re-wiring:
```
$ node regen-fixtures-check
fatal: ambiguous argument 'ORIG_HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
child_process.js:642
    throw err;
    ^

Error: Command failed: git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD
fatal: ambiguous argument 'ORIG_HEAD': unknown revision or path not in the working tree.
```