### PR TITLE
Re-add missing self properties

### DIFF
--- a/ern-api-gen/resources/swift/libraries/ern/apidatamodel.mustache
+++ b/ern-api-gen/resources/swift/libraries/ern/apidatamodel.mustache
@@ -18,10 +18,10 @@
 
     public override init() {
 {{#requiredParams}}
-        {{baseName}} = {{dataType}}()
+        self.{{baseName}} = {{dataType}}()
 {{/requiredParams}}
 {{#optionalParams}}
-        {{baseName}} = nil
+        self.{{baseName}} = nil
 {{/optionalParams}}
         super.init()
     }
@@ -38,10 +38,10 @@
 {{/isPrimitiveType}}
 {{^isPrimitiveType}}
 {{^isListContainer}}
-            {{baseName}} = {{dataType}}(dictionary: {{baseName}}Dict)
+            self.{{baseName}} = {{dataType}}(dictionary: {{baseName}}Dict)
 {{/isListContainer}}
 {{#isListContainer}}
-            {{baseName}} = {{baseName}}Dict.map({ obj in
+            self.{{baseName}} = {{baseName}}Dict.map({ obj in
 {{complexType}}(dictionary: obj as! [AnyHashable: Any])
             })
 {{/isListContainer}}
@@ -61,9 +61,9 @@
 {{^isPrimitiveType}}
 
         if let {{baseName}}Dict = dictionary["{{baseName}}"] as? [AnyHashable: Any] {
-            {{baseName}} = {{dataType}}(dictionary: {{baseName}}Dict)
+            self.{{baseName}} = {{dataType}}(dictionary: {{baseName}}Dict)
         } else {
-            {{baseName}} = nil
+            self.{{baseName}} = nil
         }
 {{/isPrimitiveType}}
 {{/optionalParams}}
@@ -74,12 +74,12 @@
     public func toDictionary() -> NSDictionary {
         var dict = [
 {{#requiredParams}}
-            "{{baseName}}": {{baseName}}{{^isPrimitiveType}}.toDictionary(){{/isPrimitiveType}},
+            "{{baseName}}": self.{{baseName}}{{^isPrimitiveType}}.toDictionary(){{/isPrimitiveType}},
 {{/requiredParams}}
         ] as [AnyHashable: Any]
 
 {{#optionalParams}}
-        if let nonNull{{baseName}} = {{baseName}} {
+        if let nonNull{{baseName}} = self.{{baseName}} {
             dict["{{baseName}}"] = nonNull{{baseName}}{{^isPrimitiveType}}.toDictionary(){{/isPrimitiveType}}
         }
 {{/optionalParams}}
@@ -108,10 +108,10 @@ public class {{requestDataType}}: ElectrodeObject, Bridgeable {
 
     public override init() {
 {{#requiredParams}}
-        {{baseName}} = {{dataType}}()
+        self.{{baseName}} = {{dataType}}()
 {{/requiredParams}}
 {{#optionalParams}}
-        {{baseName}} = nil
+        self.{{baseName}} = nil
 {{/optionalParams}}
         super.init()
     }
@@ -128,10 +128,10 @@ public class {{requestDataType}}: ElectrodeObject, Bridgeable {
 {{/isPrimitiveType}}
 {{^isPrimitiveType}}
 {{^isListContainer}}
-            {{baseName}} = {{dataType}}(dictionary: {{baseName}}Dict)
+            self.{{baseName}} = {{dataType}}(dictionary: {{baseName}}Dict)
 {{/isListContainer}}
 {{#isListContainer}}
-            {{baseName}} = {{baseName}}Dict.map({ obj in
+            self.{{baseName}} = {{baseName}}Dict.map({ obj in
 {{complexType}}(dictionary: obj as! [AnyHashable: Any])
             })
 {{/isListContainer}}
@@ -140,20 +140,20 @@ public class {{requestDataType}}: ElectrodeObject, Bridgeable {
         } else {
             assertionFailure("\({{requestDataType}}.tag) missing one or more required properties[{{#requiredParams}}{{baseName}}{{^last}},{{/last}}{{/requiredParams}}]")
 {{#requiredParams}}
-            {{baseName}} = dictionary["{{baseName}}"] as! {{dataType}}
+            self.{{baseName}} = dictionary["{{baseName}}"] as! {{dataType}}
 {{/requiredParams}}
         }
 
 {{#optionalParams}}
 {{#isPrimitiveType}}
-        {{baseName}} = dictionary["{{baseName}}"] as? {{dataType}}
+        self.{{baseName}} = dictionary["{{baseName}}"] as? {{dataType}}
 {{/isPrimitiveType}}
 {{^isPrimitiveType}}
 
         if let {{baseName}}Dict = dictionary["{{baseName}}"] as? [AnyHashable: Any] {
-            {{baseName}} = {{dataType}}(dictionary: {{baseName}}Dict)
+            self.{{baseName}} = {{dataType}}(dictionary: {{baseName}}Dict)
         } else {
-            {{baseName}} = nil
+            self.{{baseName}} = nil
         }
 {{/isPrimitiveType}}
 {{/optionalParams}}
@@ -164,12 +164,12 @@ public class {{requestDataType}}: ElectrodeObject, Bridgeable {
     public func toDictionary() -> NSDictionary {
         var dict = [
 {{#requiredParams}}
-            "{{baseName}}": {{baseName}}{{^isPrimitiveType}}.toDictionary(){{/isPrimitiveType}},
+            "{{baseName}}": self.{{baseName}}{{^isPrimitiveType}}.toDictionary(){{/isPrimitiveType}},
 {{/requiredParams}}
         ] as [AnyHashable: Any]
 
 {{#optionalParams}}
-        if let nonNull{{baseName}} = {{baseName}} {
+        if let nonNull{{baseName}} = self.{{baseName}} {
             dict["{{baseName}}"] = nonNull{{baseName}}{{^isPrimitiveType}}.toDictionary(){{/isPrimitiveType}}
         }
 {{/optionalParams}}

--- a/ern-api-gen/resources/swift/libraries/ern/model.mustache
+++ b/ern-api-gen/resources/swift/libraries/ern/model.mustache
@@ -29,10 +29,10 @@
 
     public override init() {
 {{#requiredVars}}
-        {{name}} = {{datatype}}()
+        self.{{name}} = {{datatype}}()
 {{/requiredVars}}
 {{#optionalVars}}
-        {{name}} = nil
+        self.{{name}} = nil
 {{/optionalVars}}
         super.init()
     }
@@ -42,7 +42,7 @@
 {{#isNotContainer}}
 {{^isPrimitiveType}}
         if let {{name}}Dict = dictionary["{{name}}"] as? [AnyHashable: Any] {
-            {{name}} = {{datatype}}(dictionary: {{name}}Dict)
+            self.{{name}} = {{datatype}}(dictionary: {{name}}Dict)
         } else {
             assertionFailure("\({{classname}}.tag) missing one or more required properties [{{name}}]")
             {{name}} = dictionary["{{name}}"] as! {{datatype}}
@@ -53,17 +53,17 @@
             self.{{name}} = {{name}}
         } else {
             assertionFailure("\({{classname}}.tag) missing one or more required properties [{{name}}]")
-            {{name}} = dictionary["{{name}}"] as! {{datatype}}
+            self.{{name}} = dictionary["{{name}}"] as! {{datatype}}
         }
 {{/isPrimitiveType}}
 {{/isNotContainer}}
 {{^isNotContainer}}
         if let valid{{nameInCamelCase}} = try? NSObject.generateObject(data: dictionary["{{name}}"], classType: Array<Any>.self, itemType: {{complexType}}.self),
              let {{baseName}}List = valid{{nameInCamelCase}} as? {{datatype}}  {
-                 {{name}} = {{baseName}}List
+                 self.{{name}} = {{baseName}}List
              } else {
                  assertionFailure("\({{classname}}.tag) missing one or more required properties[{{name}}]")
-                 {{name}} = dictionary["{{name}}"] as! {{datatype}}
+                 self.{{name}} = dictionary["{{name}}"] as! {{datatype}}
              }
 {{/isNotContainer}}
 {{/requiredVars}}
@@ -71,17 +71,17 @@
 {{#optionalVars}}
 {{#isNotContainer}}
         if let {{name}}{{^isPrimitiveType}}Dict{{/isPrimitiveType}} = dictionary["{{name}}"] as? {{#isPrimitiveType}}{{datatype}}{{/isPrimitiveType}}{{^isPrimitiveType}}[AnyHashable: Any]{{/isPrimitiveType}} {
-            {{name}} = {{^isPrimitiveType}}{{datatype}}(dictionary: {{name}}Dict){{/isPrimitiveType}}{{#isPrimitiveType}}{{name}}{{/isPrimitiveType}}
+            self.{{name}} = {{^isPrimitiveType}}{{datatype}}(dictionary: {{name}}Dict){{/isPrimitiveType}}{{#isPrimitiveType}}{{name}}{{/isPrimitiveType}}
         } else {
-            {{name}} = nil
+            self.{{name}} = nil
         }
 {{/isNotContainer}}
 {{^isNotContainer}}
         if let valid{{nameInCamelCase}} = try? NSObject.generateObject(data: dictionary["{{name}}"], classType: [Any].self, itemType: {{complexType}}.self),
             let {{baseName}}List = valid{{nameInCamelCase}} as? {{datatype}} {
-            {{name}} = {{baseName}}List
+            self.{{name}} = {{baseName}}List
         } else {
-            {{name}} = nil
+            self.{{name}} = nil
         }
 {{/isNotContainer}}
 {{/optionalVars}}
@@ -93,11 +93,11 @@
         var dict = [:] as [AnyHashable: Any]
 
 {{#requiredVars}}
-        dict["{{name}}"] = {{name}}{{^isPrimitiveType}}{{#isNotContainer}}.toDictionary(){{/isNotContainer}}{{^isNotContainer}}.map { $0.toDictionary() }{{/isNotContainer}}{{/isPrimitiveType}}
+        dict["{{name}}"] = self.{{name}}{{^isPrimitiveType}}{{#isNotContainer}}.toDictionary(){{/isNotContainer}}{{^isNotContainer}}.map { $0.toDictionary() }{{/isNotContainer}}{{/isPrimitiveType}}
 {{/requiredVars}}
 
 {{#optionalVars}}
-        if let nonNull{{nameInCamelCase}} = {{name}} {
+        if let nonNull{{nameInCamelCase}} = self.{{name}} {
             dict["{{name}}"] = nonNull{{nameInCamelCase}}{{^isPrimitiveType}}{{#isNotContainer}}.toDictionary(){{/isNotContainer}}{{^isNotContainer}}.map { $0.toDictionary() }{{/isNotContainer}}{{/isPrimitiveType}}
         }
 {{/optionalVars}}
@@ -139,10 +139,10 @@ public class {{classname}}: ElectrodeObject, Bridgeable {
 
     public override init() {
 {{#requiredVars}}
-        {{name}} = {{datatype}}()
+        self.{{name}} = {{datatype}}()
 {{/requiredVars}}
 {{#optionalVars}}
-        {{name}} = nil
+        self.{{name}} = nil
 {{/optionalVars}}
         super.init()
     }
@@ -152,10 +152,10 @@ public class {{classname}}: ElectrodeObject, Bridgeable {
 {{#isNotContainer}}
 {{^isPrimitiveType}}
         if let {{name}}Dict = dictionary["{{name}}"] as? [AnyHashable: Any] {
-            {{name}} = {{datatype}}(dictionary: {{name}}Dict)
+            self.{{name}} = {{datatype}}(dictionary: {{name}}Dict)
         } else {
             assertionFailure("\({{classname}}.tag) missing one or more required properties [{{name}}]")
-            {{name}} = dictionary["{{name}}"] as! {{datatype}}
+            self.{{name}} = dictionary["{{name}}"] as! {{datatype}}
         }
 {{/isPrimitiveType}}
 {{#isPrimitiveType}}
@@ -163,17 +163,17 @@ public class {{classname}}: ElectrodeObject, Bridgeable {
             self.{{name}} = {{name}}
         } else {
             assertionFailure("\({{classname}}.tag) missing one or more required properties [{{name}}]")
-            {{name}} = dictionary["{{name}}"] as! {{datatype}}
+            self.{{name}} = dictionary["{{name}}"] as! {{datatype}}
         }
 {{/isPrimitiveType}}
 {{/isNotContainer}}
 {{^isNotContainer}}
         if let valid{{nameInCamelCase}} = try? NSObject.generateObject(data: dictionary["{{name}}"], classType: [Any].self, itemType: {{complexType}}.self),
              let {{baseName}}List = valid{{nameInCamelCase}} as? {{datatype}}  {
-                 {{name}} = {{baseName}}List
+                 self.{{name}} = {{baseName}}List
              } else {
-             assertionFailure("\({{classname}}.tag) missing one or more required properties[{{name}}]")
-             {{name}} = dictionary["{{name}}"] as! {{datatype}}
+                 assertionFailure("\({{classname}}.tag) missing one or more required properties[{{name}}]")
+                 self.{{name}} = dictionary["{{name}}"] as! {{datatype}}
              }
 {{/isNotContainer}}
 {{/requiredVars}}
@@ -181,17 +181,17 @@ public class {{classname}}: ElectrodeObject, Bridgeable {
 {{#optionalVars}}
 {{#isNotContainer}}
         if let {{name}}{{^isPrimitiveType}}Dict{{/isPrimitiveType}} = dictionary["{{name}}"] as? {{#isPrimitiveType}}{{datatype}}{{/isPrimitiveType}}{{^isPrimitiveType}}[AnyHashable: Any]{{/isPrimitiveType}} {
-            {{name}} = {{^isPrimitiveType}}{{datatype}}(dictionary: {{name}}Dict){{/isPrimitiveType}}{{#isPrimitiveType}}{{name}}{{/isPrimitiveType}}
+            self.{{name}} = {{^isPrimitiveType}}{{datatype}}(dictionary: {{name}}Dict){{/isPrimitiveType}}{{#isPrimitiveType}}{{name}}{{/isPrimitiveType}}
         } else {
-            {{name}} = nil
+            self.{{name}} = nil
         }
 {{/isNotContainer}}
 {{^isNotContainer}}
         if let valid{{nameInCamelCase}} = try? NSObject.generateObject(data: dictionary["{{name}}"], classType: [Any].self, itemType: {{complexType}}.self),
             let {{baseName}}List = valid{{nameInCamelCase}} as? {{datatype}} {
-            {{name}} = {{baseName}}List
+            self.{{name}} = {{baseName}}List
         } else {
-            {{name}} = nil
+            self.{{name}} = nil
         }
 {{/isNotContainer}}
 {{/optionalVars}}
@@ -203,11 +203,11 @@ public class {{classname}}: ElectrodeObject, Bridgeable {
         var dict = [:] as [AnyHashable: Any]
 
 {{#requiredVars}}
-        dict["{{name}}"] = {{name}}{{^isPrimitiveType}}{{#isNotContainer}}.toDictionary(){{/isNotContainer}}{{^isNotContainer}}.map { $0.toDictionary() }{{/isNotContainer}}{{/isPrimitiveType}}
+        dict["{{name}}"] = self.{{name}}{{^isPrimitiveType}}{{#isNotContainer}}.toDictionary(){{/isNotContainer}}{{^isNotContainer}}.map { $0.toDictionary() }{{/isNotContainer}}{{/isPrimitiveType}}
 {{/requiredVars}}
 
 {{#optionalVars}}
-        if let nonNull{{nameInCamelCase}} = {{name}} {
+        if let nonNull{{nameInCamelCase}} = self.{{name}} {
             dict["{{name}}"] = nonNull{{nameInCamelCase}}{{^isPrimitiveType}}{{#isNotContainer}}.toDictionary(){{/isNotContainer}}{{^isNotContainer}}.map { $0.toDictionary() }{{/isNotContainer}}{{/isPrimitiveType}}
         }
 {{/optionalVars}}

--- a/system-tests/fixtures/api/complex-api/IOS/ErnObject.swift
+++ b/system-tests/fixtures/api/complex-api/IOS/ErnObject.swift
@@ -39,17 +39,17 @@
     }
 
     public override init() {
-        name = String()
-        version = Double()
-        value = nil
-        domain = nil
-        path = nil
-        uri = nil
-        expiry = nil
-        leftButton = nil
-        rightButtons = nil
-        isGuestUser = nil
-        mergeType = nil
+        self.name = String()
+        self.version = Double()
+        self.value = nil
+        self.domain = nil
+        self.path = nil
+        self.uri = nil
+        self.expiry = nil
+        self.leftButton = nil
+        self.rightButtons = nil
+        self.isGuestUser = nil
+        self.mergeType = nil
         super.init()
     }
 
@@ -58,60 +58,60 @@
             self.name = name
         } else {
             assertionFailure("\(ErnObject.tag) missing one or more required properties [name]")
-            name = dictionary["name"] as! String
+            self.name = dictionary["name"] as! String
         }
         if let version = dictionary["version"] as? Double {
             self.version = version
         } else {
             assertionFailure("\(ErnObject.tag) missing one or more required properties [version]")
-            version = dictionary["version"] as! Double
+            self.version = dictionary["version"] as! Double
         }
 
         if let value = dictionary["value"] as? String {
-            value = value
+            self.value = value
         } else {
-            value = nil
+            self.value = nil
         }
         if let domain = dictionary["domain"] as? String {
-            domain = domain
+            self.domain = domain
         } else {
-            domain = nil
+            self.domain = nil
         }
         if let path = dictionary["path"] as? String {
-            path = path
+            self.path = path
         } else {
-            path = nil
+            self.path = nil
         }
         if let uri = dictionary["uri"] as? String {
-            uri = uri
+            self.uri = uri
         } else {
-            uri = nil
+            self.uri = nil
         }
         if let expiry = dictionary["expiry"] as? Int64 {
-            expiry = expiry
+            self.expiry = expiry
         } else {
-            expiry = nil
+            self.expiry = nil
         }
         if let leftButtonDict = dictionary["leftButton"] as? [AnyHashable: Any] {
-            leftButton = NavBarButton(dictionary: leftButtonDict)
+            self.leftButton = NavBarButton(dictionary: leftButtonDict)
         } else {
-            leftButton = nil
+            self.leftButton = nil
         }
         if let validRightButtons = try? NSObject.generateObject(data: dictionary["rightButtons"], classType: [Any].self, itemType: NavBarButton.self),
             let rightButtonsList = validRightButtons as? [NavBarButton] {
-            rightButtons = rightButtonsList
+            self.rightButtons = rightButtonsList
         } else {
-            rightButtons = nil
+            self.rightButtons = nil
         }
         if let isGuestUser = dictionary["isGuestUser"] as? Bool {
-            isGuestUser = isGuestUser
+            self.isGuestUser = isGuestUser
         } else {
-            isGuestUser = nil
+            self.isGuestUser = nil
         }
         if let mergeType = dictionary["mergeType"] as? Int {
-            mergeType = mergeType
+            self.mergeType = mergeType
         } else {
-            mergeType = nil
+            self.mergeType = nil
         }
 
         super.init(dictionary: dictionary)
@@ -120,34 +120,34 @@
     public func toDictionary() -> NSDictionary {
         var dict = [:] as [AnyHashable: Any]
 
-        dict["name"] = name
-        dict["version"] = version
+        dict["name"] = self.name
+        dict["version"] = self.version
 
-        if let nonNullValue = value {
+        if let nonNullValue = self.value {
             dict["value"] = nonNullValue
         }
-        if let nonNullDomain = domain {
+        if let nonNullDomain = self.domain {
             dict["domain"] = nonNullDomain
         }
-        if let nonNullPath = path {
+        if let nonNullPath = self.path {
             dict["path"] = nonNullPath
         }
-        if let nonNullUri = uri {
+        if let nonNullUri = self.uri {
             dict["uri"] = nonNullUri
         }
-        if let nonNullExpiry = expiry {
+        if let nonNullExpiry = self.expiry {
             dict["expiry"] = nonNullExpiry
         }
-        if let nonNullLeftButton = leftButton {
+        if let nonNullLeftButton = self.leftButton {
             dict["leftButton"] = nonNullLeftButton.toDictionary()
         }
-        if let nonNullRightButtons = rightButtons {
+        if let nonNullRightButtons = self.rightButtons {
             dict["rightButtons"] = nonNullRightButtons.map { $0.toDictionary() }
         }
-        if let nonNullIsGuestUser = isGuestUser {
+        if let nonNullIsGuestUser = self.isGuestUser {
             dict["isGuestUser"] = nonNullIsGuestUser
         }
-        if let nonNullMergeType = mergeType {
+        if let nonNullMergeType = self.mergeType {
             dict["mergeType"] = nonNullMergeType
         }
         return dict as NSDictionary
@@ -196,17 +196,17 @@ public class ErnObject: ElectrodeObject, Bridgeable {
     }
 
     public override init() {
-        name = String()
-        version = Double()
-        value = nil
-        domain = nil
-        path = nil
-        uri = nil
-        expiry = nil
-        leftButton = nil
-        rightButtons = nil
-        isGuestUser = nil
-        mergeType = nil
+        self.name = String()
+        self.version = Double()
+        self.value = nil
+        self.domain = nil
+        self.path = nil
+        self.uri = nil
+        self.expiry = nil
+        self.leftButton = nil
+        self.rightButtons = nil
+        self.isGuestUser = nil
+        self.mergeType = nil
         super.init()
     }
 
@@ -215,60 +215,60 @@ public class ErnObject: ElectrodeObject, Bridgeable {
             self.name = name
         } else {
             assertionFailure("\(ErnObject.tag) missing one or more required properties [name]")
-            name = dictionary["name"] as! String
+            self.name = dictionary["name"] as! String
         }
         if let version = dictionary["version"] as? Double {
             self.version = version
         } else {
             assertionFailure("\(ErnObject.tag) missing one or more required properties [version]")
-            version = dictionary["version"] as! Double
+            self.version = dictionary["version"] as! Double
         }
 
         if let value = dictionary["value"] as? String {
-            value = value
+            self.value = value
         } else {
-            value = nil
+            self.value = nil
         }
         if let domain = dictionary["domain"] as? String {
-            domain = domain
+            self.domain = domain
         } else {
-            domain = nil
+            self.domain = nil
         }
         if let path = dictionary["path"] as? String {
-            path = path
+            self.path = path
         } else {
-            path = nil
+            self.path = nil
         }
         if let uri = dictionary["uri"] as? String {
-            uri = uri
+            self.uri = uri
         } else {
-            uri = nil
+            self.uri = nil
         }
         if let expiry = dictionary["expiry"] as? Int64 {
-            expiry = expiry
+            self.expiry = expiry
         } else {
-            expiry = nil
+            self.expiry = nil
         }
         if let leftButtonDict = dictionary["leftButton"] as? [AnyHashable: Any] {
-            leftButton = NavBarButton(dictionary: leftButtonDict)
+            self.leftButton = NavBarButton(dictionary: leftButtonDict)
         } else {
-            leftButton = nil
+            self.leftButton = nil
         }
         if let validRightButtons = try? NSObject.generateObject(data: dictionary["rightButtons"], classType: [Any].self, itemType: NavBarButton.self),
             let rightButtonsList = validRightButtons as? [NavBarButton] {
-            rightButtons = rightButtonsList
+            self.rightButtons = rightButtonsList
         } else {
-            rightButtons = nil
+            self.rightButtons = nil
         }
         if let isGuestUser = dictionary["isGuestUser"] as? Bool {
-            isGuestUser = isGuestUser
+            self.isGuestUser = isGuestUser
         } else {
-            isGuestUser = nil
+            self.isGuestUser = nil
         }
         if let mergeType = dictionary["mergeType"] as? Int {
-            mergeType = mergeType
+            self.mergeType = mergeType
         } else {
-            mergeType = nil
+            self.mergeType = nil
         }
 
         super.init(dictionary: dictionary)
@@ -277,34 +277,34 @@ public class ErnObject: ElectrodeObject, Bridgeable {
     public func toDictionary() -> NSDictionary {
         var dict = [:] as [AnyHashable: Any]
 
-        dict["name"] = name
-        dict["version"] = version
+        dict["name"] = self.name
+        dict["version"] = self.version
 
-        if let nonNullValue = value {
+        if let nonNullValue = self.value {
             dict["value"] = nonNullValue
         }
-        if let nonNullDomain = domain {
+        if let nonNullDomain = self.domain {
             dict["domain"] = nonNullDomain
         }
-        if let nonNullPath = path {
+        if let nonNullPath = self.path {
             dict["path"] = nonNullPath
         }
-        if let nonNullUri = uri {
+        if let nonNullUri = self.uri {
             dict["uri"] = nonNullUri
         }
-        if let nonNullExpiry = expiry {
+        if let nonNullExpiry = self.expiry {
             dict["expiry"] = nonNullExpiry
         }
-        if let nonNullLeftButton = leftButton {
+        if let nonNullLeftButton = self.leftButton {
             dict["leftButton"] = nonNullLeftButton.toDictionary()
         }
-        if let nonNullRightButtons = rightButtons {
+        if let nonNullRightButtons = self.rightButtons {
             dict["rightButtons"] = nonNullRightButtons.map { $0.toDictionary() }
         }
-        if let nonNullIsGuestUser = isGuestUser {
+        if let nonNullIsGuestUser = self.isGuestUser {
             dict["isGuestUser"] = nonNullIsGuestUser
         }
-        if let nonNullMergeType = mergeType {
+        if let nonNullMergeType = self.mergeType {
             dict["mergeType"] = nonNullMergeType
         }
         return dict as NSDictionary

--- a/system-tests/fixtures/api/complex-api/IOS/NavBarButton.swift
+++ b/system-tests/fixtures/api/complex-api/IOS/NavBarButton.swift
@@ -23,9 +23,9 @@
     }
 
     public override init() {
-        name = String()
-        identifier = String()
-        showIcon = nil
+        self.name = String()
+        self.identifier = String()
+        self.showIcon = nil
         super.init()
     }
 
@@ -34,19 +34,19 @@
             self.name = name
         } else {
             assertionFailure("\(NavBarButton.tag) missing one or more required properties [name]")
-            name = dictionary["name"] as! String
+            self.name = dictionary["name"] as! String
         }
         if let identifier = dictionary["identifier"] as? String {
             self.identifier = identifier
         } else {
             assertionFailure("\(NavBarButton.tag) missing one or more required properties [identifier]")
-            identifier = dictionary["identifier"] as! String
+            self.identifier = dictionary["identifier"] as! String
         }
 
         if let showIcon = dictionary["showIcon"] as? Bool {
-            showIcon = showIcon
+            self.showIcon = showIcon
         } else {
-            showIcon = nil
+            self.showIcon = nil
         }
 
         super.init(dictionary: dictionary)
@@ -55,10 +55,10 @@
     public func toDictionary() -> NSDictionary {
         var dict = [:] as [AnyHashable: Any]
 
-        dict["name"] = name
-        dict["identifier"] = identifier
+        dict["name"] = self.name
+        dict["identifier"] = self.identifier
 
-        if let nonNullShowIcon = showIcon {
+        if let nonNullShowIcon = self.showIcon {
             dict["showIcon"] = nonNullShowIcon
         }
         return dict as NSDictionary
@@ -91,9 +91,9 @@ public class NavBarButton: ElectrodeObject, Bridgeable {
     }
 
     public override init() {
-        name = String()
-        identifier = String()
-        showIcon = nil
+        self.name = String()
+        self.identifier = String()
+        self.showIcon = nil
         super.init()
     }
 
@@ -102,19 +102,19 @@ public class NavBarButton: ElectrodeObject, Bridgeable {
             self.name = name
         } else {
             assertionFailure("\(NavBarButton.tag) missing one or more required properties [name]")
-            name = dictionary["name"] as! String
+            self.name = dictionary["name"] as! String
         }
         if let identifier = dictionary["identifier"] as? String {
             self.identifier = identifier
         } else {
             assertionFailure("\(NavBarButton.tag) missing one or more required properties [identifier]")
-            identifier = dictionary["identifier"] as! String
+            self.identifier = dictionary["identifier"] as! String
         }
 
         if let showIcon = dictionary["showIcon"] as? Bool {
-            showIcon = showIcon
+            self.showIcon = showIcon
         } else {
-            showIcon = nil
+            self.showIcon = nil
         }
 
         super.init(dictionary: dictionary)
@@ -123,10 +123,10 @@ public class NavBarButton: ElectrodeObject, Bridgeable {
     public func toDictionary() -> NSDictionary {
         var dict = [:] as [AnyHashable: Any]
 
-        dict["name"] = name
-        dict["identifier"] = identifier
+        dict["name"] = self.name
+        dict["identifier"] = self.identifier
 
-        if let nonNullShowIcon = showIcon {
+        if let nonNullShowIcon = self.showIcon {
             dict["showIcon"] = nonNullShowIcon
         }
         return dict as NSDictionary

--- a/system-tests/fixtures/api/complex-api/IOS/TestMultiArgsData.swift
+++ b/system-tests/fixtures/api/complex-api/IOS/TestMultiArgsData.swift
@@ -12,8 +12,8 @@
     }
 
     public override init() {
-        key1 = String()
-        key2 = Int()
+        self.key1 = String()
+        self.key2 = Int()
         super.init()
     }
 
@@ -36,8 +36,8 @@
 
     public func toDictionary() -> NSDictionary {
         var dict = [
-            "key1": key1,
-            "key2": key2,
+            "key1": self.key1,
+            "key2": self.key2,
         ] as [AnyHashable: Any]
 
         return dict as NSDictionary
@@ -59,8 +59,8 @@ public class TestMultiArgsData: ElectrodeObject, Bridgeable {
     }
 
     public override init() {
-        key1 = String()
-        key2 = Int()
+        self.key1 = String()
+        self.key2 = Int()
         super.init()
     }
 
@@ -73,8 +73,8 @@ public class TestMultiArgsData: ElectrodeObject, Bridgeable {
             self.key2 = key2
         } else {
             assertionFailure("\(TestMultiArgsData.tag) missing one or more required properties[key1,key2]")
-            key1 = dictionary["key1"] as! String
-            key2 = dictionary["key2"] as! Int
+            self.key1 = dictionary["key1"] as! String
+            self.key2 = dictionary["key2"] as! Int
         }
 
 
@@ -83,8 +83,8 @@ public class TestMultiArgsData: ElectrodeObject, Bridgeable {
 
     public func toDictionary() -> NSDictionary {
         var dict = [
-            "key1": key1,
-            "key2": key2,
+            "key1": self.key1,
+            "key2": self.key2,
         ] as [AnyHashable: Any]
 
         return dict as NSDictionary

--- a/system-tests/fixtures/api/test-api/IOS/Item.swift
+++ b/system-tests/fixtures/api/test-api/IOS/Item.swift
@@ -14,9 +14,9 @@
     }
 
     public override init() {
-        id = Int64()
-        name = String()
-        desc = nil
+        self.id = Int64()
+        self.name = String()
+        self.desc = nil
         super.init()
     }
 
@@ -25,19 +25,19 @@
             self.id = id
         } else {
             assertionFailure("\(Item.tag) missing one or more required properties [id]")
-            id = dictionary["id"] as! Int64
+            self.id = dictionary["id"] as! Int64
         }
         if let name = dictionary["name"] as? String {
             self.name = name
         } else {
             assertionFailure("\(Item.tag) missing one or more required properties [name]")
-            name = dictionary["name"] as! String
+            self.name = dictionary["name"] as! String
         }
 
         if let desc = dictionary["desc"] as? String {
-            desc = desc
+            self.desc = desc
         } else {
-            desc = nil
+            self.desc = nil
         }
 
         super.init(dictionary: dictionary)
@@ -46,10 +46,10 @@
     public func toDictionary() -> NSDictionary {
         var dict = [:] as [AnyHashable: Any]
 
-        dict["id"] = id
-        dict["name"] = name
+        dict["id"] = self.id
+        dict["name"] = self.name
 
-        if let nonNullDesc = desc {
+        if let nonNullDesc = self.desc {
             dict["desc"] = nonNullDesc
         }
         return dict as NSDictionary
@@ -73,9 +73,9 @@ public class Item: ElectrodeObject, Bridgeable {
     }
 
     public override init() {
-        id = Int64()
-        name = String()
-        desc = nil
+        self.id = Int64()
+        self.name = String()
+        self.desc = nil
         super.init()
     }
 
@@ -84,19 +84,19 @@ public class Item: ElectrodeObject, Bridgeable {
             self.id = id
         } else {
             assertionFailure("\(Item.tag) missing one or more required properties [id]")
-            id = dictionary["id"] as! Int64
+            self.id = dictionary["id"] as! Int64
         }
         if let name = dictionary["name"] as? String {
             self.name = name
         } else {
             assertionFailure("\(Item.tag) missing one or more required properties [name]")
-            name = dictionary["name"] as! String
+            self.name = dictionary["name"] as! String
         }
 
         if let desc = dictionary["desc"] as? String {
-            desc = desc
+            self.desc = desc
         } else {
-            desc = nil
+            self.desc = nil
         }
 
         super.init(dictionary: dictionary)
@@ -105,10 +105,10 @@ public class Item: ElectrodeObject, Bridgeable {
     public func toDictionary() -> NSDictionary {
         var dict = [:] as [AnyHashable: Any]
 
-        dict["id"] = id
-        dict["name"] = name
+        dict["id"] = self.id
+        dict["name"] = self.name
 
-        if let nonNullDesc = desc {
+        if let nonNullDesc = self.desc {
             dict["desc"] = nonNullDesc
         }
         return dict as NSDictionary


### PR DESCRIPTION
SwiftLint and/or SwiftFormat accidentally removed `self.` from api swift templates, which was merged in #1420

This re-adds them.