### PR TITLE
Fix local run of system tests

### DIFF
--- a/system-tests/tests/create-api-impl-js-fixture.js
+++ b/system-tests/tests/create-api-impl-js-fixture.js
@@ -15,7 +15,8 @@ const excludeFilter = [
   'WalmartItemApi.spec.js',
   'SysteTestEventApi.spec.js',
   'SystemTestsApi.spec.js',
-  '.yarn-integrity'
+  '.yarn-integrity',
+  'node_modules'
 ].map(s => `**/${s}`).join(',')
 
 run(`create-api-impl ${f.movieApiPkgName} -p ${f.movieApiImplPkgName} --skipNpmCheck --jsOnly --outputDirectory ${process.cwd()} --force`)

--- a/system-tests/tests/create-api-impl-native-fixture.js
+++ b/system-tests/tests/create-api-impl-native-fixture.js
@@ -16,7 +16,8 @@ const excludeFilter = [
   'SysteTestEventApi.spec.js',
   'SystemTestsApi.spec.js',
   '.yarn-integrity',
-  'ElectrodeApiImpl/Libraries'
+  'ElectrodeApiImpl/Libraries',
+  'node_modules'
 ].map(s => `**/${s}`).join(',')
 
 run(`create-api-impl ${f.movieApiPkgName} -p ${f.movieApiImplPkgName} --skipNpmCheck --nativeOnly --outputDirectory ${process.cwd()} --force`)


### PR DESCRIPTION
Fix a bug that is causing system tests to fail when run locally, under certain conditions (after a local fixture regeneration for api-impl fixtures, `node_modules` directory is created locally -excluded from git- and as it was not excluded from the list of directories to parse to compare files from, it was failing in case the fixture had been regenerated a while back and some node_modules files changed since then).

On another note, noticed through this PR that the files under `system-tests/tests` are excluded from prettier checks. Can see that due to missing trailing comma in arrays. Shouldn't be the case, created issue https://github.com/electrode-io/electrode-native/issues/1474 for follow up on this.