### PR TITLE
Add new devJsBundle option to create-container command

### DIFF
--- a/docs/cli/create-container.md
+++ b/docs/cli/create-container.md
@@ -19,6 +19,11 @@
 * Create a new container including all the MiniApps listed in the Cauldron for the given *complete native application descriptor*  
 * Use this option if you want to locally generate a container that mirrors the container of a given native application version.  
 
+`--devJsBundle`  
+
+* Will generate a development JavaScript bundle rather than a production one.
+**Default** false
+
 `--fromGitBranches`
 
 * Create Container using the latest commits made to each of the MiniApp branches (HEAD), rather than using the MiniApps SHAs that are inside the current Container version.  

--- a/ern-container-gen/src/generateContainer.ts
+++ b/ern-container-gen/src/generateContainer.ts
@@ -61,6 +61,7 @@ export async function generateContainer(
     .run(
       bundleMiniAppsFromComposite({
         compositeDir: config.composite.path,
+        dev: !!config.devJsBundle,
         outDir: config.outDir,
         platform: config.targetPlatform,
         sourceMapOutput: config.sourceMapOutput,

--- a/ern-container-gen/src/types/ContainerGeneratorConfig.ts
+++ b/ern-container-gen/src/types/ContainerGeneratorConfig.ts
@@ -35,4 +35,8 @@ export interface ContainerGeneratorConfig {
    * Path to source map file
    */
   sourceMapOutput?: string
+  /**
+   * Indicates whether to generate a dev or release JS bundle
+   */
+  devJsBundle?: boolean
 }

--- a/ern-local-cli/src/commands/create-container.ts
+++ b/ern-local-cli/src/commands/create-container.ts
@@ -54,6 +54,11 @@ export const builder = (argv: Argv) => {
         'Optional extra run configuration (json string or local/cauldron path to config file)',
       type: 'string',
     })
+    .option('devJsBundle', {
+      describe:
+        'Generate a development JavaScript bundle rather than a production one',
+      type: 'boolean',
+    })
     .option('fromGitBranches', {
       describe:
         'Create Container based on MiniApps branches rather than current MiniApps SHAs',
@@ -98,6 +103,7 @@ export const commandHandler = async ({
   baseComposite,
   compositeDir,
   descriptor,
+  devJsBundle,
   extra,
   fromGitBranches,
   ignoreRnpmAssets,
@@ -110,6 +116,7 @@ export const commandHandler = async ({
   baseComposite?: PackagePath
   compositeDir?: string
   descriptor?: AppVersionDescriptor
+  devJsBundle?: boolean
   extra?: string
   fromGitBranches?: boolean
   ignoreRnpmAssets?: boolean
@@ -178,6 +185,7 @@ Output directory should either not exist (it will be created) or should be empty
     outDir = outDir || Platform.getContainerGenOutDirectory(platform)
     await kax.task('Generating Container locally').run(
       runLocalContainerGen(platform, composite, {
+        devJsBundle,
         extra: extraObj,
         ignoreRnpmAssets,
         outDir,
@@ -197,6 +205,7 @@ Output directory should either not exist (it will be created) or should be empty
       outDir || Platform.getContainerGenOutDirectory(descriptor.platform!)
     await kax.task('Generating Container from Cauldron').run(
       runCauldronContainerGen(descriptor, composite, {
+        devJsBundle,
         outDir,
         sourceMapOutput,
       })

--- a/ern-orchestrator/src/container.ts
+++ b/ern-orchestrator/src/container.ts
@@ -36,12 +36,14 @@ export async function runLocalContainerGen(
     jsMainModuleName,
     extra,
     sourceMapOutput,
+    devJsBundle,
   }: {
     outDir?: string
     ignoreRnpmAssets?: boolean
     jsMainModuleName?: string
     extra?: any
     sourceMapOutput?: string
+    devJsBundle?: boolean
   }
 ): Promise<ContainerGenResult> {
   try {
@@ -54,6 +56,7 @@ export async function runLocalContainerGen(
       generator.generate({
         androidConfig: (extra && extra.androidConfig) || {},
         composite,
+        devJsBundle,
         ignoreRnpmAssets,
         jsMainModuleName,
         outDir,
@@ -73,10 +76,12 @@ export async function runCauldronContainerGen(
   napDescriptor: AppVersionDescriptor,
   composite: Composite,
   {
+    devJsBundle,
     jsMainModuleName,
     outDir,
     sourceMapOutput,
   }: {
+    devJsBundle?: boolean
     jsMainModuleName?: string
     outDir?: string
     sourceMapOutput?: string
@@ -107,6 +112,10 @@ export async function runCauldronContainerGen(
           androidConfig:
             containerGeneratorConfig && containerGeneratorConfig.androidConfig,
           composite,
+          devJsBundle:
+            devJsBundle === undefined
+              ? containerGeneratorConfig.devJsBundle
+              : devJsBundle,
           ignoreRnpmAssets:
             containerGeneratorConfig &&
             containerGeneratorConfig.ignoreRnpmAssets,


### PR DESCRIPTION
Add new `--devJsBundle` option flag to `create-container` command to generate and inject a dev JavaScript bundle in the locally generated container, rather than a production one.

This new flag is part of the `ContainerGeneratorConfig` meaning that it can also be specified in a container generator configuration in Cauldron, to generate containers with a dev JS bundle rather than a production one.

Closes https://github.com/electrode-io/electrode-native/issues/1461