### PR TITLE
Enable basic GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: ci
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: yarn
+      - run: yarn check:lint
+      - run: yarn test:unit

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 ![Current version](https://img.shields.io/npm/v/ern-local-cli.svg?label=current)
 [![Coverage Status](https://coveralls.io/repos/github/electrode-io/electrode-native/badge.svg?branch=master&service=github)](https://coveralls.io/github/electrode-io/electrode-native?branch=master&service=github)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![ci][1]][2]
 
 | Test Suite | Status |
 | :--- | :--- |
@@ -116,3 +117,6 @@ Thank you.
 [Electrode Native Case Study]: https://www.walmartlabs.com/case-studies/electrode-native
 
 [CocoaPods]: https://cocoapods.org
+
+[1]: https://github.com/electrode-io/electrode-native/workflows/ci/badge.svg
+[2]: https://github.com/electrode-io/electrode-native/actions


### PR DESCRIPTION
This adds a basic GitHub Actions CI config, running Lint checks and unit tests (using Node.js v10 and v12).

We can just run this in parallel to the existing CI for a while to see how it works out.