### PR TITLE
Throw an error on mismatching native module versions

### DIFF
--- a/ern-composite-gen/package.json
+++ b/ern-composite-gen/package.json
@@ -35,6 +35,7 @@
   },
   "homepage": "http://www.electrode.io",
   "dependencies": {
+    "cli-table": "^0.3.1",
     "js-beautify": "^1.11.0",
     "ern-core": "1000.0.0",
     "fs-extra": "^8.1.0",


### PR DESCRIPTION
Throw an error when generating a composite that includes local miniapps, if there happens to some some native module(s) versions mismatch.

This PR follows an issue that was identified in `0.41.0`, when using `ern start` with some local miniapps using mismatched native modules version, resulting in some obscure packager error. Better to fail early in this case, with a clear error message.

**Sample error output**

```
✖ An error occurred: Mismatching native module versions detected.
✖ Native module(s) versions should be aligned across miniapps.
✖ You should resolve the following version mismatches prior to retrying.
✖ ┌──────────────────────────────────────────────────────────────┬─────────┐
✖ │ path                                                         │ version │
✖ ├──────────────────────────────────────────────────────────────┼─────────┤
✖ │ /Users/foo/miniappA/node_modules/react-native-maps           │ 0.26.0  │
✖ ├──────────────────────────────────────────────────────────────┼─────────┤
✖ │ /Users/foo/miniappB/node_modules/react-native-maps           │ 0.24.0  │
✖ └──────────────────────────────────────────────────────────────┴─────────┘
```

To be released in `0.41.1`