### PR TITLE
Fix CodePush disableDuplicateReleaseError flag behavior

### DIFF
--- a/ern-core/src/CodePushSdk.ts
+++ b/ern-core/src/CodePushSdk.ts
@@ -55,13 +55,14 @@ export default class CodePushSdk {
       delete updateMetadata.rollout
     }
     try {
-      return this.codePush.release(
+      const res = await this.codePush.release(
         appName,
         deploymentName,
         filePath,
         targetBinaryVersion,
         updateMetadata
       )
+      return res
     } catch (error) {
       if (
         disableDuplicateReleaseError &&
@@ -86,12 +87,13 @@ export default class CodePushSdk {
       delete updateMetadata.rollout
     }
     try {
-      return this.codePush.promote(
+      const res = await this.codePush.promote(
         appName,
         sourceDeploymentName,
         destinationDeploymentName,
         updateMetadata
       )
+      return res
     } catch (error) {
       if (
         disableDuplicateReleaseError &&


### PR DESCRIPTION
Fix issue causing `--disableDuplicateReleaseError` flag on `code-push release` and `code-push promote` commands not being considered.

Due to the fact that the code wasn't awaiting on some async method calls, so in case of an exception the catch block was completely skipped (bubbling up to whichever first upstream catch block)