### PR TITLE
Add missing handling of inPlace option in publish-container command

### DIFF
--- a/ern-local-cli/src/commands/publish-container.ts
+++ b/ern-local-cli/src/commands/publish-container.ts
@@ -59,6 +59,7 @@ const publisherPackagePrefix = 'ern-container-publisher-'
 export const commandHandler = async ({
   containerPath,
   extra,
+  inPlace,
   platform,
   publisher,
   url,
@@ -66,6 +67,7 @@ export const commandHandler = async ({
 }: {
   containerPath?: string
   extra?: string
+  inPlace?: boolean
   platform: NativePlatform
   publisher: PackagePath
   url: string
@@ -98,6 +100,7 @@ export const commandHandler = async ({
     containerPath,
     containerVersion: version,
     extra: extraObj,
+    inPlace,
     platform,
     publisher,
     url,


### PR DESCRIPTION
`--inPlace` option was defined in command options but not handled at all in command implementation. 