### PR TITLE
Fix yarn info bug

### DIFF
--- a/ern-core/src/YarnCli.ts
+++ b/ern-core/src/YarnCli.ts
@@ -98,7 +98,11 @@ export class YarnCli {
         cp.stderr.on('data', data => {
           log.trace(data)
           const jsonLine = JSON.parse(data.toString())
-          reject(jsonLine.data)
+          // 'warning' and 'error' packet types are sent to stderr
+          // we want to fail only on 'error'
+          if (jsonLine.type === 'error') {
+            reject(jsonLine.data)
+          }
         })
       })
     }


### PR DESCRIPTION
Fix a bug in `YarnCli:info` method, causing the method, in some conditions, to wrongly reject the promise.