### PR TITLE
Throw error rather than log return

### DIFF
--- a/ern-core/src/MiniApp.ts
+++ b/ern-core/src/MiniApp.ts
@@ -375,7 +375,7 @@ module.exports = {
               } else {
                 // This is a third party native dependency. If it's not in the master manifest,
                 // then it means that it is not supported by the platform yet. Fail.
-                return log.error(
+                throw new Error(
                   `${dep.name} plugin is not yet supported. Consider adding support for it to the master manifest`
                 )
               }


### PR DESCRIPTION
Using `ern add` to add a native module that is not yet supported in the manifest results in the following output :

```
$ ern add foo
✖ foo plugin is not yet supported. Consider adding support for it to the master manifest
ℹ Successfully added foo
```

The problem here is the misinformation given by the last log line. Indeed, the dependency is not added to the package.json of the miniapp in that case. 
Fix is just to throw an error rather that returning from the function, so that caller does not continue execution as if everything went fine.

```
$ ern add foo
✖ An error occured : foo plugin is not yet supported. Consider adding support for it to the master manifest
```

