### PR TITLE
Only upload sources to Bugsnag for Hermes bundles

### DIFF
--- a/ern-container-gen-android/src/AndroidGenerator.ts
+++ b/ern-container-gen-android/src/AndroidGenerator.ts
@@ -390,6 +390,7 @@ export default class AndroidGenerator implements ContainerGenerator {
           jsBundlePath: bundle.bundlePath,
         })
       )
+      bundle.isHermesBundle = true
     }
   }
 

--- a/ern-core/src/ReactNativeCli.ts
+++ b/ern-core/src/ReactNativeCli.ts
@@ -21,6 +21,8 @@ export interface BundlingResult {
   bundlePath: string
   // Full path to the source map (if any)
   sourceMapPath?: string
+  // Is this an hermes bundle ?
+  isHermesBundle?: boolean
 }
 
 export default class ReactNativeCli {

--- a/ern-core/src/bugsnagUpload.ts
+++ b/ern-core/src/bugsnagUpload.ts
@@ -9,6 +9,7 @@ export async function bugsnagUpload({
   minifiedUrl,
   projectRoot,
   sourceMap,
+  uploadSources,
   uploadSourcesGlob,
 }: {
   apiKey: string
@@ -16,6 +17,7 @@ export async function bugsnagUpload({
   minifiedUrl: string
   projectRoot: string
   sourceMap: string
+  uploadSources: boolean
   uploadSourcesGlob: string[]
 }) {
   const agent = createProxyAgentFromErnConfig('bugsnagProxy', { https: true })
@@ -29,7 +31,7 @@ export async function bugsnagUpload({
     minifiedUrl,
     projectRoot,
     sourceMap,
-    uploadSources: true,
+    uploadSources,
     uploadSourcesGlob,
   }
   log.trace(

--- a/ern-orchestrator/src/codepush.ts
+++ b/ern-orchestrator/src/codepush.ts
@@ -407,17 +407,19 @@ export async function performCodePushOtaUpdate(
         : path.join(bundleOutputDirectory, 'MiniApp.jsbundle')
 
     sourceMapOutput = sourceMapOutput || path.join(createTmpDir(), 'index.map')
-    await kax.task('Generating composite bundle for miniapps').run(
-      reactnative.bundle({
-        assetsDest: bundleOutputDirectory,
-        bundleOutput: bundleOutputPath,
-        dev: false,
-        entryFile: `index.${platform}.js`,
-        platform,
-        sourceMapOutput,
-        workingDir: tmpWorkingDir,
-      })
-    )
+    const bundlingResult = await kax
+      .task('Generating composite bundle for miniapps')
+      .run(
+        reactnative.bundle({
+          assetsDest: bundleOutputDirectory,
+          bundleOutput: bundleOutputPath,
+          dev: false,
+          entryFile: `index.${platform}.js`,
+          platform,
+          sourceMapOutput,
+          workingDir: tmpWorkingDir,
+        })
+      )
 
     if (platform === 'android') {
       const conf = await cauldron.getContainerGeneratorConfig(napDescriptor)
@@ -437,6 +439,7 @@ export async function performCodePushOtaUpdate(
               jsBundlePath: bundleOutputPath,
             })
           )
+        bundlingResult.isHermesBundle = true
       }
     }
 
@@ -534,6 +537,7 @@ export async function performCodePushOtaUpdate(
             minifiedUrl,
             projectRoot,
             sourceMap,
+            uploadSources: !!bundlingResult.isHermesBundle,
             uploadSourcesGlob: composite
               .getMiniAppsPackages()
               .map(p => `**/${p.name}/**/@(*.js|*.ts)`),

--- a/ern-orchestrator/src/syncCauldronContainer.ts
+++ b/ern-orchestrator/src/syncCauldronContainer.ts
@@ -176,6 +176,7 @@ export async function syncCauldronContainer(
           minifiedUrl,
           projectRoot,
           sourceMap,
+          uploadSources: !!containerGenRes.bundlingResult.isHermesBundle,
           uploadSourcesGlob: composite
             .getMiniAppsPackages()
             .map(p => `**/${p.name}/**/@(*.js|*.ts)`),


### PR DESCRIPTION
Per Bugsnag documentation, it is not needed to upload sources for non Hermes bundles, as the sources referenced in the source map of non hermes bundles are directly inlined inside the source map itself.

This PR ensure that we only upload sources to Bugsnag for Hermes bundles.