### PR TITLE
skip native dependencies check during code push promote

### DIFF
--- a/docs/cli/code-push/promote.md
+++ b/docs/cli/code-push/promote.md
@@ -14,61 +14,16 @@ ern code-push promote
 
 #### Options
 
-`--reuseReleaseBinaryVersion`
+`--description/--des`
 
-* Indicates whether to reuse the target binary version that was used for the initial release
-* If omitted, and `targetBinaryVersion` is not set, the promotion will target the exact version of the descriptor
-* This option is mutually exclusive with `targetBinaryVersion`
+* Description of the changes made to the app with this release. If omitted, the description from the release being promoted will be used.
 
-`--sourceDescriptor <descriptor>`
+* **Default** Empty string
 
-* Specify the native application version from which to promote a release in the form of a *complete native application descriptor*.
-* The release to be promoted will be the latest non disabled release of this native application version.
-* **Default** The command will list all released native applications versions stored in the Cauldron and will prompt to select a target native application version from the list.
+`--disableDuplicateReleaseError`
 
-`--targetDescriptors <descriptors..>`
+* When this flag is set, promoting a package that is identical to the latest release on the target deployment will produce a warning instead of an error
 
-* Specify one or more target native application version to promote the release to, in the form of a *complete native application descriptor* list (separated by spaces).
-* The target descriptor can be the same as the source descriptor if the promotion is only changing the deployment name (for example promoting a release from Staging to Production for the same native application version).
-
-`--targetSemVerDescriptor <descriptor>`
-
-* A native descriptor using a semantic version string for its version. The promotion will target all native application versions matching the semver.
-
-If no `targetDescriptors` nor a `targetSemVerDescriptor` is specified, the command will list all released native application versions stored in the Cauldron and will display a prompt to select one or more target native application version(s) for the promotion.
-
-`--sourceDeploymentName`
-
-* The deployment name of the release to promote (Staging for example).
-* **Default** The command will prompt to input the deployment name, or display a list of deployment names stored in the Cauldron, to choose from.
-
-`--targetDeploymentName`
-
-* The deployment name to promote the release to (Production for example).
-* **Default** The command will prompt to input the deployment name, or display a list of deployment names stored in the Cauldron, to choose from.
-
-`--targetBinaryVersion/-t <targetBinaryVersion>`
-
-* Semver expression that specifies the binary app version this promotion is targeting
-* If omitted, and `reuseReleaseBinaryVersion` is not set, the promotion will target the exact version of the descriptor
-* If `versionModifier` is specified in the codePush config, it will be applied
-* For using `targetBinaryVersion` option users must target only 1 descriptor
-* For using `targetBinaryVersion` option users cannot use semVerDescriptor
-* This option is mutually exclusive with `reuseReleaseBinaryVersion`
-
-`--mandatory/-m`
-
-* Specify that the promoted release is mandatory (will be immediately downloaded and installed).
-* **Default**  false
-
-`--rollout/-r <percentage>`
-
-* Specify the percentage of users who will have access to this release.
-* **Default**  100
-
-`--skipConfirmation/-s`
-
-* Skip confirmation prompts
 * **Default** false
 
 `--force/-f`
@@ -81,17 +36,67 @@ If no `targetDescriptors` nor a `targetSemVerDescriptor` is specified, the comma
 * Promote the release matching this specific label.
 * **Default** The latest release matching sourceDescriptor/sourceDeploymentName pair will be promoted.
 
-`--description/--des`
+`--mandatory/-m`
 
-* Description of the changes made to the app with this release. If omitted, the description from the release being promoted will be used.
+* Specify that the promoted release is mandatory (will be immediately downloaded and installed).
+* **Default**  false
 
-* **Default** Empty string
+`--reuseReleaseBinaryVersion`
 
-`--disableDuplicateReleaseError`
+* Indicates whether to reuse the target binary version that was used for the initial release
+* If omitted, and `targetBinaryVersion` is not set, the promotion will target the exact version of the descriptor
+* This option is mutually exclusive with `targetBinaryVersion`
 
-* When this flag is set, promoting a package that is identical to the latest release on the target deployment will produce a warning instead of an error
+`--rollout/-r <percentage>`
 
+* Specify the percentage of users who will have access to this release.
+* **Default**  100
+
+`--skipConfirmation/-s`
+
+* Skip confirmation prompts
 * **Default** false
+
+`--skipNativeDependenciesVersionAlignedCheck/-n`
+* Skip the check to compare native dependencies version alignment
+* This flag helps skipping native dependencies check for promoting same bundle label to multiple target versions
+* **Default** false
+
+`--sourceDeploymentName`
+
+* The deployment name of the release to promote (Staging for example).
+* **Default** The command will prompt to input the deployment name, or display a list of deployment names stored in the Cauldron, to choose from.
+
+`--sourceDescriptor <descriptor>`
+
+* Specify the native application version from which to promote a release in the form of a *complete native application descriptor*.
+* The release to be promoted will be the latest non disabled release of this native application version.
+* **Default** The command will list all released native applications versions stored in the Cauldron and will prompt to select a target native application version from the list.
+
+`--targetBinaryVersion/-t <targetBinaryVersion>`
+
+* Semver expression that specifies the binary app version this promotion is targeting
+* If omitted, and `reuseReleaseBinaryVersion` is not set, the promotion will target the exact version of the descriptor
+* If `versionModifier` is specified in the codePush config, it will be applied
+* For using `targetBinaryVersion` option users must target only 1 descriptor
+* For using `targetBinaryVersion` option users cannot use semVerDescriptor
+* This option is mutually exclusive with `reuseReleaseBinaryVersion`
+
+`--targetDeploymentName`
+
+* The deployment name to promote the release to (Production for example).
+* **Default** The command will prompt to input the deployment name, or display a list of deployment names stored in the Cauldron, to choose from.
+
+`--targetDescriptors <descriptors..>`
+
+* Specify one or more target native application version to promote the release to, in the form of a *complete native application descriptor* list (separated by spaces).
+* The target descriptor can be the same as the source descriptor if the promotion is only changing the deployment name (for example promoting a release from Staging to Production for the same native application version).
+
+`--targetSemVerDescriptor <descriptor>`
+
+* A native descriptor using a semantic version string for its version. The promotion will target all native application versions matching the semver.
+
+* If no `targetDescriptors` nor a `targetSemVerDescriptor` is specified, the command will list all released native application versions stored in the Cauldron and will display a prompt to select one or more target native application version(s) for the promotion.
 
 #### Related commands
 

--- a/ern-local-cli/src/commands/code-push/promote.ts
+++ b/ern-local-cli/src/commands/code-push/promote.ts
@@ -66,6 +66,12 @@ export const builder = (argv: Argv) => {
       describe: 'Skip confirmation prompts',
       type: 'boolean',
     })
+    .option('skipNativeDependenciesVersionAlignedCheck', {
+      alias: 'n',
+      describe:
+        'Skip the check to compare native dependencies version alignment',
+      type: 'boolean',
+    })
     .option('sourceDeploymentName', {
       describe:
         'Name of the deployment environment to promote the release from',
@@ -117,6 +123,7 @@ export const commandHandler = async ({
   targetSemVerDescriptor,
   rollout,
   skipConfirmation,
+  skipNativeDependenciesVersionAlignedCheck,
 }: {
   description?: string
   disableDuplicateReleaseError?: boolean
@@ -132,6 +139,7 @@ export const commandHandler = async ({
   targetSemVerDescriptor?: string
   rollout?: number
   skipConfirmation?: boolean
+  skipNativeDependenciesVersionAlignedCheck?: boolean
 }) => {
   await logErrorAndExitIfNotSatisfied({
     checkIfCodePushOptionsAreValid: {
@@ -238,6 +246,7 @@ export const commandHandler = async ({
       mandatory,
       reuseReleaseBinaryVersion,
       rollout,
+      skipNativeDependenciesVersionAlignedCheck,
       targetBinaryVersion,
     }
   )

--- a/ern-orchestrator/src/codepush.ts
+++ b/ern-orchestrator/src/codepush.ts
@@ -87,20 +87,20 @@ export async function performCodePushPromote(
     force = false,
     label,
     mandatory,
-    rollout,
     reuseReleaseBinaryVersion,
-    targetBinaryVersion,
+    rollout,
     skipNativeDependenciesVersionAlignedCheck = false,
+    targetBinaryVersion,
   }: {
     description?: string
     disableDuplicateReleaseError?: boolean
     force?: boolean
     label?: string
     mandatory?: boolean
-    rollout?: number
     reuseReleaseBinaryVersion?: boolean
-    targetBinaryVersion?: string
+    rollout?: number
     skipNativeDependenciesVersionAlignedCheck?: boolean
+    targetBinaryVersion?: string
   } = {}
 ) {
   let cauldron

--- a/ern-orchestrator/test/codepush-test.ts
+++ b/ern-orchestrator/test/codepush-test.ts
@@ -297,6 +297,47 @@ describe('codepush', () => {
       )
     })
 
+    it('should skip native dependencies compatiblity check if source and target version promoted are same', async () => {
+      prepareStubs({
+        compatibility_areCompatible: false,
+      })
+
+      assert(
+        await doesNotThrow(
+          sut.performCodePushPromote,
+          sut,
+          testAndroid1770Descriptor,
+          [testAndroid1770Descriptor],
+          'QA',
+          'Production',
+          {
+            label: 'v18',
+          }
+        )
+      )
+    })
+
+    it('should skip native dependencies compatiblity check if skipNativeDependenciesVersionAlignedCheck is set to true', async () => {
+      prepareStubs({
+        compatibility_areCompatible: false,
+      })
+
+      assert(
+        await doesNotThrow(
+          sut.performCodePushPromote,
+          sut,
+          testAndroid1770Descriptor,
+          [testAndroid1780Descriptor],
+          'QA',
+          'Production',
+          {
+            label: 'v18',
+            skipNativeDependenciesVersionAlignedCheck: true,
+          }
+        )
+      )
+    })
+
     it('should throw if some MiniApps include imcompatible native dependencies with target native application version and force flag is false', async () => {
       prepareStubs({
         compatibility_areCompatible: false,
@@ -307,7 +348,7 @@ describe('codepush', () => {
           sut.performCodePushPromote,
           sut,
           testAndroid1770Descriptor,
-          [testAndroid1770Descriptor],
+          [testAndroid1780Descriptor],
           'QA',
           'Production',
           {
@@ -327,7 +368,7 @@ describe('codepush', () => {
           sut.performCodePushPromote,
           sut,
           testAndroid1770Descriptor,
-          [testAndroid1770Descriptor],
+          [testAndroid1780Descriptor],
           'QA',
           'Production',
           {

--- a/ern-util-dev/fixtures/default-cauldron-fixture.json
+++ b/ern-util-dev/fixtures/default-cauldron-fixture.json
@@ -96,6 +96,7 @@
               "ernPlatformVersion": "1000.0.0",
               "isReleased": false,
               "binary": null,
+              "yarnLocks": {},
               "container": {
                 "nativeDeps": [
                   "react-native-electrode-bridge@1.4.9",


### PR DESCRIPTION
Moving forward we'd skip the native dependencies alignment checks during the code-push promotion 
- if the source and target app version is the same during the code-push promotion of the bundle. As the native dependencies alignment check is already done during the code-push release.
-  if the source and target app version is different and one needs to skip native dependencies alignment check, pass the `skipNativeDependenciesVersionAlignedCheck` as `true`. 