### PR TITLE
Add resetCache option to start command

### DIFF
--- a/docs/cli/start.md
+++ b/docs/cli/start.md
@@ -51,6 +51,10 @@ If you do not pass an argument to this command, you are prompted to select a nat
 `--port`
 * Port on which the local packager should listen on *(default: 8081)*
 
+`--resetCache`\
+
+* Indicates whether to reset the React Native cache prior to bundling
+
 **Platform Specific Options**
 
 `Android`
@@ -79,6 +83,8 @@ If you do not pass an argument to this command, you are prompted to select a nat
 `--launchEnvVars`
 * Environment variables to pass to the application when launching it (correspond to the `Environment Variables` in application scheme run config in XCode as can be seen on screenshot below).
 * Make sure to use `=` on the command line to provide this option, and keep the string in quotes. The string should contain `key=value` pairs delimited by spaces. For example `--launchEnvVars="aKey=aValue anotherKey=anotherValue"`
+
+* **Default** false
 
 ![xcode scheme run](../images/xcode-scheme-run.png)
 

--- a/ern-local-cli/src/commands/start.ts
+++ b/ern-local-cli/src/commands/start.ts
@@ -99,6 +99,11 @@ export const builder = (argv: Argv) => {
       describe: 'Port to use for the local package',
       type: 'string',
     })
+    .option('resetCache', {
+      describe:
+        'Indicates whether to reset the React Native cache prior to bundling',
+      type: 'boolean',
+    })
     .group(
       ['activityName', 'launchFlags', 'packageName'],
       'Android binary launch options:'
@@ -129,6 +134,7 @@ export const commandHandler = async ({
   port,
   watchNodeModules,
   disableBinaryStore,
+  resetCache,
 }: {
   activityName?: string
   baseComposite?: PackagePath
@@ -147,6 +153,7 @@ export const commandHandler = async ({
   port?: string
   watchNodeModules?: string[]
   disableBinaryStore?: boolean
+  resetCache?: boolean
 } = {}) => {
   await logErrorAndExitIfNotSatisfied({
     metroServerIsNotRunning: {
@@ -177,6 +184,7 @@ export const commandHandler = async ({
     miniapps,
     packageName,
     port,
+    resetCache,
     watchNodeModules,
   })
 }

--- a/ern-orchestrator/src/start.ts
+++ b/ern-orchestrator/src/start.ts
@@ -38,6 +38,7 @@ export default async function start({
   disableBinaryStore,
   host,
   port,
+  resetCache,
 }: {
   baseComposite?: PackagePath
   compositeDir?: string
@@ -56,6 +57,7 @@ export default async function start({
   disableBinaryStore?: boolean
   host?: string
   port?: string
+  resetCache?: boolean
 } = {}) {
   const cauldron = await getActiveCauldron({ throwIfNoActiveCauldron: false })
   if (!cauldron && descriptor) {
@@ -153,7 +155,7 @@ export default async function start({
       ...linkedMiniAppsPackageNames,
       ...watchNodeModules,
     ],
-    resetCache: true,
+    resetCache,
   })
 
   if (descriptor && !disableBinaryStore) {


### PR DESCRIPTION
Left over from https://github.com/electrode-io/electrode-native/pull/1520

Add `resetCache` option to `start` command. 