### PR TITLE
Fix entry file resolution for code-push release command

### DIFF
--- a/ern-orchestrator/src/codepush.ts
+++ b/ern-orchestrator/src/codepush.ts
@@ -408,6 +408,11 @@ export async function performCodePushOtaUpdate(
         : path.join(bundleOutputDirectory, 'MiniApp.jsbundle')
 
     sourceMapOutput = sourceMapOutput || path.join(createTmpDir(), 'index.map')
+    const entryFile = fs.existsSync(
+      path.join(tmpWorkingDir, `index.${platform}.js`)
+    )
+      ? `index.${platform}.js`
+      : 'index.js'
     const bundlingResult = await kax
       .task('Generating composite bundle for miniapps')
       .run(
@@ -415,7 +420,7 @@ export async function performCodePushOtaUpdate(
           assetsDest: bundleOutputDirectory,
           bundleOutput: bundleOutputPath,
           dev: false,
-          entryFile: `index.${platform}.js`,
+          entryFile,
           platform,
           resetCache: true,
           sourceMapOutput,


### PR DESCRIPTION
Align logic for resolving entry file for `code-push release` command with the one used by composite generator.

Basically, use the platform specific entry file if present (`index.android.js` or `index.ios.js`), otherwise fallback to platform agnostic entry file (`index.js`).

This fixes an issue where only `index.js` is present, which currently causes the `code-push release` command to fail