### PR TITLE
Fix system tests and improve error messaging

### DIFF
--- a/ern-container-gen-ios/src/IosGenerator.ts
+++ b/ern-container-gen-ios/src/IosGenerator.ts
@@ -82,6 +82,10 @@ export default class IosGenerator implements ContainerGenerator {
   public async fillContainerHull(
     config: ContainerGeneratorConfig
   ): Promise<void> {
+    if (process.platform !== 'darwin') {
+      throw new Error('iOS Container generation is only supported on macOS.')
+    }
+
     const pathSpec = {
       outputDir: config.outDir,
       projectHullDir: path.join(PATH_TO_HULL_DIR, '{.*,*}'),

--- a/system-tests/src/tests/create-container-ios-fixture.js
+++ b/system-tests/src/tests/create-container-ios-fixture.js
@@ -18,12 +18,18 @@ const excludeFilter = [
   .map(s => `**/${s}`)
   .join(',')
 
-run(
-  `create-container --miniapps ${miniapps.join(
-    ' '
-  )} -p ios --out ${process.cwd()}`
-)
-assert(
-  sameDirContent(f.pathToIosContainerFixture, process.cwd(), { excludeFilter }),
-  'Generated IOS Container differ from reference fixture !'
-)
+const command = `create-container --miniapps ${miniapps.join(
+  ' '
+)} -p ios --out ${process.cwd()}`
+
+if (process.platform === 'darwin') {
+  run(command)
+  assert(
+    sameDirContent(f.pathToIosContainerFixture, process.cwd(), {
+      excludeFilter,
+    }),
+    'Generated IOS Container differ from reference fixture !'
+  )
+} else {
+  run(command, { expectedExitCode: 1 })
+}

--- a/system-tests/src/tests/misc.js
+++ b/system-tests/src/tests/misc.js
@@ -92,7 +92,8 @@ run(
 )
 run(`cauldron get nativeapp ${androidNativeApplicationDescriptor}`)
 run(
-  `cauldron add miniapps ${f.movieListMiniAppPgkName}@${f.movieListMiniAppPkgVersion} -d ${iosNativeApplicationDescriptor}`
+  `cauldron add miniapps ${f.movieListMiniAppPgkName}@${f.movieListMiniAppPkgVersion} -d ${iosNativeApplicationDescriptor}`,
+  { expectedExitCode: process.platform === 'darwin' ? 0 : 1 }
 )
 run(`cauldron get nativeapp ${iosNativeApplicationDescriptor}`)
 run(
@@ -100,7 +101,8 @@ run(
 )
 run(`cauldron get nativeapp ${androidNativeApplicationDescriptor}`)
 run(
-  `cauldron add miniapps ${f.movieDetailsMiniAppPkgName}@${f.movieDetailsMiniAppPkgVersion} -d ${iosNativeApplicationDescriptor}`
+  `cauldron add miniapps ${f.movieDetailsMiniAppPkgName}@${f.movieDetailsMiniAppPkgVersion} -d ${iosNativeApplicationDescriptor}`,
+  { expectedExitCode: process.platform === 'darwin' ? 0 : 1 }
 )
 run(`cauldron get nativeapp ${iosNativeApplicationDescriptor}`)
 run(
@@ -115,7 +117,8 @@ run(
   `cauldron add jsapiimpls ${f.movieApiImplJsPkgName}@${f.movieApiImplJsPkgVersion} -d ${androidNativeApplicationDescriptor}`
 )
 run(
-  `cauldron add jsapiimpls ${f.movieApiImplJsPkgName}@${f.movieApiImplJsPkgVersion} -d ${iosNativeApplicationDescriptor}`
+  `cauldron add jsapiimpls ${f.movieApiImplJsPkgName}@${f.movieApiImplJsPkgVersion} -d ${iosNativeApplicationDescriptor}`,
+  { expectedExitCode: process.platform === 'darwin' ? 0 : 1 }
 )
 run(`cauldron get nativeapp`)
 
@@ -132,9 +135,9 @@ run(
 
 // Container gen should be successful for the two following commands
 run(`create-container --miniapps file:${miniAppPath} -p android`)
-run(`create-container --miniapps file:${miniAppPath} -p ios`)
+run(`create-container --miniapps file:${miniAppPath} -p ios`, { expectedExitCode: process.platform === 'darwin' ? 0 : 1 })
 
-// transform-container / publish-coontainer should be successful
+// transform-container / publish-container should be successful
 run(
   `transform-container --containerPath ${defaultAndroidContainerGenPath} --platform android --transformer dummy`
 )


### PR DESCRIPTION
Now that CocoaPods is required for iOS container generation, macOS is a requirement. It'll fail on Linux and Windows:

```
spawnp => command: pod args: ["install"] options: {}
[ Running pod install (Failed) ]
popd
/tmp/tmp-5319hpxSXui6YFVV /tmp/tmp-5319hpxSXui6YFVV
popd
/tmp/tmp-5319hpxSXui6YFVV
[ Generating Container (Failed) ]
[ Generating Container locally (Failed) ]
✖ An error occurred: spawn pod ENOENT
Error: spawn pod ENOENT
    at Process.ChildProcess._handle.onexit (internal/child_process.js:240:19)
    at onErrorNT (internal/child_process.js:415:16)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```

With this PR we're checking the platform and error earlier with an error message, instead of failing later on.

Note: While CocoaPods itself (the `pod` command) does appear to have some Linux compatibility (I was able to install and run it on my Linux test machine `gem install cocoapods`), it's mostly useful for some server side Swift stuff (?).

With the `pod` command available, it will just delay the eventual error by a little bit:

```
checking whether the C compiler works... no
/usr/bin/bash: line 24: xcrun: command not found
/usr/bin/bash: line 24: xcrun: command not found
~/Library/Caches/CocoaPods/Pods/Release/Flipper-Glog/0.3.6-1dfd6/missing: Unknown `--is-lightweight' option
```