### PR TITLE
Fix platform installation

### DIFF
--- a/ern-core/src/Platform.ts
+++ b/ern-core/src/Platform.ts
@@ -110,10 +110,11 @@ export default class Platform {
     const pathToVersion = this.getRootPlatformVersionPath(version)
 
     try {
-      shell.mkdir('-p', path.join(pathToVersion, 'node_modules'))
+      shell.mkdir(pathToVersion)
       shell.pushd(pathToVersion)
       if (this.isYarnInstalled()) {
         // Favor yarn if it is installed as it will greatly speed up install
+        execSync(`yarn init --yes`, { cwd: pathToVersion })
         execSync(
           `yarn add ${ERN_LOCAL_CLI_PACKAGE}@${version} --exact --ignore-engines`,
           {
@@ -121,6 +122,7 @@ export default class Platform {
           }
         )
       } else {
+        execSync(`npm init --yes`, { cwd: pathToVersion })
         execSync(`npm install ${ERN_LOCAL_CLI_PACKAGE}@${version} --exact`, {
           cwd: pathToVersion,
         })

--- a/ern-core/test/Platform-test.ts
+++ b/ern-core/test/Platform-test.ts
@@ -218,11 +218,19 @@ describe('Platform', () => {
       expect(() => Platform.installPlatform('6.0.0')).to.throw
     })
 
-    it('should create complete directory hierarchy', () => {
+    it('should use yarn init to create a package.json', () => {
       Platform.installPlatform('3.0.0')
-      expect(
-        fs.existsSync(path.join(ernHomePath, 'versions/3.0.0/node_modules'))
-      ).true
+      sandbox.assert.calledWith(
+        execSyncStub,
+        'yarn init --yes',
+        sinon.match.any
+      )
+    })
+
+    it('should use npm init to create a package.json', () => {
+      isYarnInstalledReturn = false
+      Platform.installPlatform('3.0.0')
+      sandbox.assert.calledWith(execSyncStub, 'npm init --yes', sinon.match.any)
     })
 
     it('should use yarn add to install platform if yarn is installed', () => {


### PR DESCRIPTION
This fixes: https://github.com/electrode-io/electrode-native/issues/1611

**Root cause**
The `yarn add` command on [this](https://github.com/electrode-io/electrode-native/blob/889074ee62b6899690066ba3c2c9450591970e81/ern-core/src/Platform.ts#L118) line fails silently (but the `ern platform install` operation is marked as successful) because there's no `package.json` in the current folder.  

**Solution**
The initial platform version (the latest) is fetched correctly because it's an entirely different code path ([here](https://github.com/electrode-io/electrode-native/blob/889074ee62b6899690066ba3c2c9450591970e81/global-cli/src/index.js#L85)). For now I've just copied the relevant line but it might be even nicer to unify the platform installation code paths. However, I couldn't figure out what the best place would be. 
I thought of changing the implementation in `Platform.ts`, and import it in `global-cli/src/index.js` but `ern-core` isn't a dependency of `global-cli` at the moment.  Would it be OK to add this dependency?

Apart from this change, there are more differences between the platform-install implementations in `ern-core` and `global-cli`. The one in `global-cli` has some extra logic to support Windows machines, which the implementation in `Platform.ts` doesn't have. This probably means that the `ern platform install` command will still be broken for Windows users after this change is merged... 