### PR TITLE
Update Azure pipelines hosted images

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,12 +21,12 @@ stages:
     jobs:
       - job: Windows
         pool:
-          vmImage: 'win1803'
+          vmImage: 'windows-latest'
         steps:
           - template: azure/templates/unit-tests.yml
       - job: macOS
         pool:
-          vmImage: 'macOS-10.13'
+          vmImage: 'macOS-10.15'
         steps:
           - template: azure/templates/unit-tests.yml
       - job: Linux


### PR DESCRIPTION
This PR address the following warning that appeared recently when running our CI pipeline in Azure DevOps:
 
> ##[warning]This pipeline uses a Microsoft-hosted agent image that will be removed on March 23, 2020 (MacOS-10.13). You must make changes to your pipeline before that date, or else your pipeline will fail

> ##[warning]This pipeline uses a Microsoft-hosted agent image that will be removed on March 23, 2020 (Win 1803). You must make changes to your pipeline before that date, or else your pipeline will fail

Both `MacOS-10.13` and `Win 1803` images have been communicated as deprecated through a [recent blog post](https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/). This PR replace the images with proper ones picked from the [official list of available hosted agents](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml), respectively `MacOS-10.15` and `windows-latest`. 