### PR TITLE
Add sdk to iOS simulator list

### DIFF
--- a/ern-core/src/ios.ts
+++ b/ern-core/src/ios.ts
@@ -11,8 +11,8 @@ import kax from './kax'
 
 export interface IosDevice {
   name: string
+  sdk: string
   udid: string
-  version: string
 }
 
 export async function getiPhoneSimulators(): Promise<any> {
@@ -38,7 +38,7 @@ export function getiPhoneRealDevices() {
 
 export async function askUserToSelectAniPhoneDevice(devices: IosDevice[]) {
   const choices = _.map(devices, (val, key) => ({
-    name: `${val.name} udid: ${val.udid} version: ${val.version}`,
+    name: `${val.name} (${val.sdk}) [${val.udid}]`,
     value: val,
   }))
 
@@ -55,9 +55,9 @@ export async function askUserToSelectAniPhoneDevice(devices: IosDevice[]) {
 }
 
 export async function askUserToSelectAniPhoneSimulator() {
-  const iPhoneDevices = await getiPhoneSimulators()
-  const choices = _.map(iPhoneDevices, (val, key) => ({
-    name: `${val.name} (UDID ${val.udid})`,
+  const simulators = await getiPhoneSimulators()
+  const choices = _.map(simulators, (val, key) => ({
+    name: `${val.name} (${val.sdk}) [${val.udid}]`,
     value: val,
   }))
 
@@ -115,8 +115,8 @@ export function parseIOSDevicesList(
     ) {
       list.push({
         name: device[1],
+        sdk: device[2],
         udid: device[3],
-        version: device[2],
       })
     }
 

--- a/ern-core/test/ios-test.js
+++ b/ern-core/test/ios-test.js
@@ -17,6 +17,19 @@ const iPhoneSimulators = require('./fixtures/ios_iphone_simulators.json')
 
 const sandbox = sinon.createSandbox()
 
+const deviceList = [
+  {
+    name: 'iPhone 5s',
+    sdk: '11.1',
+    udid: 'CEF8F618-82F3-4BE5-A2B6-92A96F83687A',
+  },
+  {
+    name: 'iPhone 8',
+    sdk: '13.4.1',
+    udid: '17043F85-C66D-405F-8D13-38460DEF27B6',
+  },
+]
+
 let getDevicesStub
 let getKnownDevicesStub
 let getComputerNameStub
@@ -42,32 +55,12 @@ describe('ios utils', () => {
 
   describe('askUserToSelectAniPhoneDevice', () => {
     it('prompt user to select iPhone Device', async () => {
-      const deviceList = [
-        {
-          name: 'iPhone 5s',
-          udid: 'CEF8F618-82F3-4BE5-A2B6-92A96F83687A',
-          version: '11.1',
-        },
-        {
-          name: 'iPhone 5s',
-          udid: 'CEF8F618-82F3-4BE5-A2B6-92A96F83687A',
-          version: '11.1',
-        },
-      ]
       const inquirerIosStub = sinon.stub(inquirer, 'prompt').resolves({
-        selectedDevice: {
-          name: 'iPhone 5s',
-          udid: 'CEF8F618-82F3-4BE5-A2B6-92A96F83687A',
-          version: '11.1',
-        },
+        selectedDevice: deviceList[0],
       })
       const result = await ios.askUserToSelectAniPhoneDevice(deviceList)
       inquirerIosStub.restore()
-      expect(result).to.deep.equal({
-        name: 'iPhone 5s',
-        udid: 'CEF8F618-82F3-4BE5-A2B6-92A96F83687A',
-        version: '11.1',
-      })
+      expect(result).to.deep.equal(deviceList[0])
     })
   })
 
@@ -80,19 +73,11 @@ describe('ios utils', () => {
       }
       ernConfigGetStub.returns(config)
       const inquirerIosStub = sinon.stub(inquirer, 'prompt').resolves({
-        selectedSimulator: {
-          name: 'iPhone 5s',
-          udid: 'CEF8F618-82F3-4BE5-A2B6-92A96F83687A',
-          version: '11.1',
-        },
+        selectedSimulator: deviceList[1],
       })
       const result = await ios.askUserToSelectAniPhoneSimulator()
       inquirerIosStub.restore()
-      expect(result).to.deep.equal({
-        name: 'iPhone 5s',
-        udid: 'CEF8F618-82F3-4BE5-A2B6-92A96F83687A',
-        version: '11.1',
-      })
+      expect(result).to.deep.equal(deviceList[1])
     })
 
     it('prompt user if simulator is missing and previous emulator flag is true ', async () => {
@@ -103,19 +88,11 @@ describe('ios utils', () => {
       }
       ernConfigGetStub.returns(config)
       const inquirerIosStub = sinon.stub(inquirer, 'prompt').resolves({
-        selectedSimulator: {
-          name: 'iPhone 5s',
-          udid: 'CEF8F618-82F3-4BE5-A2B6-92A96F83687A',
-          version: '11.1',
-        },
+        selectedSimulator: deviceList[0],
       })
       const result = await ios.askUserToSelectAniPhoneSimulator()
       inquirerIosStub.restore()
-      expect(result).to.deep.equal({
-        name: 'iPhone 5s',
-        udid: 'CEF8F618-82F3-4BE5-A2B6-92A96F83687A',
-        version: '11.1',
-      })
+      expect(result).to.deep.equal(deviceList[0])
     })
 
     it('do not prompt user to select iPhone Simulator if usePreviousEmulator is true', async () => {
@@ -147,8 +124,8 @@ describe('ios utils', () => {
       ).to.deep.equal([
         {
           name: 'Hilarious Phone Name',
+          sdk: '11.1',
           udid: '695c329443f455c75b5454aacb72ace87b66351e',
-          version: '11.1',
         },
       ])
     })


### PR DESCRIPTION
Quick PR that adds the sdk (i.e. iOS version) to simulators in the interactive prompt shown for `ern run-ios`. Previously it was only displayed for devices.

We now also have a **consistent** output format (not only between devices and simulators, also with how devices are listed using `xcrun instruments -s`)

Sample output:

```
? Choose an iOS simulator
  iPad (5th generation) (10.3) [17043F85-C66D-405F-8D13-38460DEF27B6]
  iPad Pro (12.9-inch) (2nd generation) (10.3) [6B94537E-0E7C-4293-982F-BC12A7A3268D]
  iPad Pro (10.5-inch) (10.3) [28463F95-C420-429B-94D0-B25FD23049D1]
❯ iPhone 7 (13.4) [F200BD5C-77CE-48D5-A2D0-FA952723A381]
  iPhone 8 (13.4) [8ED6419D-7069-46C9-9531-32BC60C0D107]
  iPhone 8 Plus (13.4) [535A2C2F-F20E-4069-A5B4-95A7567B0F1E]
  iPhone 11 (13.4) [716A758A-E400-4A92-8F8B-05D901964435]
(Move up and down to reveal more choices)
```

Closes #1588