### PR TITLE
Fix base api system test

### DIFF
--- a/system-tests/src/tests/create-api-base-fixture.js
+++ b/system-tests/src/tests/create-api-base-fixture.js
@@ -21,7 +21,7 @@ const excludeFilter = [
   .join(',')
 
 run(
-  `create-api ${f.testApiName} -p ${f.testApiPkgName} -u "generated" --skipNpmCheck`
+  `create-api ${f.testApiName} -p ${f.testApiPkgName} --schemaPath ${f.pathToTestApiSchema} -u "generated" --skipNpmCheck`
 )
 
 const fixtureApiPath = f.pathToBaseApiFixture


### PR DESCRIPTION
Fix an issue with API system test failing due to differences in the fixture v.s generated API schemas.

This is due to the fact that the fixture regeneration script is using [a fixed schema path](https://github.com/electrode-io/electrode-native/blob/v0.39.0/system-tests/regen-fixtures.js#L116-L118) to regenerate the API, while the system test was not using the same schema path.

This will fix daily system test runs in Azure DevOps pipeline which is currently broken.
