### PR TITLE
Add raw logger

### DIFF
--- a/ern-core/src/coloredLog.ts
+++ b/ern-core/src/coloredLog.ts
@@ -32,6 +32,10 @@ export default class ColoredLog {
         level <= LogLevel.Info
           ? (msg: string) => kax.info(msg)
           : () => this.noop(),
+      raw:
+        level < LogLevel.Off
+          ? (msg: string) => kax.raw(msg)
+          : () => this.noop(),
       trace:
         level <= LogLevel.Trace
           ? (msg: string) => kax.raw(msg)
@@ -45,6 +49,10 @@ export default class ColoredLog {
 
   get level(): LogLevel {
     return this.pLevel
+  }
+
+  public raw(msg: string) {
+    this.loggers.raw(msg)
   }
 
   public trace(msg: string) {


### PR DESCRIPTION
Add new `log.raw` method which internally will call `kax.raw`.
`raw` logs do not have any level and will be logged whatever current log level is (as long as it's not off, i.e `LogLevel.Off`).
Raw logger can be used to log strings without them being icon prefixed (and colored) based on the log level.