### PR TITLE
Update run-ios error message

### DIFF
--- a/ern-local-cli/src/commands/run-ios.ts
+++ b/ern-local-cli/src/commands/run-ios.ts
@@ -90,7 +90,7 @@ export const commandHandler = async ({
   usePreviousDevice?: boolean
 }) => {
   if (process.platform !== 'darwin') {
-    return log.error('This command can only be used on Mac OS X')
+    return log.error('This command is only supported on macOS')
   }
   deviceConfig.updateDeviceConfig('ios', usePreviousDevice)
 


### PR DESCRIPTION
Very quick one to update platform error message of `run-ios` command to make the wording on par with the error message introduced in https://github.com/electrode-io/electrode-native/pull/1575