### PR TITLE
Use cross-spawn in ern-core

### DIFF
--- a/ern-core/package.json
+++ b/ern-core/package.json
@@ -45,6 +45,7 @@
     "chalk": "^2.4.1",
     "cli-table": "^0.3.1",
     "code-push": "^2.0.6",
+    "cross-spawn": "^7.0.2",
     "decompress-zip": "^0.3.1",
     "ern-bugsnag-sourcemaps": "^1.0.0",
     "form-data": "^2.5.0",

--- a/ern-core/src/YarnCli.ts
+++ b/ern-core/src/YarnCli.ts
@@ -5,7 +5,7 @@ import fs from 'fs-extra'
 import { PackagePath } from './PackagePath'
 import { execp } from './childProcess'
 import log from './log'
-import { spawn } from 'child_process'
+import { spawn } from 'cross-spawn'
 import { readPackageJson } from './packageJsonFileUtils'
 
 export class YarnCli {

--- a/ern-core/src/childProcess.ts
+++ b/ern-core/src/childProcess.ts
@@ -1,4 +1,5 @@
-import { exec, spawn, ChildProcess } from 'child_process'
+import { exec, ChildProcess } from 'child_process'
+import { spawn } from 'cross-spawn'
 import log from './log'
 
 interface ExecOpts {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/archiver": "^3.0.0",
     "@types/chai": "^4.2.9",
     "@types/cli-table": "^0.3.0",
+    "@types/cross-spawn": "^6.0.1",
     "@types/fast-levenshtein": "^0.0.1",
     "@types/fs-extra": "^8.1.0",
     "@types/fs-readdir-recursive": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1573,6 +1573,13 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/cross-spawn@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/cross-spawn/-/cross-spawn-6.0.1.tgz#60fa0c87046347c17d9735e5289e72b804ca9b63"
+  integrity sha512-MtN1pDYdI6D6QFDzy39Q+6c9rl2o/xN7aWGe6oZuzqq5N6+YuwFsWiEAv3dNzvzN9YzU+itpN8lBzFpphQKLAw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -3323,6 +3330,15 @@ cross-spawn@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
   integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
+cross-spawn@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.2.tgz#d0d7dcfa74e89115c7619f4f721a94e1fdb716d6"
+  integrity sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"


### PR DESCRIPTION
Use `spawn` from [`cross-spawn`](https://www.npmjs.com/package/cross-spawn) instead of Node's own `child_process`, due to cross platform compatibility issues running executables/scripts (Linux, macOS, and Windows).

Some more details and background info in this almost 10 year old thread:
https://github.com/nodejs/node-v0.x-archive/issues/2318

This fix is related to an issue found with Yarn on Windows.

Fixes #1527