### PR TITLE
Refactor manifest plugin config

### DIFF
--- a/ern-api-impl-gen/src/generators/android/ApiImplAndroidGenerator.ts
+++ b/ern-api-impl-gen/src/generators/android/ApiImplAndroidGenerator.ts
@@ -106,7 +106,10 @@ export default class ApiImplAndroidGenerator implements ApiImplGeneratable {
       )
       let pluginPath: PackagePath
       for (pluginPath of pluginsPaths) {
-        const pluginConfig = await manifest.getPluginConfig(pluginPath)
+        const pluginConfig = await manifest.getPluginConfig(
+          pluginPath,
+          'android'
+        )
         if (pluginConfig) {
           log.debug(`Copying ${pluginPath.name} to ${outputDirectory}`)
           this.copyPluginToOutput(
@@ -133,13 +136,10 @@ export default class ApiImplAndroidGenerator implements ApiImplGeneratable {
     paths: any,
     pluginOutputDirectory: string,
     pluginPath: PackagePath,
-    pluginConfig: PluginConfig
+    pluginConfig: PluginConfig<'android'>
   ) {
     if (pluginPath.name === 'react-native') {
       return
-    }
-    if (!pluginConfig.android) {
-      throw new Error('Missing android plugin configuration')
     }
     log.debug(`injecting ${pluginPath.name} code.`)
     const pluginSrcDirectory = path.join(
@@ -147,7 +147,7 @@ export default class ApiImplAndroidGenerator implements ApiImplGeneratable {
       'node_modules',
       pluginPath.name!,
       'android',
-      pluginConfig.android.moduleName,
+      pluginConfig.moduleName,
       SRC_MAIN_JAVA_DIR,
       '*'
     )

--- a/ern-composite-gen/src/GeneratedComposite.ts
+++ b/ern-composite-gen/src/GeneratedComposite.ts
@@ -76,12 +76,15 @@ export class GeneratedComposite implements Composite {
         result.push(dependency)
         continue
       }
-      const pluginConfig = await manifest.getPluginConfig(dependency)
 
-      if (platform === 'android' && pluginConfig?.android) {
-        result.push(dependency)
-      } else if (platform === 'ios' && pluginConfig?.ios) {
-        result.push(dependency)
+      if (platform === 'android') {
+        if (await manifest.getPluginConfig(dependency, 'android')) {
+          result.push(dependency)
+        }
+      } else {
+        if (await manifest.getPluginConfig(dependency, 'ios')) {
+          result.push(dependency)
+        }
       }
     }
     return result

--- a/ern-composite-gen/src/WorkspaceComposite.ts
+++ b/ern-composite-gen/src/WorkspaceComposite.ts
@@ -77,11 +77,12 @@ export class WorkspaceComposite implements Composite {
         result.push(dependency)
         continue
       }
-      const pluginConfig = await manifest.getPluginConfig(dependency)
 
-      if (platform === 'android' && pluginConfig?.android) {
-        result.push(dependency)
-      } else if (platform === 'ios' && pluginConfig?.ios) {
+      if (platform === 'android') {
+        if (await manifest.getPluginConfig(dependency, 'android')) {
+          result.push(dependency)
+        }
+      } else if (await manifest.getPluginConfig(dependency, 'ios')) {
         result.push(dependency)
       }
     }

--- a/ern-container-gen/src/generatePluginsMustacheViews.ts
+++ b/ern-container-gen/src/generatePluginsMustacheViews.ts
@@ -1,4 +1,4 @@
-import { log, manifest, PackagePath } from 'ern-core'
+import { log, manifest, PackagePath, PluginConfig } from 'ern-core'
 
 export async function generatePluginsMustacheViews(
   plugins: PackagePath[],
@@ -10,20 +10,25 @@ export async function generatePluginsMustacheViews(
     if (plugin.name === 'react-native') {
       continue
     }
-    const pluginConfig = await manifest.getPluginConfig(plugin)
-    if (!pluginConfig) {
-      continue
+
+    let pluginConfig: PluginConfig<'android' | 'ios'> | undefined
+    if (platform === 'android') {
+      pluginConfig = await manifest.getPluginConfig(plugin, 'android')
+    } else {
+      pluginConfig = await manifest.getPluginConfig(plugin, 'ios')
     }
-    if (!pluginConfig[platform]) {
+    if (!pluginConfig) {
       log.warn(
         `${plugin.name} does not have any injection configuration for ${platform} platform`
       )
       continue
     }
-    const pluginHook = pluginConfig[platform]!.pluginHook
+
+    const pluginHook = pluginConfig.pluginHook
     let containerHeader
     if (platform === 'ios') {
-      containerHeader = pluginConfig[platform]!.containerPublicHeader
+      containerHeader = (pluginConfig as PluginConfig<'ios'>)
+        .containerPublicHeader
     }
 
     if (!pluginHook && !containerHeader) {


### PR DESCRIPTION
Refactor manifest plugin configuration, getting rid of some verbosity and improve type safety. 
One of the main change is that `getPluginConfig` method now takes the `platform` for which to get configuration of. Therefore, instead of returning the whole `ios` and `android` configuration objects, it only returns the configuration of the requested platform.

This PR is in the context of RN61+ support, as this refactoring is needed to more easily support some needed changes in the manifest plugin configuration in this context. It's been open separately not to pollute RN61+ support PR with such a consequent refactoring.