### PR TITLE
Add build step and more platforms to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,16 +2,29 @@ name: ci
 on: [push, pull_request]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [10, 12, 14]
+        node: [12]
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        include:
+          - node: 10
+            os: ubuntu-latest
+          - node: 14
+            os: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ matrix.node }}
+      - run: yarn
+      - run: yarn build
+      - run: yarn test:unit
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
       - run: yarn
       - run: yarn check:lint
-      - run: yarn test:unit


### PR DESCRIPTION
Extend GitHub Actions CI matrix with additional platforms, and also run `yarn build`.

Instead of just `ubuntu-latest`, with this we're now also running build+unit tests on `macos-latest` and `windows-latest`. Node.js matrix [10, 12, 14] we'll keep on Linux only for now, macOS and Windows are using Node.js 12.

`yarn check:lint` only runs on Linux/Node.js 12.

The new config will yield 5 different jobs, all running in parallel.