### PR TITLE
Consider cauldron container config for resetCache flag

### DIFF
--- a/ern-local-cli/src/commands/bundlestore/upload.ts
+++ b/ern-local-cli/src/commands/bundlestore/upload.ts
@@ -72,7 +72,6 @@ export const builder = (argv: Argv) => {
       type: 'boolean',
     })
     .option('resetCache', {
-      default: false,
       describe:
         'Indicates whether to reset the React Native cache prior to bundling',
       type: 'boolean',

--- a/ern-local-cli/src/commands/cauldron/add/jsapiimpls.ts
+++ b/ern-local-cli/src/commands/cauldron/add/jsapiimpls.ts
@@ -29,7 +29,6 @@ export const builder = (argv: Argv) => {
     .coerce('descriptor', d => AppVersionDescriptor.fromString(d))
     .coerce('jsapiimpls', d => d.map(PackagePath.fromString))
     .option('resetCache', {
-      default: false,
       describe:
         'Indicates whether to reset the React Native cache prior to bundling',
       type: 'boolean',

--- a/ern-local-cli/src/commands/cauldron/add/miniapps.ts
+++ b/ern-local-cli/src/commands/cauldron/add/miniapps.ts
@@ -30,7 +30,6 @@ export const builder = (argv: Argv) => {
     .coerce('descriptor', d => AppVersionDescriptor.fromString(d))
     .coerce('miniapps', d => d.map(PackagePath.fromString))
     .option('resetCache', {
-      default: false,
       describe:
         'Indicates whether to reset the React Native cache prior to bundling',
       type: 'boolean',

--- a/ern-local-cli/src/commands/cauldron/batch.ts
+++ b/ern-local-cli/src/commands/cauldron/batch.ts
@@ -46,7 +46,6 @@ export const builder = (argv: Argv) => {
       type: 'array',
     })
     .option('resetCache', {
-      default: false,
       describe:
         'Indicates whether to reset the React Native cache prior to bundling',
       type: 'boolean',

--- a/ern-local-cli/src/commands/cauldron/del/jsapiimpls.ts
+++ b/ern-local-cli/src/commands/cauldron/del/jsapiimpls.ts
@@ -30,7 +30,6 @@ export const builder = (argv: Argv) => {
     .coerce('descriptor', d => AppVersionDescriptor.fromString(d))
     .coerce('jsapiimpls', d => d.map(PackagePath.fromString))
     .option('resetCache', {
-      default: false,
       describe:
         'Indicates whether to reset the React Native cache prior to bundling',
       type: 'boolean',

--- a/ern-local-cli/src/commands/cauldron/del/miniapps.ts
+++ b/ern-local-cli/src/commands/cauldron/del/miniapps.ts
@@ -30,7 +30,6 @@ export const builder = (argv: Argv) => {
     .coerce('descriptor', d => AppVersionDescriptor.fromString(d))
     .coerce('miniapps', d => d.map(PackagePath.fromString))
     .option('resetCache', {
-      default: false,
       describe:
         'Indicates whether to reset the React Native cache prior to bundling',
       type: 'boolean',

--- a/ern-local-cli/src/commands/cauldron/regen-container.ts
+++ b/ern-local-cli/src/commands/cauldron/regen-container.ts
@@ -33,7 +33,6 @@ export const builder = (argv: Argv) => {
       type: 'boolean',
     })
     .option('resetCache', {
-      default: false,
       describe:
         'Indicates whether to reset the React Native cache prior to bundling',
       type: 'boolean',

--- a/ern-local-cli/src/commands/cauldron/update/jsapiimpls.ts
+++ b/ern-local-cli/src/commands/cauldron/update/jsapiimpls.ts
@@ -29,7 +29,6 @@ export const builder = (argv: Argv) => {
     .coerce('descriptor', d => AppVersionDescriptor.fromString(d))
     .coerce('jsapiimpls', d => d.map(PackagePath.fromString))
     .option('resetCache', {
-      default: false,
       describe:
         'Indicates whether to reset the React Native cache prior to bundling',
       type: 'boolean',

--- a/ern-local-cli/src/commands/cauldron/update/miniapps.ts
+++ b/ern-local-cli/src/commands/cauldron/update/miniapps.ts
@@ -34,7 +34,6 @@ export const builder = (argv: Argv) => {
     })
     .coerce('miniapps', d => d.map(PackagePath.fromString))
     .option('resetCache', {
-      default: false,
       describe:
         'Indicates whether to reset the React Native cache prior to bundling',
       type: 'boolean',

--- a/ern-local-cli/src/commands/create-container.ts
+++ b/ern-local-cli/src/commands/create-container.ts
@@ -86,7 +86,6 @@ export const builder = (argv: Argv) => {
       type: 'string',
     })
     .option('resetCache', {
-      default: false,
       describe:
         'Indicates whether to reset the React Native cache prior to bundling',
       type: 'boolean',

--- a/ern-orchestrator/src/container.ts
+++ b/ern-orchestrator/src/container.ts
@@ -127,7 +127,7 @@ export async function runCauldronContainerGen(
           jsMainModuleName,
           outDir: outDir || Platform.getContainerGenOutDirectory(platform),
           plugins,
-          resetCache,
+          resetCache: resetCache ?? containerGeneratorConfig?.resetCache,
           sourceMapOutput,
           targetPlatform: platform,
         })


### PR DESCRIPTION
This PR allows `resetCache` option to be set in a container configuration in cauldron.
The code was previously only considering the `resetCache` option passed on the command line, but ignoring this option in any case if it was set in cauldron.
Logic here, as for other options, is that the option, if explicitly provided on command line, will take precedence over whichever value set in cauldron (if any). If it's not provided on the command line, the value (if any) from cauldron will be used.
Removing default `false` value for this option, in all commands, so that it remains `undefined` if not set, which makes nullish coalescing logic (`??`) properly work.