### PR TITLE
ERNDelegate should be nullable, optional in swift

### DIFF
--- a/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeReactNative.h
+++ b/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeReactNative.h
@@ -105,7 +105,7 @@ NS_ASSUME_NONNULL_BEGIN
                         {{/hasAtleastOneApiImplConfig}}
                         __attribute((deprecated("use -startWithConfigurations:ernDelegate instead")));
 
-+ (void)startWithConfigurations:(id<ElectrodePluginConfig>)reactContainerConfig ernDelegate:(id<ERNDelegate>)ernDelegate
++ (void)startWithConfigurations:(id<ElectrodePluginConfig>)reactContainerConfig ernDelegate:(id<ERNDelegate> _Nullable)ernDelegate
                         {{#plugins}}
                         {{#configurable}}
                         {{{lcname}}}: (id<ElectrodePluginConfig>) {{{lcname}}}

--- a/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeReactNative.m
+++ b/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeReactNative.m
@@ -152,7 +152,7 @@ static NSString *enableBundleStore = @"enableBundleStore";
     });
 }
 
-+ (void)startWithConfigurations:(id<ElectrodePluginConfig>)reactContainerConfig ernDelegate:(id<ERNDelegate>)ernDelegate
++ (void)startWithConfigurations:(id<ElectrodePluginConfig>)reactContainerConfig ernDelegate:(id<ERNDelegate> _Nullable)ernDelegate
                 {{#plugins}}
                 {{#configurable}}
                 {{{lcname}}}: (id<ElectrodePluginConfig>) {{{lcname}}}

--- a/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeReactNative.h
+++ b/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeReactNative.h
@@ -76,7 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)startWithConfigurations:(id<ElectrodePluginConfig>)reactContainerConfig
                         __attribute((deprecated("use -startWithConfigurations:ernDelegate instead")));
 
-+ (void)startWithConfigurations:(id<ElectrodePluginConfig>)reactContainerConfig ernDelegate:(id<ERNDelegate>)ernDelegate
++ (void)startWithConfigurations:(id<ElectrodePluginConfig>)reactContainerConfig ernDelegate:(id<ERNDelegate> _Nullable)ernDelegate
 ;
 
 

--- a/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeReactNative.m
+++ b/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeReactNative.m
@@ -137,7 +137,7 @@ static NSString *enableBundleStore = @"enableBundleStore";
     });
 }
 
-+ (void)startWithConfigurations:(id<ElectrodePluginConfig>)reactContainerConfig ernDelegate:(id<ERNDelegate>)ernDelegate
++ (void)startWithConfigurations:(id<ElectrodePluginConfig>)reactContainerConfig ernDelegate:(id<ERNDelegate> _Nullable)ernDelegate
 
 {
     id sharedInstance = [ElectrodeReactNative sharedInstance];


### PR DESCRIPTION
erndelegate shouldn't be required in swift, this will also surpress null warning on objective c