### PR TITLE
Fix an issue in ios plugin config generator

### DIFF
--- a/ern-core/src/IosPluginConfigGenerator.ts
+++ b/ern-core/src/IosPluginConfigGenerator.ts
@@ -35,7 +35,7 @@ export class IosPluginConfigGenerator {
     config.copy = [
       {
         dest: `{{{projectName}}}/Libraries/${projName}`,
-        source: `${rootXcodeProjPath}/**`,
+        source: `${rootXcodeProjPath}/*`,
       },
     ]
 


### PR DESCRIPTION
Use single-star `*` glob pattern rather than double-star `**` by default when generating iOS plugin configuration.

Copying with the `**` leads to a messed up flattened file structure, which makes the resulting target directory ugly and polluted with unnecessary files, but can also lead to some side effects causing container generation to fail.