### PR TITLE
Refactor generateComposite

### DIFF
--- a/ern-composite-gen/src/addRNDepToPjson.ts
+++ b/ern-composite-gen/src/addRNDepToPjson.ts
@@ -1,0 +1,7 @@
+import { readPackageJson, writePackageJson } from 'ern-core'
+
+export async function addRNDepToPjson(dir: string, version: string) {
+  const compositePackageJson = await readPackageJson(dir)
+  compositePackageJson.dependencies['react-native'] = version
+  return writePackageJson(dir, compositePackageJson)
+}

--- a/ern-composite-gen/src/addRNStartScriptToPjson.ts
+++ b/ern-composite-gen/src/addRNStartScriptToPjson.ts
@@ -1,0 +1,9 @@
+import { readPackageJson, writePackageJson } from 'ern-core'
+
+export async function addRNStartScriptToPjson({ cwd }: { cwd: string }) {
+  const packageJson = await readPackageJson(cwd)
+  packageJson.scripts = packageJson.scripts ?? {}
+  packageJson.scripts.start =
+    'node node_modules/react-native/local-cli/cli.js start'
+  await writePackageJson(cwd, packageJson)
+}

--- a/ern-composite-gen/src/applyYarnResolutions.ts
+++ b/ern-composite-gen/src/applyYarnResolutions.ts
@@ -1,0 +1,21 @@
+import { log, readPackageJson, shell, writePackageJson, yarn } from 'ern-core'
+
+export async function applyYarnResolutions({
+  cwd,
+  resolutions,
+}: {
+  cwd: string
+  resolutions: { [pkg: string]: string }
+}) {
+  log.debug('Adding yarn resolutions to package.json')
+  log.trace(`resolutions : ${JSON.stringify(resolutions, null, 2)}`)
+  const compositePackageJson = await readPackageJson(cwd)
+  compositePackageJson.resolutions = resolutions
+  await writePackageJson(cwd, compositePackageJson)
+  try {
+    shell.pushd(cwd)
+    await yarn.install()
+  } finally {
+    shell.popd()
+  }
+}

--- a/ern-composite-gen/src/createBabelRc.ts
+++ b/ern-composite-gen/src/createBabelRc.ts
@@ -1,0 +1,111 @@
+import fs from 'fs-extra'
+import path from 'path'
+import uuidv4 from 'uuid/v4'
+import semver from 'semver'
+import { log, readPackageJson, writePackageJson } from 'ern-core'
+import { getNodeModuleVersion } from './getNodeModuleVersion'
+
+export async function createBabelRc({ cwd }: { cwd: string }) {
+  log.debug('Creating top level composite .babelrc')
+  const compositePackageJson = await readPackageJson(cwd)
+  const compositeNodeModulesPath = path.join(cwd, 'node_modules')
+  const compositeReactNativeVersion = await getNodeModuleVersion({
+    cwd,
+    name: 'react-native',
+  })
+
+  const compositeBabelRc: { plugins: any[]; presets?: string[] } = {
+    plugins: [],
+  }
+
+  // Ugly hacky way of handling module-resolver babel plugin
+  // At least it has some guarantees to make it safer but its just a temporary
+  // solution until we figure out a more proper way of handling this plugin
+  log.debug(
+    'Taking care of potential Babel module-resolver plugins used by MiniApps'
+  )
+  let moduleResolverAliases: { [k: string]: any } = {}
+  for (const dependency of Object.keys(compositePackageJson.dependencies)) {
+    const miniAppPackagePath = path.join(compositeNodeModulesPath, dependency)
+    let miniAppPackageJson
+    try {
+      miniAppPackageJson = await readPackageJson(miniAppPackagePath)
+    } catch (e) {
+      // swallow (for test. to be fixed)
+      continue
+    }
+    const miniAppName = miniAppPackageJson.name
+    if (miniAppPackageJson.babel) {
+      if (miniAppPackageJson.babel.plugins) {
+        for (const babelPlugin of miniAppPackageJson.babel.plugins) {
+          if (Array.isArray(babelPlugin)) {
+            if (babelPlugin.includes('module-resolver')) {
+              // Add unique name to this composite top level module-resolver to avoid
+              // it messing with other module-resolver plugin configurations that could
+              // be defined in the .babelrc config of individual MiniApps
+              // https://babeljs.io/docs/en/options#plugin-preset-merging
+              babelPlugin.push(uuidv4())
+              // Copy over module-resolver plugin & config to top level composite .babelrc
+              log.debug(
+                `Taking care of module-resolver Babel plugin for ${miniAppName} MiniApp`
+              )
+              if (compositeBabelRc.plugins.length === 0) {
+                // First MiniApp to add module-resolver plugin & config
+                // easy enough, we just copy over the plugin & config
+                compositeBabelRc.plugins.push(<any>babelPlugin)
+                for (const x of babelPlugin) {
+                  if (x instanceof Object && x.alias) {
+                    moduleResolverAliases = x.alias
+                    break
+                  }
+                }
+              } else {
+                // Another MiniApp  has already declared module-resolver
+                // plugin & config. If we have conflicts for aliases, we'll just abort
+                // bundling as of now to avoid generating a potentially unstable bundle
+                for (const item of babelPlugin) {
+                  if (item instanceof Object && item.alias) {
+                    for (const aliasKey of Object.keys(item.alias)) {
+                      if (
+                        moduleResolverAliases[aliasKey] &&
+                        moduleResolverAliases[aliasKey] !== item.alias[aliasKey]
+                      ) {
+                        throw new Error('Babel module-resolver alias conflict')
+                      } else if (!moduleResolverAliases[aliasKey]) {
+                        moduleResolverAliases[aliasKey] = item.alias[aliasKey]
+                      }
+                    }
+                  }
+                }
+              }
+            } else {
+              log.warn(
+                `Unsupported Babel plugin type ${babelPlugin.toString()} in ${miniAppName} MiniApp`
+              )
+            }
+          } else {
+            log.warn(
+              `Unsupported Babel plugin type ${babelPlugin.toString()} in ${miniAppName} MiniApp`
+            )
+          }
+        }
+      }
+      log.debug(
+        `Removing babel object from ${miniAppName} MiniApp package.json`
+      )
+      delete miniAppPackageJson.babel
+      await writePackageJson(miniAppPackagePath, miniAppPackageJson)
+    }
+  }
+
+  if (semver.gte(compositeReactNativeVersion, '0.57.0')) {
+    compositeBabelRc.presets = ['module:metro-react-native-babel-preset']
+  } else {
+    compositeBabelRc.presets = ['react-native']
+  }
+
+  return fs.writeFile(
+    path.join(cwd, '.babelrc'),
+    JSON.stringify(compositeBabelRc, null, 2)
+  )
+}

--- a/ern-composite-gen/src/createBaseCompositeImports.ts
+++ b/ern-composite-gen/src/createBaseCompositeImports.ts
@@ -1,0 +1,16 @@
+import fs from 'fs-extra'
+import path from 'path'
+import { readPackageJson } from 'ern-core'
+
+export async function createBaseCompositeImports({ cwd }: { cwd: string }) {
+  let content = ''
+
+  const dependencies: string[] = []
+  const compositePackageJson = await readPackageJson(cwd)
+  for (const dependency of Object.keys(compositePackageJson.dependencies)) {
+    content += `import '${dependency}'\n`
+    dependencies.push(dependency)
+  }
+
+  await fs.writeFile(path.join(cwd, 'composite-imports.js'), content)
+}

--- a/ern-composite-gen/src/createIndexJs.ts
+++ b/ern-composite-gen/src/createIndexJs.ts
@@ -1,0 +1,22 @@
+import path from 'path'
+import fs from 'fs-extra'
+import { readPackageJson } from 'ern-core'
+
+export async function createIndexJs({ cwd }: { cwd: string }) {
+  let entryIndexJsContent = ''
+
+  const dependencies: string[] = []
+  const compositePackageJson = await readPackageJson(cwd)
+  for (const dependency of Object.keys(compositePackageJson.dependencies)) {
+    entryIndexJsContent += `import '${dependency}'\n`
+    dependencies.push(dependency)
+  }
+
+  await fs.writeFile(path.join(cwd, 'index.js'), entryIndexJsContent)
+  // Still also generate index.android.js and index.ios.js for backward compatibility with
+  // Container generated with Electrode Native < 0.33.0, as these Containers are still
+  // looking for these files.
+  // TO BE REMOVED IN 0.40.0
+  await fs.writeFile(path.join(cwd, 'index.ios.js'), entryIndexJsContent)
+  await fs.writeFile(path.join(cwd, 'index.android.js'), entryIndexJsContent)
+}

--- a/ern-composite-gen/src/createMetroConfig.ts
+++ b/ern-composite-gen/src/createMetroConfig.ts
@@ -1,0 +1,65 @@
+import fs from 'fs-extra'
+import path from 'path'
+
+export async function createMetroConfig({ cwd }: { cwd: string }) {
+  return fs.writeFile(
+    path.join(cwd, 'metro.config.js'),
+    `const blacklist = require('metro-config/src/defaults/blacklist');
+module.exports = {
+  resolver: {
+    sourceExts: ['jsx', 'js', 'ts', 'tsx', 'mjs'],
+    blacklistRE: blacklist([
+      // Ignore IntelliJ directories
+      /.*\\.idea\\/.*/,
+      // ignore git directories
+      /.*\\.git\\/.*/,
+      // Ignore android directories
+      /.*\\/app\\/build\\/.*/,
+    ]),
+    assetExts: [
+      // Image formats
+      "bmp",
+      "gif",
+      "jpg",
+      "jpeg",
+      "png",
+      "psd",
+      "svg",
+      "webp", 
+      // Video formats
+      "m4v",
+      "mov",
+      "mp4",
+      "mpeg",
+      "mpg",
+      "webm", 
+      // Audio formats
+      "aac",
+      "aiff",
+      "caf",
+      "m4a",
+      "mp3",
+      "wav", 
+      // Document formats
+      "html",
+      "pdf",
+      // Font formats
+      "otf",
+      "ttf", 
+      // Archives (virtual files)
+      "zip"
+    ]
+  },
+  transformer: {
+    getTransformOptions: async () => ({
+      transform: {
+        experimentalImportSupport: false,
+        inlineRequires: false,
+      },
+    }),
+    assetPlugins: ['ern-bundle-store-metro-asset-plugin'],
+  },
+};
+`
+  )
+}

--- a/ern-composite-gen/src/createRNCliConfig.ts
+++ b/ern-composite-gen/src/createRNCliConfig.ts
@@ -1,0 +1,8 @@
+import fs from 'fs-extra'
+import path from 'path'
+
+export async function createRNCliConfig({ cwd }: { cwd: string }) {
+  const sourceExts =
+    "module.exports = { resolver: { sourceExts: ['jsx', 'js', 'ts', 'tsx', 'mjs'] } };"
+  await fs.writeFile(path.join(cwd, 'rn-cli.config.js'), sourceExts)
+}

--- a/ern-composite-gen/src/generateComposite.ts
+++ b/ern-composite-gen/src/generateComposite.ts
@@ -1,27 +1,26 @@
-import {
-  gitCli,
-  log,
-  PackagePath,
-  shell,
-  yarn,
-  readPackageJson,
-  writePackageJson,
-  kax,
-  YarnLockParser,
-} from 'ern-core'
+import { gitCli, log, PackagePath, shell, yarn, kax } from 'ern-core'
 import { cleanupCompositeDir } from './cleanupCompositeDir'
-import {
-  MiniAppsDeltas,
-  getMiniAppsDeltas,
-  getPackageJsonDependenciesUsingMiniAppDeltas,
-  runYarnUsingMiniAppDeltas,
-} from './miniAppsDeltasUtils'
 import fs from 'fs-extra'
 import path from 'path'
 import semver from 'semver'
 import _ from 'lodash'
 import { CompositeGeneratorConfig } from './types'
 import uuidv4 from 'uuid/v4'
+import { addRNDepToPjson } from './addRNDepToPjson'
+import { getNodeModuleVersion } from './getNodeModuleVersion'
+import { addRNStartScriptToPjson } from './addRNStartScriptToPjson'
+import { createIndexJs } from './createIndexJs'
+import { createBaseCompositeImports } from './createBaseCompositeImports'
+import { patchMetroBabelRcRoots } from './patchMetroBabelRcRoots'
+import { patchMetro51AssetsBug } from './patchMetro51AssetsBug'
+import { patchMetroBabelEnv } from './patchMetroBabelEnv'
+import { createBabelRc } from './createBabelRc'
+import { applyYarnResolutions } from './applyYarnResolutions'
+import { createMetroConfig } from './createMetroConfig'
+import { createRNCliConfig } from './createRNCliConfig'
+import { installPackages } from './installPackages'
+import { installPackagesWithoutYarnLock } from './installPackagesWithoutYarnLock'
+import { installExtraPackages } from './installExtraPackages'
 
 export async function generateComposite(config: CompositeGeneratorConfig) {
   log.debug(`generateComposite config : ${JSON.stringify(config, null, 2)}`)
@@ -99,10 +98,10 @@ Composite output directory should either not exist (it will be created) or shoul
 
   shell.pushd(outDir)
   try {
-    await installJsPackagesWithoutYarnLock({ jsPackages, outDir })
-    await createCompositeImportsJsBasedOnPackageJson({ outDir })
+    await installPackagesWithoutYarnLock({ cwd: outDir, jsPackages })
+    await createBaseCompositeImports({ cwd: outDir })
     if (extraJsDependencies) {
-      await installExtraJsDependencies({ outDir, extraJsDependencies })
+      await installExtraPackages({ cwd: outDir, extraJsDependencies })
     }
   } finally {
     shell.popd()
@@ -135,21 +134,21 @@ async function generateFullComposite(
   shell.pushd(outDir)
 
   try {
-    await installJsPackages({
+    await installPackages({
+      cwd: outDir,
       jsApiImplDependencies,
       miniApps,
-      outDir,
       pathToYarnLock,
     })
-    await addStartScriptToPackageJson({ outDir })
-    await createIndexJsBasedOnPackageJson({ outDir })
+    await addRNStartScriptToPjson({ cwd: outDir })
+    await createIndexJs({ cwd: outDir })
     if (extraJsDependencies) {
-      await installExtraJsDependencies({
+      await installExtraPackages({
+        cwd: outDir,
         extraJsDependencies: [
           PackagePath.fromString('ern-bundle-store-metro-asset-plugin'),
           ...extraJsDependencies,
         ],
-        outDir,
       })
     }
     if (resolutions) {
@@ -157,590 +156,23 @@ async function generateFullComposite(
       // any file patches in node_modules, as it will run
       // `yarn install`, thus potentially clearing any previously
       // applied patches
-      await applyYarnResolutions({ outDir, resolutions })
+      await applyYarnResolutions({ cwd: outDir, resolutions })
     }
-    await addBabelrcRoots({ outDir })
-    await createCompositeBabelRc({ outDir })
-    await createMetroConfigJs({ outDir })
-    await createRnCliConfig({ outDir })
-    const rnVersion = await getCompositeReactNativeVersion({ outDir })
-    await addReactNativeDependencyToPackageJson(outDir, rnVersion)
-    if (semver.lt(rnVersion, '0.60.0')) {
-      await patchMetro51({ outDir })
-    }
-    await patchMetroBabelEnv({ outDir })
-  } finally {
-    shell.popd()
-  }
-}
-
-async function addReactNativeDependencyToPackageJson(
-  dir: string,
-  version: string
-) {
-  const compositePackageJson = await readPackageJson(dir)
-  compositePackageJson.dependencies['react-native'] = version
-  await writePackageJson(dir, compositePackageJson)
-}
-
-async function installJsPackagesUsingYarnLock({
-  outDir,
-  pathToYarnLock,
-  jsPackages,
-}: {
-  outDir: string
-  pathToYarnLock: string
-  jsPackages: PackagePath[]
-}) {
-  const compositePackageJson: any = {}
-
-  if (_.some(jsPackages, m => !m.version)) {
-    throw new Error(
-      '[generateComposite] When providing a yarn lock you cannot pass MiniApps without an explicit version'
-    )
-  }
-
-  if (!(await fs.pathExists(pathToYarnLock))) {
-    throw new Error(
-      `[generateComposite] Path to yarn.lock does not exist (${pathToYarnLock})`
-    )
-  }
-
-  log.debug(`Copying yarn.lock to ${outDir}`)
-  shell.cp(pathToYarnLock, path.join(outDir, 'yarn.lock'))
-
-  const yarnLock = await fs.readFile(pathToYarnLock, 'utf8')
-  const miniAppsDeltas: MiniAppsDeltas = getMiniAppsDeltas(jsPackages, yarnLock)
-
-  log.debug(
-    `[generateComposite] miniAppsDeltas: ${JSON.stringify(miniAppsDeltas)}`
-  )
-
-  compositePackageJson.dependencies = getPackageJsonDependenciesUsingMiniAppDeltas(
-    miniAppsDeltas,
-    yarnLock
-  )
-
-  await writePackageJson(outDir, compositePackageJson)
-
-  // Now that the composite package.json is similar to the one used to generated yarn.lock
-  // we can run yarn install to get back to the exact same dependency graph as the previously
-  // generated composite
-  await kax.task('Running yarn install').run(yarn.install())
-  await runYarnUsingMiniAppDeltas(miniAppsDeltas)
-}
-
-async function installJsPackagesWithoutYarnLock({
-  outDir,
-  jsPackages,
-}: {
-  outDir: string
-  jsPackages: PackagePath[]
-}) {
-  // No yarn.lock path was provided, just add miniapps one by one
-  log.debug('[generateComposite] no yarn lock provided')
-  await yarn.init()
-  const nbJsPackages = jsPackages.length
-  for (let i = 0; i < nbJsPackages; i++) {
-    await kax
-      .task(`[${i + 1}/${nbJsPackages}] Adding ${jsPackages[i]}`)
-      .run(yarn.add(jsPackages[i]))
-  }
-}
-
-async function createIndexJsBasedOnPackageJson({ outDir }: { outDir: string }) {
-  let entryIndexJsContent = ''
-
-  const dependencies: string[] = []
-  const compositePackageJson = await readPackageJson(outDir)
-  for (const dependency of Object.keys(compositePackageJson.dependencies)) {
-    entryIndexJsContent += `import '${dependency}'\n`
-    dependencies.push(dependency)
-  }
-
-  await fs.writeFile(path.join(outDir, 'index.js'), entryIndexJsContent)
-  // Still also generate index.android.js and index.ios.js for backward compatibility with
-  // Container generated with Electrode Native < 0.33.0, as these Containers are still
-  // looking for these files.
-  // TO BE REMOVED IN 0.40.0
-  await fs.writeFile(path.join(outDir, 'index.ios.js'), entryIndexJsContent)
-  await fs.writeFile(path.join(outDir, 'index.android.js'), entryIndexJsContent)
-}
-
-async function createCompositeImportsJsBasedOnPackageJson({
-  outDir,
-}: {
-  outDir: string
-}) {
-  let content = ''
-
-  const dependencies: string[] = []
-  const compositePackageJson = await readPackageJson(outDir)
-  for (const dependency of Object.keys(compositePackageJson.dependencies)) {
-    content += `import '${dependency}'\n`
-    dependencies.push(dependency)
-  }
-
-  await fs.writeFile(path.join(outDir, 'composite-imports.js'), content)
-}
-
-async function addStartScriptToPackageJson({ outDir }: { outDir: string }) {
-  const packageJson = await readPackageJson(outDir)
-  packageJson.scripts = {
-    start: 'node node_modules/react-native/local-cli/cli.js start',
-  }
-  await writePackageJson(outDir, packageJson)
-}
-
-async function addBabelrcRoots({ outDir }: { outDir: string }) {
-  const compositePackageJson = await readPackageJson(outDir)
-  const compositeNodeModulesPath = path.join(outDir, 'node_modules')
-  const compositeReactNativeVersion = await getCompositeReactNativeVersion({
-    outDir,
-  })
-  const compositeMetroVersion = await getCompositeMetroVersion({ outDir })
-  const dependencies: string[] = Object.keys(compositePackageJson.dependencies)
-
-  // Any dependency that has the useBabelRc set in their package.json
-  // as follow ...
-  //
-  // "ern": {
-  //   "useBabelRc": true
-  // }
-  //
-  // ... is added to the babelRcRoots array, so that we can properly
-  // configure Babel to process the .babelrc of these dependencies.
-  const babelRcRootsRe: RegExp[] = []
-  const babelRcRootsPaths: string[] = []
-  for (const dependency of dependencies) {
-    if (await fs.pathExists(path.join(compositeNodeModulesPath, dependency))) {
-      const depPackageJson = await readPackageJson(
-        path.join(compositeNodeModulesPath, dependency)
-      )
-      if (depPackageJson.ern?.useBabelRc === true) {
-        babelRcRootsRe.push(new RegExp(`node_modules\/${dependency}(?!.+\/)`))
-        babelRcRootsPaths.push(`./node_modules/${dependency}`)
-      }
-    }
-  }
-
-  // If React Native version is greater or equal than 0.56.0
-  // it is using Babel 7
-  // In that case, because we still want to process .babelrc
-  // of some MiniApps that need their .babelrc to be processed
-  // during bundling, we need to use the babelrcRoots option of
-  // Babel 7 (https://babeljs.io/docs/en/options#babelrcroots)
-  // Unfortunately, there is no way -as of metro latest version-
-  // to provide this option to the metro bundler.
-  // A pull request will be opened to metro to properly support
-  // this option, but meanwhile, we are just directly patching the
-  // metro transformer source file to make use of this option.
-  // This code will be kept even when a new version of metro supporting
-  // this option will be released, to keep backward compatibility.
-  // It will be deprecated at some point.
-  if (
-    semver.gte(compositeReactNativeVersion, '0.56.0') &&
-    babelRcRootsRe.length > 0
-  ) {
-    let pathToFileToPatch
-    if (semver.lt(compositeMetroVersion, '0.51.0')) {
-      // For versions of metro < 0.51.0, we are patching the reactNativeTransformer.js file
-      // https://github.com/facebook/metro/blob/v0.50.0/packages/metro/src/reactNativeTransformer.js#L120
-      pathToFileToPatch = path.join(
-        compositeNodeModulesPath,
-        'metro/src/reactNativeTransformer.js'
-      )
-    } else {
-      // For versions of metro >= 0.51.0, we are patching the index.js file
-      // https://github.com/facebook/metro/blob/v0.51.0/packages/metro-react-native-babel-transformer/src/index.js#L120
-      const pathInCommunityCli = path.join(
-        compositeNodeModulesPath,
-        '@react-native-community/cli/node_modules/metro-react-native-babel-transformer/src/index.js'
-      )
-      if (await fs.pathExists(pathInCommunityCli)) {
-        pathToFileToPatch = pathInCommunityCli
-      } else {
-        pathToFileToPatch = path.join(
-          compositeNodeModulesPath,
-          'metro-react-native-babel-transformer/src/index.js'
-        )
-      }
-    }
-
-    const fileToPatch = await fs.readFile(pathToFileToPatch)
-    const lineToPatch = `let config = Object.assign({}, babelRC, extraConfig);`
-    // Just add extra code line to inject babelrcRoots option
-
-    const patch = `extraConfig.babelrcRoots = [
-${babelRcRootsRe.map(b => b.toString()).join(',')} ]
-${lineToPatch}`
-    const patchedFile = fileToPatch.toString().replace(lineToPatch, patch)
-    await fs.writeFile(pathToFileToPatch, patchedFile)
-  }
-
-  // If React Native version is less than 0.56 it is still using Babel 6.
-  // In that case .babelrc files will be processed in any node_modules
-  // which is not a desired behavior.
-  // Therefore we just remove all .babelrc from all node_modules.
-  // We only keep .babelrc of node_modules that are "whitelisted",
-  // as we want them to be processed.
-  if (semver.lt(compositeReactNativeVersion, '0.56.0')) {
-    log.debug('Removing .babelrc files from all modules')
-    if (babelRcRootsPaths.length > 0) {
-      log.debug(
-        `Preserving .babelrc of whitelisted node_modules : ${JSON.stringify(
-          babelRcRootsPaths,
-          null,
-          2
-        )}`
-      )
-      for (const babelRcRoot of babelRcRootsPaths) {
-        shell.cp(
-          path.join(babelRcRoot, '.babelrc'),
-          path.join(babelRcRoot, '.babelrcback')
-        )
-      }
-    }
-    shell.rm('-rf', path.join('node_modules', '**', '.babelrc'))
-    if (babelRcRootsPaths.length > 0) {
-      for (const babelRcRoot of babelRcRootsPaths) {
-        shell.cp(
-          path.join(babelRcRoot, '.babelrcback'),
-          path.join(babelRcRoot, '.babelrc')
-        )
-      }
-    }
-  }
-}
-
-async function getCompositeReactNativeVersion({
-  outDir,
-}: {
-  outDir: string
-}): Promise<string> {
-  const compositeNodeModulesPath = path.join(outDir, 'node_modules')
-  const pathToReactNativeNodeModuleDir = path.join(
-    compositeNodeModulesPath,
-    'react-native'
-  )
-
-  const reactNativePackageJson = await readPackageJson(
-    pathToReactNativeNodeModuleDir
-  )
-  return reactNativePackageJson.version
-}
-
-async function getCompositeMetroVersion({
-  outDir,
-}: {
-  outDir: string
-}): Promise<string> {
-  const compositeNodeModulesPath = path.join(outDir, 'node_modules')
-  const pathToMetroNodeModuleDir = path.join(compositeNodeModulesPath, 'metro')
-  let metroPackageJson
-  if (await fs.pathExists(pathToMetroNodeModuleDir)) {
-    metroPackageJson = await readPackageJson(pathToMetroNodeModuleDir)
-  }
-  return metroPackageJson?.version ?? '0.0.0'
-}
-
-async function patchMetro51({ outDir }: { outDir: string }) {
-  const metroVersion = await getCompositeMetroVersion({ outDir })
-  const compositeNodeModulesPath = path.join(outDir, 'node_modules')
-  // Only of use for RN < 0.60.0
-  if (metroVersion === '0.51.1') {
-    const pathToFileToPatch = path.join(
-      compositeNodeModulesPath,
-      'metro-resolver/src/resolve.js'
-    )
-    const stringToReplace = `const assetNames = resolveAsset(dirPath, fileNameHint, platform);`
-    const replacementString = `let assetNames;
-    try { assetNames = resolveAsset(dirPath, fileNameHint, platform); } catch (e) {}`
-    const fileToPatch = await fs.readFile(pathToFileToPatch)
-    const patchedFile = fileToPatch
-      .toString()
-      .replace(stringToReplace, replacementString)
-    return fs.writeFile(pathToFileToPatch, patchedFile)
-  }
-}
-
-//
-// Patch a metro bug related to BABEL_ENV resolution
-// This bug was fixed in metro through:
-// https://github.com/facebook/metro/commit/c509a89af9015b6d6b34c07a26ea59b73d87cd53
-// It has not been released yet and will anyway not be available for older
-// versions of React Native.
-// Patching is therefore done here, independently of the version of RN used.
-// We can keep this patch potentially forever as the replacement it is doing can
-// also be safely applied in any case, even on top of a metro release that contain the fix.
-async function patchMetroBabelEnv({ outDir }: { outDir: string }) {
-  const filesToPach = [
-    path.join(
-      outDir,
-      'node_modules/metro-react-native-babel-transformer/src/index.js'
-    ),
-    path.join(outDir, 'node_modules/metro-babel-transformer/src/index.js'),
-  ]
-  const stringToReplace = 'process.env.BABEL_ENV = OLD_BABEL_ENV;'
-  const replacementString =
-    'if (OLD_BABEL_ENV) { process.env.BABEL_ENV = OLD_BABEL_ENV; }'
-  for (const fileToPatch of filesToPach) {
-    if (await fs.pathExists(fileToPatch)) {
-      const file = await fs.readFile(fileToPatch)
-      const patchedFile = file
-        .toString()
-        .replace(stringToReplace, replacementString)
-      await fs.writeFile(fileToPatch, patchedFile)
-    }
-  }
-}
-
-export async function applyYarnResolutions({
-  outDir,
-  resolutions,
-}: {
-  outDir: string
-  resolutions: { [pkg: string]: string }
-}) {
-  log.debug('Adding yarn resolutions to package.json')
-  log.trace(`resolutions : ${JSON.stringify(resolutions, null, 2)}`)
-  const compositePackageJson = await readPackageJson(outDir)
-  compositePackageJson.resolutions = resolutions
-  await writePackageJson(outDir, compositePackageJson)
-  try {
-    shell.pushd(outDir)
-    await yarn.install()
-  } finally {
-    shell.popd()
-  }
-}
-
-async function createCompositeBabelRc({ outDir }: { outDir: string }) {
-  log.debug('Creating top level composite .babelrc')
-  const compositePackageJson = await readPackageJson(outDir)
-  const compositeNodeModulesPath = path.join(outDir, 'node_modules')
-  const compositeReactNativeVersion = await getCompositeReactNativeVersion({
-    outDir,
-  })
-
-  const compositeBabelRc: { plugins: any[]; presets?: string[] } = {
-    plugins: [],
-  }
-
-  // Ugly hacky way of handling module-resolver babel plugin
-  // At least it has some guarantees to make it safer but its just a temporary
-  // solution until we figure out a more proper way of handling this plugin
-  log.debug(
-    'Taking care of potential Babel module-resolver plugins used by MiniApps'
-  )
-  let moduleResolverAliases: { [k: string]: any } = {}
-  for (const dependency of Object.keys(compositePackageJson.dependencies)) {
-    const miniAppPackagePath = path.join(compositeNodeModulesPath, dependency)
-    let miniAppPackageJson
-    try {
-      miniAppPackageJson = await readPackageJson(miniAppPackagePath)
-    } catch (e) {
-      // swallow (for test. to be fixed)
-      continue
-    }
-    const miniAppName = miniAppPackageJson.name
-    if (miniAppPackageJson.babel) {
-      if (miniAppPackageJson.babel.plugins) {
-        for (const babelPlugin of miniAppPackageJson.babel.plugins) {
-          if (Array.isArray(babelPlugin)) {
-            if (babelPlugin.includes('module-resolver')) {
-              // Add unique name to this composite top level module-resolver to avoid
-              // it messing with other module-resolver plugin configurations that could
-              // be defined in the .babelrc config of individual MiniApps
-              // https://babeljs.io/docs/en/options#plugin-preset-merging
-              babelPlugin.push(uuidv4())
-              // Copy over module-resolver plugin & config to top level composite .babelrc
-              log.debug(
-                `Taking care of module-resolver Babel plugin for ${miniAppName} MiniApp`
-              )
-              if (compositeBabelRc.plugins.length === 0) {
-                // First MiniApp to add module-resolver plugin & config
-                // easy enough, we just copy over the plugin & config
-                compositeBabelRc.plugins.push(<any>babelPlugin)
-                for (const x of babelPlugin) {
-                  if (x instanceof Object && x.alias) {
-                    moduleResolverAliases = x.alias
-                    break
-                  }
-                }
-              } else {
-                // Another MiniApp  has already declared module-resolver
-                // plugin & config. If we have conflicts for aliases, we'll just abort
-                // bundling as of now to avoid generating a potentially unstable bundle
-                for (const item of babelPlugin) {
-                  if (item instanceof Object && item.alias) {
-                    for (const aliasKey of Object.keys(item.alias)) {
-                      if (
-                        moduleResolverAliases[aliasKey] &&
-                        moduleResolverAliases[aliasKey] !== item.alias[aliasKey]
-                      ) {
-                        throw new Error('Babel module-resolver alias conflict')
-                      } else if (!moduleResolverAliases[aliasKey]) {
-                        moduleResolverAliases[aliasKey] = item.alias[aliasKey]
-                      }
-                    }
-                  }
-                }
-              }
-            } else {
-              log.warn(
-                `Unsupported Babel plugin type ${babelPlugin.toString()} in ${miniAppName} MiniApp`
-              )
-            }
-          } else {
-            log.warn(
-              `Unsupported Babel plugin type ${babelPlugin.toString()} in ${miniAppName} MiniApp`
-            )
-          }
-        }
-      }
-      log.debug(
-        `Removing babel object from ${miniAppName} MiniApp package.json`
-      )
-      delete miniAppPackageJson.babel
-      await writePackageJson(miniAppPackagePath, miniAppPackageJson)
-    }
-  }
-
-  if (semver.gte(compositeReactNativeVersion, '0.57.0')) {
-    compositeBabelRc.presets = ['module:metro-react-native-babel-preset']
-  } else {
-    compositeBabelRc.presets = ['react-native']
-  }
-
-  return fs.writeFile(
-    path.join(outDir, '.babelrc'),
-    JSON.stringify(compositeBabelRc, null, 2)
-  )
-}
-
-async function createMetroConfigJs({ outDir }: { outDir: string }) {
-  return fs.writeFile(
-    path.join(outDir, 'metro.config.js'),
-    `const blacklist = require('metro-config/src/defaults/blacklist');
-module.exports = {
-  resolver: {
-    blacklistRE: blacklist([
-      // Ignore IntelliJ directories
-      /.*\\.idea\\/.*/,
-      // ignore git directories
-      /.*\\.git\\/.*/,
-      // Ignore android directories
-      /.*\\/app\\/build\\/.*/,
-    ]),
-    assetExts: [
-      // Image formats
-      "bmp",
-      "gif",
-      "jpg",
-      "jpeg",
-      "png",
-      "psd",
-      "svg",
-      "webp", 
-      // Video formats
-      "m4v",
-      "mov",
-      "mp4",
-      "mpeg",
-      "mpg",
-      "webm", 
-      // Audio formats
-      "aac",
-      "aiff",
-      "caf",
-      "m4a",
-      "mp3",
-      "wav", 
-      // Document formats
-      "html",
-      "pdf",
-      // Font formats
-      "otf",
-      "ttf", 
-      // Archives (virtual files)
-      "zip"
-    ]
-  },
-  transformer: {
-    getTransformOptions: async () => ({
-      transform: {
-        experimentalImportSupport: false,
-        inlineRequires: false,
-      },
-    }),
-    assetPlugins: ['ern-bundle-store-metro-asset-plugin'],
-  },
-};
-`
-  )
-}
-
-async function createRnCliConfig({ outDir }: { outDir: string }) {
-  const compositeReactNativeVersion = await getCompositeReactNativeVersion({
-    outDir,
-  })
-  let sourceExts
-  if (semver.gte(compositeReactNativeVersion, '0.57.0')) {
-    sourceExts =
-      "module.exports = { resolver: { sourceExts: ['jsx', 'js', 'ts', 'tsx', 'mjs'] } };"
-  } else {
-    sourceExts =
-      "module.exports = { getSourceExts: () => ['jsx', 'js', 'ts', 'tsx', 'mjs'] }"
-  }
-  await fs.writeFile(path.join(outDir, 'rn-cli.config.js'), sourceExts)
-}
-
-async function installJsPackages({
-  jsApiImplDependencies,
-  miniApps,
-  outDir,
-  pathToYarnLock,
-}: {
-  jsApiImplDependencies?: PackagePath[]
-  miniApps: PackagePath[]
-  outDir: string
-  pathToYarnLock?: string
-}) {
-  const jsPackages = jsApiImplDependencies
-    ? [...miniApps, ...jsApiImplDependencies]
-    : miniApps
-
-  if (pathToYarnLock && _.some(jsPackages, p => p.isFilePath)) {
-    log.warn(
-      'Yarn lock will not be used as some of the MiniApp paths are file based'
-    )
-    pathToYarnLock = undefined
-  }
-
-  if (pathToYarnLock) {
-    await installJsPackagesUsingYarnLock({
-      jsPackages,
-      outDir,
-      pathToYarnLock,
+    await patchMetroBabelRcRoots({ cwd: outDir })
+    await createBabelRc({ cwd: outDir })
+    await createMetroConfig({ cwd: outDir })
+    const rnVersion = await getNodeModuleVersion({
+      cwd: outDir,
+      name: 'react-native',
     })
-  } else {
-    await installJsPackagesWithoutYarnLock({ jsPackages, outDir })
-  }
-}
-
-async function installExtraJsDependencies({
-  outDir,
-  extraJsDependencies,
-}: {
-  outDir: string
-  extraJsDependencies: PackagePath[]
-}) {
-  shell.pushd(outDir)
-  try {
-    for (const extraJsDependency of extraJsDependencies || []) {
-      await yarn.add(extraJsDependency)
+    if (semver.gte(rnVersion, '0.57.0')) {
+      await createRNCliConfig({ cwd: outDir })
     }
+    await addRNDepToPjson(outDir, rnVersion)
+    if (semver.lt(rnVersion, '0.60.0')) {
+      await patchMetro51AssetsBug({ cwd: outDir })
+    }
+    await patchMetroBabelEnv({ cwd: outDir })
   } finally {
     shell.popd()
   }

--- a/ern-composite-gen/src/getNodeModuleVersion.ts
+++ b/ern-composite-gen/src/getNodeModuleVersion.ts
@@ -1,0 +1,18 @@
+import path from 'path'
+import fs from 'fs-extra'
+import { readPackageJson } from 'ern-core'
+
+export async function getNodeModuleVersion({
+  cwd,
+  name,
+}: {
+  cwd: string
+  name: string
+}) {
+  const pathToModule = path.join(cwd, `node_modules/${name}`)
+  if (!(await fs.pathExists(pathToModule))) {
+    throw new Error(`Path ${pathToModule} not found`)
+  }
+  const pJson = await readPackageJson(pathToModule)
+  return pJson.version
+}

--- a/ern-composite-gen/src/installExtraPackages.ts
+++ b/ern-composite-gen/src/installExtraPackages.ts
@@ -1,0 +1,18 @@
+import { PackagePath, shell, yarn } from 'ern-core'
+
+export async function installExtraPackages({
+  cwd,
+  extraJsDependencies,
+}: {
+  cwd: string
+  extraJsDependencies: PackagePath[]
+}) {
+  shell.pushd(cwd)
+  try {
+    for (const extraJsDependency of extraJsDependencies || []) {
+      await yarn.add(extraJsDependency)
+    }
+  } finally {
+    shell.popd()
+  }
+}

--- a/ern-composite-gen/src/installPackages.ts
+++ b/ern-composite-gen/src/installPackages.ts
@@ -1,0 +1,35 @@
+import _ from 'lodash'
+import { log, PackagePath } from 'ern-core'
+import { installPackagesUsingYarnLock } from './installPackagesUsingYarnLock'
+import { installPackagesWithoutYarnLock } from './installPackagesWithoutYarnLock'
+
+export async function installPackages({
+  cwd,
+  jsApiImplDependencies,
+  miniApps,
+  pathToYarnLock,
+}: {
+  cwd: string
+  jsApiImplDependencies?: PackagePath[]
+  miniApps: PackagePath[]
+  pathToYarnLock?: string
+}) {
+  const jsPackages = jsApiImplDependencies
+    ? [...miniApps, ...jsApiImplDependencies]
+    : miniApps
+
+  if (pathToYarnLock && _.some(jsPackages, p => p.isFilePath)) {
+    log.warn(
+      'Yarn lock will not be used as some of the MiniApp paths are file based'
+    )
+    pathToYarnLock = undefined
+  }
+
+  return pathToYarnLock
+    ? installPackagesUsingYarnLock({
+        cwd,
+        jsPackages,
+        pathToYarnLock,
+      })
+    : installPackagesWithoutYarnLock({ cwd, jsPackages })
+}

--- a/ern-composite-gen/src/installPackagesUsingYarnLock.ts
+++ b/ern-composite-gen/src/installPackagesUsingYarnLock.ts
@@ -1,0 +1,57 @@
+import _ from 'lodash'
+import fs from 'fs-extra'
+import path from 'path'
+import { kax, log, PackagePath, shell, writePackageJson, yarn } from 'ern-core'
+import {
+  MiniAppsDeltas,
+  getMiniAppsDeltas,
+  getPackageJsonDependenciesUsingMiniAppDeltas,
+  runYarnUsingMiniAppDeltas,
+} from './miniAppsDeltasUtils'
+
+export async function installPackagesUsingYarnLock({
+  cwd,
+  pathToYarnLock,
+  jsPackages,
+}: {
+  cwd: string
+  pathToYarnLock: string
+  jsPackages: PackagePath[]
+}) {
+  const compositePackageJson: any = {}
+
+  if (_.some(jsPackages, m => !m.version)) {
+    throw new Error(
+      '[generateComposite] When providing a yarn lock you cannot pass MiniApps without an explicit version'
+    )
+  }
+
+  if (!(await fs.pathExists(pathToYarnLock))) {
+    throw new Error(
+      `[generateComposite] Path to yarn.lock does not exist (${pathToYarnLock})`
+    )
+  }
+
+  log.debug(`Copying yarn.lock to ${cwd}`)
+  shell.cp(pathToYarnLock, path.join(cwd, 'yarn.lock'))
+
+  const yarnLock = await fs.readFile(pathToYarnLock, 'utf8')
+  const miniAppsDeltas: MiniAppsDeltas = getMiniAppsDeltas(jsPackages, yarnLock)
+
+  log.debug(
+    `[generateComposite] miniAppsDeltas: ${JSON.stringify(miniAppsDeltas)}`
+  )
+
+  compositePackageJson.dependencies = getPackageJsonDependenciesUsingMiniAppDeltas(
+    miniAppsDeltas,
+    yarnLock
+  )
+
+  await writePackageJson(cwd, compositePackageJson)
+
+  // Now that the composite package.json is similar to the one used to generated yarn.lock
+  // we can run yarn install to get back to the exact same dependency graph as the previously
+  // generated composite
+  await kax.task('Running yarn install').run(yarn.install())
+  await runYarnUsingMiniAppDeltas(miniAppsDeltas)
+}

--- a/ern-composite-gen/src/installPackagesWithoutYarnLock.ts
+++ b/ern-composite-gen/src/installPackagesWithoutYarnLock.ts
@@ -1,0 +1,24 @@
+import { kax, log, PackagePath, shell, yarn } from 'ern-core'
+
+export async function installPackagesWithoutYarnLock({
+  cwd,
+  jsPackages,
+}: {
+  cwd: string
+  jsPackages: PackagePath[]
+}) {
+  // No yarn.lock path was provided, just add miniapps one by one
+  log.debug('[generateComposite] no yarn lock provided')
+  shell.pushd(cwd)
+  try {
+    await yarn.init()
+    const nbJsPackages = jsPackages.length
+    for (let i = 0; i < nbJsPackages; i++) {
+      await kax
+        .task(`[${i + 1}/${nbJsPackages}] Adding ${jsPackages[i]}`)
+        .run(yarn.add(jsPackages[i]))
+    }
+  } finally {
+    shell.popd()
+  }
+}

--- a/ern-composite-gen/src/patchMetro51AssetsBug.ts
+++ b/ern-composite-gen/src/patchMetro51AssetsBug.ts
@@ -1,0 +1,26 @@
+import fs from 'fs-extra'
+import path from 'path'
+import { getNodeModuleVersion } from './getNodeModuleVersion'
+
+export async function patchMetro51AssetsBug({ cwd }: { cwd: string }) {
+  const metroVersion = await getNodeModuleVersion({
+    cwd,
+    name: 'metro',
+  })
+  const compositeNodeModulesPath = path.join(cwd, 'node_modules')
+  // Only of use for RN < 0.60.0
+  if (metroVersion === '0.51.1') {
+    const pathToFileToPatch = path.join(
+      compositeNodeModulesPath,
+      'metro-resolver/src/resolve.js'
+    )
+    const stringToReplace = `const assetNames = resolveAsset(dirPath, fileNameHint, platform);`
+    const replacementString = `let assetNames;
+    try { assetNames = resolveAsset(dirPath, fileNameHint, platform); } catch (e) {}`
+    const fileToPatch = await fs.readFile(pathToFileToPatch)
+    const patchedFile = fileToPatch
+      .toString()
+      .replace(stringToReplace, replacementString)
+    return fs.writeFile(pathToFileToPatch, patchedFile)
+  }
+}

--- a/ern-composite-gen/src/patchMetroBabelEnv.ts
+++ b/ern-composite-gen/src/patchMetroBabelEnv.ts
@@ -1,0 +1,33 @@
+import fs from 'fs-extra'
+import path from 'path'
+
+//
+// Patch a metro bug related to BABEL_ENV resolution
+// This bug was fixed in metro through:
+// https://github.com/facebook/metro/commit/c509a89af9015b6d6b34c07a26ea59b73d87cd53
+// It has not been released yet and will anyway not be available for older
+// versions of React Native.
+// Patching is therefore done here, independently of the version of RN used.
+// We can keep this patch potentially forever as the replacement it is doing can
+// also be safely applied in any case, even on top of a metro release that contain the fix.
+export async function patchMetroBabelEnv({ cwd }: { cwd: string }) {
+  const filesToPach = [
+    path.join(
+      cwd,
+      'node_modules/metro-react-native-babel-transformer/src/index.js'
+    ),
+    path.join(cwd, 'node_modules/metro-babel-transformer/src/index.js'),
+  ]
+  const stringToReplace = 'process.env.BABEL_ENV = OLD_BABEL_ENV;'
+  const replacementString =
+    'if (OLD_BABEL_ENV) { process.env.BABEL_ENV = OLD_BABEL_ENV; }'
+  for (const fileToPatch of filesToPach) {
+    if (await fs.pathExists(fileToPatch)) {
+      const file = await fs.readFile(fileToPatch)
+      const patchedFile = file
+        .toString()
+        .replace(stringToReplace, replacementString)
+      await fs.writeFile(fileToPatch, patchedFile)
+    }
+  }
+}

--- a/ern-composite-gen/src/patchMetroBabelRcRoots.ts
+++ b/ern-composite-gen/src/patchMetroBabelRcRoots.ts
@@ -1,0 +1,130 @@
+import fs from 'fs-extra'
+import path from 'path'
+import semver from 'semver'
+import { log, readPackageJson, shell } from 'ern-core'
+import { getNodeModuleVersion } from './getNodeModuleVersion'
+
+export async function patchMetroBabelRcRoots({ cwd }: { cwd: string }) {
+  const compositePackageJson = await readPackageJson(cwd)
+  const compositeNodeModulesPath = path.join(cwd, 'node_modules')
+  const compositeReactNativeVersion = await getNodeModuleVersion({
+    cwd,
+    name: 'react-native',
+  })
+  const compositeMetroVersion = await getNodeModuleVersion({
+    cwd,
+    name: 'metro',
+  })
+  const dependencies: string[] = Object.keys(compositePackageJson.dependencies)
+
+  // Any dependency that has the useBabelRc set in their package.json
+  // as follow ...
+  //
+  // "ern": {
+  //   "useBabelRc": true
+  // }
+  //
+  // ... is added to the babelRcRoots array, so that we can properly
+  // configure Babel to process the .babelrc of these dependencies.
+  const babelRcRootsRe: RegExp[] = []
+  const babelRcRootsPaths: string[] = []
+  for (const dependency of dependencies) {
+    if (await fs.pathExists(path.join(compositeNodeModulesPath, dependency))) {
+      const depPackageJson = await readPackageJson(
+        path.join(compositeNodeModulesPath, dependency)
+      )
+      if (depPackageJson.ern?.useBabelRc === true) {
+        babelRcRootsRe.push(new RegExp(`node_modules\/${dependency}(?!.+\/)`))
+        babelRcRootsPaths.push(`./node_modules/${dependency}`)
+      }
+    }
+  }
+
+  // If React Native version is greater or equal than 0.56.0
+  // it is using Babel 7
+  // In that case, because we still want to process .babelrc
+  // of some MiniApps that need their .babelrc to be processed
+  // during bundling, we need to use the babelrcRoots option of
+  // Babel 7 (https://babeljs.io/docs/en/options#babelrcroots)
+  // Unfortunately, there is no way -as of metro latest version-
+  // to provide this option to the metro bundler.
+  // A pull request will be opened to metro to properly support
+  // this option, but meanwhile, we are just directly patching the
+  // metro transformer source file to make use of this option.
+  // This code will be kept even when a new version of metro supporting
+  // this option will be released, to keep backward compatibility.
+  // It will be deprecated at some point.
+  if (
+    semver.gte(compositeReactNativeVersion, '0.56.0') &&
+    babelRcRootsRe.length > 0
+  ) {
+    let pathToFileToPatch
+    if (semver.lt(compositeMetroVersion, '0.51.0')) {
+      // For versions of metro < 0.51.0, we are patching the reactNativeTransformer.js file
+      // https://github.com/facebook/metro/blob/v0.50.0/packages/metro/src/reactNativeTransformer.js#L120
+      pathToFileToPatch = path.join(
+        compositeNodeModulesPath,
+        'metro/src/reactNativeTransformer.js'
+      )
+    } else {
+      // For versions of metro >= 0.51.0, we are patching the index.js file
+      // https://github.com/facebook/metro/blob/v0.51.0/packages/metro-react-native-babel-transformer/src/index.js#L120
+      const pathInCommunityCli = path.join(
+        compositeNodeModulesPath,
+        '@react-native-community/cli/node_modules/metro-react-native-babel-transformer/src/index.js'
+      )
+      if (await fs.pathExists(pathInCommunityCli)) {
+        pathToFileToPatch = pathInCommunityCli
+      } else {
+        pathToFileToPatch = path.join(
+          compositeNodeModulesPath,
+          'metro-react-native-babel-transformer/src/index.js'
+        )
+      }
+    }
+
+    const fileToPatch = await fs.readFile(pathToFileToPatch)
+    const lineToPatch = `let config = Object.assign({}, babelRC, extraConfig);`
+    // Just add extra code line to inject babelrcRoots option
+
+    const patch = `extraConfig.babelrcRoots = [
+${babelRcRootsRe.map(b => b.toString()).join(',')} ]
+${lineToPatch}`
+    const patchedFile = fileToPatch.toString().replace(lineToPatch, patch)
+    await fs.writeFile(pathToFileToPatch, patchedFile)
+  }
+
+  // If React Native version is less than 0.56 it is still using Babel 6.
+  // In that case .babelrc files will be processed in any node_modules
+  // which is not a desired behavior.
+  // Therefore we just remove all .babelrc from all node_modules.
+  // We only keep .babelrc of node_modules that are "whitelisted",
+  // as we want them to be processed.
+  if (semver.lt(compositeReactNativeVersion, '0.56.0')) {
+    log.debug('Removing .babelrc files from all modules')
+    if (babelRcRootsPaths.length > 0) {
+      log.debug(
+        `Preserving .babelrc of whitelisted node_modules : ${JSON.stringify(
+          babelRcRootsPaths,
+          null,
+          2
+        )}`
+      )
+      for (const babelRcRoot of babelRcRootsPaths) {
+        shell.cp(
+          path.join(babelRcRoot, '.babelrc'),
+          path.join(babelRcRoot, '.babelrcback')
+        )
+      }
+    }
+    shell.rm('-rf', path.join('node_modules', '**', '.babelrc'))
+    if (babelRcRootsPaths.length > 0) {
+      for (const babelRcRoot of babelRcRootsPaths) {
+        shell.cp(
+          path.join(babelRcRoot, '.babelrcback'),
+          path.join(babelRcRoot, '.babelrc')
+        )
+      }
+    }
+  }
+}

--- a/ern-composite-gen/test/compositegen-test.ts
+++ b/ern-composite-gen/test/compositegen-test.ts
@@ -2,24 +2,23 @@ import { assert, expect } from 'chai'
 import { doesThrow } from 'ern-util-dev'
 import sinon from 'sinon'
 import path from 'path'
-import fs from 'fs'
-import {
-  applyYarnResolutions,
-  generateComposite,
-} from '../src/generateComposite'
+import fs from 'fs-extra'
+import { applyYarnResolutions } from '../src/applyYarnResolutions'
+import { generateComposite } from '../src/generateComposite'
 import {
   getMiniAppsDeltas,
   getPackageJsonDependenciesUsingMiniAppDeltas,
   runYarnUsingMiniAppDeltas,
 } from '../src/miniAppsDeltasUtils'
 import * as ernUtil from 'ern-core'
-const { PackagePath, YarnCli, shell } = ernUtil
+const { YarnCli, shell } = ernUtil
+import { PackagePath } from 'ern-core'
 const sandbox = sinon.createSandbox()
 
 // Spies
-let yarnCliStub
+let yarnCliStub: any
 
-let tmpOutDir
+let tmpOutDir: string
 const currentDir = __dirname
 const pathToFixtures = path.join(currentDir, 'fixtures')
 const pathToSampleYarnLock = path.join(pathToFixtures, 'sample.yarn.lock')
@@ -228,18 +227,28 @@ describe('ern-container-gen utils.js', () => {
   })
 
   const createCompositeNodeModulesReactNativePackageJson = (
-    rootDir,
-    rnVersion
+    rootDir: string,
+    rnVersion: string
   ) => {
     const pathToCompositeNodeModulesReactNative = path.join(
       rootDir,
       'node_modules',
       'react-native'
     )
+    const pathToCompositeNodeModulesMetro = path.join(
+      rootDir,
+      'node_modules',
+      'metro'
+    )
     ernUtil.shell.mkdir('-p', pathToCompositeNodeModulesReactNative)
     fs.writeFileSync(
       path.join(pathToCompositeNodeModulesReactNative, 'package.json'),
       JSON.stringify({ version: rnVersion })
+    )
+    ernUtil.shell.mkdir('-p', pathToCompositeNodeModulesMetro)
+    fs.writeFileSync(
+      path.join(pathToCompositeNodeModulesMetro, 'package.json'),
+      JSON.stringify({ version: '0.51.0' })
     )
   }
 
@@ -351,7 +360,7 @@ describe('ern-container-gen utils.js', () => {
       yarnCliStub.install.callsFake(() =>
         createCompositeNodeModulesReactNativePackageJson(tmpOutDir, '0.56.0')
       )
-      const miniApps = []
+      const miniApps: PackagePath[] = []
       assert(
         await doesThrow(generateComposite, null, {
           miniApps,
@@ -401,7 +410,7 @@ describe('ern-container-gen utils.js', () => {
   // ==========================================================
   // generateComposite [without yarn lock]
   // ==========================================================
-  const fakeYarnInit = (rootDir, rnVersion) => {
+  const fakeYarnInit = (rootDir: string, rnVersion: string) => {
     fs.writeFileSync(
       path.join(tmpOutDir, 'package.json'),
       JSON.stringify({ dependencies: {} })
@@ -469,7 +478,7 @@ describe('ern-container-gen utils.js', () => {
         'c/**/left-pad': '1.1.2',
         'd2/left-pad': '1.1.1',
       }
-      await applyYarnResolutions({ outDir: tmpOutDir, resolutions })
+      await applyYarnResolutions({ cwd: tmpOutDir, resolutions })
       const packageJson: any = JSON.parse(
         fs.readFileSync(packageJsonPath).toString()
       )
@@ -483,7 +492,7 @@ describe('ern-container-gen utils.js', () => {
         'c/**/left-pad': '1.1.2',
         'd2/left-pad': '1.1.1',
       }
-      await applyYarnResolutions({ outDir: tmpOutDir, resolutions })
+      await applyYarnResolutions({ cwd: tmpOutDir, resolutions })
       const packageJson: any = JSON.parse(
         fs.readFileSync(packageJsonPath).toString()
       )
@@ -497,7 +506,7 @@ describe('ern-container-gen utils.js', () => {
         'c/**/left-pad': '1.1.2',
         'd2/left-pad': '1.1.1',
       }
-      await applyYarnResolutions({ outDir: tmpOutDir, resolutions })
+      await applyYarnResolutions({ cwd: tmpOutDir, resolutions })
       assert(yarnCliStub.install.calledOnce)
     })
   })

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@types/ncp": "^2.0.3",
     "@types/node-fetch": "^2.5.4",
     "@types/semver": "^6.2.0",
+    "@types/sinon": "^7.5.2",
     "@types/shelljs": "^0.8.6",
     "@types/treeify": "^1.0.0",
     "@types/tunnel": "^0.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1720,6 +1720,11 @@
     "@types/glob" "*"
     "@types/node" "*"
 
+"@types/sinon@^7.5.2":
+  version "7.5.2"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-7.5.2.tgz#5e2f1d120f07b9cda07e5dedd4f3bf8888fccdb9"
+  integrity sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg==
+
 "@types/through@*":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/through/-/through-0.0.29.tgz#72943aac922e179339c651fa34a4428a4d722f93"


### PR DESCRIPTION
Quick refactoring of `ern-composite-gen` module to extract utility functions inlined in `generateComposite` to dedicated files.

This is some prep-work for further refactoring / improvements to this module.

Also includes adding `@types/sinon` to `devDependencies` ... while updating tests post refactoring, I came to notice that new TS policy introduced in https://github.com/electrode-io/electrode-native/pull/1502 also applies to tests source files, so got a lot of red warnings popping in the file as soon as I opened it, even though I didn't realized it before because the tests are explicitly excluded from compilation so no errors caught when running build checks. Will have to look into potentially removing them from exclusion and fix all of them.