### PR TITLE
Fix crash when calling optional delegate method

### DIFF
--- a/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeReactNative.m
+++ b/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeReactNative.m
@@ -311,7 +311,9 @@ static NSString *enableBundleStore = @"enableBundleStore";
             if ([localModuleInstance  respondsToSelector:selector]) {
                 NSLog(@"RCTDidInitializeModuleNotification received");
                 ((void (*)(id, SEL))[localModuleInstance methodForSelector:selector])(localModuleInstance, selector);
-                [self.ernDelegate rctModuleDidInitialize];
+                if ([self.ernDelegate respondsToSelector:@selector(rctModuleDidInitialize)]) {
+                    [self.ernDelegate rctModuleDidInitialize];
+                }
             }
             if ([localModuleInstance  respondsToSelector:transceiverReadySelector]) {
                 ((void (*)(id, SEL))[localModuleInstance methodForSelector:transceiverReadySelector])(localModuleInstance, transceiverReadySelector);

--- a/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeReactNative.m
+++ b/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeReactNative.m
@@ -256,7 +256,9 @@ static NSString *enableBundleStore = @"enableBundleStore";
             if ([localModuleInstance  respondsToSelector:selector]) {
                 NSLog(@"RCTDidInitializeModuleNotification received");
                 ((void (*)(id, SEL))[localModuleInstance methodForSelector:selector])(localModuleInstance, selector);
-                [self.ernDelegate rctModuleDidInitialize];
+                if ([self.ernDelegate respondsToSelector:@selector(rctModuleDidInitialize)]) {
+                    [self.ernDelegate rctModuleDidInitialize];
+                }
             }
             if ([localModuleInstance  respondsToSelector:transceiverReadySelector]) {
                 ((void (*)(id, SEL))[localModuleInstance methodForSelector:transceiverReadySelector])(localModuleInstance, transceiverReadySelector);


### PR DESCRIPTION
Method is marked as optional, should check if delegate responds to selector before calling.