### PR TITLE
Fix version option of ern command

### DIFF
--- a/ern-local-cli/src/index.ts
+++ b/ern-local-cli/src/index.ts
@@ -248,7 +248,7 @@ Please switch to a version of Node satisfying the version requirement`)
     await showInfo()
   }
 
-  if (process.argv.slice(1).includes('--version')) {
+  if (process.argv[2] === '--version') {
     return showVersion()
   }
 


### PR DESCRIPTION
`ern --version` can be used to display the global CLI / local CLI version.

The problem with prior implementation was that some commands are exposing a `--version` option. For example `publish-container` has a `--version` option to specify the version to use for the container. When using `--version` on `publish-container` was leading to the command being short circuited and the version of the platform shown instead. Only workaround was to use the shorthand `-v` option of `publish-container` command.

This PR fixes this issues, by only displaying version of ern when using `ern --version`, and not when `--version` is an option present on any arbitrary command line.