### PR TITLE
Fix a regression of ern start command

### DIFF
--- a/ern-orchestrator/src/start.ts
+++ b/ern-orchestrator/src/start.ts
@@ -255,7 +255,7 @@ async function replacePackageInCompositeWithLinkedPackage(
     'node_modules/react',
     'node_modules/react-native-electrode-bridge',
     '.git',
-    ...excludedPackages.map(d => path.normalize(`node_modules/${d.basePath}`)),
+    ...excludedPackages.map(d => path.normalize(`node_modules/${d.name}`)),
   ].map(f => path.join(sourceLinkDir, f))
 
   const excludedDirectoriesRe = new RegExp(


### PR DESCRIPTION
`ern start` bug fixed in https://github.com/electrode-io/electrode-native/pull/1411 started reappearing in ern `0.39.0`. This PR fixes this regression.
Fix will be shipped in patch release `0.40.3`