### PR TITLE
Local config improvements

### DIFF
--- a/docs/cli/platform/config/set.md
+++ b/docs/cli/platform/config/set.md
@@ -68,7 +68,7 @@ HTTP/HTTPS proxy to use to connect to the bundle store server.
 Should be the full url to the proxy, including the port. For example `http://10.0.0.0:9089`.  
 **default** : no proxy
 
-- `sourceMapStoreProxy` [string]  
+- `sourceMapStoreProxy` [string]
 HTTP/HTTPS proxy to use to connect to the source map store server.  
 Should be the full url to the proxy, including the port. For example `http://10.0.0.0:9089`.  
 **default** : no proxy
@@ -81,5 +81,18 @@ Should be the full url to the proxy, including the port. For example `http://10.
 #### Remarks
  
 * In case a value already exists in the configuration for a given key, this command will not fail and will overwrite the existing value.
+
+### Placeholders
+
+Electrode Native supports the following placeholders and will replace them accordingly when loading the configuration :
+
+- `${env.ENV_VAR_KEY}`\
+Will be replaced with the value of `ENV_VAR_KEY` environment variable.
+
+- `${ERNRC}`\
+Will be replaced with the path to the directory containing the resolved `.ernrc` configuration.
+
+- `${PWD}`\
+Will be replaced with current process working directory.
 
 [Electrode Native bundle store server]: https://github.com/electrode-io/ern-bundle-store

--- a/ern-core/src/config/InMemErnConfig.ts
+++ b/ern-core/src/config/InMemErnConfig.ts
@@ -3,16 +3,17 @@ import { ErnConfig } from './ErnConfig'
 export class InMemErnConfig implements ErnConfig {
   private readonly obj: any
 
-  constructor(public readonly config = {}) {
+  constructor(public readonly config = {}, public readonly ernRcDir: string) {
     this.obj = config
   }
 
   public get(key?: string, defaultValue?: any): any {
+    const transObj = this.envTransform(this.obj)
     return key
-      ? this.obj[key] !== undefined
-        ? this.obj[key]
+      ? transObj[key] !== undefined
+        ? transObj[key]
         : defaultValue
-      : JSON.parse(JSON.stringify(this.obj))
+      : JSON.parse(JSON.stringify(transObj))
   }
 
   public set(key: string, value: any): void {
@@ -25,5 +26,20 @@ export class InMemErnConfig implements ErnConfig {
       return true
     }
     return false
+  }
+
+  public envTransform(obj: any) {
+    let objStr = JSON.stringify(obj)
+    objStr = objStr
+      // Replace all ${env.[ENV_VAR_KEY]} with resolved values
+      .replace(
+        /\$\{env\.([^\}]+)\}/g,
+        (match: string, envKey: string) => process.env[envKey]!
+      )
+      // Replace ${PWD} with current process working directory
+      .replace(/\$\{PWD\}/g, process.cwd().replace(/\\/g, '\\\\'))
+      // Replace ${ERNRC} with directory containing the .ernrc config
+      .replace(/\$\{ERNRC\}/g, this.ernRcDir.replace(/\\/g, '\\\\'))
+    return JSON.parse(objStr)
   }
 }

--- a/ern-core/src/config/JsonFileErnConfig.ts
+++ b/ern-core/src/config/JsonFileErnConfig.ts
@@ -1,6 +1,7 @@
 import { ErnConfig } from './ErnConfig'
 import { InMemErnConfig } from './InMemErnConfig'
 import fs from 'fs'
+import path from 'path'
 
 export class JsonFileErnConfig implements ErnConfig {
   private readonly inMemConfig: InMemErnConfig
@@ -9,7 +10,7 @@ export class JsonFileErnConfig implements ErnConfig {
     const conf = fs.existsSync(this.jsonFilePath)
       ? JSON.parse(fs.readFileSync(this.jsonFilePath, 'utf-8'))
       : {}
-    this.inMemConfig = new InMemErnConfig(conf)
+    this.inMemConfig = new InMemErnConfig(conf, path.dirname(jsonFilePath))
   }
 
   public get(key?: string, defaultValue?: any): any {

--- a/ern-core/src/config/index.ts
+++ b/ern-core/src/config/index.ts
@@ -1,15 +1,28 @@
 import { JsonFileErnConfig } from './JsonFileErnConfig'
-import fs from 'fs'
+import fs from 'fs-extra'
 import path from 'path'
 import os from 'os'
 
 const ERN_ROOT_PATH = process.env.ERN_HOME || path.join(os.homedir(), '.ern')
 const ERN_RC_GLOBAL_FILE_PATH = path.join(ERN_ROOT_PATH, '.ernrc')
-const ERN_RC_LOCAL_FILE_PATH = path.join(process.cwd(), '.ernrc')
+export const ERN_RC_LOCAL_FILE_PATH = resolveLocalErnRc()
 
-const ernRcFilePath = fs.existsSync(ERN_RC_LOCAL_FILE_PATH)
+const ernRcFilePath = ERN_RC_LOCAL_FILE_PATH
   ? ERN_RC_LOCAL_FILE_PATH
   : ERN_RC_GLOBAL_FILE_PATH
+
+export function resolveLocalErnRc(dir?: string) {
+  let directory = dir || process.cwd()
+  let prevDirectory
+  while (directory !== prevDirectory) {
+    prevDirectory = directory
+    const pathToErnRc = path.join(directory, '.ernrc')
+    if (fs.existsSync(pathToErnRc)) {
+      return pathToErnRc
+    }
+    directory = path.dirname(directory)
+  }
+}
 
 export * from './ErnConfig'
 export * from './InMemErnConfig'

--- a/ern-core/test/config/InMemErnConfig-test.ts
+++ b/ern-core/test/config/InMemErnConfig-test.ts
@@ -4,34 +4,40 @@ import { expect } from 'chai'
 describe('InMemErnConfig', () => {
   describe('get', () => {
     it('should return the value associated to the given key', () => {
-      const sut = new InMemErnConfig({
-        testKey: 'testValue',
-      })
+      const sut = new InMemErnConfig(
+        {
+          testKey: 'testValue',
+        },
+        ''
+      )
       expect(sut.get('testKey')).equal('testValue')
     })
 
     it('should return undefined if the key does not exist and no defaultValue was provided', () => {
-      const sut = new InMemErnConfig()
+      const sut = new InMemErnConfig(undefined, '')
       expect(sut.get('testKey')).undefined
     })
 
     it('should return the provided defaultValue if the key does not exist', () => {
-      const sut = new InMemErnConfig()
+      const sut = new InMemErnConfig(undefined, '')
       expect(sut.get('testKey', 'testDefaultValue')).equal('testDefaultValue')
     })
   })
 
   describe('set', () => {
     it('should create the key if it does not exist', () => {
-      const sut = new InMemErnConfig()
+      const sut = new InMemErnConfig(undefined, '')
       sut.set('testKey', 'testValue')
       expect(sut.get('testKey')).equal('testValue')
     })
 
     it('should overwrite previous value of key if key exist', () => {
-      const sut = new InMemErnConfig({
-        testKey: 'testValue',
-      })
+      const sut = new InMemErnConfig(
+        {
+          testKey: 'testValue',
+        },
+        ''
+      )
       sut.set('testKey', 'newValue')
       expect(sut.get('testKey')).equal('newValue')
     })
@@ -39,23 +45,69 @@ describe('InMemErnConfig', () => {
 
   describe('del', () => {
     it('should delete the key', () => {
-      const sut = new InMemErnConfig({
-        testKey: 'testValue',
-      })
+      const sut = new InMemErnConfig(
+        {
+          testKey: 'testValue',
+        },
+        ''
+      )
       sut.del('testKey')
       expect(sut.get('testKey')).undefined
     })
 
     it('should return false if the key does not exist', () => {
-      const sut = new InMemErnConfig()
+      const sut = new InMemErnConfig(undefined, '')
       expect(sut.del('testKey')).false
     })
 
     it('should return true if the key was deleted', () => {
-      const sut = new InMemErnConfig({
-        testKey: 'testValue',
-      })
+      const sut = new InMemErnConfig(
+        {
+          testKey: 'testValue',
+        },
+        ''
+      )
       expect(sut.del('testKey')).true
     })
+  })
+
+  it('should replace ${env.[ENV_VAR_KEY]} placeholders with matching env var value', () => {
+    const sut = new InMemErnConfig(
+      {
+        keyA: '${env.TEST_ERN_ENV_VAR}',
+        keyB: '${env.TEST_ERN_ENV_VAR}',
+      },
+      ''
+    )
+    const testValue = 'testValue'
+    process.env.TEST_ERN_ENV_VAR = testValue
+    expect(sut.get('keyA')).eql(testValue)
+    expect(sut.get('keyB')).eql(testValue)
+  })
+
+  it('should replace ${PWD} placeholders with current process working directory', () => {
+    const cwd = process.cwd()
+    const sut = new InMemErnConfig(
+      {
+        keyA: '${PWD}',
+        keyB: '${PWD}',
+      },
+      ''
+    )
+    expect(sut.get('keyA')).eql(cwd)
+    expect(sut.get('keyB')).eql(cwd)
+  })
+
+  it('should replace ${ERNRC} placeholders with resolved .ernrc directory', () => {
+    const pathToErnRc = '/path/to/.ernrc'
+    const sut = new InMemErnConfig(
+      {
+        keyA: '${ERNRC}',
+        keyB: '${ERNRC}',
+      },
+      pathToErnRc
+    )
+    expect(sut.get('keyA')).eql(pathToErnRc)
+    expect(sut.get('keyB')).eql(pathToErnRc)
   })
 })

--- a/ern-core/test/config/config-test.ts
+++ b/ern-core/test/config/config-test.ts
@@ -1,0 +1,23 @@
+import { resolveLocalErnRc } from '../../src/config'
+import createTmpDir from '../../src/createTmpDir'
+import { expect } from 'chai'
+import fs from 'fs-extra'
+import path from 'path'
+
+describe('resolveLocalErnRc', () => {
+  it('should return current directory if it contains a .ernrc', () => {
+    const tmpDir = createTmpDir()
+    const pathToErnRc = path.join(tmpDir, '.ernrc')
+    fs.writeFileSync(pathToErnRc, '{}')
+    expect(resolveLocalErnRc(tmpDir)).eql(pathToErnRc)
+  })
+
+  it('should bubble up parent directory chain until it finds a .ernrc ', () => {
+    const tmpDir = createTmpDir()
+    const nestedDir = path.join(tmpDir, 'a/b/c')
+    const pathToErnRc = path.join(tmpDir, 'a', '.ernrc')
+    fs.mkdirpSync(nestedDir)
+    fs.writeFileSync(pathToErnRc, '{}')
+    expect(resolveLocalErnRc(nestedDir)).eql(pathToErnRc)
+  })
+})


### PR DESCRIPTION
- Look up in parent directories chain to resolve `.ernrc` configuration file
- Add support for some initial placeholders that can be used in `.ernrc` configuration files

With this update, one will be able to get rid of some `ern platform config set` commands especially in CI envs, which was the only way until now to set some configuration keys with a value coming from an environment variable (in our case, this will speed up our CI runs a bit because we won't have to run these commands). 

These changes are also necessary to support upcoming Electrode Native workspaces feature.