### PR TITLE
Add new inPlace option to publishers config

### DIFF
--- a/docs/cli/publish-container.md
+++ b/docs/cli/publish-container.md
@@ -66,6 +66,10 @@ This publisher is mostly used for testing and as starter simple publisher refere
   In that case, the configuration will be read from the file stored in Cauldron.   
   For this way to work, the file must exist in Cauldron (you can add a file to the cauldron by using the [ern cauldron add file] command). 
 
+`--inPlace`
+
+* Run the publisher directly from the container directory instead of a temporary directory
+* Defaults to `false`
 
 #### Related commands
 

--- a/ern-container-publisher/src/publishContainer.ts
+++ b/ern-container-publisher/src/publishContainer.ts
@@ -4,22 +4,26 @@ import { createTmpDir, shell, Platform } from 'ern-core'
 import path from 'path'
 
 export default async function publishContainer(conf: ContainerPublisherConfig) {
-  // Duplicate the directory containing generated Container to a temporary
-  // directory, and pass this temporary directory to the publisher.
-  // This is done because Container generation and publication are
-  // clearly distinct (separation of concerns), we don't want the publisher
-  // to update the Container generated code for its publication needs.
-  // It also ensures that this function can be called multiple times
-  // with different publishers for the same Container (idempotent).
-  // Otherwise, if publication changes were made to the original Container
-  // path, it would be much harder to use a different publisher for the
-  // same Container.
-  const publicationWorkingDir = createTmpDir()
-  shell.cp(
-    '-Rf',
-    path.join(conf.containerPath, '{.*,*}'),
-    publicationWorkingDir
-  )
+  let publicationWorkingDir = conf.containerPath
+  if (!conf.inPlace) {
+    // Duplicate the directory containing generated Container to a temporary
+    // directory, and pass this temporary directory to the publisher.
+    // This is done because Container generation and publication are
+    // clearly distinct (separation of concerns), we don't want the publisher
+    // to update the Container generated code for its publication needs.
+    // It also ensures that this function can be called multiple times
+    // with different publishers for the same Container (idempotent).
+    // Otherwise, if publication changes were made to the original Container
+    // path, it would be much harder to use a different publisher for the
+    // same Container.
+    publicationWorkingDir = createTmpDir()
+    shell.cp(
+      '-Rf',
+      path.join(conf.containerPath, '{.*,*}'),
+      publicationWorkingDir
+    )
+  }
+
   conf.containerPath = publicationWorkingDir
   conf.ernVersion = Platform.currentVersion
 

--- a/ern-container-publisher/src/types/ContainerPublisherConfig.ts
+++ b/ern-container-publisher/src/types/ContainerPublisherConfig.ts
@@ -38,4 +38,10 @@ export interface ContainerPublisherConfig {
    * Specific to the publisher
    */
   extra?: any
+  /**
+   * Publish the container in place rather
+   * than copying it to a temporary directory
+   * to run publisher from
+   */
+  inPlace?: boolean
 }

--- a/ern-local-cli/src/commands/publish-container.ts
+++ b/ern-local-cli/src/commands/publish-container.ts
@@ -21,6 +21,12 @@ export const builder = (argv: Argv) => {
         'Optional extra publisher configuration (json string or local/cauldron path to config file)',
       type: 'string',
     })
+    .option('inPlace', {
+      default: false,
+      describe:
+        'Run the publisher directly from the container directory instead of a temporary directory',
+      type: 'boolean',
+    })
     .option('platform', {
       choices: ['android', 'ios'],
       demandOption: true,

--- a/ern-orchestrator/src/runContainerPipeline.ts
+++ b/ern-orchestrator/src/runContainerPipeline.ts
@@ -65,6 +65,7 @@ export async function runContainerPipeline({
               containerPath,
               containerVersion,
               extra,
+              inPlace: pipelineElt.inPlace,
               platform,
               publisher: PackagePath.fromString(pipelineElt.name),
               url: pipelineElt.url,


### PR DESCRIPTION
Add new `inPlace` option flag to publishers configuration.

This flag, if set, will not copy the container to a temporary directory to run publisher from, but will directly run the publisher from the generated container directory.

This flag is disabled by default to keep current publishers behavior. It can be set as an option to `publish-container` command or directly inside a publisher configuration of a container generator pipeline in the cauldron.

Thing is, for CI environments, where we generate the container and immediately publish it and then trash the workspace, there is no need to go through a temporary copy as we won't run the publishers multiple times on the same container but just once in the context of the job execution. Enabling this flag will allow us to greatly reduce the time it takes to run our publishers on CI, especially for huge iOS containers that have been transformed to fat binaries, as the copy operation is taking a while.