### PR TITLE
Set node engine restriction to >=10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10, 12, 14]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/docs/overview/requirements.md
+++ b/docs/overview/requirements.md
@@ -2,19 +2,19 @@
 
 Depending on whether you are building Android or iOS apps, the following tools are required:
 
-- Node.js >= 8.3
-- NPM >= 3.0
+- Node.js >= 10
+- npm >= 5.6.0
 - Android Studio (for Android apps)
 - Xcode >= 10 (for iOS apps)
 - CocoaPods (if using a version of React Native >= 0.60)
 
 ### [Node](https://nodejs.org/en/)
 
-Electrode Native is primarily a Node.js application therefore, Node 8+ must be installed on your workstation.  
+Electrode Native is primarily a Node.js application therefore, Node 10+ must be installed on your workstation.  
 
-**Note** You also need to install NPM or Yarn in order to install the Electrode Native platform. When you install Node.js, NPM is automatically installed.
+**Note** You also need to install npm or Yarn in order to install the Electrode Native platform. When you install Node.js, npm is automatically installed.
 
-### [NPM](https://npmsjs.com) or [Yarn](https://yarnpkg.com)
+### [npm](https://npmsjs.com) or [Yarn](https://yarnpkg.com)
 
 ### [Git](https://git-scm.com/downloads)
 
@@ -50,6 +50,6 @@ If running Electrode Native on a Mac, and using a version of React Native >= 0.6
 
 ### What about React Native ?
 
-You don't need to have React Native installed on your machine. If you have it already installed, that's great--it's not really a problem. The same applies for yarn and CodePush.
+You don't need to have React Native installed on your machine. If you have it already installed, that's great--it's not really a problem. The same applies for Yarn and CodePush.
 
 Electrode Native ships with its own local version of React Native as well as Yarn and CodePush. Including these tools shorten our list of requirements--which ultimately simplifies setup for you and also makes the platform safer and stable as it does not require multiple versions of these tools--even though, every user could have a different version of these tools already installed.

--- a/docs/overview/what-is-ern.md
+++ b/docs/overview/what-is-ern.md
@@ -8,7 +8,7 @@ The core of the Electrode Native is written in TypeScript and ES6. Some parts al
 
 When it comes to the platform code percentage of JavaScript code versus Native code, a good approximation would be 70% JavaScript and 30% native code.
 
-Electrode Native is composed of several modules that can be accessed using the Electrode Native CLI. Electrode Native runs on Node 6 runtime or newer versions. Electrode Native runs on Mac OS X only. Windows support is scheduled to follow. Electrode Native also runs on Linux; however only minimal testing has verified this support.
+Electrode Native is composed of several modules that can be accessed using the Electrode Native CLI. Electrode Native runs on Node.js 10 or newer. Windows support should be considered experimental.
 
 Electrode Native modules and features are briefly described below. You can find more information about each module in the specific module documentation.
 

--- a/docs/platform-parts/cli/index.md
+++ b/docs/platform-parts/cli/index.md
@@ -1,4 +1,4 @@
-The Electrode Native CLI is the Electrode Native platform command line client. The Electrode Native CLI is written in JavaScript (ES6) and runs in Node 6+.
+The Electrode Native CLI is the Electrode Native platform command line client. The Electrode Native CLI is written in JavaScript (ES6) and runs on Node 10+.
 
 Use the Electrode Native CLI to access platform functionality. However, if you are working only on the mobile application side, you may not need to use the Electrode Native CLI at all.
 

--- a/envalidate.sh
+++ b/envalidate.sh
@@ -63,7 +63,7 @@ normal=$(tput sgr0)
 bright=$(tput bold)
 
 # command line programs
-printf "${bright} --- Node.js 8.3 or later ---${normal}\n"
+printf "${bright} --- Node.js 10 or later ---${normal}\n"
 
 echo "node    $(echo_if $(program_is_installed node))"
 $(print_version node)
@@ -79,7 +79,7 @@ echo "yarn    $(echo_if $(program_is_installed yarn))"
 $(print_version yarn)
 printf "\n"
 
-printf "${bright} --- Xcode 8.3.2 or later for iOS apps ---${normal}\n"
+printf "${bright} --- Xcode 10 or later for iOS apps ---${normal}\n"
 
 echo "Xcode  $(echo_if $(program_is_installed xcodebuild))"
 $(print_version xcodebuild -version)

--- a/ern-core/package.json
+++ b/ern-core/package.json
@@ -41,7 +41,6 @@
     "@octokit/rest": "16.33.1",
     "@yarnpkg/lockfile": "^1.1.0",
     "archiver": "^2.1.1",
-    "bluebird": "^3.5.1",
     "chalk": "^2.4.1",
     "cli-table": "^0.3.1",
     "code-push": "^2.0.6",

--- a/ern-core/src/ReactNativeCli.ts
+++ b/ern-core/src/ReactNativeCli.ts
@@ -47,18 +47,7 @@ export default class ReactNativeCli {
       template ? ` --template ${template}` : ''
     }`
 
-    return template
-      ? // For some reason, when using 'react-native init' with
-        // the template option, stdin redirection matters.
-        // By default using 'pipe' for stdin, but this cause
-        // 'react-native init' command to stall with Node 8.
-        // The problem is not present with Node 10 and above
-        // But because Electrode Native min requirement is Node 8
-        // we need to handle this specific case.
-        spawnp(this.binaryPath, initCmd.split(' '), {
-          stdio: ['ignore', 'pipe', 'pipe'],
-        })
-      : execp(`${this.binaryPath} ${initCmd}`)
+    return execp(`${this.binaryPath} ${initCmd}`)
   }
 
   public async bundle({

--- a/ern-core/test/android-test.ts
+++ b/ern-core/test/android-test.ts
@@ -1,7 +1,6 @@
 import { assert, expect } from 'chai'
 import { beforeTest, afterTest } from 'ern-util-dev'
 import fs from 'fs'
-import Prom from 'bluebird'
 import path from 'path'
 import * as childProcess from '../src/childProcess'
 import sinon from 'sinon'
@@ -9,7 +8,9 @@ import * as android from '../src/android'
 import ernConfig from '../src/config'
 import inquirer from 'inquirer'
 import * as fixtures from './fixtures/common'
-const readFile = Prom.promisify(fs.readFile)
+import util from 'util'
+
+const readFile = util.promisify(fs.readFile)
 const sandbox = sinon.createSandbox()
 
 let ernConfigGetStub

--- a/ern-core/test/ios-test.js
+++ b/ern-core/test/ios-test.js
@@ -1,20 +1,17 @@
 import { assert, expect } from 'chai'
 import fs from 'fs'
 import path from 'path'
-import Promise from 'bluebird'
-//import * as ios from '../src/ios'
-import * as childProcess from 'child_process'
 import sinon from 'sinon'
 import inquirer from 'inquirer'
 import * as fixtures from './fixtures/common'
 import ernConfig from '../src/config'
+import util from 'util'
 
 const simctl = require('node-simctl')
 const ios = require('../src/ios')
 
 const computerName = 'Funny MacBook Pro (47)\n'
-// util.promisify function added to the core only after node 8
-const readFile = Promise.promisify(fs.readFile)
+const readFile = util.promisify(fs.readFile)
 const iPhoneSimulatorsWithNoIphone = require('./fixtures/ios_no_iphone_simulators.json')
 const iPhoneSimulators = require('./fixtures/ios_iphone_simulators.json')
 

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "typescript": "^3.7.5"
   },
   "engines": {
-    "node": ">=8.3"
+    "node": ">=10"
   },
   "workspaces": [
     "ern-*"


### PR DESCRIPTION
Node.js 8 has [reached end-of-life](https://nodejs.org/en/about/releases/) at the end of last year. It is no longer supported, and we're already starting to see issues (#1556). Node.js 14 was released today.
React Native set their minimum Node.js version to 10 [at the end of February](https://github.com/facebook/react-native/commit/f0c7178a3a24e7694b765946f0d884104c8cfa4c).
In order to not run into more dependency and security issues, we need to update as well.

With this, we can also remove `bluebird`, and a no-longer needed workaround from `ReactNativeCli.ts`.