### PR TITLE
iOS - add extra dev menu

### DIFF
--- a/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeReactNative.m
+++ b/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeReactNative.m
@@ -329,6 +329,24 @@ static NSString *enableBundleStore = @"enableBundleStore";
         [RCTPresentedViewController() presentViewController:navController animated:YES completion:NULL];
     }];
     [[self.bridge devMenu] addItem:dev];
+    BOOL enableDev = [[RCTBundleURLProvider sharedSettings] enableDev];
+    NSString *enableDevTitle = enableDev ? @"Disable Dev": @"Enable Dev";
+    RCTDevMenuItem *enableDevMenu = [RCTDevMenuItem buttonItemWithTitle:enableDevTitle handler:^{
+        [[RCTBundleURLProvider sharedSettings] setEnableDev:!enableDev];
+        __strong RCTBridge *strongBridge = self.bridge;
+        strongBridge.bundleURL = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+        [strongBridge reload];
+    }];
+    [[self.bridge devMenu] addItem:enableDevMenu];
+    BOOL enableMinify = [[RCTBundleURLProvider sharedSettings] enableMinification];
+    NSString *minifyTitle = enableMinify ? @"Disable Minification" : @"Enable Minification";
+    RCTDevMenuItem *enableMinifyMenu = [RCTDevMenuItem buttonItemWithTitle:minifyTitle handler:^{
+        [[RCTBundleURLProvider sharedSettings] setEnableMinification:!enableMinify];
+        __strong RCTBridge *strongBridge = self.bridge;
+        strongBridge.bundleURL = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+        [strongBridge reload];
+    }];
+    [[self.bridge devMenu] addItem:enableMinifyMenu];
 }
 
 - (void) signalElectrodeOnReactNativeInitialized: (NSNotification *) notification {

--- a/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeReactNative.m
+++ b/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeReactNative.m
@@ -274,6 +274,24 @@ static NSString *enableBundleStore = @"enableBundleStore";
         [RCTPresentedViewController() presentViewController:navController animated:YES completion:NULL];
     }];
     [[self.bridge devMenu] addItem:dev];
+    BOOL enableDev = [[RCTBundleURLProvider sharedSettings] enableDev];
+    NSString *enableDevTitle = enableDev ? @"Disable Dev": @"Enable Dev";
+    RCTDevMenuItem *enableDevMenu = [RCTDevMenuItem buttonItemWithTitle:enableDevTitle handler:^{
+        [[RCTBundleURLProvider sharedSettings] setEnableDev:!enableDev];
+        __strong RCTBridge *strongBridge = self.bridge;
+        strongBridge.bundleURL = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+        [strongBridge reload];
+    }];
+    [[self.bridge devMenu] addItem:enableDevMenu];
+    BOOL enableMinify = [[RCTBundleURLProvider sharedSettings] enableMinification];
+    NSString *minifyTitle = enableMinify ? @"Disable Minification" : @"Enable Minification";
+    RCTDevMenuItem *enableMinifyMenu = [RCTDevMenuItem buttonItemWithTitle:minifyTitle handler:^{
+        [[RCTBundleURLProvider sharedSettings] setEnableMinification:!enableMinify];
+        __strong RCTBridge *strongBridge = self.bridge;
+        strongBridge.bundleURL = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+        [strongBridge reload];
+    }];
+    [[self.bridge devMenu] addItem:enableMinifyMenu];
 }
 
 - (void) signalElectrodeOnReactNativeInitialized: (NSNotification *) notification {


### PR DESCRIPTION
add `Disable/EnableDev` and `Disable/Enable Minification` in dev Menu.
In android react native has a dev menu that allow users to disable/enable dev/minification but in iOS dev option is switched on and minification is switched off. we add two extra dev menu items to toggle these two values.
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-01-30 at 17 57 44](https://user-images.githubusercontent.com/52257109/73566170-090d6c80-4418-11ea-970d-d4e26a07ec0c.png)
