### PR TITLE
Fix ern dev version issue

### DIFF
--- a/ern-local-cli/src/index.dev.js
+++ b/ern-local-cli/src/index.dev.js
@@ -3,13 +3,10 @@ const path = require('path')
 const Module = require('module')
 const oload = Module._load
 
+const workspacePath = path.resolve(__dirname, '../..')
+
 process.env.ERN_ENV = 'development'
-process.env.TS_NODE_PROJECT = path.resolve(
-  __dirname,
-  '..',
-  '..',
-  'tsconfig.json'
-)
+process.env.TS_NODE_PROJECT = path.resolve(workspacePath, 'tsconfig.json')
 
 let tsNodeSourceMapSupportModule
 Module._load = function(file, parent) {
@@ -23,6 +20,9 @@ Module._load = function(file, parent) {
   }
 }
 
-require('tsconfig-paths/register')
-require('ts-node').register({ transpileOnly: true })
+require(path.normalize(`${workspacePath}/node_modules/tsconfig-paths/register`))
+require(path.normalize(`${workspacePath}/node_modules/ts-node`)).register({
+  dir: workspacePath,
+  transpileOnly: true,
+})
 require('./index.ts')


### PR DESCRIPTION
This PR fixes an issue experienced when using Electrode Native development version (1000.0.0) in some context.

Electrode Native dev version is transpiling TypeScript files on the fly and fails if there is some type issues in any of the source files, based on the rules of the current compiler version and config.

I experienced `ern` failing with such type issues when run from a directory containing a different JS project with it's own `node_modules`. It appears that it was considering some typescript configuration file from the local `node_modules` in some way, rather than the one of Electrode Native project. 

This PR ensure that Electrode Native dev uses `ts-node` and `ts-config-path` from Electrode Native workspace, and also sets the [dir](https://github.com/TypeStrong/ts-node#cli-and-programmatic-options) option of `ts-node` to make sure that working directory used for TS config resolution is the root Electrode Native workspace directory rather than the one from where `ern` is executed (as it defaults to `process.cwd()`), effectively fixing the experienced issue.