### PR TITLE
Fix Android SDK path resolution

### DIFF
--- a/ern-core/src/android.ts
+++ b/ern-core/src/android.ts
@@ -1,3 +1,4 @@
+import fs from 'fs-extra'
 import inquirer from 'inquirer'
 import shell from './shell'
 import ernConfig from './config'
@@ -384,14 +385,24 @@ export async function installApk(pathToApk: string) {
   return execp(`${androidAdbPath()} install -r ${pathToApk}`)
 }
 
+export function androidSdkRoot(): string | undefined {
+  return process.env.ANDROID_SDK_ROOT ?? process.env.ANDROID_HOME
+}
+
 export function androidAdbPath(): string {
-  return process.env.ANDROID_HOME
-    ? `${process.env.ANDROID_HOME}/platform-tools/adb`
-    : 'adb'
+  const sdkRoot = androidSdkRoot()
+  return sdkRoot ? `${sdkRoot}/platform-tools/adb` : 'adb'
 }
 
 export function androidEmulatorPath(): string {
-  return process.env.ANDROID_HOME
-    ? `${process.env.ANDROID_HOME}/tools/emulator`
-    : 'emulator'
+  const sdkRoot = androidSdkRoot()
+  if (sdkRoot) {
+    if (fs.existsSync(`${sdkRoot}/emulator/emulator`)) {
+      return `${sdkRoot}/emulator/emulator`
+    }
+    if (fs.existsSync(`${sdkRoot}/tools/emulator`)) {
+      return `${sdkRoot}/tools/emulator`
+    }
+  }
+  return 'emulator'
 }


### PR DESCRIPTION
This PR addresses two closely related issues:

## Android SDK path environment variable

A while ago `ANDROID_HOME` was [deprecated](https://developer.android.com/studio/command-line/variables#envar) and replaced with `ANDROID_SDK_ROOT`. For various reasons (mainly backwards compatibility with older versions of the Android Gradle plugin) most people will now have to set **both** variables for the foreseeable future. 🤦‍♂

The problem is that some people might only set one or the other.

With a new function `androidSdkRoot` that returns either `ANDROID_SDK_ROOT` or `ANDROID_HOME`, we now support both (giving the newer `ANDROID_SDK_ROOT` precedence).

## Location of the `emulator` binary

Also for quite some time now, the Emulator has been shipped [as its own package](https://developer.android.com/studio/releases/emulator#25-3) - in the `$sdk/emulator/` folder. Historically appears it was shipped with Tools, and located in `$sdk/tools/`. A smaller `emulator` executable can be found in that directory for **some** Android SDK installations as well.

The problem is that some newer (?) Android SDK installations appear to be missing that `$sdk/tools/` folder altogether.

In any case, we now support both potential locations for `emulator`.