### PR TITLE
Format and standardize package.json files

### DIFF
--- a/ern-api-gen/package.json
+++ b/ern-api-gen/package.json
@@ -4,53 +4,38 @@
   "description": "Electrode Native API generator",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "homepage": "http://www.electrode.io",
+  "scripts": {
+    "build": "ern-typescript",
+    "coverage": "ern-nyc",
+    "instrument-dist": "ern-instrument-dist",
+    "prepublish": "npm run build",
+    "test": "ern-mocha"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/electrode-io/electrode-native.git"
   },
+  "keywords": [
+    "android",
+    "api",
+    "electrode",
+    "ern",
+    "ios",
+    "node",
+    "react-native"
+  ],
+  "contributors": [
+    "Benoit Lemaire <blemaire@walmartlabs.com>",
+    "Bharath Marulasiddappa <BMarulasiddappa@walmartlabs.com>",
+    "Deepu Ganapathiyadan <DGanapathiyadan@walmartlabs.com>",
+    "Krunal Shah <KShah1@walmartlabs.com>",
+    "Weijie Li <WLi@walmartlabs.com>"
+  ],
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/electrode-io/electrode-native/issues"
   },
-  "scripts": {
-    "build": "ern-typescript",
-    "test": "ern-mocha",
-    "coverage": "ern-nyc",
-    "prepublish": "npm run build",
-    "instrument-dist": "ern-instrument-dist"
-  },
-  "keywords": [
-    "electrode",
-    "ern",
-    "react-native",
-    "api",
-    "node",
-    "android",
-    "ios"
-  ],
-  "contributors": [
-    {
-      "name": "Benoit Lemaire",
-      "email": "blemaire@walmartlabs.com"
-    },
-    {
-      "name": "Bharath Marulasiddappa",
-      "email": "BMarulasiddappa@walmartlabs.com"
-    },
-    {
-      "name": "Deepu Ganapathiyadan",
-      "email": "DGanapathiyadan@walmartlabs.com"
-    },
-    {
-      "name": "Krunal Shah",
-      "email": "KShah1@walmartlabs.com"
-    },
-    {
-      "name": "Weijie Li",
-      "email": "WLi@walmartlabs.com"
-    }
-  ],
-  "license": "Apache-2.0",
+  "homepage": "http://www.electrode.io",
   "dependencies": {
     "ern-core": "1000.0.0",
     "fs-extra": "^8.1.0",

--- a/ern-api-impl-gen/package.json
+++ b/ern-api-impl-gen/package.json
@@ -4,55 +4,41 @@
   "description": "Electrode Native API implementation projects generator",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "homepage": "http://www.electrode.io",
+  "scripts": {
+    "build": "ern-typescript",
+    "coverage": "ern-nyc",
+    "instrument-dist": "ern-instrument-dist",
+    "prepublish": "yarn run build",
+    "test": "ern-mocha"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/electrode-io/electrode-native.git"
   },
+  "keywords": [
+    "android",
+    "api",
+    "electrode",
+    "ern",
+    "generator",
+    "ios",
+    "node",
+    "react-native"
+  ],
+  "contributors": [
+    "Benoit Lemaire <blemaire@walmartlabs.com>",
+    "Bharath Marulasiddappa <BMarulasiddappa@walmartlabs.com>",
+    "Deepu Ganapathiyadan <DGanapathiyadan@walmartlabs.com>",
+    "Krunal Shah <KShah1@walmartlabs.com>",
+    "Weijie Li <WLi@walmartlabs.com>"
+  ],
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/electrode-io/electrode-native/issues"
   },
-  "keywords": [
-    "electrode",
-    "ern",
-    "react-native",
-    "generator",
-    "api",
-    "node",
-    "android",
-    "ios"
-  ],
-  "contributors": [
-    {
-      "name": "Benoit Lemaire",
-      "email": "blemaire@walmartlabs.com"
-    },
-    {
-      "name": "Bharath Marulasiddappa",
-      "email": "BMarulasiddappa@walmartlabs.com"
-    },
-    {
-      "name": "Deepu Ganapathiyadan",
-      "email": "DGanapathiyadan@walmartlabs.com"
-    },
-    {
-      "name": "Krunal Shah",
-      "email": "KShah1@walmartlabs.com"
-    },
-    {
-      "name": "Weijie Li",
-      "email": "WLi@walmartlabs.com"
-    }
-  ],
-  "scripts": {
-    "test": "ern-mocha",
-    "build": "ern-typescript",
-    "coverage": "ern-nyc",
-    "prepublish": "yarn run build",
-    "instrument-dist": "ern-instrument-dist"
-  },
-  "license": "Apache-2.0",
+  "homepage": "http://www.electrode.io",
   "dependencies": {
+    "@yarnpkg/lockfile": "^1.0.2",
     "chalk": "^2.4.1",
     "ern-api-gen": "1000.0.0",
     "ern-core": "1000.0.0",
@@ -61,8 +47,7 @@
     "mustache": "^2.3.1",
     "semver": "5.5.0",
     "xcode": "^1.0.0",
-    "xcode-ern": "^1.0.12",
-    "@yarnpkg/lockfile": "^1.0.2"
+    "xcode-ern": "^1.0.12"
   },
   "devDependencies": {
     "ern-util-dev": "1000.0.0"

--- a/ern-cauldron-api/package.json
+++ b/ern-cauldron-api/package.json
@@ -4,59 +4,44 @@
   "description": "Electrode Native Cauldron Client",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "homepage": "http://www.electrode.io",
+  "scripts": {
+    "build": "ern-typescript",
+    "coverage": "ern-nyc",
+    "instrument-dist": "ern-instrument-dist",
+    "prepublish": "yarn run build",
+    "test": "ern-mocha"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/electrode-io/electrode-native.git"
   },
+  "keywords": [
+    "android",
+    "cauldron",
+    "electrode",
+    "ern",
+    "ios",
+    "node",
+    "react-native"
+  ],
+  "contributors": [
+    "Benoit Lemaire <blemaire@walmartlabs.com>",
+    "Bharath Marulasiddappa <BMarulasiddappa@walmartlabs.com>",
+    "Deepu Ganapathiyadan <DGanapathiyadan@walmartlabs.com>",
+    "Krunal Shah <KShah1@walmartlabs.com>",
+    "Weijie Li <WLi@walmartlabs.com>"
+  ],
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/electrode-io/electrode-native/issues"
   },
-  "keywords": [
-    "electrode",
-    "ern",
-    "react-native",
-    "cauldron",
-    "node",
-    "android",
-    "ios"
-  ],
-  "contributors": [
-    {
-      "name": "Benoit Lemaire",
-      "email": "blemaire@walmartlabs.com"
-    },
-    {
-      "name": "Bharath Marulasiddappa",
-      "email": "BMarulasiddappa@walmartlabs.com"
-    },
-    {
-      "name": "Deepu Ganapathiyadan",
-      "email": "DGanapathiyadan@walmartlabs.com"
-    },
-    {
-      "name": "Krunal Shah",
-      "email": "KShah1@walmartlabs.com"
-    },
-    {
-      "name": "Weijie Li",
-      "email": "WLi@walmartlabs.com"
-    }
-  ],
-  "scripts": {
-    "test": "ern-mocha",
-    "build": "ern-typescript",
-    "coverage": "ern-nyc",
-    "prepublish": "yarn run build",
-    "instrument-dist": "ern-instrument-dist"
-  },
-  "license": "Apache-2.0",
+  "homepage": "http://www.electrode.io",
   "dependencies": {
     "@hapi/joi": "^15.0.1",
+    "ern-core": "1000.0.0",
     "fs-extra": "^8.1.0",
     "lodash": "^4.17.14",
     "semver": "^5.5.0",
-    "ern-core": "1000.0.0",
     "uuid": "^3.3.2"
   },
   "devDependencies": {

--- a/ern-composite-gen/package.json
+++ b/ern-composite-gen/package.json
@@ -4,55 +4,43 @@
   "description": "Electrode Native Composite Generator",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "homepage": "http://www.electrode.io",
+  "scripts": {
+    "build": "ern-typescript",
+    "coverage": "ern-nyc",
+    "instrument-dist": "ern-instrument-dist",
+    "prepublish": "yarn run build",
+    "test": "ern-mocha"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/electrode-io/electrode-native.git"
   },
+  "keywords": [
+    "composite",
+    "electrode",
+    "ern",
+    "generator",
+    "node",
+    "react-native"
+  ],
+  "contributors": [
+    "Benoit Lemaire <blemaire@walmartlabs.com>",
+    "Bharath Marulasiddappa <BMarulasiddappa@walmartlabs.com>",
+    "Deepu Ganapathiyadan <DGanapathiyadan@walmartlabs.com>",
+    "Krunal Shah <KShah1@walmartlabs.com>"
+  ],
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/electrode-io/electrode-native/issues"
   },
-  "keywords": [
-    "electrode",
-    "ern",
-    "react-native",
-    "generator",
-    "composite",
-    "node"
-  ],
-  "contributors": [
-    {
-      "name": "Benoit Lemaire",
-      "email": "blemaire@walmartlabs.com"
-    },
-    {
-      "name": "Bharath Marulasiddappa",
-      "email": "BMarulasiddappa@walmartlabs.com"
-    },
-    {
-      "name": "Deepu Ganapathiyadan",
-      "email": "DGanapathiyadan@walmartlabs.com"
-    },
-    {
-      "name": "Krunal Shah",
-      "email": "KShah1@walmartlabs.com"
-    }
-  ],
-  "scripts": {
-    "build": "ern-typescript",
-    "test": "ern-mocha",
-    "coverage": "ern-nyc",
-    "prepublish": "yarn run build",
-    "instrument-dist": "ern-instrument-dist"
-  },
-  "license": "Apache-2.0",
+  "homepage": "http://www.electrode.io",
   "dependencies": {
     "ern-core": "1000.0.0",
     "fs-extra": "^8.1.0",
     "fs-readdir-recursive": "^1.1.0",
     "mustache": "^2.3.1",
-    "uuid": "^3.3.2",
-    "semver": "^5.5.0"
+    "semver": "^5.5.0",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "ern-util-dev": "1000.0.0"

--- a/ern-container-gen-android/package.json
+++ b/ern-container-gen-android/package.json
@@ -4,50 +4,52 @@
   "description": "Electrode Native Official Android Container Generator",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "homepage": "http://www.electrode.io",
+  "scripts": {
+    "build": "ern-typescript && ern-copyfiles",
+    "coverage": "ern-nyc",
+    "instrument-dist": "ern-instrument-dist && ern-copyfiles",
+    "prepublish": "yarn run build",
+    "test": "ern-mocha"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/electrode-io/electrode-native.git"
   },
+  "keywords": [
+    "android",
+    "container",
+    "electrode",
+    "ern",
+    "generator",
+    "react-native"
+  ],
+  "contributors": [
+    "Benoit Lemaire <blemaire@walmartlabs.com>",
+    "Bharath Marulasiddappa <BMarulasiddappa@walmartlabs.com>",
+    "Deepu Ganapathiyadan <DGanapathiyadan@walmartlabs.com>",
+    "Krunal Shah <KShah1@walmartlabs.com>",
+    "Weijie Li <WLi@walmartlabs.com>"
+  ],
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/electrode-io/electrode-native/issues"
   },
-  "keywords": [
-    "electrode",
-    "ern",
-    "react-native",
-    "generator",
-    "container",
-    "android"
-  ],
-  "contributors": [
-    {
-      "name": "Benoit Lemaire",
-      "email": "blemaire@walmartlabs.com"
-    },
-    {
-      "name": "Bharath Marulasiddappa",
-      "email": "BMarulasiddappa@walmartlabs.com"
-    },
-    {
-      "name": "Deepu Ganapathiyadan",
-      "email": "DGanapathiyadan@walmartlabs.com"
-    },
-    {
-      "name": "Krunal Shah",
-      "email": "KShah1@walmartlabs.com"
-    },
-    {
-      "name": "Weijie Li",
-      "email": "WLi@walmartlabs.com"
-    }
-  ],
-  "scripts": {
-    "build": "ern-typescript && ern-copyfiles",
-    "test": "ern-mocha",
-    "coverage": "ern-nyc",
-    "prepublish": "yarn run build",
-    "instrument-dist": "ern-instrument-dist && ern-copyfiles"
+  "homepage": "http://www.electrode.io",
+  "dependencies": {
+    "decompress-zip": "^0.3.1",
+    "ern-container-gen": "1000.0.0",
+    "ern-core": "1000.0.0",
+    "fs-extra": "^8.1.0",
+    "fs-readdir-recursive": "^1.1.0",
+    "lodash": "^4.17.14",
+    "semver": "^6.0.0"
+  },
+  "devDependencies": {
+    "copyfiles": "^2.0.0",
+    "ern-util-dev": "1000.0.0"
+  },
+  "engines": {
+    "node": ">=6"
   },
   "copyFiles": [
     {
@@ -58,22 +60,5 @@
       "source": "src/templates",
       "dest": "dist"
     }
-  ],
-  "license": "Apache-2.0",
-  "dependencies": {
-    "ern-container-gen": "1000.0.0",
-    "ern-core": "1000.0.0",
-    "fs-extra": "^8.1.0",
-    "decompress-zip": "^0.3.1",
-    "lodash": "^4.17.14",
-    "fs-readdir-recursive": "^1.1.0",
-    "semver": "^6.0.0"
-  },
-  "devDependencies": {
-    "ern-util-dev": "1000.0.0",
-    "copyfiles": "^2.0.0"
-  },
-  "engines": {
-    "node": ">=6"
-  }
+  ]
 }

--- a/ern-container-gen-ios/package.json
+++ b/ern-container-gen-ios/package.json
@@ -4,71 +4,56 @@
   "description": "Electrode Native Official iOS Container Generator",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "homepage": "http://www.electrode.io",
+  "scripts": {
+    "build": "ern-typescript && ern-copyfiles",
+    "coverage": "ern-nyc",
+    "instrument-dist": "ern-instrument-dist && ern-copyfiles",
+    "prepublish": "yarn run build",
+    "test": "ern-mocha"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/electrode-io/electrode-native.git"
   },
+  "keywords": [
+    "container",
+    "electrode",
+    "ern",
+    "generator",
+    "ios",
+    "react-native"
+  ],
+  "contributors": [
+    "Benoit Lemaire <blemaire@walmartlabs.com>",
+    "Bharath Marulasiddappa <BMarulasiddappa@walmartlabs.com>",
+    "Deepu Ganapathiyadan <DGanapathiyadan@walmartlabs.com>",
+    "Krunal Shah <KShah1@walmartlabs.com>",
+    "Weijie Li <WLi@walmartlabs.com>"
+  ],
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/electrode-io/electrode-native/issues"
   },
-  "keywords": [
-    "electrode",
-    "ern",
-    "react-native",
-    "generator",
-    "container",
-    "ios"
-  ],
-  "contributors": [
-    {
-      "name": "Benoit Lemaire",
-      "email": "blemaire@walmartlabs.com"
-    },
-    {
-      "name": "Bharath Marulasiddappa",
-      "email": "BMarulasiddappa@walmartlabs.com"
-    },
-    {
-      "name": "Deepu Ganapathiyadan",
-      "email": "DGanapathiyadan@walmartlabs.com"
-    },
-    {
-      "name": "Krunal Shah",
-      "email": "KShah1@walmartlabs.com"
-    },
-    {
-      "name": "Weijie Li",
-      "email": "WLi@walmartlabs.com"
-    }
-  ],
-  "scripts": {
-    "build": "ern-typescript && ern-copyfiles",
-    "test": "ern-mocha",
-    "coverage": "ern-nyc",
-    "prepublish": "yarn run build",
-    "instrument-dist": "ern-instrument-dist && ern-copyfiles"
+  "homepage": "http://www.electrode.io",
+  "dependencies": {
+    "ern-container-gen": "1000.0.0",
+    "ern-core": "1000.0.0",
+    "fs-extra": "^8.1.0",
+    "fs-readdir-recursive": "^1.1.0",
+    "lodash": "^4.17.14",
+    "xcode-ern": "^1.0.12"
+  },
+  "devDependencies": {
+    "copyfiles": "^2.0.0",
+    "ern-util-dev": "1000.0.0"
+  },
+  "engines": {
+    "node": ">=6"
   },
   "copyFiles": [
     {
       "source": "src/hull",
       "dest": "dist"
     }
-  ],
-  "license": "Apache-2.0",
-  "dependencies": {
-    "ern-container-gen": "1000.0.0",
-    "ern-core": "1000.0.0",
-    "fs-extra": "^8.1.0",
-    "xcode-ern": "^1.0.12",
-    "lodash": "^4.17.14",
-    "fs-readdir-recursive": "^1.1.0"
-  },
-  "devDependencies": {
-    "ern-util-dev": "1000.0.0",
-    "copyfiles": "^2.0.0"
-  },
-  "engines": {
-    "node": ">=6"
-  }
+  ]
 }

--- a/ern-container-gen/package.json
+++ b/ern-container-gen/package.json
@@ -4,57 +4,42 @@
   "description": "Electrode Native Container Generator",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "homepage": "http://www.electrode.io",
+  "scripts": {
+    "build": "ern-typescript",
+    "coverage": "ern-nyc",
+    "instrument-dist": "ern-instrument-dist",
+    "prepublish": "yarn run build",
+    "test": "ern-mocha"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/electrode-io/electrode-native.git"
   },
+  "keywords": [
+    "android",
+    "container",
+    "electrode",
+    "ern",
+    "generator",
+    "ios",
+    "node",
+    "react-native"
+  ],
+  "contributors": [
+    "Benoit Lemaire <blemaire@walmartlabs.com>",
+    "Bharath Marulasiddappa <BMarulasiddappa@walmartlabs.com>",
+    "Deepu Ganapathiyadan <DGanapathiyadan@walmartlabs.com>",
+    "Krunal Shah <KShah1@walmartlabs.com>",
+    "Weijie Li <WLi@walmartlabs.com>"
+  ],
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/electrode-io/electrode-native/issues"
   },
-  "keywords": [
-    "electrode",
-    "ern",
-    "react-native",
-    "generator",
-    "container",
-    "node",
-    "android",
-    "ios"
-  ],
-  "contributors": [
-    {
-      "name": "Benoit Lemaire",
-      "email": "blemaire@walmartlabs.com"
-    },
-    {
-      "name": "Bharath Marulasiddappa",
-      "email": "BMarulasiddappa@walmartlabs.com"
-    },
-    {
-      "name": "Deepu Ganapathiyadan",
-      "email": "DGanapathiyadan@walmartlabs.com"
-    },
-    {
-      "name": "Krunal Shah",
-      "email": "KShah1@walmartlabs.com"
-    },
-    {
-      "name": "Weijie Li",
-      "email": "WLi@walmartlabs.com"
-    }
-  ],
-  "scripts": {
-    "build": "ern-typescript",
-    "test": "ern-mocha",
-    "coverage": "ern-nyc",
-    "prepublish": "yarn run build",
-    "instrument-dist": "ern-instrument-dist"
-  },
-  "license": "Apache-2.0",
+  "homepage": "http://www.electrode.io",
   "dependencies": {
-    "ern-core": "1000.0.0",
     "ern-composite-gen": "1000.0.0",
+    "ern-core": "1000.0.0",
     "fs-extra": "^8.1.0",
     "fs-readdir-recursive": "^1.1.0",
     "mustache": "^2.3.1",
@@ -62,8 +47,8 @@
     "xcode-ern": "^1.0.12"
   },
   "devDependencies": {
-    "ern-util-dev": "1000.0.0",
-    "copyfiles": "^2.0.0"
+    "copyfiles": "^2.0.0",
+    "ern-util-dev": "1000.0.0"
   },
   "engines": {
     "node": ">=6"

--- a/ern-container-publisher/package.json
+++ b/ern-container-publisher/package.json
@@ -4,54 +4,39 @@
   "description": "Electrode Native Container Publisher",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "homepage": "http://www.electrode.io",
+  "scripts": {
+    "build": "ern-typescript && ern-copyfiles",
+    "coverage": "ern-nyc",
+    "instrument-dist": "ern-instrument-dist && ern-copyfiles",
+    "prepublish": "yarn run build",
+    "test": "ern-mocha"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/electrode-io/electrode-native.git"
   },
+  "keywords": [
+    "android",
+    "container",
+    "electrode",
+    "ern",
+    "ios",
+    "node",
+    "publisher",
+    "react-native"
+  ],
+  "contributors": [
+    "Benoit Lemaire <blemaire@walmartlabs.com>",
+    "Bharath Marulasiddappa <BMarulasiddappa@walmartlabs.com>",
+    "Deepu Ganapathiyadan <DGanapathiyadan@walmartlabs.com>",
+    "Krunal Shah <KShah1@walmartlabs.com>",
+    "Weijie Li <WLi@walmartlabs.com>"
+  ],
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/electrode-io/electrode-native/issues"
   },
-  "keywords": [
-    "electrode",
-    "ern",
-    "react-native",
-    "publisher",
-    "container",
-    "node",
-    "android",
-    "ios"
-  ],
-  "contributors": [
-    {
-      "name": "Benoit Lemaire",
-      "email": "blemaire@walmartlabs.com"
-    },
-    {
-      "name": "Bharath Marulasiddappa",
-      "email": "BMarulasiddappa@walmartlabs.com"
-    },
-    {
-      "name": "Deepu Ganapathiyadan",
-      "email": "DGanapathiyadan@walmartlabs.com"
-    },
-    {
-      "name": "Krunal Shah",
-      "email": "KShah1@walmartlabs.com"
-    },
-    {
-      "name": "Weijie Li",
-      "email": "WLi@walmartlabs.com"
-    }
-  ],
-  "scripts": {
-    "build": "ern-typescript && ern-copyfiles",
-    "test": "ern-mocha",
-    "coverage": "ern-nyc",
-    "prepublish": "yarn run build",
-    "instrument-dist": "ern-instrument-dist && ern-copyfiles"
-  },
-  "license": "Apache-2.0",
+  "homepage": "http://www.electrode.io",
   "dependencies": {
     "ern-core": "1000.0.0"
   },

--- a/ern-container-transformer/package.json
+++ b/ern-container-transformer/package.json
@@ -4,50 +4,38 @@
   "description": "Electrode Native Container Transformer",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "homepage": "http://www.electrode.io",
+  "scripts": {
+    "build": "ern-typescript",
+    "coverage": "ern-nyc",
+    "instrument-dist": "ern-instrument-dist",
+    "prepublish": "yarn run build",
+    "test": "ern-mocha"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/electrode-io/electrode-native.git"
   },
+  "keywords": [
+    "android",
+    "container",
+    "electrode",
+    "ern",
+    "ios",
+    "node",
+    "react-native",
+    "trasnformer"
+  ],
+  "contributors": [
+    "Benoit Lemaire <blemaire@walmartlabs.com>",
+    "Bharath Marulasiddappa <BMarulasiddappa@walmartlabs.com>",
+    "Deepu Ganapathiyadan <DGanapathiyadan@walmartlabs.com>",
+    "Krunal Shah <KShah1@walmartlabs.com>"
+  ],
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/electrode-io/electrode-native/issues"
   },
-  "keywords": [
-    "electrode",
-    "ern",
-    "react-native",
-    "trasnformer",
-    "container",
-    "node",
-    "android",
-    "ios"
-  ],
-  "contributors": [
-    {
-      "name": "Benoit Lemaire",
-      "email": "blemaire@walmartlabs.com"
-    },
-    {
-      "name": "Bharath Marulasiddappa",
-      "email": "BMarulasiddappa@walmartlabs.com"
-    },
-    {
-      "name": "Deepu Ganapathiyadan",
-      "email": "DGanapathiyadan@walmartlabs.com"
-    },
-    {
-      "name": "Krunal Shah",
-      "email": "KShah1@walmartlabs.com"
-    }
-  ],
-  "scripts": {
-    "build": "ern-typescript",
-    "test": "ern-mocha",
-    "coverage": "ern-nyc",
-    "prepublish": "yarn run build",
-    "instrument-dist": "ern-instrument-dist"
-  },
-  "license": "Apache-2.0",
+  "homepage": "http://www.electrode.io",
   "dependencies": {
     "ern-core": "1000.0.0"
   },

--- a/ern-core/package.json
+++ b/ern-core/package.json
@@ -4,57 +4,39 @@
   "description": "Electrode Native Core",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "homepage": "http://www.electrode.io",
+  "scripts": {
+    "build": "ern-typescript",
+    "coverage": "ern-nyc",
+    "instrument-dist": "ern-instrument-dist",
+    "prepublish": "yarn run build",
+    "test": "ern-mocha"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/electrode-io/electrode-native.git"
   },
-  "bugs": {
-    "url": "https://github.com/electrode-io/electrode-native/issues"
-  },
   "keywords": [
+    "android",
     "electrode",
     "electrode-native",
     "ern",
-    "react-native",
+    "ios",
     "node",
-    "android",
-    "ios"
+    "react-native"
   ],
   "contributors": [
-    {
-      "name": "Benoit Lemaire",
-      "email": "blemaire@walmartlabs.com"
-    },
-    {
-      "name": "Bharath Marulasiddappa",
-      "email": "BMarulasiddappa@walmartlabs.com"
-    },
-    {
-      "name": "Deepu Ganapathiyadan",
-      "email": "DGanapathiyadan@walmartlabs.com"
-    },
-    {
-      "name": "Frieder Bluemle",
-      "email": "frieder.bluemle@walmartlabs.com"
-    },
-    {
-      "name": "Krunal Shah",
-      "email": "KShah1@walmartlabs.com"
-    },
-    {
-      "name": "Weijie Li",
-      "email": "WLi@walmartlabs.com"
-    }
+    "Benoit Lemaire <blemaire@walmartlabs.com>",
+    "Bharath Marulasiddappa <BMarulasiddappa@walmartlabs.com>",
+    "Deepu Ganapathiyadan <DGanapathiyadan@walmartlabs.com>",
+    "Frieder Bluemle <frieder.bluemle@walmartlabs.com>",
+    "Krunal Shah <KShah1@walmartlabs.com>",
+    "Weijie Li <WLi@walmartlabs.com>"
   ],
-  "scripts": {
-    "build": "ern-typescript",
-    "test": "ern-mocha",
-    "coverage": "ern-nyc",
-    "prepublish": "yarn run build",
-    "instrument-dist": "ern-instrument-dist"
-  },
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/electrode-io/electrode-native/issues"
+  },
+  "homepage": "http://www.electrode.io",
   "dependencies": {
     "@octokit/rest": "16.33.1",
     "@yarnpkg/lockfile": "^1.1.0",

--- a/ern-local-cli/package.json
+++ b/ern-local-cli/package.json
@@ -4,54 +4,39 @@
   "description": "Electrode Native Local CLI",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "homepage": "http://www.electrode.io",
+  "scripts": {
+    "build": "ern-typescript",
+    "coverage": "ern-nyc",
+    "instrument-dist": "ern-instrument-dist",
+    "postinstall": "node scripts/postinstall.js",
+    "prepublish": "yarn run build",
+    "test": "ern-mocha"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/electrode-io/electrode-native.git"
   },
+  "keywords": [
+    "android",
+    "client",
+    "electrode",
+    "ern",
+    "ios",
+    "node",
+    "react-native"
+  ],
+  "contributors": [
+    "Benoit Lemaire <blemaire@walmartlabs.com>",
+    "Bharath Marulasiddappa <BMarulasiddappa@walmartlabs.com>",
+    "Deepu Ganapathiyadan <DGanapathiyadan@walmartlabs.com>",
+    "Krunal Shah <KShah1@walmartlabs.com>",
+    "Weijie Li <WLi@walmartlabs.com>"
+  ],
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/electrode-io/electrode-native/issues"
   },
-  "keywords": [
-    "electrode",
-    "ern",
-    "react-native",
-    "client",
-    "node",
-    "android",
-    "ios"
-  ],
-  "contributors": [
-    {
-      "name": "Benoit Lemaire",
-      "email": "blemaire@walmartlabs.com"
-    },
-    {
-      "name": "Bharath Marulasiddappa",
-      "email": "BMarulasiddappa@walmartlabs.com"
-    },
-    {
-      "name": "Deepu Ganapathiyadan",
-      "email": "DGanapathiyadan@walmartlabs.com"
-    },
-    {
-      "name": "Krunal Shah",
-      "email": "KShah1@walmartlabs.com"
-    },
-    {
-      "name": "Weijie Li",
-      "email": "WLi@walmartlabs.com"
-    }
-  ],
-  "scripts": {
-    "build": "ern-typescript",
-    "test": "ern-mocha",
-    "coverage": "ern-nyc",
-    "prepublish": "yarn run build",
-    "postinstall": "node scripts/postinstall.js",
-    "instrument-dist": "ern-instrument-dist"
-  },
-  "license": "Apache-2.0",
+  "homepage": "http://www.electrode.io",
   "dependencies": {
     "chalk": "^2.4.1",
     "cli-table": "^0.3.1",
@@ -79,8 +64,8 @@
     "lodash": "^4.17.14",
     "node-ipc": "^9.1.1",
     "semver": "^5.5.0",
-    "untildify": "^4.0.0",
     "treeify": "^1.1.0",
+    "untildify": "^4.0.0",
     "validate-npm-package-name": "^3.0.0",
     "yargs": "^14.2.0",
     "yauzl": "^2.10.0",

--- a/ern-orchestrator/package.json
+++ b/ern-orchestrator/package.json
@@ -4,49 +4,37 @@
   "description": "Electrode Native Orchestrator",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "homepage": "http://www.electrode.io",
+  "scripts": {
+    "build": "ern-typescript",
+    "coverage": "ern-nyc",
+    "instrument-dist": "ern-instrument-dist",
+    "prepublish": "yarn run build",
+    "test": "ern-mocha"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/electrode-io/electrode-native.git"
   },
+  "keywords": [
+    "android",
+    "client",
+    "electrode",
+    "ern",
+    "ios",
+    "node",
+    "react-native"
+  ],
+  "contributors": [
+    "Benoit Lemaire <blemaire@walmartlabs.com>",
+    "Bharath Marulasiddappa <BMarulasiddappa@walmartlabs.com>",
+    "Deepu Ganapathiyadan <DGanapathiyadan@walmartlabs.com>",
+    "Krunal Shah <KShah1@walmartlabs.com>"
+  ],
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/electrode-io/electrode-native/issues"
   },
-  "keywords": [
-    "electrode",
-    "ern",
-    "react-native",
-    "client",
-    "node",
-    "android",
-    "ios"
-  ],
-  "contributors": [
-    {
-      "name": "Benoit Lemaire",
-      "email": "blemaire@walmartlabs.com"
-    },
-    {
-      "name": "Bharath Marulasiddappa",
-      "email": "BMarulasiddappa@walmartlabs.com"
-    },
-    {
-      "name": "Deepu Ganapathiyadan",
-      "email": "DGanapathiyadan@walmartlabs.com"
-    },
-    {
-      "name": "Krunal Shah",
-      "email": "KShah1@walmartlabs.com"
-    }
-  ],
-  "scripts": {
-    "build": "ern-typescript",
-    "test": "ern-mocha",
-    "coverage": "ern-nyc",
-    "prepublish": "yarn run build",
-    "instrument-dist": "ern-instrument-dist"
-  },
-  "license": "Apache-2.0",
+  "homepage": "http://www.electrode.io",
   "dependencies": {
     "@octokit/rest": "16.33.1",
     "@yarnpkg/lockfile": "^1.1.0",

--- a/ern-runner-gen-android/package.json
+++ b/ern-runner-gen-android/package.json
@@ -4,59 +4,38 @@
   "description": "Electrode Native Official Android Runner Project Generator",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "homepage": "http://www.electrode.io",
+  "scripts": {
+    "build": "ern-typescript && ern-copyfiles",
+    "coverage": "ern-nyc",
+    "instrument-dist": "ern-instrument-dist && ern-copyfiles",
+    "prepublish": "yarn run build",
+    "regen-fixtures": "../node_modules/.bin/ts-node test/regen-fixtures",
+    "test": "ern-mocha"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/electrode-io/electrode-native.git"
   },
+  "keywords": [
+    "android",
+    "electrode",
+    "ern",
+    "node",
+    "react-native",
+    "runner"
+  ],
+  "contributors": [
+    "Benoit Lemaire <blemaire@walmartlabs.com>",
+    "Bharath Marulasiddappa <BMarulasiddappa@walmartlabs.com>",
+    "Deepu Ganapathiyadan <DGanapathiyadan@walmartlabs.com>",
+    "Krunal Shah <KShah1@walmartlabs.com>",
+    "Weijie Li <WLi@walmartlabs.com>"
+  ],
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/electrode-io/electrode-native/issues"
   },
-  "keywords": [
-    "electrode",
-    "ern",
-    "react-native",
-    "runner",
-    "node",
-    "android"
-  ],
-  "contributors": [
-    {
-      "name": "Benoit Lemaire",
-      "email": "blemaire@walmartlabs.com"
-    },
-    {
-      "name": "Bharath Marulasiddappa",
-      "email": "BMarulasiddappa@walmartlabs.com"
-    },
-    {
-      "name": "Deepu Ganapathiyadan",
-      "email": "DGanapathiyadan@walmartlabs.com"
-    },
-    {
-      "name": "Krunal Shah",
-      "email": "KShah1@walmartlabs.com"
-    },
-    {
-      "name": "Weijie Li",
-      "email": "WLi@walmartlabs.com"
-    }
-  ],
-  "scripts": {
-    "build": "ern-typescript && ern-copyfiles",
-    "test": "ern-mocha",
-    "coverage": "ern-nyc",
-    "prepublish": "yarn run build",
-    "regen-fixtures": "../node_modules/.bin/ts-node test/regen-fixtures",
-    "instrument-dist": "ern-instrument-dist && ern-copyfiles"
-  },
-  "copyFiles": [
-    {
-      "source": "src/hull",
-      "dest": "dist"
-    }
-  ],
-  "license": "Apache-2.0",
+  "homepage": "http://www.electrode.io",
   "dependencies": {
     "ern-core": "1000.0.0",
     "ern-runner-gen": "1000.0.0",
@@ -64,10 +43,16 @@
     "mustache": "^2.3.1"
   },
   "devDependencies": {
-    "ern-util-dev": "1000.0.0",
-    "copyfiles": "^2.0.0"
+    "copyfiles": "^2.0.0",
+    "ern-util-dev": "1000.0.0"
   },
   "engines": {
     "node": ">=6"
-  }
+  },
+  "copyFiles": [
+    {
+      "source": "src/hull",
+      "dest": "dist"
+    }
+  ]
 }

--- a/ern-runner-gen-ios/package.json
+++ b/ern-runner-gen-ios/package.json
@@ -4,59 +4,38 @@
   "description": "Electrode Native Offical iOS Runner Project Generator",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "homepage": "http://www.electrode.io",
+  "scripts": {
+    "build": "ern-typescript && ern-copyfiles",
+    "coverage": "ern-nyc",
+    "instrument-dist": "ern-instrument-dist && ern-copyfiles",
+    "prepublish": "yarn run build",
+    "regen-fixtures": "../node_modules/.bin/ts-node test/regen-fixtures",
+    "test": "ern-mocha"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/electrode-io/electrode-native.git"
   },
-  "bugs": {
-    "url": "https://github.com/electrode-io/electrode-native/issues"
-  },
   "keywords": [
     "electrode",
     "ern",
-    "react-native",
-    "runner",
+    "ios",
     "node",
-    "ios"
+    "react-native",
+    "runner"
   ],
   "contributors": [
-    {
-      "name": "Benoit Lemaire",
-      "email": "blemaire@walmartlabs.com"
-    },
-    {
-      "name": "Bharath Marulasiddappa",
-      "email": "BMarulasiddappa@walmartlabs.com"
-    },
-    {
-      "name": "Deepu Ganapathiyadan",
-      "email": "DGanapathiyadan@walmartlabs.com"
-    },
-    {
-      "name": "Krunal Shah",
-      "email": "KShah1@walmartlabs.com"
-    },
-    {
-      "name": "Weijie Li",
-      "email": "WLi@walmartlabs.com"
-    }
-  ],
-  "scripts": {
-    "build": "ern-typescript && ern-copyfiles",
-    "test": "ern-mocha",
-    "coverage": "ern-nyc",
-    "prepublish": "yarn run build",
-    "regen-fixtures": "../node_modules/.bin/ts-node test/regen-fixtures",
-    "instrument-dist": "ern-instrument-dist && ern-copyfiles"
-  },
-  "copyFiles": [
-    {
-      "source": "src/hull",
-      "dest": "dist"
-    }
+    "Benoit Lemaire <blemaire@walmartlabs.com>",
+    "Bharath Marulasiddappa <BMarulasiddappa@walmartlabs.com>",
+    "Deepu Ganapathiyadan <DGanapathiyadan@walmartlabs.com>",
+    "Krunal Shah <KShah1@walmartlabs.com>",
+    "Weijie Li <WLi@walmartlabs.com>"
   ],
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/electrode-io/electrode-native/issues"
+  },
+  "homepage": "http://www.electrode.io",
   "dependencies": {
     "ern-core": "1000.0.0",
     "ern-runner-gen": "1000.0.0",
@@ -64,10 +43,16 @@
     "mustache": "^2.3.1"
   },
   "devDependencies": {
-    "ern-util-dev": "1000.0.0",
-    "copyfiles": "^2.0.0"
+    "copyfiles": "^2.0.0",
+    "ern-util-dev": "1000.0.0"
   },
   "engines": {
     "node": ">=6"
-  }
+  },
+  "copyFiles": [
+    {
+      "source": "src/hull",
+      "dest": "dist"
+    }
+  ]
 }

--- a/ern-runner-gen/package.json
+++ b/ern-runner-gen/package.json
@@ -4,53 +4,38 @@
   "description": "Electrode Native Runner Project Generator",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "homepage": "http://www.electrode.io",
+  "scripts": {
+    "build": "ern-typescript",
+    "coverage": "ern-nyc",
+    "instrument-dist": "ern-instrument-dist",
+    "prepublish": "yarn run build",
+    "test": "ern-mocha"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/electrode-io/electrode-native.git"
   },
+  "keywords": [
+    "android",
+    "electrode",
+    "ern",
+    "ios",
+    "node",
+    "react-native",
+    "runner"
+  ],
+  "contributors": [
+    "Benoit Lemaire <blemaire@walmartlabs.com>",
+    "Bharath Marulasiddappa <BMarulasiddappa@walmartlabs.com>",
+    "Deepu Ganapathiyadan <DGanapathiyadan@walmartlabs.com>",
+    "Krunal Shah <KShah1@walmartlabs.com>",
+    "Weijie Li <WLi@walmartlabs.com>"
+  ],
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/electrode-io/electrode-native/issues"
   },
-  "keywords": [
-    "electrode",
-    "ern",
-    "react-native",
-    "runner",
-    "node",
-    "android",
-    "ios"
-  ],
-  "contributors": [
-    {
-      "name": "Benoit Lemaire",
-      "email": "blemaire@walmartlabs.com"
-    },
-    {
-      "name": "Bharath Marulasiddappa",
-      "email": "BMarulasiddappa@walmartlabs.com"
-    },
-    {
-      "name": "Deepu Ganapathiyadan",
-      "email": "DGanapathiyadan@walmartlabs.com"
-    },
-    {
-      "name": "Krunal Shah",
-      "email": "KShah1@walmartlabs.com"
-    },
-    {
-      "name": "Weijie Li",
-      "email": "WLi@walmartlabs.com"
-    }
-  ],
-  "scripts": {
-    "build": "ern-typescript",
-    "test": "ern-mocha",
-    "coverage": "ern-nyc",
-    "prepublish": "yarn run build",
-    "instrument-dist": "ern-instrument-dist"
-  },
-  "license": "Apache-2.0",
+  "homepage": "http://www.electrode.io",
   "dependencies": {
     "ern-core": "1000.0.0"
   },

--- a/ern-util-dev/package.json
+++ b/ern-util-dev/package.json
@@ -3,65 +3,50 @@
   "version": "1000.0.0",
   "description": "Electrode Native Platform Development Utilities",
   "main": "index.js",
-  "homepage": "http://www.electrode.io",
+  "bin": {
+    "ern-copyfiles": "bin/ern-copyfiles.js",
+    "ern-instrument-dist": "bin/ern-instrument-dist.js",
+    "ern-mocha": "bin/ern-mocha.js",
+    "ern-nyc": "bin/ern-nyc.js",
+    "ern-typescript": "bin/ern-typescript.js"
+  },
+  "scripts": {
+    "test": "node bin/ern-mocha.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/electrode-io/electrode-native.git"
   },
-  "bugs": {
-    "url": "https://github.com/electrode-io/electrode-native/issues"
-  },
   "keywords": [
     "electrode",
     "ern",
+    "node",
     "react-native",
-    "utilities",
-    "node"
+    "utilities"
   ],
+  "author": "",
   "contributors": [
-    {
-      "name": "Benoit Lemaire",
-      "email": "blemaire@walmartlabs.com"
-    },
-    {
-      "name": "Bharath Marulasiddappa",
-      "email": "BMarulasiddappa@walmartlabs.com"
-    },
-    {
-      "name": "Deepu Ganapathiyadan",
-      "email": "DGanapathiyadan@walmartlabs.com"
-    },
-    {
-      "name": "Krunal Shah",
-      "email": "KShah1@walmartlabs.com"
-    },
-    {
-      "name": "Weijie Li",
-      "email": "WLi@walmartlabs.com"
-    }
+    "Benoit Lemaire <blemaire@walmartlabs.com>",
+    "Bharath Marulasiddappa <BMarulasiddappa@walmartlabs.com>",
+    "Deepu Ganapathiyadan <DGanapathiyadan@walmartlabs.com>",
+    "Krunal Shah <KShah1@walmartlabs.com>",
+    "Weijie Li <WLi@walmartlabs.com>"
   ],
-  "scripts": {
-    "test": "node bin/ern-mocha.js"
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/electrode-io/electrode-native/issues"
   },
+  "homepage": "http://www.electrode.io",
   "dependencies": {
-    "shelljs": "^0.8.2",
-    "tmp": "^0.0.33",
+    "colors": "^1.3.1",
+    "diff": "^3.5.0",
+    "dir-compare": "^1.4.0",
     "fs-readdir-recursive": "^1.1.0",
     "istanbul": "^0.4.5",
-    "dir-compare": "^1.4.0",
-    "diff": "^3.5.0",
-    "colors": "^1.3.1"
-  },
-  "bin": {
-    "ern-mocha": "bin/ern-mocha.js",
-    "ern-nyc": "bin/ern-nyc.js",
-    "ern-typescript": "bin/ern-typescript.js",
-    "ern-copyfiles": "bin/ern-copyfiles.js",
-    "ern-instrument-dist": "bin/ern-instrument-dist.js"
+    "shelljs": "^0.8.2",
+    "tmp": "^0.0.33"
   },
   "engines": {
     "node": ">=4.5"
-  },
-  "author": "",
-  "license": "Apache-2.0"
+  }
 }

--- a/global-cli/package.json
+++ b/global-cli/package.json
@@ -6,44 +6,29 @@
   "bin": {
     "ern": "bin/ern.js"
   },
-  "homepage": "http://www.electrode.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/electrode-io/electrode-native.git"
   },
+  "keywords": [
+    "client",
+    "electrode",
+    "ern",
+    "node",
+    "react-native"
+  ],
+  "contributors": [
+    "Benoit Lemaire <blemaire@walmartlabs.com>",
+    "Bharath Marulasiddappa <BMarulasiddappa@walmartlabs.com>",
+    "Deepu Ganapathiyadan <DGanapathiyadan@walmartlabs.com>",
+    "Krunal Shah <KShah1@walmartlabs.com>",
+    "Weijie Li <WLi@walmartlabs.com>"
+  ],
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/electrode-io/electrode-native/issues"
   },
-  "keywords": [
-    "electrode",
-    "ern",
-    "react-native",
-    "client",
-    "node"
-  ],
-  "contributors": [
-    {
-      "name": "Benoit Lemaire",
-      "email": "blemaire@walmartlabs.com"
-    },
-    {
-      "name": "Bharath Marulasiddappa",
-      "email": "BMarulasiddappa@walmartlabs.com"
-    },
-    {
-      "name": "Deepu Ganapathiyadan",
-      "email": "DGanapathiyadan@walmartlabs.com"
-    },
-    {
-      "name": "Krunal Shah",
-      "email": "KShah1@walmartlabs.com"
-    },
-    {
-      "name": "Weijie Li",
-      "email": "WLi@walmartlabs.com"
-    }
-  ],
-  "license": "Apache-2.0",
+  "homepage": "http://www.electrode.io",
   "dependencies": {
     "chalk": "^2.3.0",
     "ora": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -3,14 +3,12 @@
   "version": "1000.0.0",
   "private": true,
   "description": "",
-  "keywords": [],
-  "license": "Apache-2.0",
   "scripts": {
     "build": "lerna run build",
     "check": "yarn check:lint && yarn check:yarnlock",
     "check:lint": "tslint -c tslint.json '**/src/**/*.ts' '**/test/**/*.ts' -e '**/node_modules/**'",
-    "check:yarnlock": "node yarn-lock-check",
     "check:regen-fixtures": "node regen-fixtures-check",
+    "check:yarnlock": "node yarn-lock-check",
     "coverage:ci": "yarn coverage:unit && yarn coverage:system && yarn istanbul report --include=**/.coverage/coverage-final.json text-lcov | yarn coveralls",
     "coverage:local": "yarn coverage:unit && yarn coverage:system && yarn istanbul report --include=**/.coverage/coverage-final.json html",
     "coverage:system": "rimraf .nyc_output && lerna run build && lerna run instrument-dist && node system-tests/src/system-tests-coverage",
@@ -27,9 +25,16 @@
     "test:system": "yarn build && lerna run instrument-dist && node system-tests/src/system-tests",
     "test:unit": "lerna run test --no-bail"
   },
-  "workspaces": [
-    "ern-*"
-  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/electrode-io/electrode-native.git"
+  },
+  "keywords": [],
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/electrode-io/electrode-native/issues"
+  },
+  "homepage": "http://www.electrode.io",
   "dependencies": {
     "@types/node": "^11.13.8",
     "chalk": "^2.4.2",
@@ -39,31 +44,31 @@
     "@types/archiver": "^3.0.0",
     "@types/chai": "^4.2.9",
     "@types/cli-table": "^0.3.0",
-    "@types/inquirer": "^6.5.0",
     "@types/fast-levenshtein": "^0.0.1",
-    "@types/fs-readdir-recursive": "^1.0.0",
     "@types/fs-extra": "^8.1.0",
+    "@types/fs-readdir-recursive": "^1.0.0",
     "@types/get-folder-size": "^2.0.0",
-    "@types/got": "^9.6.9",
     "@types/glob": "^7.1.1",
+    "@types/got": "^9.6.9",
+    "@types/hapi__joi": "^15.0.4",
+    "@types/inquirer": "^6.5.0",
     "@types/lodash": "^4.14.149",
     "@types/mocha": "^5.2.7",
     "@types/mustache": "^0.8.32",
     "@types/ncp": "^2.0.3",
     "@types/node-fetch": "^2.5.4",
     "@types/semver": "^6.2.0",
-    "@types/sinon": "^7.5.2",
     "@types/shelljs": "^0.8.6",
+    "@types/sinon": "^7.5.2",
+    "@types/tmp": "^0.1.0",
     "@types/treeify": "^1.0.0",
     "@types/tunnel": "^0.0.1",
-    "@types/tmp": "^0.1.0",
     "@types/uuid": "^3.4.6",
+    "@types/validate-npm-package-name": "^3.0.0",
     "@types/yargs": "^13.0.3",
+    "@types/yarnpkg__lockfile": "^1.1.3",
     "@types/yauzl": "^2.9.1",
     "@types/yazl": "^2.4.2",
-    "@types/yarnpkg__lockfile": "^1.1.3",
-    "@types/hapi__joi": "^15.0.4",
-    "@types/validate-npm-package-name": "^3.0.0",
     "@yarnpkg/lockfile": "^1.1.0",
     "chai": "^4.2.0",
     "colors": "^1.4.0",
@@ -99,12 +104,7 @@
   "engines": {
     "node": ">=6"
   },
-  "bugs": {
-    "url": "https://github.com/electrode-io/electrode-native/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/electrode-io/electrode-native.git"
-  },
-  "homepage": "http://www.electrode.io"
+  "workspaces": [
+    "ern-*"
+  ]
 }


### PR DESCRIPTION
Related: #1473 #1506 #1507

Part of #1511

With this, all 18 primary `package.json` files in the repo follow a common and standardized formatting and key order.

Some significant simplifications and line savings were achieved by using simple strings instead of full objects for `contributors`. All dependencies were sorted alphabetically.

This PR does _not_ change/update any dependencies or add/remove any fields.

While there is no single authoritative field order for package.json files, several projects exist that aim to provide a "opinionated standard", e.g. [sort-package-json](https://github.com/keithamus/sort-package-json), [fixpack](https://github.com/HenrikJoreteg/fixpack), [prettier-package-json](https://github.com/cameronhunter/prettier-package-json). It's important to point out that all three projects are _incompatible_ with each other, meaning when the default configuration is applied to the same `package.json` file, it will continuously cause reformatting.

Lacking a "globally accepted standard", the key order chosen in this PR was derived from the following (from highest to lowest priority):

1. The ordering of a _default_ `package.json` as generated by npm/Yarn
1. The official documentation of [package.json by npmjs.org](https://docs.npmjs.com/files/package.json)
1. As much as possible, keeping common patterns set by the three tools mentioned above
1. When possible, keeping common patterns in this repo to minimize the required line changes

In particular the first item can be considered as the only "true" standard. The official docs by npmjs.org are missing several possible keys, and are not fully in sync with what is generated by npm/Yarn.

<details>
<summary>Tool config details</summary>

### sort-package-json

Does not allow configurations, so it can not be used as the final formatter.

### prettier-package-json

A modified default config has been pushed here:
https://github.com/friederbluemle/prettier-package-json/blob/fb-custom/src/defaultOptions.js

The order can also be passed on command line:

```
prettier-package-json --key-order \$schema,name,version,private,description,main,browser,types,files,bin,scripts,repository,keywords,author,contributors,license,bugs,homepage,man,directories,config,dependencies,devDependencies,peerDependencies,bundledDependencies,optionalDependencies,engines,os,cpu,publishConfig,workspaces
```

Note: Currently, `prettier-package-json` will also reorder `scripts` in a non-alphabetical way. See https://github.com/cameronhunter/prettier-package-json/issues/26 for additional details. There _will_ be modified lines when using it in this repo.

### fixpack

A `.fixpackrc` file with the custom order can be found here: https://github.com/friederbluemle/misc/blob/master/.fixpackrc
With this file, `fixpack` should fully pass all newly formatted `package.json` files.
</details>
