### PR TITLE
Fix baseComposite option for start command

### DIFF
--- a/ern-orchestrator/src/start.ts
+++ b/ern-orchestrator/src/start.ts
@@ -82,7 +82,11 @@ export default async function start({
     const compositeGenConfig = await cauldron.getCompositeGeneratorConfig(
       descriptor
     )
-    baseComposite = baseComposite || compositeGenConfig?.baseComposite
+    baseComposite =
+      baseComposite ??
+      (compositeGenConfig?.baseComposite &&
+        PackagePath.fromString(compositeGenConfig.baseComposite))
+
     resolutions = compositeGenConfig?.resolutions
   }
 


### PR DESCRIPTION
After https://github.com/electrode-io/electrode-native/pull/1532 and https://github.com/electrode-io/electrode-native/pull/1544 I found one more place where the `baseComposite` wasn't wrapped into a `PackagePath`