### PR TITLE
Fix ern-api-gen ServiceLoader file handling

### DIFF
--- a/ern-api-gen/src/java/ServiceLoader.ts
+++ b/ern-api-gen/src/java/ServiceLoader.ts
@@ -1,4 +1,3 @@
-import os from 'os'
 import fs from 'fs'
 import path from 'path'
 import { log } from 'ern-core'
@@ -26,7 +25,7 @@ export default {
       }
 
       try {
-        lines.push(...fs.readFileSync(meta.getPath(), 'utf8').split(os.EOL))
+        lines.push(...fs.readFileSync(meta.getPath(), 'utf8').split(/\r?\n/))
       } catch (e) {
         log.warn(`Error loading ${className}. error: ${e}`)
         return ret


### PR DESCRIPTION
Allow `ServiceLoader` to read all available code generators in `META-INF/services` regardless of the line endings used in file that declares them (`io.swagger.codegen.CodegenConfig`).

Note: ServiceLoader is not part of Swagger, but a reimplementation/mockup of Java's own [`java.util.ServiceLoader`](https://docs.oracle.com/javase/7/docs/api/java/util/ServiceLoader.html).

Previously, this would fail if `os.EOL` returns something other than the actual line ending marker (`LF`) used. For example on Windows (where `os.EOL` returns `CRLF`), `load` would return _one_ long string instead of 7 individual items, because none of the lines are recognized:

```
  1) CodegenConfigurator
       should do something async:
     Error: Can't load config class with name android Available:
      at Object.forName (src\CodegenConfigLoader.ts:24:13)
      at CodegenConfigurator.toClientOptInput (src\config\CodegenConfigurator.ts:381:40)
      at Context.<anonymous> (test\CodegenConfigurator-test.js:56:26)
      at processImmediate (internal/timers.js:456:21)
```

There will be one more related follow-up PR for `ern-core` to make the logic line 
ending agnostic. (#1598)