### PR TITLE
Remove overlay permission upon app startup in Android

### DIFF
--- a/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactActivityDelegate.java
+++ b/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactActivityDelegate.java
@@ -8,7 +8,6 @@ import android.os.Bundle;
 import android.provider.Settings;
 import android.support.annotation.NonNull;
 import android.view.View;
-import android.widget.Toast;
 
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactNativeHost;
@@ -134,28 +133,15 @@ public class ElectrodeReactActivityDelegate extends ReactActivityDelegate {
     }
 
     private ReactRootView createReactRootView(@NonNull String componentName, @Nullable Bundle props, boolean newInstance) {
-        // Ask for overlay permission. This is required only during development and is needed for
-        // ReactNative to display the Debug menu as an overlay
-        if (ElectrodeReactContainer.isReactNativeDeveloperSupport()
-                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
-                && !Settings.canDrawOverlays(getContext())) {
-            Intent serviceIntent = new Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION);
-            serviceIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            mCurrentActivity.startActivity(serviceIntent);
-            mCurrentActivity.finish();
-            Toast.makeText(mCurrentActivity, "You must allow overlays first", Toast.LENGTH_SHORT).show();
-            return null;
-        } else {
-            Bundle finalProps = getLaunchOptions();
-            if (props != null) {
-                if (finalProps != null) {
-                    finalProps.putAll(props);
-                } else {
-                    finalProps = props;
-                }
+        Bundle finalProps = getLaunchOptions();
+        if (props != null) {
+            if (finalProps != null) {
+                finalProps.putAll(props);
+            } else {
+                finalProps = props;
             }
-            return getReactAppView(componentName, finalProps, newInstance);
         }
+        return getReactAppView(componentName, finalProps, newInstance);
     }
 
     /**

--- a/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactContainer.java
+++ b/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactContainer.java
@@ -179,7 +179,6 @@ public class ElectrodeReactContainer {
             {{#isCodePushPluginIncluded}}
             CodePush.setReactInstanceHolder(sElectrodeReactNativeHost);
             {{/isCodePushPluginIncluded}}
-            askForOverlayPermissionIfDebug(application);
 
             sReactPackages.add(new MainReactPackage());
             {{#plugins}}
@@ -212,19 +211,6 @@ public class ElectrodeReactContainer {
             Log.d(TAG, "ELECTRODE REACT-NATIVE ENGINE INITIALIZED\n" + reactContainerConfig.toString());
         } else {
             Log.i(TAG, "Ignoring duplicate initialize call, electrode container is already initialized or is being initialized");
-        }
-    }
-
-    private static void askForOverlayPermissionIfDebug(Application application) {
-        // Ask for overlay permission for the application if
-        // developer mode is enabled and Android version is Marshmallow
-        // or above
-        if (isReactNativeDeveloperSupport &&
-                Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
-                !Settings.canDrawOverlays(application)) {
-            Intent serviceIntent = new Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION);
-            serviceIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            application.startActivity(serviceIntent);
         }
     }
 

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactActivityDelegate.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactActivityDelegate.java
@@ -8,7 +8,6 @@ import android.os.Bundle;
 import android.provider.Settings;
 import android.support.annotation.NonNull;
 import android.view.View;
-import android.widget.Toast;
 
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactNativeHost;
@@ -134,28 +133,15 @@ public class ElectrodeReactActivityDelegate extends ReactActivityDelegate {
     }
 
     private ReactRootView createReactRootView(@NonNull String componentName, @Nullable Bundle props, boolean newInstance) {
-        // Ask for overlay permission. This is required only during development and is needed for
-        // ReactNative to display the Debug menu as an overlay
-        if (ElectrodeReactContainer.isReactNativeDeveloperSupport()
-                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
-                && !Settings.canDrawOverlays(getContext())) {
-            Intent serviceIntent = new Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION);
-            serviceIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            mCurrentActivity.startActivity(serviceIntent);
-            mCurrentActivity.finish();
-            Toast.makeText(mCurrentActivity, "You must allow overlays first", Toast.LENGTH_SHORT).show();
-            return null;
-        } else {
-            Bundle finalProps = getLaunchOptions();
-            if (props != null) {
-                if (finalProps != null) {
-                    finalProps.putAll(props);
-                } else {
-                    finalProps = props;
-                }
+        Bundle finalProps = getLaunchOptions();
+        if (props != null) {
+            if (finalProps != null) {
+                finalProps.putAll(props);
+            } else {
+                finalProps = props;
             }
-            return getReactAppView(componentName, finalProps, newInstance);
         }
+        return getReactAppView(componentName, finalProps, newInstance);
     }
 
     /**

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactContainer.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactContainer.java
@@ -139,7 +139,6 @@ public class ElectrodeReactContainer {
             }
 
             sElectrodeReactNativeHost = new ElectrodeReactNativeHost(application);
-            askForOverlayPermissionIfDebug(application);
 
             sReactPackages.add(new MainReactPackage());
             sReactPackages.add(new BridgePlugin().hook(application, null));
@@ -162,19 +161,6 @@ public class ElectrodeReactContainer {
             Log.d(TAG, "ELECTRODE REACT-NATIVE ENGINE INITIALIZED\n" + reactContainerConfig.toString());
         } else {
             Log.i(TAG, "Ignoring duplicate initialize call, electrode container is already initialized or is being initialized");
-        }
-    }
-
-    private static void askForOverlayPermissionIfDebug(Application application) {
-        // Ask for overlay permission for the application if
-        // developer mode is enabled and Android version is Marshmallow
-        // or above
-        if (isReactNativeDeveloperSupport &&
-                Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
-                !Settings.canDrawOverlays(application)) {
-            Intent serviceIntent = new Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION);
-            serviceIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            application.startActivity(serviceIntent);
         }
     }
 


### PR DESCRIPTION
Since React Native 52, the dev screen is displayed using the `currentActivity` context instead of using the overlay permission. This PR is to remove the dependency electrode native has added inside the container code. 

Reference: 
https://github.com/facebook/react-native/commit/d19afc73f5048f81656d0b4424232ce6d69a6368