### PR TITLE
Add baseComposite option to code-push release command

### DIFF
--- a/docs/cli/code-push/release.md
+++ b/docs/cli/code-push/release.md
@@ -18,6 +18,10 @@ ern code-push release
 
 ### Options
 
+`--baseComposite <compositePath>`
+
+* Git or File System path, to the custom Composite repository (refer to the [custom Composite documentation][4] for more information).
+
 `--miniapps`
 
 * One or more MiniApps (separated by spaces) version(s) to CodePush.
@@ -103,3 +107,4 @@ If no `descriptors` nor a `semVerDescriptor` is specified, the command will list
 [1]: ../code-push.md
 [2]: ./promote.md
 [3]: ./patch.md
+[4]: ../../platform-parts/composite/index.md

--- a/ern-local-cli/src/commands/code-push/release.ts
+++ b/ern-local-cli/src/commands/code-push/release.ts
@@ -23,6 +23,11 @@ export const desc =
 
 export const builder = (argv: Argv) => {
   return argv
+    .option('baseComposite', {
+      describe: 'Base Composite',
+      type: 'string',
+    })
+    .coerce('baseComposite', d => PackagePath.fromString(d))
     .option('deploymentName', {
       describe: 'Deployment to release the update to',
       type: 'string',
@@ -97,6 +102,7 @@ export const builder = (argv: Argv) => {
 }
 
 export const commandHandler = async ({
+  baseComposite,
   deploymentName,
   description,
   descriptors = [],
@@ -111,6 +117,7 @@ export const commandHandler = async ({
   sourceMapOutput,
   targetBinaryVersion,
 }: {
+  baseComposite?: PackagePath
   deploymentName: string
   description: string
   descriptors?: AppVersionDescriptor[]
@@ -218,6 +225,7 @@ export const commandHandler = async ({
       miniAppsPackages,
       jsApiImplsPackages,
       {
+        baseComposite,
         codePushIsMandatoryRelease: mandatory,
         codePushRolloutPercentage: rollout,
         description,

--- a/ern-orchestrator/src/codepush.ts
+++ b/ern-orchestrator/src/codepush.ts
@@ -294,7 +294,10 @@ export async function performCodePushOtaUpdate(
     const compositeGenConfig = await cauldron.getCompositeGeneratorConfig(
       napDescriptor
     )
-    baseComposite = baseComposite ?? compositeGenConfig?.baseComposite
+    baseComposite =
+      baseComposite ??
+      (compositeGenConfig?.baseComposite &&
+        PackagePath.fromString(compositeGenConfig.baseComposite))
     await cauldron.beginTransaction()
     const codePushPlugin = _.find(
       plugins,


### PR DESCRIPTION
Add missing `--baseComposite` option to `code-push release` command.
The logic for this option was already in place in `performCodePushOtaUpdate` method, so it's clear that missed adding this option to this command when this feature was introduced.
Also apply fix from https://github.com/electrode-io/electrode-native/pull/1532 for properly coercing base composite config from cauldron.