### PR TITLE
Bump TypeScript target to es2108

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2015",
-    "lib": ["es2017"],
+    "target": "es2018",
+    "lib": ["es2018"],
     "baseUrl": ".",
     "paths": {
       "ern-*": ["ern-*/src"]
@@ -15,5 +15,5 @@
     "strictNullChecks": true,
     "outDir": "dist",
     "noImplicitAny": true
-  }  
+  }
 }

--- a/tsconfig.release.json
+++ b/tsconfig.release.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "es2018",
     "allowJs": false,
     "esModuleInterop": true,
-    "lib": ["es2017"],
+    "lib": ["es2018"],
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,


### PR DESCRIPTION
Now that `ern` has a Node version requirement  of `>=10`, we can bump TypeScript target to `es2018`, fully supported by Node 10, so that TypeScript will emit `es2018` JS code on transpiling.