### PR TITLE
Show manifest and config details in ern header

### DIFF
--- a/ern-core/src/Manifest.ts
+++ b/ern-core/src/Manifest.ts
@@ -434,9 +434,10 @@ export interface IosPluginStaticLib {
   target: string
 }
 
-export interface ManifestOverrideConfig {
+export interface OverrideManifestConfig {
   url: string
   type: 'partial' | 'full'
+  source: 'cauldron' | '.ernrc'
 }
 
 const pluginConfigFileName = 'config.json'
@@ -445,7 +446,7 @@ const npmScopeModuleRe = /@(.*)\/(.*)/
 const ERN_MANIFEST_MASTER_GIT_REPO = `https://github.com/electrode-io/electrode-native-manifest.git`
 
 export class Manifest {
-  public static getOverrideManifestConfig: () => Promise<ManifestOverrideConfig | void>
+  public static getOverrideManifestConfig: () => Promise<OverrideManifestConfig | void>
 
   public readonly masterManifest: LocalManifest | GitManifest
   private manifestOverrideType: 'partial' | 'full'

--- a/ern-core/src/config/index.ts
+++ b/ern-core/src/config/index.ts
@@ -1,29 +1,18 @@
+import { resolveLocalErnRc } from './resolveLocalErnRc'
 import { JsonFileErnConfig } from './JsonFileErnConfig'
-import fs from 'fs-extra'
 import path from 'path'
 import os from 'os'
 
-const ERN_ROOT_PATH = process.env.ERN_HOME || path.join(os.homedir(), '.ern')
-const ERN_RC_GLOBAL_FILE_PATH = path.join(ERN_ROOT_PATH, '.ernrc')
+export const ERN_ROOT_PATH =
+  process.env.ERN_HOME || path.join(os.homedir(), '.ern')
+export const ERN_RC_GLOBAL_FILE_PATH = path.join(ERN_ROOT_PATH, '.ernrc')
 export const ERN_RC_LOCAL_FILE_PATH = resolveLocalErnRc()
 
-const ernRcFilePath = ERN_RC_LOCAL_FILE_PATH
+export const ernRcFilePath = ERN_RC_LOCAL_FILE_PATH
   ? ERN_RC_LOCAL_FILE_PATH
   : ERN_RC_GLOBAL_FILE_PATH
 
-export function resolveLocalErnRc(dir?: string) {
-  let directory = dir || process.cwd()
-  let prevDirectory
-  while (directory !== prevDirectory) {
-    prevDirectory = directory
-    const pathToErnRc = path.join(directory, '.ernrc')
-    if (fs.existsSync(pathToErnRc)) {
-      return pathToErnRc
-    }
-    directory = path.dirname(directory)
-  }
-}
-
+export * from './resolveLocalErnRc'
 export * from './ErnConfig'
 export * from './InMemErnConfig'
 export * from './JsonFileErnConfig'

--- a/ern-core/src/config/resolveLocalErnRc.ts
+++ b/ern-core/src/config/resolveLocalErnRc.ts
@@ -1,0 +1,15 @@
+import fs from 'fs-extra'
+import path from 'path'
+
+export function resolveLocalErnRc(dir?: string) {
+  let directory = dir || process.cwd()
+  let prevDirectory
+  while (directory !== prevDirectory) {
+    prevDirectory = directory
+    const pathToErnRc = path.join(directory, '.ernrc')
+    if (fs.existsSync(pathToErnRc)) {
+      return pathToErnRc
+    }
+    directory = path.dirname(directory)
+  }
+}

--- a/ern-core/src/index.ts
+++ b/ern-core/src/index.ts
@@ -92,7 +92,7 @@ export { BundlingResult } from './ReactNativeCli'
 
 export { AndroidPluginConfigGenerator } from './AndroidPluginConfigGenerator'
 export { IosPluginConfigGenerator } from './IosPluginConfigGenerator'
-export { ManifestOverrideConfig } from './Manifest'
+export { OverrideManifestConfig } from './Manifest'
 export { PluginConfigGenerator } from './PluginConfigGenerator'
 
 export * from './NativePlatform'
@@ -107,3 +107,4 @@ export { getCodePushInitConfig } from './getCodePushInitConfig'
 export { PackageManager } from './PackageManager'
 export { LogLevel } from './coloredLog'
 export { IosDevice } from './ios'
+export { ernRcFilePath, ERN_RC_GLOBAL_FILE_PATH } from './config'


### PR DESCRIPTION
Because of electrode native support for arbitrary .ernrc config location, as well as arbitrary master/override manifest locations, it can quickly become unclear to know which config file is being used by the command, as well as which manifest and where it is being set. This can result in users experiencing issues with some commands, just because for example they overrode a manifest locally and forgot about it, or set a .ernrc in their directory tree, that is being picked up when it shouldn't ... or other random issue.

This PR adds extra information to ern command header, to clearly indicate the location of the .ernrc config file in use, as well as the location of override/master manifest (and where they are set). Each extra information line (config / override manifest / master manifest) is only displayed if the value is differing from the default one (global config / no override manifest / official master manifest).

Some examples :

- Local .ernrc and custom override / master manifest set in .ernrc

```
Config: /Users/foo/bar/.ernrc
Override manifest: /Users/foo/bar/my-manifest (set in .ernrc)
Master manifest: /Users/foo/bar/electrode-native-manifest (set in .ernrc)
```

- Manifest override set in cauldron

```
Override manifest: git@github.com:foo/manifest.git (set in cauldron)
```

- Custom local .ernrc

```
Config: /Users/foo/bar/.ernrc
```