### PR TITLE
Update cli code-push docs

### DIFF
--- a/docs/cli/code-push.md
+++ b/docs/cli/code-push.md
@@ -2,31 +2,33 @@
 
 Electrode Native ships with a [CodePush] integration, to allow for releasing code updates over the air, to released native application versions.
 
-A few commands are exposed by Electrode Native to release CodePush updates, promote releases and update existing releases distribution details. 
+A few commands are exposed by Electrode Native to release CodePush updates, promote releases and update existing releases distribution details.
 
 Please note that only JavaScript code can be updated through CodePush releases, not native code.
 
 ### Prerequisites
 
-0. A Cauldron needs to be active
+A Cauldron needs to be active
 
 `code-push` commands only works with a supporting Cauldron. You should have properly setup and activated a Cauldron in order to work with CodePush.
 
-1. Creating a CodePush account
+### Setup
+
+#### Step 1: Create a CodePush account
 
 CodePush was recently integrated into Microsoft App Center, therefore you'll need to follow instructions on [this page](https://docs.microsoft.com/en-us/appcenter/distribution/codepush/migrationguide) to setup an app center account.
 
-After installing the App Center CLI and logging in through the CLI, please keep the generated token (a.k.a access key) handy, as Electrode Native needs it to perform `code-push` related commands. 
+After installing the App Center CLI and logging in through the CLI, please keep the generated token (a.k.a access key) handy, as Electrode Native needs it to perform `code-push` related commands.
 
 You'll then need to add the code push access key to the local Electrode Native configuration. This needs to be done local to each workstation/box that need to issue `code-push` commands. The CodePush access key is not stored in the Cauldron, for security reasons.
 
-```shell
-$ ern platform config set codePushAccessKey YOUR_CODE_PUSH_ACCESS_KEY
+```sh
+ern platform config set codePushAccessKey YOUR_CODE_PUSH_ACCESS_KEY
 ```
 
-2. Creating your application in CodePush
+#### Step 2: Create your application in CodePush
 
-Once you are logged-in with the App Center CLI, you'll need to create your application in App Center. 
+Once you are logged-in with the App Center CLI, you'll need to create your application in App Center.
 
 We recommend that you create two different application entries, for your application, one per platform. For example if your application is named `MyAwesomeApp`, you should create an application named `MyAwesomeAppIos` and another named `MyAwesomeAppAndroid`.
 
@@ -34,83 +36,84 @@ The name of the unsuffixed application should match the name you will use (or th
 
 Refer to the App Center documentation for more details on the command, but for illustration, here are the commands we would run based on our imaginary application name:
 
-```shell
-$ appcenter apps create -p "React-Native" -o "iOS" -d "MyAwesomeAppIos"
-$ appcenter apps create -p "React-Native" -o "Android" -d "MyAwesomeAppAndroid"
+```sh
+appcenter apps create -p "React-Native" -o "iOS" -d "MyAwesomeAppIos"
+appcenter apps create -p "React-Native" -o "Android" -d "MyAwesomeAppAndroid"
 ```
 
-3. [Optional] Set the application names in your Cauldron configuration
+#### Step 3: [Optional] Set the application names in your Cauldron configuration
 
-If you have named your CodePush application as recommended, with a platform suffix (`MyAwesomeApp` -> `MyAwesomeAppIos` and `MyAwesomeAppAndroid`) then you don't have to do any specific configuration in the Cauldron as this convention will be used when running `code-push` commands. 
+If you have named your CodePush application as recommended, with a platform suffix (`MyAwesomeApp` -> `MyAwesomeAppIos` and `MyAwesomeAppAndroid`) then you don't have to do any specific configuration in the Cauldron as this convention will be used when running `code-push` commands.
 
 However, if you have used a different naming convention, for example if you name `MyAwesomeApp` Android as `MyAwesomeAppForAndroid`, you will need to specify the custom name in your Cauldron configuration. You should edit the `cauldron.json` file of your Cauldron manually, as we don't have commands yet to edit configuration in the Cauldron.
 
-You should specify the custom application name in the `codePush` config object of the native application platform, as follow :
+You should specify the custom application name in the `codePush` config object of the native application platform, as follow:
 
 ```json
-"nativeApps": [
 {
-  "name": "MyAwesomeApp",
-  "platforms": [
-  {
-    "name": "android",
-    "config": {
-      "codePush": {
-        "appName": "MyAwesomeAppForAndroid"
+  "nativeApps": [{
+    "name": "MyAwesomeApp",
+    "platforms": [{
+      "name": "android",
+      "config": {
+        "codePush": {
+          "appName": "MyAwesomeAppForAndroid"
+        }
       }
-    }
-  ...
+    }]
+  }]
+}
 ```
 
-4. Creating your CodePush deployment names
+#### Step 4: Create your CodePush deployment names
 
-Think about deployment names as different deployment environments. You can choose as many deployment names as you see fit, though most users usually stick with the basic deployment names `Staging` and `Production` that app center creates for you when you add your app.  
-You will get a different 'key' for each app name / deployment name combination.  
+Think about deployment names as different deployment environments. You can choose as many deployment names as you see fit, though most users usually stick with the basic deployment names `Staging` and `Production` that app center creates for you when you add your app.
+
+You will get a different 'key' for each app name / deployment name combination.
+
 The keys are stored in your native application, and based upon the key you select at runtime, your native application will only retrieve the releases from a specific deployment name.
 
 Enter the command below to list the deployments associated with an app
 
-```shell
-$ appcenter codepush deployment list -a <YourAppName>
+```sh
+appcenter codepush deployment list -a <YourAppName>
 ```
 
 Refer to the App center documentation for more details on how to create deployment environments, but for illustration, here are the commands we would run for our `MyAwesomeApp` application, to create `Dev` deployment name :
 
-```shell
-$ appcenter codepush deployment add -a MyAwesomeAppIos Dev
-$ appcenter codepush deployment add -a MyAwesomeAppAndroid Dev
+```sh
+appcenter codepush deployment add -a MyAwesomeAppIos Dev
+appcenter codepush deployment add -a MyAwesomeAppAndroid Dev
 ```
 
-NOTE: If you get `not a valid application id` error, Execute `appcenter apps list` command to get the application id to pass in for the commads. 
+NOTE: If you get `not a valid application id` error, run the `appcenter apps list` command to get the application id to pass in for the commands.
 
-
-5. [Optional] Store the deployment names in your Cauldron
+#### Step 5: [Optional] Store the deployment names in your Cauldron
 
 You need to pass a deployment name to all `code-push` commands. This deployment name can be provided as a command option, however if you'd rather like to be prompted for a deployment name to choose from, you can store the deployments names associated to a native application name/platform inside the Cauldron `codePush` configuration.
 
 For illustration, here is how we would store the two deployments we created for our `MyAwesomeApp` Android in our Cauldron:
 
 ```json
-"nativeApps": [
 {
-  "name": "MyAwesomeApp",
-  "platforms": [
-  {
-    "name": "android",
-    "config": {
-      "codePush": {
-         "deployments": [
-            { "name": "Production" },
-            { "name": "Staging" }
-          ]
-      }
+  "name": "android",
+  "config": {
+    "codePush": {
+      "deployments": [{
+          "name": "Production"
+        },
+        {
+          "name": "Staging"
+        }
+      ]
     }
-  ...
+  }
+}
 ```
 
-6. [Optional] Configure version name modifiers in Cauldron
+#### Step 6: [Optional] Configure version name modifiers in Cauldron
 
-Some native applications are using version name modifiers to distinguish between different environments. For example for our `MyAwesomeApp` on Android, we might use the version suffix `-qa-debug` to denote a debug version built for `QA` and `dev-debug` to denote a `Development` debug version. In this case, for any given version number (for example `1.0.0`) we can have three `variants` of the version : `1.0.0` (Production), `1.0.0-dev-debug` (Dev) and `1.0.0-qa-debug` (QA). 
+Some native applications are using version name modifiers to distinguish between different environments. For example for our `MyAwesomeApp` on Android, we might use the version suffix `-qa-debug` to denote a debug version built for `QA` and `dev-debug` to denote a `Development` debug version. In this case, for any given version number (for example `1.0.0`) we can have three `variants` of the version : `1.0.0` (Production), `1.0.0-dev-debug` (Dev) and `1.0.0-qa-debug` (QA).
 
 The problem in that scenario, is that, when doing a release targeting a specific native application version, `CodePush` will only install it for versions matching the targetted version string. i.e if we are doing a CodePush release targeting `1.0.0`, then, users running the `1.0.0-dev-debug` version won't get the release.
 
@@ -119,45 +122,39 @@ If you are using version modifiers for your native application, then you should 
 For example, for your Android application, if `-dev-debug` versions are associated to your `Staging` deployment name and `-qa-debug` versions are associated to your `QA` deployment name, then you should setup the following `codePush` configuration in your Cauldron :
 
 ```json
-"nativeApps": [
 {
-  "name": "MyAwesomeApp",
-  "platforms": [
-  {
-    "name": "android",
-    "config": {
-      "codePush": {
-         "deployments": [
-           "Staging",
-           "QA",
-           "Production"
-          ],
-          "versionModifiers": [
-            {
-              "deploymentName": "Staging",
-              "modifier": "$1-qa-debug"
-            },
-            {
-              "deploymentName": "QA",
-              "modifier": "$1-dev-debug"
-            }
-          ]
+  "name": "android",
+  "config": {
+    "codePush": {
+      "deployments": [
+        "Staging",
+        "QA",
+        "Production"
+      ],
+      "versionModifiers": [{
+          "deploymentName": "Staging",
+          "modifier": "$1-qa-debug"
+        },
+        {
+          "deploymentName": "QA",
+          "modifier": "$1-dev-debug"
         }
-      }
+      ]
     }
-  ...
+  }
+}
 ```
 
-7. [Optional] Limit the number of CodePush entries in your Cauldron
+#### Step 7: [Optional] Limit the number of CodePush entries in your Cauldron
 
 For each CodePush release or promotion, a specific CodePush entry will be stored in the native application version in the Cauldron.
 
 If you are doing a lot of CodePush releases, you might want to limit the number of CodePush entries stored in the Cauldron, to keep only the last X entries.
 
-This can be achieved through Cauldron `codePush` configuration in the Cauldron top level `config` object. For example, if we desired to keep track of only the last two CodePush release entries for each native application version (per deployment name), our configuration would be as follow :
+This can be achieved through Cauldron `codePush` configuration in the Cauldron top level `config` object. For example, if we desired to keep track of only the last two CodePush release entries for each native application version (per deployment name), our configuration would be as follow:
 
 ```json
-"config": {
+{
   "codePush": {
     "entriesLimit": 2
   }
@@ -166,25 +163,26 @@ This can be achieved through Cauldron `codePush` configuration in the Cauldron t
 
 By default, if not configured in Cauldron, all CodePush entries will be stored.
 
-8. Setup code-push in your MiniApp(s)
+#### Step 8: Setup code-push in your MiniApp(s)
 
 For each of your MiniApp(s) that should support over the air updates, you should add the `react-native-code-push` dependency.
 
-If not done already, add the `react-native-code-push` dependency to your MiniApp. 
-From your MiniApp root directory, run the following command : 
+If not done already, add the `react-native-code-push` dependency to your MiniApp.
+From your MiniApp root directory, run the following command:
 
-```shell
-$ ern add react-native-code-push
+```sh
+ern add react-native-code-push
 ```
 
 Then in your MiniApp, decorate your MiniApp `Component` class with `codePush`, as illustrated by the following sample :
 
-```javascript
+```js
 import codePush from "react-native-code-push";
-[...]
 
-class App extends Component<{}> {
-  [...]
+// [...]
+
+class App extends Component {
+  // [...]
 }
 
 App = codePush({
@@ -196,34 +194,33 @@ App = codePush({
 
 You can use different values for `checkFrequency` or `installMode` based on your use case.
 
-Refer to the official [code-push plugin documentation](https://github.com/Microsoft/react-native-code-push#plugin-usage) for more details.
+Refer to the official [code-push plugin documentation](https://github.com/microsoft/react-native-code-push#plugin-usage) for more details.
 
-9. [Native Application] Initialize the Container with the CodePush configuration
+#### Step 9: [Native Application] Initialize the Container with the CodePush configuration
 
 On the native side, as soon as you create a Container that includes at least in the native application code, you will need to initialize the Container with a `CodePush` plugin configuration. This configuration takes the `deployment key` to be used at runtime. This is at this step that you can select which deployment key to be used, based on the build type.
 
 Here follows an illustration on how to initialize the Container with CodePush configuration on both Android and iOS.
 
-**Android**
+##### Android
 
 ```java
 ElectrodeReactContainer.initialize(
-  [...]
-  new CodePushPlugin.Config("DEPLOYMENT_KEY")
+        new CodePushPlugin.Config("DEPLOYMENT_KEY")
+        // [...]
+);
 ```
 
-**iOS**
+##### iOS
 
-```objectivec
+```objc
 ElectrodeContainerConfig *containerConfig = [[ElectrodeContainerConfig alloc] init];
 ElectrodeCodePushConfig *codePushConfig = [[ElectrodeCodePushConfig alloc] initWithDeploymentKey:@"DEPLOYMENT_KEY" serverURL:nil containerConfig:containerConfig];
 [ElectrodeReactNative startWithConfigurations:containerConfig electrodeCodePushConfig:codePushConfig];
 ```
 
-10. CodePush your first release !
+#### Step 10: CodePush your first release
 
-Head over to the [code-push release] command documentation to do your first release through CodePush.
+Head over to the [code-push release][1] command documentation to do your first release through CodePush.
 
-[code-push release] | Issue a CodePush release 
- 
-[code-push release]: ./release.md
+[1]: ./code-push/release.md

--- a/docs/cli/code-push/patch.md
+++ b/docs/cli/code-push/patch.md
@@ -1,18 +1,20 @@
 ## `ern code-push patch`
 
-[code-push commands prerequisites] needs to be met in order to execute this command
+code-push [prerequisites][1] need to be met in order to run this command
 
-#### Description
+### Description
 
 * Patch a CodePush release.
 * This command only works for entries that have been released through `ern code-push release` or promoted through `ern code-push promote`.
 * Update the corresponding CodePush entry in Cauldron with the changes.
 
-#### Syntax
+### Syntax
 
-`ern code-push patch`  
+```sh
+ern code-push patch
+```
 
-**Options**  
+#### Options
 
 `--descriptor/-d <descriptor>`
 
@@ -45,14 +47,15 @@
 * **Default**  No change to the rollout percentage.
 
 `--description/--des`
+
 * Description of the changes made to the app with this release
 * **Default**  Empty String
 
-#### Related commands
+### Related commands
 
-[code-push promote] | Promote a release to a different deployment name  
-[code-push release] | Issue a CodePush release
- 
-[code-push promote]: ./promote.md
-[code-push release]: ./release.md
-[code-push commands prerequisites]: ../code-push.md
+* [code-push promote][2] | Promote a release to a different deployment name
+* [code-push release][3] | Issue a CodePush release
+
+[1]: ../code-push.md
+[2]: ./promote.md
+[3]: ./release.md

--- a/docs/cli/code-push/promote.md
+++ b/docs/cli/code-push/promote.md
@@ -1,16 +1,18 @@
 ## `ern code-push promote`
 
-[code-push commands prerequisites] needs to be met in order to execute this command
+code-push [prerequisites][1] need to be met in order to run this command
 
-#### Description
+### Description
 
 * Promote a CodePush release to a different deployment name and/or native application versions.
 
 #### Syntax
 
-`ern code-push promote`  
+```sh
+ern code-push promote
+```
 
-**Options**  
+#### Options
 
 `--reuseReleaseBinaryVersion`
 
@@ -27,7 +29,7 @@
 `--targetDescriptors <descriptors..>`
 
 * Specify one or more target native application version to promote the release to, in the form of a *complete native application descriptor* list (separated by spaces).
-* The target descriptor can be the same as the source descriptor if the promotion is just changing the deployment name (for example promoting a release from Staging to Production for the same native application version).
+* The target descriptor can be the same as the source descriptor if the promotion is only changing the deployment name (for example promoting a release from Staging to Production for the same native application version).
 
 `--targetSemVerDescriptor <descriptor>`
 
@@ -76,13 +78,13 @@ If no `targetDescriptors` nor a `targetSemVerDescriptor` is specified, the comma
 
 `--label/-l`
 
-* Promote the release matching this specific label. 
+* Promote the release matching this specific label.
 * **Default** The latest release matching sourceDescriptor/sourceDeploymentName pair will be promoted.
 
 `--description/--des`
 
 * Description of the changes made to the app with this release. If omitted, the description from the release being promoted will be used.
- 
+
 * **Default** Empty string
 
 `--disableDuplicateReleaseError`
@@ -93,8 +95,9 @@ If no `targetDescriptors` nor a `targetSemVerDescriptor` is specified, the comma
 
 #### Related commands
 
-[code-push release] | Issue a CodePush release 
-[code-push patch] | Patch a release
- 
-[code-push release]: ./release.md
-[code-push patch]: ./patch.md
+* [code-push release][2] | Issue a CodePush release
+* [code-push patch][3] | Patch a release
+
+[1]: ../code-push.md
+[2]: ./release.md
+[3]: ./patch.md

--- a/docs/cli/code-push/release.md
+++ b/docs/cli/code-push/release.md
@@ -1,8 +1,8 @@
 ## `ern code-push release`
 
-[code-push commands prerequisites] needs to be met in order to execute this command
+code-push [prerequisites][1] need to be met in order to run this command
 
-#### Description
+### Description
 
 * Release one or more MiniApp(s) version(s) to one or more released native application version(s).
 * Perform compatibility checks to ensure that the new MiniApp(s) version(s) are compatible with the target native application version(s).
@@ -10,11 +10,13 @@
 
 **Note:** The `ern code-push <miniapps..>` command can release JavaScript code only, not native. Therefore compatibility checks will ensure that the MiniApp(s) native dependencies are compatible with the versions running in the target native application version.
 
-#### Syntax
+### Syntax
 
-`ern code-push release`  
+```sh
+ern code-push release
+```
 
-**Options**  
+### Options
 
 `--miniapps`
 
@@ -55,6 +57,7 @@ If no `descriptors` nor a `semVerDescriptor` is specified, the command will list
 * **Default**  The command will display a prompt asking to input the deployment name. If deployment names for your native applications are stored in the Cauldron, the prompt will display the deployment names and ask to select one.
 
 `--targetBinaryVersion/-t <targetBinaryVersion>`
+
 * Semver expression that specifies the binary app version this release is targeting
 * If omitted, the release will target the exact version of the descriptor
 * If versionModifier is specified in the codePush config , exact version of the descriptor is appended to versionModifier
@@ -88,14 +91,15 @@ If no `descriptors` nor a `semVerDescriptor` is specified, the command will list
 
 * **Default** false
 
-#### Remarks
+### Remarks
 
 * MiniApps are packaged in a single JavaScript bundle. If the native application version contains 5 MiniApps and only one MiniApp is updated, then the remaining 4 MiniApp versions will remain untouched in the bundle.
 
-#### Related commands
+### Related commands
 
-[code-push promote] | Promote a release to a different deployment name  
-[code-push patch] | Patch a release
- 
-[code-push promote]: ./promote.md
-[code-push patch]: ./patch.md
+* [code-push promote] | Promote a release to a different deployment name
+* [code-push patch] | Patch a release
+
+[1]: ../code-push.md
+[2]: ./promote.md
+[3]: ./patch.md


### PR DESCRIPTION
A light first-pass update of the code-push cli docs with minor wording/structural improvements.

This fixes all whitespace errors and _most_ markdownlint (_except_ `MD041/first-line-heading` and `MD013/line-length` - both of which will be addressed more broadly in an upcoming doc update)