### PR TITLE
human readable code push error message

### DIFF
--- a/ern-core/src/CodePushSdk.ts
+++ b/ern-core/src/CodePushSdk.ts
@@ -70,7 +70,7 @@ export default class CodePushSdk {
       ) {
         log.warn(error.message)
       } else {
-        throw new Error(error)
+        throw new Error(JSON.stringify(error))
       }
     }
   }
@@ -101,7 +101,7 @@ export default class CodePushSdk {
       ) {
         log.warn(error.message)
       } else {
-        throw new Error(error)
+        throw new Error(JSON.stringify(error))
       }
     }
   }


### PR DESCRIPTION
human readable code push error message
Before
```
✖ An error occurred: [object Object]
```

After
```
✖ [performCodePushPromote] Error: {"message":"App not found testAndroid","statusCode":404}
✖ An error occurred: {"message":"App not found testAndroid","statusCode":404}

✖ [performCodePushPromote] Error: {"message":"Deployment Staging:v2 has already been promoted to Production:v2.","statusCode":409}}
✖ An error occurred: {"message":"Deployment Staging:v2 has already been promoted to Production:v2.","statusCode":409}
```
