### PR TITLE
Fix CodePush issue

### DIFF
--- a/ern-cauldron-api/src/CauldronHelper.ts
+++ b/ern-cauldron-api/src/CauldronHelper.ts
@@ -794,7 +794,7 @@ export class CauldronHelper {
     }: {
       label?: string
     } = {}
-  ): Promise<CauldronCodePushEntry | never> {
+  ): Promise<CauldronCodePushEntry | undefined> {
     const codePushEntries = await this.cauldron.getCodePushEntries(
       descriptor,
       deploymentName
@@ -810,17 +810,8 @@ export class CauldronHelper {
         }
       } else {
         result = _.last(codePushEntries)
-        if (!result) {
-          throw new Error(
-            `No CodePush entry matching label found for ${descriptor} ${deploymentName} deployment}`
-          )
-        }
       }
       return result
-    } else {
-      throw new Error(
-        `No code push entries found for ${descriptor} ${deploymentName} deployment`
-      )
     }
   }
 

--- a/ern-cauldron-api/test/CauldronHelper-test.ts
+++ b/ern-cauldron-api/test/CauldronHelper-test.ts
@@ -2106,6 +2106,16 @@ describe('CauldronHelper.js', () => {
       )
     })
 
+    it('should return undefined if there is not mathing code push entry', async () => {
+      const fixture = cloneFixture(fixtures.defaultCauldron)
+      const cauldronHelper = createCauldronHelper({ cauldronDocument: fixture })
+      const res = await cauldronHelper.getCodePushEntry(
+        AppVersionDescriptor.fromString('test:android:17.8.0'),
+        'Production'
+      )
+      expect(res).undefined
+    })
+
     it('should return the latest CodePushed entry if label is ommited', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron)
       const cauldronHelper = createCauldronHelper({ cauldronDocument: fixture })

--- a/ern-orchestrator/src/codepush.ts
+++ b/ern-orchestrator/src/codepush.ts
@@ -121,14 +121,12 @@ export async function performCodePushPromote(
         throw new Error(`Missing version in ${targetNapDescriptor.toString()}`)
       }
 
-      let codePushEntrySource: CauldronCodePushEntry
-      try {
-        codePushEntrySource = await cauldron.getCodePushEntry(
-          sourceNapDescriptor,
-          sourceDeploymentName,
-          { label }
-        )
-      } catch (e) {
+      const codePushEntrySource = await cauldron.getCodePushEntry(
+        sourceNapDescriptor,
+        sourceDeploymentName,
+        { label }
+      )
+      if (!codePushEntrySource) {
         throw new Error(
           `No CodePush entry found in Cauldron matching [desc: ${sourceNapDescriptor} dep: ${sourceDeploymentName} label: ${label ||
             'latest'}`


### PR DESCRIPTION
Fix a regression with `code-push release` command introduced in `0.40.0` causing `code-push release` command to fail with such an error message

```
An error occurred: No code push entries found for [descriptor] [deploymentName] deployment
```

when performing a code push to a descriptor with no prior code push performed to it.