### PR TITLE
Fix iOS native api implementation project generation with RN61+

### DIFF
--- a/ern-api-impl-gen/hull/ios/ElectrodeApiImpl.xcodeproj/project.pbxproj
+++ b/ern-api-impl-gen/hull/ios/ElectrodeApiImpl.xcodeproj/project.pbxproj
@@ -391,6 +391,7 @@
 				);
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
+					"$(inherited)",
 					"-ObjC",
 					"-lc++",
 					"-lz",
@@ -545,6 +546,7 @@
 					"$(SRCROOT)/ElectrodeApiImpl/Libraries/CodePush/**",
 				);
 				OTHER_LDFLAGS = (
+					"$(inherited)",
 					"-ObjC",
 					"-lc++",
 					"-lz",
@@ -582,6 +584,7 @@
 					"$(SRCROOT)/ElectrodeApiImpl/Libraries/CodePush/**",
 				);
 				OTHER_LDFLAGS = (
+					"$(inherited)",
 					"-ObjC",
 					"-lc++",
 					"-lz",
@@ -615,7 +618,7 @@
 				DEVELOPMENT_TEAM = DXZ5VF8836;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"\"$(SRCROOT)/ElectrodeApiImpl/Libraries/CodePush\"",
+					"$(SRCROOT)/ElectrodeApiImpl/Libraries/CodePush/**",
 				);
 				INFOPLIST_FILE = ElectrodeApiImplTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/ern-api-impl-gen/hull/ios/ElectrodeApiImpl.xcodeproj/xcshareddata/xcschemes/ElectrodeApiImpl.xcscheme
+++ b/ern-api-impl-gen/hull/ios/ElectrodeApiImpl.xcodeproj/xcshareddata/xcschemes/ElectrodeApiImpl.xcscheme
@@ -4,7 +4,7 @@
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"
-      buildImplicitDependencies = "NO">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/ern-api-impl-gen/hull/ios/ElectrodeApiImpl.xcworkspace/contents.xcworkspacedata
+++ b/ern-api-impl-gen/hull/ios/ElectrodeApiImpl.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:ElectrodeApiImpl.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/ern-api-impl-gen/src/generators/ios/ApiImplIosGenerator.ts
+++ b/ern-api-impl-gen/src/generators/ios/ApiImplIosGenerator.ts
@@ -58,6 +58,7 @@ export default class ApiImplIosGenerator implements ApiImplGeneratable {
       }
 
       const projectSpec = {
+        nodeModulesRelativePath: '../node_modules',
         projectName: 'ElectrodeApiImpl',
       }
 

--- a/system-tests/fixtures/api-impl-native/ern-movie-api-impl/ios/ElectrodeApiImpl.xcodeproj/xcshareddata/xcschemes/ElectrodeApiImpl.xcscheme
+++ b/system-tests/fixtures/api-impl-native/ern-movie-api-impl/ios/ElectrodeApiImpl.xcodeproj/xcshareddata/xcschemes/ElectrodeApiImpl.xcscheme
@@ -4,7 +4,7 @@
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"
-      buildImplicitDependencies = "NO">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/system-tests/fixtures/api-impl-native/ern-movie-api-impl/ios/ElectrodeApiImpl.xcworkspace/contents.xcworkspacedata
+++ b/system-tests/fixtures/api-impl-native/ern-movie-api-impl/ios/ElectrodeApiImpl.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:ElectrodeApiImpl.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/system-tests/fixtures/api-impl-native/ern-movie-api-impl/ios/Podfile
+++ b/system-tests/fixtures/api-impl-native/ern-movie-api-impl/ios/Podfile
@@ -1,5 +1,5 @@
 platform :ios, '9.0'
-require_relative './node_modules/@react-native-community/cli-platform-ios/native_modules'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
 def add_flipper_pods!
   version = '~> 0.33.1'
@@ -21,38 +21,38 @@ def flipper_post_install(installer)
   end
 end
 
-target 'ElectrodeContainer' do
-  # Pods for ElectrodeContainer
-  pod 'FBLazyVector', :path => "node_modules/react-native/Libraries/FBLazyVector"
-  pod 'FBReactNativeSpec', :path => "node_modules/react-native/Libraries/FBReactNativeSpec"
-  pod 'RCTRequired', :path => "node_modules/react-native/Libraries/RCTRequired"
-  pod 'RCTTypeSafety', :path => "node_modules/react-native/Libraries/TypeSafety"
-  pod 'React', :path => 'node_modules/react-native/'
-  pod 'React-Core', :path => 'node_modules/react-native/'
-  pod 'React-CoreModules', :path => 'node_modules/react-native/React/CoreModules'
-  pod 'React-Core/DevSupport', :path => 'node_modules/react-native/'
-  pod 'React-RCTActionSheet', :path => 'node_modules/react-native/Libraries/ActionSheetIOS'
-  pod 'React-RCTAnimation', :path => 'node_modules/react-native/Libraries/NativeAnimation'
-  pod 'React-RCTBlob', :path => 'node_modules/react-native/Libraries/Blob'
-  pod 'React-RCTImage', :path => 'node_modules/react-native/Libraries/Image'
-  pod 'React-RCTLinking', :path => 'node_modules/react-native/Libraries/LinkingIOS'
-  pod 'React-RCTNetwork', :path => 'node_modules/react-native/Libraries/Network'
-  pod 'React-RCTSettings', :path => 'node_modules/react-native/Libraries/Settings'
-  pod 'React-RCTText', :path => 'node_modules/react-native/Libraries/Text'
-  pod 'React-RCTVibration', :path => 'node_modules/react-native/Libraries/Vibration'
-  pod 'React-Core/RCTWebSocket', :path => 'node_modules/react-native/'
+target 'ElectrodeApiImpl' do
+  # Pods for ElectrodeApiImpl
+  pod 'FBLazyVector', :path => "../node_modules/react-native/Libraries/FBLazyVector"
+  pod 'FBReactNativeSpec', :path => "../node_modules/react-native/Libraries/FBReactNativeSpec"
+  pod 'RCTRequired', :path => "../node_modules/react-native/Libraries/RCTRequired"
+  pod 'RCTTypeSafety', :path => "../node_modules/react-native/Libraries/TypeSafety"
+  pod 'React', :path => '../node_modules/react-native/'
+  pod 'React-Core', :path => '../node_modules/react-native/'
+  pod 'React-CoreModules', :path => '../node_modules/react-native/React/CoreModules'
+  pod 'React-Core/DevSupport', :path => '../node_modules/react-native/'
+  pod 'React-RCTActionSheet', :path => '../node_modules/react-native/Libraries/ActionSheetIOS'
+  pod 'React-RCTAnimation', :path => '../node_modules/react-native/Libraries/NativeAnimation'
+  pod 'React-RCTBlob', :path => '../node_modules/react-native/Libraries/Blob'
+  pod 'React-RCTImage', :path => '../node_modules/react-native/Libraries/Image'
+  pod 'React-RCTLinking', :path => '../node_modules/react-native/Libraries/LinkingIOS'
+  pod 'React-RCTNetwork', :path => '../node_modules/react-native/Libraries/Network'
+  pod 'React-RCTSettings', :path => '../node_modules/react-native/Libraries/Settings'
+  pod 'React-RCTText', :path => '../node_modules/react-native/Libraries/Text'
+  pod 'React-RCTVibration', :path => '../node_modules/react-native/Libraries/Vibration'
+  pod 'React-Core/RCTWebSocket', :path => '../node_modules/react-native/'
 
-  pod 'React-cxxreact', :path => 'node_modules/react-native/ReactCommon/cxxreact'
-  pod 'React-jsi', :path => 'node_modules/react-native/ReactCommon/jsi'
-  pod 'React-jsiexecutor', :path => 'node_modules/react-native/ReactCommon/jsiexecutor'
-  pod 'React-jsinspector', :path => 'node_modules/react-native/ReactCommon/jsinspector'
-  pod 'ReactCommon/callinvoker', :path => "node_modules/react-native/ReactCommon"
-  pod 'ReactCommon/turbomodule/core', :path => "node_modules/react-native/ReactCommon"
-  pod 'Yoga', :path => 'node_modules/react-native/ReactCommon/yoga', :modular_headers => true
+  pod 'React-cxxreact', :path => '../node_modules/react-native/ReactCommon/cxxreact'
+  pod 'React-jsi', :path => '../node_modules/react-native/ReactCommon/jsi'
+  pod 'React-jsiexecutor', :path => '../node_modules/react-native/ReactCommon/jsiexecutor'
+  pod 'React-jsinspector', :path => '../node_modules/react-native/ReactCommon/jsinspector'
+  pod 'ReactCommon/callinvoker', :path => "../node_modules/react-native/ReactCommon"
+  pod 'ReactCommon/turbomodule/core', :path => "../node_modules/react-native/ReactCommon"
+  pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga', :modular_headers => true
 
-  pod 'DoubleConversion', :podspec => 'node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
-  pod 'glog', :podspec => 'node_modules/react-native/third-party-podspecs/glog.podspec'
-  pod 'Folly', :podspec => 'node_modules/react-native/third-party-podspecs/Folly.podspec'
+  pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
+  pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
+  pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
 
   
 

--- a/system-tests/fixtures/ios-container/Podfile
+++ b/system-tests/fixtures/ios-container/Podfile
@@ -23,36 +23,36 @@ end
 
 target 'ElectrodeContainer' do
   # Pods for ElectrodeContainer
-  pod 'FBLazyVector', :path => "node_modules/react-native/Libraries/FBLazyVector"
-  pod 'FBReactNativeSpec', :path => "node_modules/react-native/Libraries/FBReactNativeSpec"
-  pod 'RCTRequired', :path => "node_modules/react-native/Libraries/RCTRequired"
-  pod 'RCTTypeSafety', :path => "node_modules/react-native/Libraries/TypeSafety"
-  pod 'React', :path => 'node_modules/react-native/'
-  pod 'React-Core', :path => 'node_modules/react-native/'
-  pod 'React-CoreModules', :path => 'node_modules/react-native/React/CoreModules'
-  pod 'React-Core/DevSupport', :path => 'node_modules/react-native/'
-  pod 'React-RCTActionSheet', :path => 'node_modules/react-native/Libraries/ActionSheetIOS'
-  pod 'React-RCTAnimation', :path => 'node_modules/react-native/Libraries/NativeAnimation'
-  pod 'React-RCTBlob', :path => 'node_modules/react-native/Libraries/Blob'
-  pod 'React-RCTImage', :path => 'node_modules/react-native/Libraries/Image'
-  pod 'React-RCTLinking', :path => 'node_modules/react-native/Libraries/LinkingIOS'
-  pod 'React-RCTNetwork', :path => 'node_modules/react-native/Libraries/Network'
-  pod 'React-RCTSettings', :path => 'node_modules/react-native/Libraries/Settings'
-  pod 'React-RCTText', :path => 'node_modules/react-native/Libraries/Text'
-  pod 'React-RCTVibration', :path => 'node_modules/react-native/Libraries/Vibration'
-  pod 'React-Core/RCTWebSocket', :path => 'node_modules/react-native/'
+  pod 'FBLazyVector', :path => "./node_modules/react-native/Libraries/FBLazyVector"
+  pod 'FBReactNativeSpec', :path => "./node_modules/react-native/Libraries/FBReactNativeSpec"
+  pod 'RCTRequired', :path => "./node_modules/react-native/Libraries/RCTRequired"
+  pod 'RCTTypeSafety', :path => "./node_modules/react-native/Libraries/TypeSafety"
+  pod 'React', :path => './node_modules/react-native/'
+  pod 'React-Core', :path => './node_modules/react-native/'
+  pod 'React-CoreModules', :path => './node_modules/react-native/React/CoreModules'
+  pod 'React-Core/DevSupport', :path => './node_modules/react-native/'
+  pod 'React-RCTActionSheet', :path => './node_modules/react-native/Libraries/ActionSheetIOS'
+  pod 'React-RCTAnimation', :path => './node_modules/react-native/Libraries/NativeAnimation'
+  pod 'React-RCTBlob', :path => './node_modules/react-native/Libraries/Blob'
+  pod 'React-RCTImage', :path => './node_modules/react-native/Libraries/Image'
+  pod 'React-RCTLinking', :path => './node_modules/react-native/Libraries/LinkingIOS'
+  pod 'React-RCTNetwork', :path => './node_modules/react-native/Libraries/Network'
+  pod 'React-RCTSettings', :path => './node_modules/react-native/Libraries/Settings'
+  pod 'React-RCTText', :path => './node_modules/react-native/Libraries/Text'
+  pod 'React-RCTVibration', :path => './node_modules/react-native/Libraries/Vibration'
+  pod 'React-Core/RCTWebSocket', :path => './node_modules/react-native/'
 
-  pod 'React-cxxreact', :path => 'node_modules/react-native/ReactCommon/cxxreact'
-  pod 'React-jsi', :path => 'node_modules/react-native/ReactCommon/jsi'
-  pod 'React-jsiexecutor', :path => 'node_modules/react-native/ReactCommon/jsiexecutor'
-  pod 'React-jsinspector', :path => 'node_modules/react-native/ReactCommon/jsinspector'
-  pod 'ReactCommon/callinvoker', :path => "node_modules/react-native/ReactCommon"
-  pod 'ReactCommon/turbomodule/core', :path => "node_modules/react-native/ReactCommon"
-  pod 'Yoga', :path => 'node_modules/react-native/ReactCommon/yoga', :modular_headers => true
+  pod 'React-cxxreact', :path => './node_modules/react-native/ReactCommon/cxxreact'
+  pod 'React-jsi', :path => './node_modules/react-native/ReactCommon/jsi'
+  pod 'React-jsiexecutor', :path => './node_modules/react-native/ReactCommon/jsiexecutor'
+  pod 'React-jsinspector', :path => './node_modules/react-native/ReactCommon/jsinspector'
+  pod 'ReactCommon/callinvoker', :path => "./node_modules/react-native/ReactCommon"
+  pod 'ReactCommon/turbomodule/core', :path => "./node_modules/react-native/ReactCommon"
+  pod 'Yoga', :path => './node_modules/react-native/ReactCommon/yoga', :modular_headers => true
 
-  pod 'DoubleConversion', :podspec => 'node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
-  pod 'glog', :podspec => 'node_modules/react-native/third-party-podspecs/glog.podspec'
-  pod 'Folly', :podspec => 'node_modules/react-native/third-party-podspecs/Folly.podspec'
+  pod 'DoubleConversion', :podspec => './node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
+  pod 'glog', :podspec => './node_modules/react-native/third-party-podspecs/glog.podspec'
+  pod 'Folly', :podspec => './node_modules/react-native/third-party-podspecs/Folly.podspec'
 
   
 

--- a/system-tests/fixtures/ios-container/Podfile.lock
+++ b/system-tests/fixtures/ios-container/Podfile.lock
@@ -297,39 +297,39 @@ PODS:
     - Yoga (~> 1.14)
 
 DEPENDENCIES:
-  - DoubleConversion (from `node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
-  - FBLazyVector (from `node_modules/react-native/Libraries/FBLazyVector`)
-  - FBReactNativeSpec (from `node_modules/react-native/Libraries/FBReactNativeSpec`)
+  - DoubleConversion (from `./node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
+  - FBLazyVector (from `./node_modules/react-native/Libraries/FBLazyVector`)
+  - FBReactNativeSpec (from `./node_modules/react-native/Libraries/FBReactNativeSpec`)
   - FlipperKit (~> 0.33.1)
   - FlipperKit/FlipperKitLayoutPlugin (~> 0.33.1)
   - FlipperKit/FlipperKitReactPlugin (~> 0.33.1)
   - FlipperKit/FlipperKitUserDefaultsPlugin (~> 0.33.1)
   - FlipperKit/SKIOSNetworkPlugin (~> 0.33.1)
-  - Folly (from `node_modules/react-native/third-party-podspecs/Folly.podspec`)
-  - glog (from `node_modules/react-native/third-party-podspecs/glog.podspec`)
-  - RCTRequired (from `node_modules/react-native/Libraries/RCTRequired`)
-  - RCTTypeSafety (from `node_modules/react-native/Libraries/TypeSafety`)
-  - React (from `node_modules/react-native/`)
-  - React-Core (from `node_modules/react-native/`)
-  - React-Core/DevSupport (from `node_modules/react-native/`)
-  - React-Core/RCTWebSocket (from `node_modules/react-native/`)
-  - React-CoreModules (from `node_modules/react-native/React/CoreModules`)
-  - React-cxxreact (from `node_modules/react-native/ReactCommon/cxxreact`)
-  - React-jsi (from `node_modules/react-native/ReactCommon/jsi`)
-  - React-jsiexecutor (from `node_modules/react-native/ReactCommon/jsiexecutor`)
-  - React-jsinspector (from `node_modules/react-native/ReactCommon/jsinspector`)
-  - React-RCTActionSheet (from `node_modules/react-native/Libraries/ActionSheetIOS`)
-  - React-RCTAnimation (from `node_modules/react-native/Libraries/NativeAnimation`)
-  - React-RCTBlob (from `node_modules/react-native/Libraries/Blob`)
-  - React-RCTImage (from `node_modules/react-native/Libraries/Image`)
-  - React-RCTLinking (from `node_modules/react-native/Libraries/LinkingIOS`)
-  - React-RCTNetwork (from `node_modules/react-native/Libraries/Network`)
-  - React-RCTSettings (from `node_modules/react-native/Libraries/Settings`)
-  - React-RCTText (from `node_modules/react-native/Libraries/Text`)
-  - React-RCTVibration (from `node_modules/react-native/Libraries/Vibration`)
-  - ReactCommon/callinvoker (from `node_modules/react-native/ReactCommon`)
-  - ReactCommon/turbomodule/core (from `node_modules/react-native/ReactCommon`)
-  - Yoga (from `node_modules/react-native/ReactCommon/yoga`)
+  - Folly (from `./node_modules/react-native/third-party-podspecs/Folly.podspec`)
+  - glog (from `./node_modules/react-native/third-party-podspecs/glog.podspec`)
+  - RCTRequired (from `./node_modules/react-native/Libraries/RCTRequired`)
+  - RCTTypeSafety (from `./node_modules/react-native/Libraries/TypeSafety`)
+  - React (from `./node_modules/react-native/`)
+  - React-Core (from `./node_modules/react-native/`)
+  - React-Core/DevSupport (from `./node_modules/react-native/`)
+  - React-Core/RCTWebSocket (from `./node_modules/react-native/`)
+  - React-CoreModules (from `./node_modules/react-native/React/CoreModules`)
+  - React-cxxreact (from `./node_modules/react-native/ReactCommon/cxxreact`)
+  - React-jsi (from `./node_modules/react-native/ReactCommon/jsi`)
+  - React-jsiexecutor (from `./node_modules/react-native/ReactCommon/jsiexecutor`)
+  - React-jsinspector (from `./node_modules/react-native/ReactCommon/jsinspector`)
+  - React-RCTActionSheet (from `./node_modules/react-native/Libraries/ActionSheetIOS`)
+  - React-RCTAnimation (from `./node_modules/react-native/Libraries/NativeAnimation`)
+  - React-RCTBlob (from `./node_modules/react-native/Libraries/Blob`)
+  - React-RCTImage (from `./node_modules/react-native/Libraries/Image`)
+  - React-RCTLinking (from `./node_modules/react-native/Libraries/LinkingIOS`)
+  - React-RCTNetwork (from `./node_modules/react-native/Libraries/Network`)
+  - React-RCTSettings (from `./node_modules/react-native/Libraries/Settings`)
+  - React-RCTText (from `./node_modules/react-native/Libraries/Text`)
+  - React-RCTVibration (from `./node_modules/react-native/Libraries/Vibration`)
+  - ReactCommon/callinvoker (from `./node_modules/react-native/ReactCommon`)
+  - ReactCommon/turbomodule/core (from `./node_modules/react-native/ReactCommon`)
+  - Yoga (from `./node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -348,55 +348,55 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   DoubleConversion:
-    :podspec: node_modules/react-native/third-party-podspecs/DoubleConversion.podspec
+    :podspec: "./node_modules/react-native/third-party-podspecs/DoubleConversion.podspec"
   FBLazyVector:
-    :path: node_modules/react-native/Libraries/FBLazyVector
+    :path: "./node_modules/react-native/Libraries/FBLazyVector"
   FBReactNativeSpec:
-    :path: node_modules/react-native/Libraries/FBReactNativeSpec
+    :path: "./node_modules/react-native/Libraries/FBReactNativeSpec"
   Folly:
-    :podspec: node_modules/react-native/third-party-podspecs/Folly.podspec
+    :podspec: "./node_modules/react-native/third-party-podspecs/Folly.podspec"
   glog:
-    :podspec: node_modules/react-native/third-party-podspecs/glog.podspec
+    :podspec: "./node_modules/react-native/third-party-podspecs/glog.podspec"
   RCTRequired:
-    :path: node_modules/react-native/Libraries/RCTRequired
+    :path: "./node_modules/react-native/Libraries/RCTRequired"
   RCTTypeSafety:
-    :path: node_modules/react-native/Libraries/TypeSafety
+    :path: "./node_modules/react-native/Libraries/TypeSafety"
   React:
-    :path: node_modules/react-native/
+    :path: "./node_modules/react-native/"
   React-Core:
-    :path: node_modules/react-native/
+    :path: "./node_modules/react-native/"
   React-CoreModules:
-    :path: node_modules/react-native/React/CoreModules
+    :path: "./node_modules/react-native/React/CoreModules"
   React-cxxreact:
-    :path: node_modules/react-native/ReactCommon/cxxreact
+    :path: "./node_modules/react-native/ReactCommon/cxxreact"
   React-jsi:
-    :path: node_modules/react-native/ReactCommon/jsi
+    :path: "./node_modules/react-native/ReactCommon/jsi"
   React-jsiexecutor:
-    :path: node_modules/react-native/ReactCommon/jsiexecutor
+    :path: "./node_modules/react-native/ReactCommon/jsiexecutor"
   React-jsinspector:
-    :path: node_modules/react-native/ReactCommon/jsinspector
+    :path: "./node_modules/react-native/ReactCommon/jsinspector"
   React-RCTActionSheet:
-    :path: node_modules/react-native/Libraries/ActionSheetIOS
+    :path: "./node_modules/react-native/Libraries/ActionSheetIOS"
   React-RCTAnimation:
-    :path: node_modules/react-native/Libraries/NativeAnimation
+    :path: "./node_modules/react-native/Libraries/NativeAnimation"
   React-RCTBlob:
-    :path: node_modules/react-native/Libraries/Blob
+    :path: "./node_modules/react-native/Libraries/Blob"
   React-RCTImage:
-    :path: node_modules/react-native/Libraries/Image
+    :path: "./node_modules/react-native/Libraries/Image"
   React-RCTLinking:
-    :path: node_modules/react-native/Libraries/LinkingIOS
+    :path: "./node_modules/react-native/Libraries/LinkingIOS"
   React-RCTNetwork:
-    :path: node_modules/react-native/Libraries/Network
+    :path: "./node_modules/react-native/Libraries/Network"
   React-RCTSettings:
-    :path: node_modules/react-native/Libraries/Settings
+    :path: "./node_modules/react-native/Libraries/Settings"
   React-RCTText:
-    :path: node_modules/react-native/Libraries/Text
+    :path: "./node_modules/react-native/Libraries/Text"
   React-RCTVibration:
-    :path: node_modules/react-native/Libraries/Vibration
+    :path: "./node_modules/react-native/Libraries/Vibration"
   ReactCommon:
-    :path: node_modules/react-native/ReactCommon
+    :path: "./node_modules/react-native/ReactCommon"
   Yoga:
-    :path: node_modules/react-native/ReactCommon/yoga
+    :path: "./node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
@@ -437,6 +437,6 @@ SPEC CHECKSUMS:
   Yoga: 3ebccbdd559724312790e7742142d062476b698e
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 882c59bec810b83b2a1d77782024f8ea7160612d
+PODFILE CHECKSUM: 735699df5890f67f20087c0961524905781404f5
 
 COCOAPODS: 1.7.3


### PR DESCRIPTION
Fix issue with iOS native api implementation project generation (`create-api-impl` command) when using a version of react native >= 0.61.0.
This issue was surfaced through system test failure.
This PR updates the API implementation iOS project hull as well as the generation logic, to properly support RN61+.

**EDIT** :  System tests ✅ 