### PR TITLE
Upload all sources to Bugsnag

### DIFF
--- a/ern-core/src/bugsnagUpload.ts
+++ b/ern-core/src/bugsnagUpload.ts
@@ -9,6 +9,7 @@ export async function bugsnagUpload({
   minifiedUrl,
   projectRoot,
   sourceMap,
+  uploadNodeModules,
   uploadSources,
   uploadSourcesGlob,
 }: {
@@ -17,8 +18,9 @@ export async function bugsnagUpload({
   minifiedUrl: string
   projectRoot: string
   sourceMap: string
+  uploadNodeModules?: boolean
   uploadSources: boolean
-  uploadSourcesGlob: string[]
+  uploadSourcesGlob?: string[]
 }) {
   const agent = createProxyAgentFromErnConfig('bugsnagProxy', { https: true })
   const codeBundleId = process.env.ERN_BUGSNAG_CODE_BUNDLE_ID
@@ -31,6 +33,7 @@ export async function bugsnagUpload({
     minifiedUrl,
     projectRoot,
     sourceMap,
+    uploadNodeModules,
     uploadSources,
     uploadSourcesGlob,
   }

--- a/ern-orchestrator/src/codepush.ts
+++ b/ern-orchestrator/src/codepush.ts
@@ -538,10 +538,8 @@ export async function performCodePushOtaUpdate(
             minifiedUrl,
             projectRoot,
             sourceMap,
+            uploadNodeModules: true,
             uploadSources: !!bundlingResult.isHermesBundle,
-            uploadSourcesGlob: composite
-              .getMiniAppsPackages()
-              .map(p => `**/${p.name}/**/@(*.js|*.ts)`),
           })
         } catch (e) {
           log.error(`Bugsnag upload failed : ${e}`)

--- a/ern-orchestrator/src/syncCauldronContainer.ts
+++ b/ern-orchestrator/src/syncCauldronContainer.ts
@@ -183,10 +183,8 @@ Please set the new container version through command options.`)
           minifiedUrl,
           projectRoot,
           sourceMap,
+          uploadNodeModules: true,
           uploadSources: !!containerGenRes.bundlingResult.isHermesBundle,
-          uploadSourcesGlob: composite
-            .getMiniAppsPackages()
-            .map(p => `**/${p.name}/**/@(*.js|*.ts)`),
         })
       } catch (e) {
         log.error(`Bugsnag upload failed : ${e}`)


### PR DESCRIPTION
Upload to Bugsnag, all sources that are referenced in the source map, even sources from the node_modules, rather than only uploading sources of miniapps.

See https://github.com/bugsnag/bugsnag-sourcemaps/pull/54#issuecomment-594071138 for rationale behind this change.