### PR TITLE
Relax container version format

### DIFF
--- a/ern-local-cli/src/commands/cauldron/add/jsapiimpls.ts
+++ b/ern-local-cli/src/commands/cauldron/add/jsapiimpls.ts
@@ -58,9 +58,6 @@ export const commandHandler = async ({
     isSupportedMiniAppOrJsApiImplVersion: {
       obj: jsapiimpls,
     },
-    isValidContainerVersion: containerVersion
-      ? { containerVersion }
-      : undefined,
     napDescriptorExistInCauldron: {
       descriptor,
       extraErrorMessage:

--- a/ern-local-cli/src/commands/cauldron/add/miniapps.ts
+++ b/ern-local-cli/src/commands/cauldron/add/miniapps.ts
@@ -59,9 +59,6 @@ export const commandHandler = async ({
     isSupportedMiniAppOrJsApiImplVersion: {
       obj: miniapps,
     },
-    isValidContainerVersion: containerVersion
-      ? { containerVersion }
-      : undefined,
     miniAppNotInNativeApplicationVersionContainer: {
       descriptor,
       extraErrorMessage:

--- a/ern-local-cli/src/commands/cauldron/batch.ts
+++ b/ern-local-cli/src/commands/cauldron/batch.ts
@@ -84,9 +84,6 @@ export const commandHandler = async ({
     isSupportedMiniAppOrJsApiImplVersion: {
       obj: [...updateMiniapps, ...addMiniapps],
     },
-    isValidContainerVersion: containerVersion
-      ? { containerVersion }
-      : undefined,
     miniAppIsInNativeApplicationVersionContainer: {
       descriptor,
       extraErrorMessage:

--- a/ern-local-cli/src/commands/cauldron/del/jsapiimpls.ts
+++ b/ern-local-cli/src/commands/cauldron/del/jsapiimpls.ts
@@ -56,9 +56,6 @@ export const commandHandler = async ({
             'To avoid conflicts with previous versions, you can only use container version newer than the current one',
         }
       : undefined,
-    isValidContainerVersion: containerVersion
-      ? { containerVersion }
-      : undefined,
     napDescriptorExistInCauldron: {
       descriptor,
       extraErrorMessage:

--- a/ern-local-cli/src/commands/cauldron/del/miniapps.ts
+++ b/ern-local-cli/src/commands/cauldron/del/miniapps.ts
@@ -59,9 +59,6 @@ export const commandHandler = async ({
             'To avoid conflicts with previous versions, you can only use container version newer than the current one',
         }
       : undefined,
-    isValidContainerVersion: containerVersion
-      ? { containerVersion }
-      : undefined,
     miniAppIsInNativeApplicationVersionContainer: {
       descriptor,
       extraErrorMessage:

--- a/ern-local-cli/src/commands/cauldron/regen-container.ts
+++ b/ern-local-cli/src/commands/cauldron/regen-container.ts
@@ -66,9 +66,6 @@ export const commandHandler = async ({
             'To avoid conflicts with previous versions, you can only use container version newer than the current one',
         }
       : undefined,
-    isValidContainerVersion: containerVersion
-      ? { containerVersion }
-      : undefined,
     napDescriptorExistInCauldron: {
       descriptor,
       extraErrorMessage:

--- a/ern-local-cli/src/commands/cauldron/update/jsapiimpls.ts
+++ b/ern-local-cli/src/commands/cauldron/update/jsapiimpls.ts
@@ -58,9 +58,6 @@ export const commandHandler = async ({
     isSupportedMiniAppOrJsApiImplVersion: {
       obj: jsapiimpls,
     },
-    isValidContainerVersion: containerVersion
-      ? { containerVersion }
-      : undefined,
     napDescriptorExistInCauldron: {
       descriptor,
       extraErrorMessage:

--- a/ern-local-cli/src/commands/cauldron/update/miniapps.ts
+++ b/ern-local-cli/src/commands/cauldron/update/miniapps.ts
@@ -89,9 +89,6 @@ export const commandHandler = async ({
     isSupportedMiniAppOrJsApiImplVersion: {
       obj: miniapps,
     },
-    isValidContainerVersion: containerVersion
-      ? { containerVersion }
-      : undefined,
     miniAppIsInNativeApplicationVersionContainer: {
       descriptor,
       extraErrorMessage:

--- a/ern-local-cli/src/lib/logErrorAndExitIfNotSatisfied.ts
+++ b/ern-local-cli/src/lib/logErrorAndExitIfNotSatisfied.ts
@@ -11,7 +11,6 @@ import fs from 'fs'
 export async function logErrorAndExitIfNotSatisfied({
   noGitOrFilesystemPath,
   noFileSystemPath,
-  isValidContainerVersion,
   isNewerContainerVersion,
   napDescriptorExistInCauldron,
   sameNativeApplicationAndPlatform,
@@ -47,10 +46,6 @@ export async function logErrorAndExitIfNotSatisfied({
   }
   noFileSystemPath?: {
     obj: string | string[]
-    extraErrorMessage?: string
-  }
-  isValidContainerVersion?: {
-    containerVersion: string
     extraErrorMessage?: string
   }
   isNewerContainerVersion?: {
@@ -178,16 +173,6 @@ export async function logErrorAndExitIfNotSatisfied({
     if (cauldronIsActive) {
       kaxTask = kax.task('Ensuring that a Cauldron is active')
       await Ensure.cauldronIsActive(cauldronIsActive.extraErrorMessage)
-      kaxTask.succeed()
-    }
-    if (isValidContainerVersion) {
-      kaxTask = kax.task(
-        `Ensuring that ${isValidContainerVersion.containerVersion} is a valid Container version`
-      )
-      Ensure.isValidContainerVersion(
-        isValidContainerVersion.containerVersion,
-        isValidContainerVersion.extraErrorMessage
-      )
       kaxTask.succeed()
     }
     if (isNewerContainerVersion) {

--- a/ern-local-cli/test/fixtures/common.js
+++ b/ern-local-cli/test/fixtures/common.js
@@ -1,7 +1,3 @@
-export const validContainerVersions = ['1.2.3', '0.0.0', '123.456.789']
-
-export const invalidContainerVersions = ['123', '1.2', '1.2.x', 'x.y.z']
-
 export const withoutGitOrFileSystemPath = [
   'package@1.2.3',
   '@scope/package@1.2.3',

--- a/ern-local-cli/test/logErrorAndExitIfNotSatisfied-test.ts
+++ b/ern-local-cli/test/logErrorAndExitIfNotSatisfied-test.ts
@@ -45,24 +45,6 @@ describe('logErrorAndExitIfNotSatisfied', () => {
     sandbox.restore()
   })
 
-  fixtures.invalidContainerVersions.forEach(containerVersion => {
-    it('[isValidContainerVersion] Should log error and exit process for invalid container version', async () => {
-      await logErrorAndExitIfNotSatisfied({
-        isValidContainerVersion: { containerVersion },
-      })
-      assertLoggedErrorAndExitedProcess()
-    })
-  })
-
-  fixtures.validContainerVersions.forEach(containerVersion => {
-    it('[isValidContainerVersion] Should not log error nor exit process for valid container version', async () => {
-      await logErrorAndExitIfNotSatisfied({
-        isValidContainerVersion: { containerVersion },
-      })
-      assertNoErrorLoggedAndNoProcessExit()
-    })
-  })
-
   it('[isNewerContainerVersion] Should log error and exit process for container version is not new', async () => {
     await logErrorAndExitIfNotSatisfied({
       isNewerContainerVersion: {

--- a/ern-orchestrator/src/syncCauldronContainer.ts
+++ b/ern-orchestrator/src/syncCauldronContainer.ts
@@ -56,6 +56,10 @@ export async function syncCauldronContainer(
         ? await cauldron.getContainerVersion(descriptor)
         : await cauldron.getTopLevelContainerVersion(descriptor)
       if (cauldronContainerNewVersion) {
+        if (!semver.valid(cauldronContainerNewVersion)) {
+          throw new Error(`${cauldronContainerNewVersion} is not a semver compliant version and therefore cannot be auto patch incremented.
+Please set the new container version through command options.`)
+        }
         cauldronContainerNewVersion = semver.inc(
           cauldronContainerNewVersion,
           'patch'

--- a/ern-orchestrator/test/Ensure-test.js
+++ b/ern-orchestrator/test/Ensure-test.js
@@ -23,29 +23,6 @@ describe('Ensure.js', () => {
   })
 
   // ==========================================================
-  // isValidContainerVersion
-  // ==========================================================
-  describe('isValidContainerVersion', () => {
-    fixtures.validContainerVersions.forEach(version => {
-      it('shoud not throw if version is valid', () => {
-        expect(
-          () => Ensure.isValidContainerVersion(version),
-          `throw for ${version}`
-        ).to.not.throw()
-      })
-    })
-
-    fixtures.invalidContainerVersions.forEach(version => {
-      it('should throw if version is invalid', () => {
-        expect(
-          () => Ensure.isValidContainerVersion(version),
-          `does not throw for ${version}`
-        ).to.throw()
-      })
-    })
-  })
-
-  // ==========================================================
   // noGitOrFilesystemPath
   // ==========================================================
   describe('noGitOrFilesystemPath', () => {


### PR DESCRIPTION
Container version format rules are too strict for no real strong underlying reason.

It looks like the restriction that any container version should be compliant with semver rules, was only done so that we could feed the versions to semver library for comparison, without causing a crash due to non semver compliance of the versions, but also to make sure that we could auto patch increment the container version upon container regeneration (for non semver compliant versions, there is no such 'patch' version).

Even though, our container version check was even more stricter than what semver allows, just rejecting any versions that wasn't formatted as `[major].[minor].[patch]`.

These are not strong enough reasons to limit container version formatting such drastically. 

Having the ability to use a more nuanced palette of version formats, open the door to more flexibility and more advanced use cases.

This PR :

- Gets rid of the `isValidContainerVersion` check. Basically any string is now a valid version.
- Updates `isNewerContainerVersion` logic to use semver comparison if both versions are semver compliant, otherwise default to basic lexicographical order.
- Adds a check in `syncCauldronContainer` in case the container version cannot be auto patch incremented (if container version is not a semver compatible one). If that's the case an exception will be thrown to let the client know that new container version needs to be explicitly provided through command options.

