### PR TITLE
Include iPad in iOS simulator deployment targets

### DIFF
--- a/ern-core/src/ios.ts
+++ b/ern-core/src/ios.ts
@@ -18,7 +18,7 @@ export interface IosDevice {
 export async function getiPhoneSimulators(): Promise<any> {
   const iosSims = await simctl.getDevices()
   return _.filter(_.flattenDeep(_.map(iosSims, (val, key) => val)), device =>
-    device.name.match(/^iPhone/)
+    device.name.match(/^iPhone|iPad/)
   )
 }
 
@@ -81,20 +81,20 @@ export async function askUserToSelectAniPhoneSimulator() {
   }
 
   // if simulator is still not resolved
-  const { selectedDevice } = await inquirer.prompt([
+  const { selectedSimulator } = await inquirer.prompt([
     <inquirer.Question>{
       choices,
-      message: 'Choose an iOS device',
-      name: 'selectedDevice',
+      message: 'Choose an iOS simulator',
+      name: 'selectedSimulator',
       type: 'list',
     },
   ])
 
   // Update the emulatorConfig
-  deviceConfig.deviceId = selectedDevice.udid
+  deviceConfig.deviceId = selectedSimulator.udid
   ernConfig.set(deviceConfigUtil.IOS_DEVICE_CONFIG, deviceConfig)
 
-  return selectedDevice
+  return selectedSimulator
 }
 
 export function parseIOSDevicesList(

--- a/ern-core/test/ios-test.js
+++ b/ern-core/test/ios-test.js
@@ -121,7 +121,7 @@ describe('ios utils', () => {
       }
       ernConfigGetStub.returns(config)
       const inquirerIosStub = sinon.stub(inquirer, 'prompt').resolves({
-        selectedDevice: {
+        selectedSimulator: {
           name: 'iPhone 5s',
           udid: 'CEF8F618-82F3-4BE5-A2B6-92A96F83687A',
           version: '11.1',
@@ -144,7 +144,7 @@ describe('ios utils', () => {
       }
       ernConfigGetStub.returns(config)
       const inquirerIosStub = sinon.stub(inquirer, 'prompt').resolves({
-        selectedDevice: {
+        selectedSimulator: {
           name: 'iPhone 5s',
           udid: 'CEF8F618-82F3-4BE5-A2B6-92A96F83687A',
           version: '11.1',


### PR DESCRIPTION
Previously `ern run-ios` would only list `iPhone`-type simulators. Now, `iPad` is included as well.

Also fixes a minor wording inconsistency (asking to choose "device" when selecting a simulator).

Fixes #1549