### PR TITLE
Speedup yarn info for local packages

### DIFF
--- a/ern-api-impl-gen/src/generators/ApiImplGen.ts
+++ b/ern-api-impl-gen/src/generators/ApiImplGen.ts
@@ -34,7 +34,7 @@ export default class ApiImplGen {
     const schemaJson = path.join(
       paths.outDirectory,
       'node_modules',
-      apiPackagePath.basePath,
+      apiPackagePath.name!,
       'schema.json'
     )
 
@@ -100,7 +100,7 @@ export default class ApiImplGen {
       }
 
       if (pluginsNames.length === 0) {
-        log.info(`no other dependencies found for ${apiPackagePath.basePath}`)
+        log.info(`no other dependencies found for ${apiPackagePath.name}`)
       }
 
       return _.map(pluginsNames, PackagePath.fromString)

--- a/ern-api-impl-gen/src/generators/android/ApiImplAndroidGenerator.ts
+++ b/ern-api-impl-gen/src/generators/android/ApiImplAndroidGenerator.ts
@@ -108,7 +108,7 @@ export default class ApiImplAndroidGenerator implements ApiImplGeneratable {
       for (pluginPath of pluginsPaths) {
         const pluginConfig = await manifest.getPluginConfig(pluginPath)
         if (pluginConfig) {
-          log.debug(`Copying ${pluginPath.basePath} to ${outputDirectory}`)
+          log.debug(`Copying ${pluginPath.name} to ${outputDirectory}`)
           this.copyPluginToOutput(
             paths,
             srcOutputDirectory,
@@ -135,17 +135,17 @@ export default class ApiImplAndroidGenerator implements ApiImplGeneratable {
     pluginPath: PackagePath,
     pluginConfig: PluginConfig
   ) {
-    if (pluginPath.basePath === 'react-native') {
+    if (pluginPath.name === 'react-native') {
       return
     }
     if (!pluginConfig.android) {
       throw new Error('Missing android plugin configuration')
     }
-    log.debug(`injecting ${pluginPath.basePath} code.`)
+    log.debug(`injecting ${pluginPath.name} code.`)
     const pluginSrcDirectory = path.join(
       paths.outDirectory,
       'node_modules',
-      pluginPath.basePath,
+      pluginPath.name!,
       'android',
       pluginConfig.android.moduleName,
       SRC_MAIN_JAVA_DIR,

--- a/ern-api-impl-gen/src/generators/js/ApiImplJsGenerator.ts
+++ b/ern-api-impl-gen/src/generators/js/ApiImplJsGenerator.ts
@@ -42,7 +42,7 @@ export default class ApiImplJsGenerator implements ApiImplGeneratable {
       )
 
       for (const api of apis) {
-        api.packageName = apiDependency.basePath
+        api.packageName = apiDependency.name
         await mustacheUtils.mustacheRenderToOutputFileUsingTemplateFile(
           mustacheFile,
           api,

--- a/ern-cauldron-api/src/CauldronHelper.ts
+++ b/ern-cauldron-api/src/CauldronHelper.ts
@@ -256,11 +256,14 @@ export class CauldronHelper {
       descriptor,
       'Cannot add a native dependency to a released native app version'
     )
-    return this.cauldron.setPackagesInContainer(
-      descriptor,
-      dependencies,
-      'nativeDeps'
+
+    // Make sure we transform local fs package path to registry paths
+    // for native dependencies
+    const deps = dependencies.map(d =>
+      PackagePath.fromString(`${d.name}@${d.version}`)
     )
+
+    return this.cauldron.setPackagesInContainer(descriptor, deps, 'nativeDeps')
   }
 
   public async removeMiniAppFromContainer(

--- a/ern-composite-gen/src/Composite.ts
+++ b/ern-composite-gen/src/Composite.ts
@@ -2,7 +2,6 @@ import {
   NativeDependencies,
   findNativeDependencies,
   PackagePath,
-  NativeDependency,
   readPackageJsonSync,
   BaseMiniApp,
   nativeDepenciesVersionResolution,
@@ -69,7 +68,7 @@ export class Composite {
     const result: PackagePath[] = []
     for (const dependency of dependencies.resolved) {
       // Always include react-native
-      if (dependency.basePath === 'react-native') {
+      if (dependency.name === 'react-native') {
         result.push(dependency)
         continue
       }
@@ -136,27 +135,12 @@ export class Composite {
     // if developer(s) forgot to npm ignore the android/ios directory
     const miniAppsPaths = this.getMiniAppsPackages().map(p => p.path)
     nativeDependencies.all = nativeDependencies.all.filter(
-      x => !miniAppsPaths.includes(x.path)
+      x => !miniAppsPaths.includes(x.basePath)
     )
     nativeDependencies.thirdPartyNotInManifest = nativeDependencies.thirdPartyNotInManifest.filter(
-      x => !miniAppsPaths.includes(x.path)
+      x => !miniAppsPaths.includes(x.basePath)
     )
     this.cachedNativeDependencies = nativeDependencies
     return this.cachedNativeDependencies
-  }
-
-  /**
-   * Get the local absolute path of a given native dependency in this Composite
-   * Returns undefined if no matching dependency was found in this Composite
-   * @param d Native dependency to find in the composite
-   */
-  public async getNativeDependencyPath(d: PackagePath): Promise<string | void> {
-    const dependencies = await this.getNativeDependencies()
-    const dependency: NativeDependency | void = dependencies.all.find(x =>
-      x.packagePath.same(d)
-    )
-    if (dependency) {
-      return dependency.path
-    }
   }
 }

--- a/ern-composite-gen/test/compositegen-test.ts
+++ b/ern-composite-gen/test/compositegen-test.ts
@@ -248,7 +248,9 @@ describe('ern-container-gen utils.js', () => {
   // ==========================================================
   describe('generateComposite [with yarn lock]', () => {
     it('should throw an exception if at least one of the MiniApp path is using a file scheme [1]', async () => {
-      const miniApps = [PackagePath.fromString('file:/Code/MiniApp')]
+      const miniApps = [
+        PackagePath.fromString(path.join(__dirname, 'fixtures', 'miniapp')),
+      ]
       assert(
         await doesThrow(generateComposite, null, {
           miniApps,
@@ -262,7 +264,7 @@ describe('ern-container-gen utils.js', () => {
     it('should throw an exception if at least one of the MiniApp path is using a file scheme [2]', async () => {
       const miniApps = [
         PackagePath.fromString('MiniAppOne@1.0.0'),
-        PackagePath.fromString('file:/Code/MiniApp'),
+        PackagePath.fromString(path.join(__dirname, 'fixtures', 'miniapp')),
       ]
       assert(
         await doesThrow(generateComposite, null, {

--- a/ern-composite-gen/test/fixtures/miniapp/package.json
+++ b/ern-composite-gen/test/fixtures/miniapp/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "miniapp",
+  "version": "1.0.0"
+}

--- a/ern-container-gen-android/src/AndroidGenerator.ts
+++ b/ern-container-gen-android/src/AndroidGenerator.ts
@@ -79,7 +79,7 @@ export default class AndroidGenerator implements ContainerGenerator {
 
     const reactNativePlugin = _.find(
       config.plugins,
-      p => p.basePath === 'react-native'
+      p => p.name === 'react-native'
     )
 
     if (!reactNativePlugin) {
@@ -102,7 +102,7 @@ export default class AndroidGenerator implements ContainerGenerator {
 
     const electrodeBridgePlugin = _.find(
       config.plugins,
-      p => p.basePath === 'react-native-electrode-bridge'
+      p => p.name === 'react-native-electrode-bridge'
     )
 
     if (electrodeBridgePlugin) {
@@ -141,28 +141,22 @@ export default class AndroidGenerator implements ContainerGenerator {
         continue
       }
 
-      if (plugin.basePath === 'react-native') {
+      if (plugin.name === 'react-native') {
         continue
       }
 
       if (!pluginConfig.android) {
         log.warn(
-          `Skipping ${plugin.basePath} as it does not have an Android configuration`
+          `Skipping ${plugin.name} as it does not have an Android configuration`
         )
         continue
       }
 
-      injectPluginsKaxTask.text = `${injectPluginsTaskMsg} [${plugin.basePath}]`
+      injectPluginsKaxTask.text = `${injectPluginsTaskMsg} [${plugin.name}]`
 
       let pathToPluginProject
 
-      const pluginSourcePath = await config.composite.getNativeDependencyPath(
-        plugin
-      )
-      if (!pluginSourcePath) {
-        throw new Error(`path to ${plugin.basePath} not found in composite`)
-      }
-
+      const pluginSourcePath = plugin.basePath
       if (await coreUtils.isDependencyPathNativeApiImpl(pluginSourcePath)) {
         // For native api implementations, if a 'ern.pluginConfig' object
         // exists in its package.json, replace pluginConfig with this one.
@@ -598,7 +592,7 @@ export default class AndroidGenerator implements ContainerGenerator {
     outDir: string
   ): Promise<any> {
     for (const plugin of plugins) {
-      if (plugin.basePath === 'react-native') {
+      if (plugin.name === 'react-native') {
         continue
       }
       const pluginConfig = await manifest.getPluginConfig(plugin)
@@ -607,7 +601,7 @@ export default class AndroidGenerator implements ContainerGenerator {
       }
       if (!pluginConfig.android) {
         log.warn(
-          `Skipping ${plugin.basePath} as it does not have an Android configuration`
+          `Skipping ${plugin.name} as it does not have an Android configuration`
         )
         continue
       }
@@ -640,7 +634,7 @@ export default class AndroidGenerator implements ContainerGenerator {
     )
     const reactNativeCodePushPlugin = _.find(
       plugins,
-      p => p.basePath === 'react-native-code-push'
+      p => p.name === 'react-native-code-push'
     )
     if (reactNativeCodePushPlugin) {
       mustacheView.isCodePushPluginIncluded = true

--- a/ern-container-gen-ios/src/IosGenerator.ts
+++ b/ern-container-gen-ios/src/IosGenerator.ts
@@ -88,7 +88,7 @@ export default class IosGenerator implements ContainerGenerator {
 
     const reactNativePlugin = _.find(
       config.plugins,
-      p => p.basePath === 'react-native'
+      p => p.name === 'react-native'
     )
     if (!reactNativePlugin) {
       throw new Error('react-native was not found in plugins list !')
@@ -171,7 +171,7 @@ export default class IosGenerator implements ContainerGenerator {
     outDir: string
   ): Promise<any> {
     for (const plugin of plugins) {
-      if (plugin.basePath === 'react-native') {
+      if (plugin.name === 'react-native') {
         continue
       }
       const pluginConfig = await manifest.getPluginConfig(plugin)
@@ -180,7 +180,7 @@ export default class IosGenerator implements ContainerGenerator {
       }
       if (!pluginConfig.ios) {
         log.warn(
-          `${plugin.basePath} does not have any injection configuration for ios platform`
+          `${plugin.name} does not have any injection configuration for ios platform`
         )
         continue
       }
@@ -249,13 +249,8 @@ export default class IosGenerator implements ContainerGenerator {
         continue
       }
 
-      const pluginSourcePath = await composite.getNativeDependencyPath(plugin)
-      if (!pluginSourcePath) {
-        throw new Error(`path to ${plugin.basePath} not found in composite`)
-      }
-
-      if (await utils.isDependencyPathNativeApiImpl(pluginSourcePath)) {
-        populateApiImplMustacheView(pluginSourcePath, mustacheView, true)
+      if (await utils.isDependencyPathNativeApiImpl(plugin.basePath)) {
+        populateApiImplMustacheView(plugin.basePath, mustacheView, true)
       }
     }
 

--- a/ern-container-gen/src/addContainerMetadata.ts
+++ b/ern-container-gen/src/addContainerMetadata.ts
@@ -8,7 +8,7 @@ export async function addContainerMetadata(conf: ContainerGeneratorConfig) {
     ernVersion: Platform.currentVersion,
     jsApiImpls: conf.composite.getJsApiImpls().map(j => j.toString()),
     miniApps: conf.composite.getMiniApps().map(m => m.packagePath.toString()),
-    nativeDeps: conf.plugins.map(p => p.toString()),
+    nativeDeps: conf.plugins.map(p => `${p.name}@${p.version}`),
     platform: conf.targetPlatform,
   }
   const pathToMetadataFile = getContainerMetadataPath(conf.outDir)

--- a/ern-container-gen/src/generateContainer.ts
+++ b/ern-container-gen/src/generateContainer.ts
@@ -37,7 +37,7 @@ export async function generateContainer(
 
   const reactNativePlugin = _.find(
     config.plugins,
-    p => p.basePath === 'react-native'
+    p => p.name === 'react-native'
   )
 
   // React-native plugin should be first in the dependencies

--- a/ern-container-gen/src/generatePluginsMustacheViews.ts
+++ b/ern-container-gen/src/generatePluginsMustacheViews.ts
@@ -7,7 +7,7 @@ export async function generatePluginsMustacheViews(
   const pluginsViews: any[] = []
   log.debug('Generating plugins mustache views')
   for (const plugin of plugins) {
-    if (plugin.basePath === 'react-native') {
+    if (plugin.name === 'react-native') {
       continue
     }
     const pluginConfig = await manifest.getPluginConfig(plugin)
@@ -16,7 +16,7 @@ export async function generatePluginsMustacheViews(
     }
     if (!pluginConfig[platform]) {
       log.warn(
-        `${plugin.basePath} does not have any injection configuration for ${platform} platform`
+        `${plugin.name} does not have any injection configuration for ${platform} platform`
       )
       continue
     }

--- a/ern-core/src/GitManifest.ts
+++ b/ern-core/src/GitManifest.ts
@@ -232,12 +232,12 @@ export default class GitManifest {
       let pluginScope
       let pluginName
       let basePluginPath
-      if (scopeNameRe.test(plugin.basePath)) {
-        pluginScope = scopeNameRe.exec(plugin.basePath)![1]
-        pluginName = scopeNameRe.exec(plugin.basePath)![2]
+      if (scopeNameRe.test(plugin.name!)) {
+        pluginScope = scopeNameRe.exec(plugin.name!)![1]
+        pluginName = scopeNameRe.exec(plugin.name!)![2]
         basePluginPath = path.join(pluginsConfigurationDirectory, pluginScope)
       } else {
-        pluginName = plugin.basePath
+        pluginName = plugin.name!
         basePluginPath = pluginsConfigurationDirectory
       }
 
@@ -301,7 +301,7 @@ export default class GitManifest {
 
     for (const pluginsConfigurationDirectory of orderedPluginsConfigurationDirectories) {
       // Directory names cannot contain '/', so, replaced by ':'
-      const pluginScopeAndName = plugin.basePath.replace(/\//g, ':')
+      const pluginScopeAndName = plugin.name!.replace(/\//g, ':')
 
       const pluginVersions = _.map(
         fs

--- a/ern-core/src/Manifest.ts
+++ b/ern-core/src/Manifest.ts
@@ -461,13 +461,13 @@ export class Manifest {
           ? overrideManifestData.targetNativeDependencies
           : [],
         masterManifestData ? masterManifestData.targetNativeDependencies : [],
-        d => PackagePath.fromString(<string>d).basePath
+        d => PackagePath.fromString(<string>d).name
       )
 
       manifestData.targetJsDependencies = _.unionBy(
         overrideManifestData ? overrideManifestData.targetJsDependencies : [],
         masterManifestData ? masterManifestData.targetJsDependencies : [],
-        d => PackagePath.fromString(<string>d).basePath
+        d => PackagePath.fromString(<string>d).name
       )
     } else if (this.overrideManifest && this.manifestOverrideType === 'full') {
       manifestData = await this.overrideManifest.getManifestData({
@@ -523,7 +523,7 @@ export class Manifest {
       manifestId,
       platformVersion,
     })
-    return _.find(nativeDependencies, d => d.basePath === dependency.basePath)
+    return _.find(nativeDependencies, d => d.name === dependency.name)
   }
 
   public async getJsDependency(
@@ -540,7 +540,7 @@ export class Manifest {
       manifestId,
       platformVersion,
     })
-    return _.find(jsDependencies, d => d.basePath === dependency.basePath)
+    return _.find(jsDependencies, d => d.name === dependency.name)
   }
 
   public async getJsAndNativeDependencies({
@@ -609,7 +609,7 @@ export class Manifest {
     )
     if (!pluginConfigPath) {
       throw new Error(
-        `There is no configuration for ${plugin.basePath} plugin in Manifest matching platform version ${platformVersion}`
+        `There is no configuration for ${plugin.name} plugin in Manifest matching platform version ${platformVersion}`
       )
     }
 
@@ -672,16 +672,16 @@ export class Manifest {
   }
 
   public getDefaultNpmPluginOrigin(plugin: PackagePath): NpmPluginOrigin {
-    if (npmScopeModuleRe.test(plugin.basePath)) {
+    if (npmScopeModuleRe.test(plugin.name!)) {
       return {
-        name: `${npmScopeModuleRe.exec(plugin.basePath)![2]}`,
-        scope: `${npmScopeModuleRe.exec(plugin.basePath)![1]}`,
+        name: `${npmScopeModuleRe.exec(plugin.name!)![2]}`,
+        scope: `${npmScopeModuleRe.exec(plugin.name!)![1]}`,
         type: 'npm',
         version: plugin.version,
       }
     } else {
       return {
-        name: plugin.basePath,
+        name: plugin.name!,
         type: 'npm',
         version: plugin.version,
       }
@@ -695,12 +695,12 @@ export class Manifest {
   ): Promise<PluginConfig | undefined> {
     await this.initOverrideManifest()
     let result
-    if (await isDependencyApi(plugin.basePath)) {
+    if (await isDependencyApi(plugin)) {
       log.debug(
         'API plugin detected. Retrieving API plugin default configuration'
       )
       result = this.getApiPluginDefaultConfig(plugin, projectName)
-    } else if (await isDependencyApiImpl(plugin.basePath)) {
+    } else if (await isDependencyApiImpl(plugin)) {
       log.debug(
         'APIImpl plugin detected. Retrieving APIImpl plugin default configuration'
       )
@@ -716,7 +716,7 @@ export class Manifest {
       )
     } else {
       log.warn(
-        `Unsupported plugin. No configuration found in manifest for ${plugin.basePath}.`
+        `Unsupported plugin. No configuration found in manifest for ${plugin.name}.`
       )
       return
       /*throw new Error(

--- a/ern-core/src/YarnCli.ts
+++ b/ern-core/src/YarnCli.ts
@@ -6,6 +6,7 @@ import { PackagePath } from './PackagePath'
 import { execp } from './childProcess'
 import log from './log'
 import { spawn } from 'child_process'
+import { readPackageJson } from './packageJsonFileUtils'
 
 export class YarnCli {
   public readonly binaryPath: string
@@ -75,9 +76,8 @@ export class YarnCli {
     log.trace(`[YarnCli] info(${dependencyPath}, {field: ${field}})`)
 
     if (dependencyPath.isFilePath) {
-      const packageJsonPath = path.join(dependencyPath.basePath, `package.json`)
-      const res = fs.readJson(packageJsonPath)
-      return field ? res[field] : res
+      const pJson = await readPackageJson(dependencyPath.basePath)
+      return field ? pJson[field] : pJson
     } else {
       const args = [
         'info',

--- a/ern-core/src/dependencyLookup.ts
+++ b/ern-core/src/dependencyLookup.ts
@@ -8,7 +8,7 @@ export async function getMiniAppsUsingNativeDependency(
   nativeDependency: PackagePath
 ): Promise<MiniApp[]> {
   const result: MiniApp[] = []
-  const nativeDependencyString = nativeDependency.basePath
+  const nativeDependencyString = nativeDependency.name!
   for (const miniAppPath of miniAppsPaths) {
     const miniApp = await kax
       .task(`Retrieving ${miniAppPath.toString()} for dependency lookup`)
@@ -16,7 +16,7 @@ export async function getMiniAppsUsingNativeDependency(
     const miniAppNativeDependencies = await miniApp.getNativeDependencies()
     const miniAppNativeDependenciesStrings = _.map(
       miniAppNativeDependencies.all,
-      d => d.packagePath.basePath
+      d => d.name!
     )
     if (miniAppNativeDependenciesStrings.includes(nativeDependencyString)) {
       result.push(miniApp)

--- a/ern-core/src/index.ts
+++ b/ern-core/src/index.ts
@@ -28,7 +28,6 @@ export { yarn, reactnative } from './clients'
 export {
   NativeDependencies,
   findNativeDependencies,
-  NativeDependency,
   getNativeDependencyPath,
 } from './nativeDependenciesLookup'
 export { tagOneLine } from './tagoneline'

--- a/ern-core/src/resolveNativeDependenciesVersions.ts
+++ b/ern-core/src/resolveNativeDependenciesVersions.ts
@@ -29,7 +29,7 @@ export function retainHighestVersions(
   dependenciesB: PackagePath[]
 ): PackagePath[] {
   const result: PackagePath[] = []
-  const groups = _.groupBy([...dependenciesA, ...dependenciesB], 'basePath')
+  const groups = _.groupBy([...dependenciesA, ...dependenciesB], 'name')
   let dependencyGroup: any
   for (dependencyGroup of Object.values(groups)) {
     let highestVersionDependency = dependencyGroup[0]
@@ -56,26 +56,26 @@ export function resolvePackageVersionsGivenMismatchLevel(
     resolved: [],
   }
 
-  const pluginsByBasePath = _.groupBy(
+  const pluginsByName = _.groupBy(
     _.unionBy(plugins, p => p.toString()),
-    'basePath'
+    'name'
   )
 
-  for (const basePath of Object.keys(pluginsByBasePath)) {
-    const entry = pluginsByBasePath[basePath]
+  for (const name of Object.keys(pluginsByName)) {
+    const entry = pluginsByName[name]
     const pluginVersions = _.map(entry, 'version')
     if (pluginVersions.length > 1) {
       // If there are multiple versions of the dependency
       if (containsVersionMismatch(<string[]>pluginVersions, mismatchLevel)) {
         // If at least one of the versions major digit differs, deem incompatibility
-        result.pluginsWithMismatchingVersions.push(basePath)
+        result.pluginsWithMismatchingVersions.push(name)
       } else {
         // No mismatchLevel version differences, just return the highest version
         result.resolved.push(
           _.find(
             entry,
             c =>
-              c.basePath === basePath &&
+              c.name === name &&
               c.version === semver.maxSatisfying(<string[]>pluginVersions, '*')
           )
         )
@@ -125,14 +125,10 @@ export function resolveNativeDependenciesVersionsEx(
   // Resolve native dependencies versions of APIs / APIs impls
   let apisAndApiImplsNativeDeps: PackagePath[] = []
   if (dependencies.apis.length > 0) {
-    apisAndApiImplsNativeDeps.push(
-      ..._.flatten(dependencies.apis.map(x => x.packagePath))
-    )
+    apisAndApiImplsNativeDeps.push(..._.flatten(dependencies.apis))
   }
   if (dependencies.nativeApisImpl.length > 0) {
-    apisAndApiImplsNativeDeps.push(
-      ..._.flatten(dependencies.nativeApisImpl.map(x => x.packagePath))
-    )
+    apisAndApiImplsNativeDeps.push(..._.flatten(dependencies.nativeApisImpl))
   }
   apisAndApiImplsNativeDeps = _.flatten(apisAndApiImplsNativeDeps)
   const apiAndApiImplsResolvedVersions = resolvePackageVersionsGivenMismatchLevel(
@@ -144,12 +140,12 @@ export function resolveNativeDependenciesVersionsEx(
   let thirdPartyNativeModules: PackagePath[] = []
   if (dependencies.thirdPartyInManifest.length > 0) {
     thirdPartyNativeModules.push(
-      ..._.flatten(dependencies.thirdPartyInManifest.map(x => x.packagePath))
+      ..._.flatten(dependencies.thirdPartyInManifest)
     )
   }
   if (dependencies.thirdPartyNotInManifest.length > 0) {
     thirdPartyNativeModules.push(
-      ..._.flatten(dependencies.thirdPartyNotInManifest.map(x => x.packagePath))
+      ..._.flatten(dependencies.thirdPartyNotInManifest)
     )
   }
   thirdPartyNativeModules = _.flatten(thirdPartyNativeModules)

--- a/ern-core/test/PackagePath-test.ts
+++ b/ern-core/test/PackagePath-test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai'
 import { PackagePath } from '../src/PackagePath'
 import os from 'os'
+import path from 'path'
 
 describe('PackagePath', () => {
   const gitSshPath =
@@ -10,10 +11,12 @@ describe('PackagePath', () => {
   const gitHttpsPath = 'https://github.com/electrode-io/electrode-native.git'
   const gitHttpsVersionPath =
     'https://github.com/electrode-io/electrode-native.git#0.11.0'
-  const fileSystemPath = 'file:/Users/blemair/Code/electrode-native'
-  const fileSystemPathWithoutPrefix = '/Users/blemair/Code/electrode-native'
-  const fileSystemPathTidle = '~/Code/electrode-native'
-  const fileSystemPathTidleExpanded = `${os.homedir()}/Code/electrode-native`
+  const fileSystemPathWithoutPrefix = path.join(
+    __dirname,
+    'fixtures',
+    'miniapp'
+  )
+  const fileSystemPath = `file:${fileSystemPathWithoutPrefix}`
   const registryPath = 'ern-local-cli'
   const registryVersionPath = 'ern-local-cli@0.11.0'
 
@@ -40,10 +43,6 @@ describe('PackagePath', () => {
 
     it('should work for a file system path without prefix', () => {
       expect(() => new PackagePath(fileSystemPathWithoutPrefix)).to.not.throw()
-    })
-
-    it('should work for a file system path with tidle', () => {
-      expect(() => new PackagePath(fileSystemPathTidle)).to.not.throw()
     })
 
     it('should work for a registry path', () => {
@@ -82,10 +81,6 @@ describe('PackagePath', () => {
       ).to.not.throw()
     })
 
-    it('should work for a file system path with tidle', () => {
-      expect(() => PackagePath.fromString(fileSystemPathTidle)).to.not.throw()
-    })
-
     it('should work for a registry path', () => {
       expect(() => PackagePath.fromString(registryPath)).to.not.throw()
     })
@@ -96,17 +91,12 @@ describe('PackagePath', () => {
   })
 
   describe('get version', () => {
-    it('should return undefined for a file system package path', () => {
-      expect(PackagePath.fromString(fileSystemPath).version).undefined
-    })
-
-    it('should return undefined for a file system package path without prefix', () => {
-      expect(PackagePath.fromString(fileSystemPathWithoutPrefix).version)
-        .undefined
-    })
-
-    it('should return undefined for a file system package path with tidle', () => {
-      expect(PackagePath.fromString(fileSystemPathTidle).version).undefined
+    it('should return the version from package.json for a file system package path', () => {
+      expect(
+        PackagePath.fromString(
+          path.join(__dirname, 'fixtures', 'ModuleFactory', 'moduleWithoutSrc')
+        ).version
+      ).eql('1.0.0')
     })
 
     it('should return undefined for a git ssh path without version', () => {
@@ -144,10 +134,6 @@ describe('PackagePath', () => {
         .false
     })
 
-    it('should return false for a file system path with tidle', () => {
-      expect(PackagePath.fromString(fileSystemPathTidle).isGitPath).false
-    })
-
     it('should return false for a registry path', () => {
       expect(PackagePath.fromString(registryPath).isGitPath).false
     })
@@ -177,10 +163,6 @@ describe('PackagePath', () => {
     it('should return true for a file system package path without prefix', () => {
       expect(PackagePath.fromString(fileSystemPathWithoutPrefix).isFilePath)
         .true
-    })
-
-    it('should return true for a file system package path with tidle', () => {
-      expect(PackagePath.fromString(fileSystemPathTidle).isFilePath).true
     })
 
     it('should return false for a registry path', () => {
@@ -221,11 +203,6 @@ describe('PackagePath', () => {
       expect(PackagePath.fromString(fileSystemPathWithoutPrefix).isRegistryPath)
         .false
     })
-
-    it('should return false for a file system package path with tidle', () => {
-      expect(PackagePath.fromString(fileSystemPathTidle).isRegistryPath).false
-    })
-
     it('should return false for a git ssh path', () => {
       expect(PackagePath.fromString(gitSshPath).isRegistryPath).false
     })
@@ -240,13 +217,6 @@ describe('PackagePath', () => {
 
     it('should return false for a git https path with version', () => {
       expect(PackagePath.fromString(gitHttpsVersionPath).isRegistryPath).false
-    })
-  })
-
-  describe('basePath', () => {
-    it('should perform tidle expansion for a tidled file path', () => {
-      const p = PackagePath.fromString(fileSystemPathTidle)
-      expect(p.basePath).equal(fileSystemPathTidleExpanded)
     })
   })
 })

--- a/ern-core/test/coreutils-test.ts
+++ b/ern-core/test/coreutils-test.ts
@@ -479,21 +479,27 @@ describe('utils.js', () => {
   describe('isDependencyApiImpl', () => {
     it('return true if regex matches', async () => {
       expect(
-        await utils.isDependencyApiImpl('react-native-header-api-impl')
+        await utils.isDependencyApiImpl(
+          PackagePath.fromString('react-native-header-api-impl')
+        )
       ).to.eql(true)
     })
 
     it('return true if ern object resolves for native api impl', async () => {
       const yarnStub = sinon.stub(yarn, 'info')
       yarnStub.resolves(yarnInfoErnApiImpl)
-      expect(await utils.isDependencyApiImpl('react-header')).to.eql(true)
+      expect(
+        await utils.isDependencyApiImpl(PackagePath.fromString('react-header'))
+      ).to.eql(true)
       yarnStub.restore()
     })
 
     it('return true if ern object resolves for js api impl', async () => {
       const yarnStub = sinon.stub(yarn, 'info')
       yarnStub.resolves(yarnInfoErnJsApiImpl)
-      expect(await utils.isDependencyApiImpl('react-header')).to.eql(true)
+      expect(
+        await utils.isDependencyApiImpl(PackagePath.fromString('react-header'))
+      ).to.eql(true)
       yarnStub.restore()
     })
   })
@@ -503,15 +509,19 @@ describe('utils.js', () => {
   // ==========================================================
   describe('isDependencyApi', () => {
     it('return true if regex matches', async () => {
-      expect(await utils.isDependencyApi('react-native-header-api')).to.eql(
-        true
-      )
+      expect(
+        await utils.isDependencyApi(
+          PackagePath.fromString('react-native-header-api')
+        )
+      ).to.eql(true)
     })
 
     it('return true if ern object resolves for api', async () => {
       const yarnStub = sinon.stub(yarn, 'info')
       yarnStub.resolves(yarnInfoErnApi)
-      expect(await utils.isDependencyApi('react-header')).to.eql(true)
+      expect(
+        await utils.isDependencyApi(PackagePath.fromString('react-header'))
+      ).to.eql(true)
       yarnStub.restore()
     })
   })
@@ -522,14 +532,20 @@ describe('utils.js', () => {
   describe('isDependencyApiOrApiImpl', () => {
     it('return true if regex matches', async () => {
       expect(
-        await utils.isDependencyApiOrApiImpl('react-native-header-api')
+        await utils.isDependencyApiOrApiImpl(
+          PackagePath.fromString('react-native-header-api')
+        )
       ).to.eql(true)
     })
 
     it('return true if ern object resolves for api', async () => {
       const yarnStub = sinon.stub(yarn, 'info')
       yarnStub.resolves(yarnInfoErnApi)
-      expect(await utils.isDependencyApiOrApiImpl('react-header')).to.eql(true)
+      expect(
+        await utils.isDependencyApiOrApiImpl(
+          PackagePath.fromString('react-header')
+        )
+      ).to.eql(true)
       yarnStub.restore()
     })
 
@@ -537,7 +553,9 @@ describe('utils.js', () => {
       const yarnStub = sinon.stub(yarn, 'info')
       yarnStub.resolves(yarnInfoErnApi)
       expect(
-        await utils.isDependencyApiOrApiImpl('react-native-header-api-impl')
+        await utils.isDependencyApiOrApiImpl(
+          PackagePath.fromString('react-native-header-api-impl')
+        )
       ).to.eql(true)
       yarnStub.restore()
     })
@@ -545,14 +563,22 @@ describe('utils.js', () => {
     it('return true if ern object resolves for native api impl', async () => {
       const yarnStub = sinon.stub(yarn, 'info')
       yarnStub.resolves(yarnInfoErnApiImpl)
-      expect(await utils.isDependencyApiOrApiImpl('react-header')).to.eql(true)
+      expect(
+        await utils.isDependencyApiOrApiImpl(
+          PackagePath.fromString('react-header')
+        )
+      ).to.eql(true)
       yarnStub.restore()
     })
 
     it('return true if ern object resolves for js api impl', async () => {
       const yarnStub = sinon.stub(yarn, 'info')
       yarnStub.resolves(yarnInfoErnJsApiImpl)
-      expect(await utils.isDependencyApiOrApiImpl('react-header')).to.eql(true)
+      expect(
+        await utils.isDependencyApiOrApiImpl(
+          PackagePath.fromString('react-header')
+        )
+      ).to.eql(true)
       yarnStub.restore()
     })
   })

--- a/ern-core/test/fixtures/ModuleFactory/moduleWithSrc/package.json
+++ b/ern-core/test/fixtures/ModuleFactory/moduleWithSrc/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "moduleWithSrc",
+  "version": "1.0.0"
+}

--- a/ern-core/test/fixtures/ModuleFactory/moduleWithoutSrc/package.json
+++ b/ern-core/test/fixtures/ModuleFactory/moduleWithoutSrc/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "moduleWithoutSrc",
+  "version": "1.0.0"
+}

--- a/ern-core/test/fixtures/miniapp/package.json
+++ b/ern-core/test/fixtures/miniapp/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "miniapp",
+  "version": "1.0.0"
+}

--- a/ern-core/test/resolveNativeDependenciesVersions-test.ts
+++ b/ern-core/test/resolveNativeDependenciesVersions-test.ts
@@ -85,45 +85,17 @@ describe('resolveNativeDependenciesVersions', () => {
     const fixture: NativeDependencies[] = [
       {
         all: [
-          {
-            packagePath: PackagePath.fromString('apiOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/apiOne',
-          },
-          {
-            packagePath: PackagePath.fromString('apiTwo@1.0.0'),
-            path: '/Users/foo/composite/node_modules/apiTwo',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeApiImplOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeApiImplOne',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeModuleOne',
-          },
+          PackagePath.fromString('apiOne@1.0.0'),
+          PackagePath.fromString('apiTwo@1.0.0'),
+          PackagePath.fromString('nativeApiImplOne@1.0.0'),
+          PackagePath.fromString('nativeModuleOne@1.0.0'),
         ],
         apis: [
-          {
-            packagePath: PackagePath.fromString('apiOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/apiOne',
-          },
-          {
-            packagePath: PackagePath.fromString('apiTwo@1.0.0'),
-            path: '/Users/foo/composite/node_modules/apiTwo',
-          },
+          PackagePath.fromString('apiOne@1.0.0'),
+          PackagePath.fromString('apiTwo@1.0.0'),
         ],
-        nativeApisImpl: [
-          {
-            packagePath: PackagePath.fromString('nativeApiImplOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeApiImplOne',
-          },
-        ],
-        thirdPartyInManifest: [
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeModuleOne',
-          },
-        ],
+        nativeApisImpl: [PackagePath.fromString('nativeApiImplOne@1.0.0')],
+        thirdPartyInManifest: [PackagePath.fromString('nativeModuleOne@1.0.0')],
         thirdPartyNotInManifest: [],
       },
     ]
@@ -137,45 +109,17 @@ describe('resolveNativeDependenciesVersions', () => {
     const fixture: NativeDependencies[] = [
       {
         all: [
-          {
-            packagePath: PackagePath.fromString('apiOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/apiOne',
-          },
-          {
-            packagePath: PackagePath.fromString('apiOne@1.0.1'),
-            path: '/Users/foo/composite/node_modules/miniAppA/apiOne',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeApiImplOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeApiImplOne',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeModuleOne',
-          },
+          PackagePath.fromString('apiOne@1.0.0'),
+          PackagePath.fromString('apiOne@1.0.1'),
+          PackagePath.fromString('nativeApiImplOne@1.0.0'),
+          PackagePath.fromString('nativeModuleOne@1.0.0'),
         ],
         apis: [
-          {
-            packagePath: PackagePath.fromString('apiOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/apiOne',
-          },
-          {
-            packagePath: PackagePath.fromString('apiOne@1.0.1'),
-            path: '/Users/foo/composite/node_modules/miniAppA/apiOne',
-          },
+          PackagePath.fromString('apiOne@1.0.0'),
+          PackagePath.fromString('apiOne@1.0.1'),
         ],
-        nativeApisImpl: [
-          {
-            packagePath: PackagePath.fromString('nativeApiImplOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeApiImplOne',
-          },
-        ],
-        thirdPartyInManifest: [
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeModuleOne',
-          },
-        ],
+        nativeApisImpl: [PackagePath.fromString('nativeApiImplOne@1.0.0')],
+        thirdPartyInManifest: [PackagePath.fromString('nativeModuleOne@1.0.0')],
         thirdPartyNotInManifest: [],
       },
     ]
@@ -191,45 +135,17 @@ describe('resolveNativeDependenciesVersions', () => {
     const fixture = [
       {
         all: [
-          {
-            packagePath: PackagePath.fromString('apiOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/apiOne',
-          },
-          {
-            packagePath: PackagePath.fromString('apiOne@1.1.0'),
-            path: '/Users/foo/composite/node_modules/miniAppA/apiOne',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeApiImplOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeApiImplOne',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeModuleOne',
-          },
+          PackagePath.fromString('apiOne@1.0.0'),
+          PackagePath.fromString('apiOne@1.1.0'),
+          PackagePath.fromString('nativeApiImplOne@1.0.0'),
+          PackagePath.fromString('nativeModuleOne@1.0.0'),
         ],
         apis: [
-          {
-            packagePath: PackagePath.fromString('apiOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/apiOne',
-          },
-          {
-            packagePath: PackagePath.fromString('apiOne@1.1.0'),
-            path: '/Users/foo/composite/node_modules/miniAppA/apiOne',
-          },
+          PackagePath.fromString('apiOne@1.0.0'),
+          PackagePath.fromString('apiOne@1.1.0'),
         ],
-        nativeApisImpl: [
-          {
-            packagePath: PackagePath.fromString('nativeApiImplOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeApiImplOne',
-          },
-        ],
-        thirdPartyInManifest: [
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeModuleOne',
-          },
-        ],
+        nativeApisImpl: [PackagePath.fromString('nativeApiImplOne@1.0.0')],
+        thirdPartyInManifest: [PackagePath.fromString('nativeModuleOne@1.0.0')],
         thirdPartyNotInManifest: [],
       },
     ]
@@ -245,45 +161,17 @@ describe('resolveNativeDependenciesVersions', () => {
     const fixture = [
       {
         all: [
-          {
-            packagePath: PackagePath.fromString('apiOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/apiOne',
-          },
-          {
-            packagePath: PackagePath.fromString('apiOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/apiOne',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeApiImplOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeApiImplOne',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeModuleOne',
-          },
+          PackagePath.fromString('apiOne@1.0.0'),
+          PackagePath.fromString('apiOne@1.0.0'),
+          PackagePath.fromString('nativeApiImplOne@1.0.0'),
+          PackagePath.fromString('nativeModuleOne@1.0.0'),
         ],
         apis: [
-          {
-            packagePath: PackagePath.fromString('apiOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/apiOne',
-          },
-          {
-            packagePath: PackagePath.fromString('apiOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/apiOne',
-          },
+          PackagePath.fromString('apiOne@1.0.0'),
+          PackagePath.fromString('apiOne@1.0.0'),
         ],
-        nativeApisImpl: [
-          {
-            packagePath: PackagePath.fromString('nativeApiImplOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeApiImplOne',
-          },
-        ],
-        thirdPartyInManifest: [
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeModuleOne',
-          },
-        ],
+        nativeApisImpl: [PackagePath.fromString('nativeApiImplOne@1.0.0')],
+        thirdPartyInManifest: [PackagePath.fromString('nativeModuleOne@1.0.0')],
         thirdPartyNotInManifest: [],
       },
     ]
@@ -296,45 +184,17 @@ describe('resolveNativeDependenciesVersions', () => {
     const fixture = [
       {
         all: [
-          {
-            packagePath: PackagePath.fromString('apiOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/apiOne',
-          },
-          {
-            packagePath: PackagePath.fromString('apiOne@2.0.0'),
-            path: '/Users/foo/composite/node_modules/apiOne',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeApiImplOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeApiImplOne',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeModuleOne',
-          },
+          PackagePath.fromString('apiOne@1.0.0'),
+          PackagePath.fromString('apiOne@2.0.0'),
+          PackagePath.fromString('nativeApiImplOne@1.0.0'),
+          PackagePath.fromString('nativeModuleOne@1.0.0'),
         ],
         apis: [
-          {
-            packagePath: PackagePath.fromString('apiOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/apiOne',
-          },
-          {
-            packagePath: PackagePath.fromString('apiOne@2.0.0'),
-            path: '/Users/foo/composite/node_modules/apiOne',
-          },
+          PackagePath.fromString('apiOne@1.0.0'),
+          PackagePath.fromString('apiOne@2.0.0'),
         ],
-        nativeApisImpl: [
-          {
-            packagePath: PackagePath.fromString('nativeApiImplOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeApiImplOne',
-          },
-        ],
-        thirdPartyInManifest: [
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeModuleOne',
-          },
-        ],
+        nativeApisImpl: [PackagePath.fromString('nativeApiImplOne@1.0.0')],
+        thirdPartyInManifest: [PackagePath.fromString('nativeModuleOne@1.0.0')],
         thirdPartyNotInManifest: [],
       },
     ]
@@ -349,44 +209,16 @@ describe('resolveNativeDependenciesVersions', () => {
     const fixture = [
       {
         all: [
-          {
-            packagePath: PackagePath.fromString('apiOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/apiOne',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeApiImplOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeApiImplOne',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeModuleOne',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeModuleOne',
-          },
+          PackagePath.fromString('apiOne@1.0.0'),
+          PackagePath.fromString('nativeApiImplOne@1.0.0'),
+          PackagePath.fromString('nativeModuleOne@1.0.0'),
+          PackagePath.fromString('nativeModuleOne@1.0.0'),
         ],
-        apis: [
-          {
-            packagePath: PackagePath.fromString('apiOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/apiOne',
-          },
-        ],
-        nativeApisImpl: [
-          {
-            packagePath: PackagePath.fromString('nativeApiImplOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeApiImplOne',
-          },
-        ],
+        apis: [PackagePath.fromString('apiOne@1.0.0')],
+        nativeApisImpl: [PackagePath.fromString('nativeApiImplOne@1.0.0')],
         thirdPartyInManifest: [
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeModuleOne',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeModuleOne',
-          },
+          PackagePath.fromString('nativeModuleOne@1.0.0'),
+          PackagePath.fromString('nativeModuleOne@1.0.0'),
         ],
         thirdPartyNotInManifest: [],
       },
@@ -403,44 +235,16 @@ describe('resolveNativeDependenciesVersions', () => {
     const fixture = [
       {
         all: [
-          {
-            packagePath: PackagePath.fromString('apiOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/apiOne',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeApiImplOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeApiImplOne',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeModuleOne',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@1.0.1'),
-            path: '/Users/foo/composite/node_modules/nativeModuleOne',
-          },
+          PackagePath.fromString('apiOne@1.0.0'),
+          PackagePath.fromString('nativeApiImplOne@1.0.0'),
+          PackagePath.fromString('nativeModuleOne@1.0.0'),
+          PackagePath.fromString('nativeModuleOne@1.0.1'),
         ],
-        apis: [
-          {
-            packagePath: PackagePath.fromString('apiOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/apiOne',
-          },
-        ],
-        nativeApisImpl: [
-          {
-            packagePath: PackagePath.fromString('nativeApiImplOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeApiImplOne',
-          },
-        ],
+        apis: [PackagePath.fromString('apiOne@1.0.0')],
+        nativeApisImpl: [PackagePath.fromString('nativeApiImplOne@1.0.0')],
         thirdPartyInManifest: [
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeModuleOne',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@1.0.1'),
-            path: '/Users/foo/composite/node_modules/nativeModuleOne',
-          },
+          PackagePath.fromString('nativeModuleOne@1.0.0'),
+          PackagePath.fromString('nativeModuleOne@1.0.1'),
         ],
         thirdPartyNotInManifest: [],
       },
@@ -456,46 +260,16 @@ describe('resolveNativeDependenciesVersions', () => {
     const fixture = [
       {
         all: [
-          {
-            packagePath: PackagePath.fromString('apiOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/apiOne',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeApiImplOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeApiImplOne',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeModuleOne',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@1.1.1'),
-            path:
-              '/Users/foo/composite/node_modules/miniappA/node_modules/nativeModuleOne',
-          },
+          PackagePath.fromString('apiOne@1.0.0'),
+          PackagePath.fromString('nativeApiImplOne@1.0.0'),
+          PackagePath.fromString('nativeModuleOne@1.0.0'),
+          PackagePath.fromString('nativeModuleOne@1.1.0'),
         ],
-        apis: [
-          {
-            packagePath: PackagePath.fromString('apiOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/apiOne',
-          },
-        ],
-        nativeApisImpl: [
-          {
-            packagePath: PackagePath.fromString('nativeApiImplOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeApiImplOne',
-          },
-        ],
+        apis: [PackagePath.fromString('apiOne@1.0.0')],
+        nativeApisImpl: [PackagePath.fromString('nativeApiImplOne@1.0.0')],
         thirdPartyInManifest: [
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeModuleOne',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@1.1.1'),
-            path:
-              '/Users/foo/composite/node_modules/miniappA/node_modules/nativeModuleOne',
-          },
+          PackagePath.fromString('nativeModuleOne@1.0.0'),
+          PackagePath.fromString('nativeModuleOne@1.1.0'),
         ],
         thirdPartyNotInManifest: [],
       },
@@ -511,46 +285,16 @@ describe('resolveNativeDependenciesVersions', () => {
     const fixture = [
       {
         all: [
-          {
-            packagePath: PackagePath.fromString('apiOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/apiOne',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeApiImplOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeApiImplOne',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeModuleOne',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@2.0.0'),
-            path:
-              '/Users/foo/composite/node_modules/miniappA/node_modules/nativeModuleOne',
-          },
+          PackagePath.fromString('apiOne@1.0.0'),
+          PackagePath.fromString('nativeApiImplOne@1.0.0'),
+          PackagePath.fromString('nativeModuleOne@1.0.0'),
+          PackagePath.fromString('nativeModuleOne@2.0.0'),
         ],
-        apis: [
-          {
-            packagePath: PackagePath.fromString('apiOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/apiOne',
-          },
-        ],
-        nativeApisImpl: [
-          {
-            packagePath: PackagePath.fromString('nativeApiImplOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeApiImplOne',
-          },
-        ],
+        apis: [PackagePath.fromString('apiOne@1.0.0')],
+        nativeApisImpl: [PackagePath.fromString('nativeApiImplOne@1.0.0')],
         thirdPartyInManifest: [
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@1.0.0'),
-            path: '/Users/foo/composite/node_modules/nativeModuleOne',
-          },
-          {
-            packagePath: PackagePath.fromString('nativeModuleOne@2.0.0'),
-            path:
-              '/Users/foo/composite/node_modules/miniappA/node_modules/nativeModuleOne',
-          },
+          PackagePath.fromString('nativeModuleOne@1.0.0'),
+          PackagePath.fromString('nativeModuleOne@2.0.0'),
         ],
         thirdPartyNotInManifest: [],
       },

--- a/ern-local-cli/src/commands/create-api-impl.ts
+++ b/ern-local-cli/src/commands/create-api-impl.ts
@@ -167,7 +167,7 @@ export const commandHandler = async ({
   // Must conform to definition of ElectrodeNativeModuleName
   if (!apiImplName) {
     // camel case api name
-    const cameCaseName = coreUtils.camelize(apiDep.basePath)
+    const cameCaseName = coreUtils.camelize(apiDep.name!)
     // remove number if present
     const nameWithNoNumber = cameCaseName.replace(/\d+/g, '')
     apiImplName = `${nameWithNoNumber}Impl${jsOnly ? 'Js' : 'Native'}`

--- a/ern-local-cli/src/commands/create-plugin-config.ts
+++ b/ern-local-cli/src/commands/create-plugin-config.ts
@@ -39,7 +39,7 @@ Make sure this command is run from a Manifest directory.`)
     shell.popd()
   }
 
-  const pluginPath = path.join(tmpDir, 'node_modules', plugin.basePath)
+  const pluginPath = path.join(tmpDir, 'node_modules', plugin.name!)
   const conf = await PluginConfigGenerator.generateFromPath({
     pluginPath,
     resolveDependencyVersion: x =>
@@ -62,7 +62,7 @@ Make sure this command is run from a Manifest directory.`)
   const pathToPluginConfig = path.join(
     'plugins',
     `ern_v${manifestBaseErnVersion}+`,
-    `${plugin.basePath}_v${pluginVersion}+`
+    `${plugin.name}_v${pluginVersion}+`
   )
   if (!(await fs.pathExists(pathToPluginConfig))) {
     await shell.mkdir('-p', pathToPluginConfig)

--- a/ern-local-cli/src/commands/list/dependencies.ts
+++ b/ern-local-cli/src/commands/list/dependencies.ts
@@ -81,7 +81,7 @@ function logDependencies(dependencies, type: string) {
   if (!_.isEmpty(dependencies)) {
     console.log(chalk.blue.bold(`=== ${type} ===`))
     for (const d of dependencies) {
-      console.log(d.packagePath.toString())
+      console.log(`${d.name}@${d.version}`)
     }
   }
 }

--- a/ern-local-cli/src/commands/platform/plugins/list.ts
+++ b/ern-local-cli/src/commands/platform/plugins/list.ts
@@ -51,7 +51,7 @@ export const commandHandler = async ({
     head: [chalk.cyan('Name'), chalk.cyan('Version')],
   })
   for (const plugin of plugins) {
-    table.push([plugin.basePath, plugin.version])
+    table.push([plugin.name, plugin.version])
   }
   log.info(table.toString())
 }

--- a/ern-local-cli/src/commands/platform/plugins/search.ts
+++ b/ern-local-cli/src/commands/platform/plugins/search.ts
@@ -52,7 +52,7 @@ export const commandHandler = async ({
   }
 
   log.info(
-    `${chalk.yellow(plugin.basePath)}@${chalk.magenta(plugin.version || '?')}`
+    `${chalk.yellow(plugin.name!)}@${chalk.magenta(plugin.version || '?')}`
   )
 }
 

--- a/ern-local-cli/src/commands/regen-api-impl.ts
+++ b/ern-local-cli/src/commands/regen-api-impl.ts
@@ -62,7 +62,7 @@ export const handler = async ({
       throw new Error('no API version. This should not happen.')
     }
     api = PackagePath.fromString(
-      `${api.basePath}${apiVersion ? `@${apiVersion}` : ''}`
+      `${api.name}${apiVersion ? `@${apiVersion}` : ''}`
     )
 
     log.info(`regenerating api implementation for ${api.toString()}`)
@@ -123,7 +123,7 @@ export const handler = async ({
 
   async function getApi(apiImplPackage: any): Promise<PackagePath> {
     for (const depKey of Object.keys(apiImplPackage.dependencies)) {
-      if (await coreUtils.isDependencyApi(depKey)) {
+      if (await coreUtils.isDependencyApi(PackagePath.fromString(depKey))) {
         // TODO: THis is by assuming that this is the only api dependency inside this implemenation.
         // TODO: This may not be right all the time as an api implementor can add more other apis as dependencies. Logic needs to be revisited.
         return PackagePath.fromString(

--- a/ern-orchestrator/src/codepush.ts
+++ b/ern-orchestrator/src/codepush.ts
@@ -298,7 +298,7 @@ export async function performCodePushOtaUpdate(
     await cauldron.beginTransaction()
     const codePushPlugin = _.find(
       plugins,
-      p => p.basePath === 'react-native-code-push'
+      p => p.name === 'react-native-code-push'
     )
     if (!codePushPlugin) {
       throw new Error('react-native-code-push plugin is not in native app !')

--- a/ern-orchestrator/src/compatibility.ts
+++ b/ern-orchestrator/src/compatibility.ts
@@ -4,7 +4,6 @@ import {
   MiniApp,
   log,
   kax,
-  NativeDependency,
   AppVersionDescriptor,
 } from 'ern-core'
 import { getActiveCauldron } from 'ern-cauldron-api'
@@ -160,7 +159,7 @@ export async function getNativeAppCompatibilityReport(
                 napDescriptor
               )
               const compatibility = getCompatibility(
-                miniappDependencies.map(m => m.packagePath),
+                miniappDependencies,
                 nativeAppDependencies,
                 {
                   uncompatibleIfARemoteDepIsMissing:
@@ -256,7 +255,7 @@ export function getCompatibility(
     const localDepVersion = localDep ? localDep.version : undefined
 
     const entry = {
-      dependencyName: remoteDep.basePath,
+      dependencyName: remoteDep.name,
       localVersion: localDepVersion,
       remoteVersion: remoteDep.version,
     }
@@ -278,9 +277,9 @@ export function getCompatibility(
       // Todo : do not infer api or api-impl by looking solely at the suffix as its not mandatory anymore, so
       // we might get false negatives
       if (
-        localDep.basePath.endsWith('-api') ||
-        localDep.basePath.endsWith('-api-impl') ||
-        localDep.basePath === 'react-native-electrode-bridge'
+        localDep.name!.endsWith('-api') ||
+        localDep.name!.endsWith('-api-impl') ||
+        localDep.name! === 'react-native-electrode-bridge'
       ) {
         if (
           semver.major(localDepVersion) ===
@@ -304,14 +303,11 @@ export function getCompatibility(
 
   if (uncompatibleIfARemoteDepIsMissing) {
     for (const localDep of localDeps) {
-      const remoteDep = _.find(
-        remoteDeps,
-        d => d.basePath === localDep.basePath
-      )
+      const remoteDep = _.find(remoteDeps, d => d.name! === localDep.name!)
       const remoteDepVersion = remoteDep ? remoteDep.version : undefined
 
       const entry = {
-        dependencyName: localDep.basePath,
+        dependencyName: localDep.name!,
         localVersion: localDep.version,
         remoteVersion: remoteDepVersion || 'MISSING',
       }

--- a/ern-orchestrator/src/composite.ts
+++ b/ern-orchestrator/src/composite.ts
@@ -144,7 +144,7 @@ export function logResolvedDependenciesTree(
   log.debug('[ == RESOLVED NATIVE DEPENDENCIES ==]')
   logDependenciesTree(
     parser,
-    resolution.resolved.map(x => PackagePath.fromString(x.basePath)),
+    resolution.resolved.map(x => PackagePath.fromString(x.name)),
     'debug'
   )
 }

--- a/ern-orchestrator/src/runMiniApp.ts
+++ b/ern-orchestrator/src/runMiniApp.ts
@@ -203,7 +203,7 @@ export async function runMiniApp(
   const compositeNativeDeps = await containerGenResult.config.composite.getNativeDependencies()
   const reactNativeDep = _.find(
     compositeNativeDeps.all,
-    p => p.packagePath.basePath === 'react-native'
+    p => p.name === 'react-native'
   )
 
   const hasErnNavigation =
@@ -221,7 +221,7 @@ export async function runMiniApp(
     reactNativeDevSupportEnabled: dev,
     reactNativePackagerHost: host,
     reactNativePackagerPort: port,
-    reactNativeVersion: reactNativeDep!.packagePath.version!,
+    reactNativeVersion: reactNativeDep!.version!,
     targetPlatform: platform,
   }
 

--- a/ern-orchestrator/src/start.ts
+++ b/ern-orchestrator/src/start.ts
@@ -121,7 +121,7 @@ export default async function start({
   const nativeModules: PackagePath[] = [
     ...nativeDependencies.thirdPartyInManifest,
     ...nativeDependencies.thirdPartyNotInManifest,
-  ].map(d => d.packagePath)
+  ]
 
   const packageCopyKaxTask = kax.task(
     'Copying all linked MiniApps to Composite'

--- a/ern-orchestrator/test/Ensure-test.js
+++ b/ern-orchestrator/test/Ensure-test.js
@@ -685,7 +685,7 @@ describe('Ensure.js', () => {
   // ==========================================================
   describe('isSupportedMiniAppOrJsApiImplVersion', () => {
     fixtures.supportedCauldronMiniAppsVersions.forEach(pkg => {
-      it('shoud not throw if suported version', () => {
+      it(`shoud not throw if suported version (pkg: ${pkg})`, () => {
         expect(
           () => Ensure.isSupportedMiniAppOrJsApiImplVersion(pkg),
           `throw for ${pkg}`
@@ -694,7 +694,7 @@ describe('Ensure.js', () => {
     })
 
     fixtures.unSupportedCauldronMiniAppsVersions.forEach(pkg => {
-      it('should throw if version is not supported', () => {
+      it(`should throw if version is not supported (pkg: ${pkg})`, () => {
         expect(
           () => Ensure.isSupportedMiniAppOrJsApiImplVersion(pkg),
           `does not throw for ${pkg}`

--- a/ern-orchestrator/test/fixtures/common.js
+++ b/ern-orchestrator/test/fixtures/common.js
@@ -35,7 +35,6 @@ export const unSupportedCauldronMiniAppsVersions = [
   'https://github.com/MiniApp.git',
   'MiniApp@^1.0.0',
   'MiniApp@~1.0.0',
-  'file://Users/foo/MiniApp',
 ]
 
 export const withFileSystemPath = ['file:/Users/username']

--- a/ern-orchestrator/test/runMiniApp-test.ts
+++ b/ern-orchestrator/test/runMiniApp-test.ts
@@ -68,11 +68,7 @@ describe('runMiniApp', () => {
           composite: {
             getNativeDependencies: () =>
               Promise.resolve({
-                all: [
-                  {
-                    packagePath: PackagePath.fromString('react-native@0.59.8'),
-                  },
-                ],
+                all: [PackagePath.fromString('react-native@0.59.8')],
                 apis: [],
                 nativeApisImpl: [],
                 thirdPartyInManifest: [],


### PR DESCRIPTION
Electrode Native is making use of `yarn info` for different reasons, one of them being to identify a module type, by looking at the `ern` property in package metadata. 

When generating containers that are including a lot of native dependencies packages, the overall cost of running a remote `yarn info` call for each package, can take minutes. In the case of container generation, considering that we first generate a composite, prior to injecting native dependencies in the container, all the native dependencies packages are going to be there locally (in `node_modules` of the composite). In that case, why incur the cost of a remote `yarn info` for each of these packages when we can just directly parse their `package.json` from disk ?

This is basically what this PR does. To achieve that, it was needed to expose the `name` of the package more directly in the case of file based packages (to avoid having to read it from the package.json every time). That's why there is quite a bit of refactoring, mostly adding a new `name` property to `PackagePath` class, having ripple effect throughout the code base (most of the time simplifying things). One problem with the `name` property though is that it'll be undefined for git based packages. Unfortunately it's difficult with git to get the name of package dynamically, unless we do a git clone (heavy) or a github raw url fetch or github api call (not that heavy but relies on having some token set in config and dependent on github provider).