### PR TITLE
Improve error message and system tests script

### DIFF
--- a/ern-core/src/MiniApp.ts
+++ b/ern-core/src/MiniApp.ts
@@ -389,8 +389,8 @@ module.exports = {
               if (manifestDep) {
                 if (dep.version !== manifestDep.version) {
                   throw new Error(
-                    `[Transitive Dependency] ${dep.name} was not added to the MiniApp`
-                  )
+                    `Version of transitive dependency ${dep.name}@${dep.version}
+does not match version declared in manifest: ${manifestDep.version}`)
                 }
               }
             }

--- a/system-tests/src/system-tests-coverage.js
+++ b/system-tests/src/system-tests-coverage.js
@@ -11,8 +11,7 @@ process.argv.push(
   '--include',
   'ern-*/dist/**/*.{ts,js}',
   'node',
-  'system-tests/src/system-tests',
-  '--all'
+  'system-tests/src/system-tests'
 )
 
 require('nyc/bin/nyc')

--- a/system-tests/src/system-tests.js
+++ b/system-tests/src/system-tests.js
@@ -6,14 +6,19 @@ const run = require('./utils/run')
 const cauldronRepoBeforeRun = require('./utils/getCurrentCauldron')()
 
 const runAll = process.argv.includes('--all')
+const interactiveSelection = process.argv.includes('-i') || process.argv.includes('--interactive')
 
 const pathToSystemTests = path.join(__dirname, 'tests')
 const testsSourceFiles = fs.readdirSync(pathToSystemTests)
 
+if (runAll) {
+  console.log('--all is deprecated and has no effect\n' +
+    'Use -i/--interactive for interactive selection, or pass the names of ' +
+    'individual tests to run.')
+}
+
 try {
-  if (runAll) {
-    runAllTests()
-  } else {
+  if (interactiveSelection) {
     inquirer
       .prompt([
         {
@@ -24,10 +29,12 @@ try {
         },
       ])
       .then(answers => {
-        for (const userSelectedTestSourceFile of answers.userSelectedTests) {
-          runTest(userSelectedTestSourceFile)
-        }
+        runTests(answers.userSelectedTests)
       })
+  } else if (process.argv.length > 2 && !runAll) {
+    runTests(process.argv.slice(2))
+  } else {
+    runTests(testsSourceFiles)
   }
 } finally {
   if (cauldronRepoBeforeRun) {
@@ -35,9 +42,9 @@ try {
   }
 }
 
-function runAllTests() {
-  for (const testSourceFile of testsSourceFiles) {
-    runTest(testSourceFile)
+function runTests(files) {
+  for (const file of files) {
+    runTest(file)
   }
 }
 


### PR DESCRIPTION
A couple of small improvements here.

Previously, when there was a mismatch in the transitive dependencies of a miniapp, it would output a misleading error message, e.g.

```
[Transitive Dependency] react-native-electrode-bridge was not added to the MiniApp
```

Now, the error message is more accurate and provides more information:

```
Version of transitive dependency react-native-electrode-bridge@1.5.24
does not match version declared in manifest: 1.5.23
```

Also improved the `system-tests.js` script:

`--all` is no longer required (instead, it will run all tests by default). If interactive mode is desired, it's still possible using the `-i/--interactive` flag. New is the possibility to pass individual test files to run, e.g.

```
yarn test:system create-api-complex-fixture misc
```

This would run the `create-api-complex-fixture.js` and `misc.js` tests.