### PR TITLE
Update ern-local-cli postinstall script

### DIFF
--- a/ern-local-cli/scripts/postinstall.js
+++ b/ern-local-cli/scripts/postinstall.js
@@ -16,7 +16,10 @@ const os = require('os')
 // ....
 // |_ .ernrc
 
-const PLATFORM_VERSION = '1000.0.0'
+const pJsonPath = path.resolve(__dirname, '..', 'package.json')
+const pJson = JSON.parse(fs.readFileSync(pJsonPath, { encoding: 'utf8' }))
+
+const PLATFORM_VERSION = pJson.version
 // Path to ern platform root directory
 const ERN_PATH = process.env['ERN_HOME'] || path.join(os.homedir(), '.ern')
 // Path to ern global configuration file


### PR DESCRIPTION
Just get the version directly from the `package.json`.
Once merged will remove extra cumbersome steps in [release process wiki page](https://github.com/electrode-io/electrode-native/wiki/New-platform-version-release-process) to manually edit the version prior to each release, which won't be needed anymore.