### PR TITLE
Fix custom composite config

### DIFF
--- a/ern-local-cli/src/commands/bundlestore/upload.ts
+++ b/ern-local-cli/src/commands/bundlestore/upload.ts
@@ -167,7 +167,8 @@ export const commandHandler = async ({
       )
       baseComposite =
         baseComposite ||
-        (compositeGenConfig && compositeGenConfig.baseComposite)
+        (compositeGenConfig?.baseComposite &&
+          PackagePath.fromString(compositeGenConfig.baseComposite))
       resolutions = compositeGenConfig && compositeGenConfig.resolutions
     }
 

--- a/ern-local-cli/src/commands/create-composite.ts
+++ b/ern-local-cli/src/commands/create-composite.ts
@@ -137,7 +137,9 @@ Output directory should either not exist (it will be created) or should be empty
       descriptor
     )
     baseComposite =
-      baseComposite || (compositeGenConfig && compositeGenConfig.baseComposite)
+      baseComposite ||
+      (compositeGenConfig?.baseComposite &&
+        PackagePath.fromString(compositeGenConfig.baseComposite))
     resolutions = compositeGenConfig && compositeGenConfig.resolutions
   }
 

--- a/ern-local-cli/src/commands/create-container.ts
+++ b/ern-local-cli/src/commands/create-container.ts
@@ -175,7 +175,9 @@ Output directory should either not exist (it will be created) or should be empty
       descriptor
     )
     baseComposite =
-      baseComposite || (compositeGenConfig && compositeGenConfig.baseComposite)
+      baseComposite ||
+      (compositeGenConfig?.baseComposite &&
+        PackagePath.fromString(compositeGenConfig.baseComposite))
   }
 
   if (!descriptor && miniapps) {

--- a/ern-orchestrator/src/composite.ts
+++ b/ern-orchestrator/src/composite.ts
@@ -66,7 +66,9 @@ export async function runCauldronCompositeGen(
       napDescriptor
     )
     baseComposite =
-      baseComposite || (compositeGenConfig && compositeGenConfig.baseComposite)
+      baseComposite ||
+      (compositeGenConfig?.baseComposite &&
+        PackagePath.fromString(compositeGenConfig.baseComposite))
     const miniapps = await cauldron.getContainerMiniApps(napDescriptor, {
       favorGitBranches,
     })

--- a/ern-orchestrator/src/container.ts
+++ b/ern-orchestrator/src/container.ts
@@ -159,7 +159,9 @@ export async function runCaudronBundleGen(
       napDescriptor
     )
     baseComposite =
-      baseComposite || (compositeGenConfig && compositeGenConfig.baseComposite)
+      baseComposite ||
+      (compositeGenConfig?.baseComposite &&
+        PackagePath.fromString(compositeGenConfig.baseComposite))
     const miniapps = await cauldron.getContainerMiniApps(napDescriptor)
     const jsApiImpls = await cauldron.getContainerJsApiImpls(napDescriptor)
     const containerGenConfig = await cauldron.getContainerGeneratorConfig(

--- a/ern-orchestrator/src/runMiniApp.ts
+++ b/ern-orchestrator/src/runMiniApp.ts
@@ -102,7 +102,9 @@ export async function runMiniApp(
   const compositeGenConfig =
     cauldron && (await cauldron.getCompositeGeneratorConfig(napDescriptor))
   baseComposite =
-    baseComposite || (compositeGenConfig && compositeGenConfig.baseComposite)
+    baseComposite ||
+    (compositeGenConfig?.baseComposite &&
+      PackagePath.fromString(compositeGenConfig.baseComposite))
 
   let entryMiniAppName = mainMiniAppName || ''
   if (miniapps) {

--- a/ern-orchestrator/src/syncCauldronContainer.ts
+++ b/ern-orchestrator/src/syncCauldronContainer.ts
@@ -7,6 +7,7 @@ import {
   SourceMapStoreSdk,
   createProxyAgentFromErnConfig,
   bugsnagUpload,
+  PackagePath,
 } from 'ern-core'
 import { getActiveCauldron } from 'ern-cauldron-api'
 import { runCauldronContainerGen } from './container'
@@ -84,7 +85,9 @@ Please set the new container version through command options.`)
     const compositeGenConfig = await cauldron.getCompositeGeneratorConfig(
       descriptor
     )
-    const baseComposite = compositeGenConfig?.baseComposite
+    const baseComposite =
+      compositeGenConfig?.baseComposite &&
+      PackagePath.fromString(compositeGenConfig.baseComposite)
 
     const compositeDir = createTmpDir()
 


### PR DESCRIPTION
Hey! 
I was facing the same issue as #1287. 
The path/url specified for the `baseComposite` key in my `config/default.json` file is correctly loaded from the config. However, it's a plain string being passed down and not a `PackagePath` as expected in the [CompositeGeneratorConfig](https://github.com/electrode-io/electrode-native/blob/7b45fec57f4ce860685ea938fcbb31d5992c0f60/ern-composite-gen/src/types/CompositeGeneratorConfig.ts#L2).

I've now solved it by wrapping the path using the `PackagePath.fromString` method, before it's passed in to the composite generation. Would this be the right place to do it?
