### PR TITLE
Fix directory name casing

### DIFF
--- a/ern-core/src/iosUtil.ts
+++ b/ern-core/src/iosUtil.ts
@@ -41,7 +41,7 @@ export async function fillProjectHull(
     if (mustacheView) {
       log.debug(`iOS: reading template files to be rendered for plugins`)
       const a = path.join(pathSpec.outputDir, 'ElectrodeContainer')
-      const b = path.join(pathSpec.outputDir, 'config')
+      const b = path.join(pathSpec.outputDir, 'Config')
       const files = [
         ...readDir(a).map(x => path.join(a, x)),
         ...readDir(b).map(x => path.join(b, x)),


### PR DESCRIPTION
[Directory name](https://github.com/electrode-io/electrode-native/tree/master/ern-container-gen-ios/src/hull/Config) is `Config` instead of `config`
