### PR TITLE
Improvements and fixes around new ern info header

### DIFF
--- a/ern-cauldron-api/src/getActiveCauldron.ts
+++ b/ern-cauldron-api/src/getActiveCauldron.ts
@@ -17,11 +17,13 @@ export default async function getActiveCauldron({
   ignoreSchemaVersionMismatch,
   localRepoPath,
   throwIfNoActiveCauldron = true,
+  silent = false,
 }: {
   ignoreRequiredErnVersionMismatch?: boolean
   ignoreSchemaVersionMismatch?: boolean
   localRepoPath?: string
   throwIfNoActiveCauldron?: boolean
+  silent?: boolean
 } = {}): Promise<CauldronHelper> {
   const repoInUse = config.get('cauldronRepoInUse')
   ignoreRequiredErnVersionMismatch =
@@ -33,7 +35,7 @@ export default async function getActiveCauldron({
   }
 
   if (repoInUse && repoInUse !== currentCauldronRepoInUse) {
-    const kaxTask = kax.task(`Connecting to the Cauldron`)
+    const kaxTask = !silent ? kax.task(`Connecting to the Cauldron`) : undefined
     try {
       const cauldronRepositories = config.get('cauldronRepositories')
       const cauldronRepoUrl = cauldronRepositories[repoInUse]
@@ -96,10 +98,14 @@ export default async function getActiveCauldron({
       }
       currentCauldronRepoInUse = repoInUse
     } catch (e) {
-      kaxTask.fail()
-      utils.logErrorAndExitProcess(e, 1)
+      if (kaxTask) {
+        kaxTask.fail()
+      }
+      throw e
     }
-    kaxTask.succeed()
+    if (kaxTask) {
+      kaxTask.succeed()
+    }
   }
 
   return Promise.resolve(currentCauldronHelperInstance)


### PR DESCRIPTION
Quick improvements and fixes around new ern info header introduced in https://github.com/electrode-io/electrode-native/pull/1572 

- Avoid polluting the info header with `connecting to cauldron` log, mixed in between info header lines, by adding a silent flag to `getActiveCauldron` function.

- Rethrow exception from `getActiveCauldron` rather than exiting the process. Our top level command handlers are anyway doing that, so there was no reason to exit process here. Moreover, this allow the info header to gracefully handle a connection error with the cauldron, by just notifying an informational message `Cannot reach Cauldron` rather than throwing and existing the process. This is also a fix in a way, because if the cauldron was unreachable (for example connected to an internal cauldron accessible only on VPN, while not being connected to VPN), then any command would fail (because the info header accessing the cauldron is executed before any command logic), even commands such as `ern cauldron repo clear` or `ern cauldron repo use` ... so there would have been no way to get out of this situation through commands, but only by updating .ernrc manually.

- Fix a logic issue that wouldn't display the override manifest information when `manifest` config was defined in`.ernrc`, without an override (only master), but an override was configured in cauldron.

- Update information message wording and formatting (bold / italic), to make it a bit more pleasing and eye catching in the terminal.