### PR TITLE
Fix conflicting bridge version

### DIFF
--- a/ern-composite-gen/src/generateComposite.ts
+++ b/ern-composite-gen/src/generateComposite.ts
@@ -179,6 +179,10 @@ async function generateFullComposite(
           `react-native@${pJson.dependencies['react-native']}`
         )
       )
+      // Also add latest version of the bridge
+      extraJsDependencies.push(
+        PackagePath.fromString(`react-native-electrode-bridge`)
+      )
       // We also need to have react added as an extra node module in metro config
       extraNodeModules.react = path.join(
         localMiniAppsPaths[0],

--- a/ern-core/src/resolveNativeDependenciesVersions.ts
+++ b/ern-core/src/resolveNativeDependenciesVersions.ts
@@ -67,9 +67,10 @@ export function resolvePackageVersionsGivenMismatchLevel(
     if (pluginVersions.length > 1) {
       // If there are multiple versions of the dependency
       if (
+        (name !== 'react-native-electrode-bridge' &&
+          containsVersionMismatch(<string[]>pluginVersions, mismatchLevel)) ||
         (name === 'react-native-electrode-bridge' &&
-          containsVersionMismatch(<string[]>pluginVersions, 'major')) ||
-        containsVersionMismatch(<string[]>pluginVersions, mismatchLevel)
+          containsVersionMismatch(<string[]>pluginVersions, 'major'))
       ) {
         // If at least one of the versions major digit differs, deem incompatibility
         result.pluginsWithMismatchingVersions.push(name)


### PR DESCRIPTION
Fix a conditional logic bug in `resolveNativeDependenciesVersions.ts` which was causing non major mismatching bridge versions to be invalidly considered as mismatching, leading to potential issues when using `ern start`.

Also, add latest version of the bridge to top level composite, for packager to properly resolve it (and avoid using a random version potentially locked by one of the miniapps).