### PR TITLE
Update Mustache and add support for partials

### DIFF
--- a/ern-api-gen/package.json
+++ b/ern-api-gen/package.json
@@ -44,7 +44,7 @@
     "lodash": "^4.17.14",
     "minimatch": "^3.0.4",
     "mkdirp": "^0.5.1",
-    "mustache": "^2.3.1",
+    "mustache": "^4.0.1",
     "semver": "^5.5.0",
     "shelljs": "^0.8.2",
     "swagger-methods": "^1.0.4",

--- a/ern-api-gen/src/java/MustacheWriter.ts
+++ b/ern-api-gen/src/java/MustacheWriter.ts
@@ -2,6 +2,7 @@ import Mustache from 'mustache'
 import { isIterable } from './isIterable'
 
 export class MustacheWriter extends Mustache.Writer {
+  // @ts-ignore
   public renderSection(token, context, partials, originalTemplate) {
     let buffer = ''
     let value = context.lookup(token[1])

--- a/ern-api-impl-gen/package.json
+++ b/ern-api-impl-gen/package.json
@@ -44,7 +44,7 @@
     "ern-core": "1000.0.0",
     "fs-extra": "^8.1.0",
     "lodash": "^4.17.14",
-    "mustache": "^2.3.1",
+    "mustache": "^4.0.1",
     "semver": "5.5.0",
     "xcode": "^1.0.0",
     "xcode-ern": "^1.0.12"

--- a/ern-api-impl-gen/src/generators/android/ApiImplAndroidGenerator.ts
+++ b/ern-api-impl-gen/src/generators/android/ApiImplAndroidGenerator.ts
@@ -222,15 +222,6 @@ export default class ApiImplAndroidGenerator implements ApiImplGeneratable {
           api.apiName
         )
         for (const file of files) {
-          if (!classNames[file]) {
-            log.warn(
-              `Skipping mustaching of ${file}. No resulting file mapping found, consider adding one. \nThis might cause issues in generated implementation project.`
-            )
-            throw new Error(
-              `Class name mapping is missing for ${file}, unable to generate implementation class file.`
-            )
-          }
-
           if (file === 'requestHandlerProvider.mustache') {
             editableFiles.push(path.join(outputDir, classNames[file]))
             if (this.regenerateApiImpl) {
@@ -238,11 +229,22 @@ export default class ApiImplAndroidGenerator implements ApiImplGeneratable {
               continue
             }
           }
-          await mustacheUtils.mustacheRenderToOutputFileUsingTemplateFile(
-            path.join(resourceDir, file),
-            api,
-            path.join(outputDir, classNames[file])
-          )
+          if (classNames[file]) {
+            const partialProxy = (name: string) => {
+              return fs.readFileSync(
+                path.join(resourceDir, `${name}.mustache`),
+                'utf8'
+              )
+            }
+            await mustacheUtils.mustacheRenderToOutputFileUsingTemplateFile(
+              path.join(resourceDir, file),
+              api,
+              path.join(outputDir, classNames[file]),
+              partialProxy
+            )
+          } else {
+            log.info(`No mapping for for ${file}. Mustaching skipped.`)
+          }
         }
         log.debug(
           `Api implementation files successfully generated for ${api.apiName}Api`

--- a/ern-composite-gen/package.json
+++ b/ern-composite-gen/package.json
@@ -36,11 +36,11 @@
   "homepage": "http://www.electrode.io",
   "dependencies": {
     "cli-table": "^0.3.1",
-    "js-beautify": "^1.11.0",
     "ern-core": "1000.0.0",
     "fs-extra": "^8.1.0",
     "fs-readdir-recursive": "^1.1.0",
-    "mustache": "^2.3.1",
+    "js-beautify": "^1.11.0",
+    "mustache": "^4.0.1",
     "semver": "^5.5.0",
     "uuid": "^3.3.2"
   },

--- a/ern-container-gen/package.json
+++ b/ern-container-gen/package.json
@@ -42,7 +42,7 @@
     "ern-core": "1000.0.0",
     "fs-extra": "^8.1.0",
     "fs-readdir-recursive": "^1.1.0",
-    "mustache": "^2.3.1",
+    "mustache": "^4.0.1",
     "semver": "^5.5.0",
     "xcode-ern": "^1.0.12"
   },

--- a/ern-core/package.json
+++ b/ern-core/package.json
@@ -56,7 +56,7 @@
     "inquirer": "^3.0.6",
     "kax": "^2.0.3",
     "lodash": "^4.17.14",
-    "mustache": "^2.3.1",
+    "mustache": "^4.0.1",
     "node-fetch": "^2.2.0",
     "node-ipc": "^9.1.1",
     "node-simctl": "^5.1.1",

--- a/ern-core/src/mustacheUtils.ts
+++ b/ern-core/src/mustacheUtils.ts
@@ -11,11 +11,12 @@ import fs from 'fs-extra'
 // returns: Rendered string output
 export async function mustacheRenderUsingTemplateFile(
   filename: string,
-  view: any
+  view: any,
+  partials?: any
 ) {
   return fs
     .readFile(filename, 'utf8')
-    .then(template => Mustache.render(template, view))
+    .then(template => Mustache.render(template, view, partials))
 }
 
 // Mustache render to an output file using a template file
@@ -25,9 +26,10 @@ export async function mustacheRenderUsingTemplateFile(
 export async function mustacheRenderToOutputFileUsingTemplateFile(
   templateFilename: string,
   view: any,
-  outputFile: string
+  outputFile: string,
+  partials?: any
 ) {
-  return mustacheRenderUsingTemplateFile(templateFilename, view).then(
+  return mustacheRenderUsingTemplateFile(templateFilename, view, partials).then(
     output => {
       return fs.writeFile(outputFile, output)
     }

--- a/ern-runner-gen-android/package.json
+++ b/ern-runner-gen-android/package.json
@@ -40,7 +40,7 @@
     "ern-core": "1000.0.0",
     "ern-runner-gen": "1000.0.0",
     "fs-readdir-recursive": "^1.1.0",
-    "mustache": "^2.3.1"
+    "mustache": "^4.0.1"
   },
   "devDependencies": {
     "copyfiles": "^2.0.0",

--- a/ern-runner-gen-ios/package.json
+++ b/ern-runner-gen-ios/package.json
@@ -41,7 +41,7 @@
     "ern-runner-gen": "1000.0.0",
     "fs-extra": "^8.1.0",
     "fs-readdir-recursive": "^1.1.0",
-    "mustache": "^2.3.1"
+    "mustache": "^4.0.1"
   },
   "devDependencies": {
     "copyfiles": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/jsonpath": "^0.2.0",
     "@types/lodash": "^4.14.150",
     "@types/mocha": "^5.2.7",
-    "@types/mustache": "^0.8.32",
+    "@types/mustache": "^4.0.1",
     "@types/node-fetch": "^2.5.7",
     "@types/semver": "^6.2.1",
     "@types/shelljs": "^0.8.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1379,10 +1379,10 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.7.tgz#315d570ccb56c53452ff8638738df60726d5b6ea"
   integrity sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
 
-"@types/mustache@^0.8.32":
-  version "0.8.32"
-  resolved "https://registry.yarnpkg.com/@types/mustache/-/mustache-0.8.32.tgz#7db3b81f2bf450bd38805f596d20eca97c4ed595"
-  integrity sha512-RTVWV485OOf4+nO2+feurk0chzHkSjkjALiejpHltyuMf/13fGymbbNNFrSKdSSUg1TIwzszXdWsVirxgqYiFA==
+"@types/mustache@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/mustache/-/mustache-4.0.1.tgz#e4d421ed2d06d463b120621774185a5cd1b92d77"
+  integrity sha512-wH6Tu9mbiOt0n5EvdoWy0VGQaJMHfLIxY/6wS0xLC7CV1taM6gESEzcYy0ZlWvxxiiljYvfDIvz4hHbUUDRlhw==
 
 "@types/node-fetch@^2.5.7":
   version "2.5.7"
@@ -5655,10 +5655,10 @@ multimatch@^4.0.0:
     arrify "^2.0.1"
     minimatch "^3.0.4"
 
-mustache@^2.3.1:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/mustache/-/mustache-2.3.2.tgz#a6d4d9c3f91d13359ab889a812954f9230a3d0c5"
-  integrity sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==
+mustache@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.0.1.tgz#d99beb031701ad433338e7ea65e0489416c854a2"
+  integrity sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA==
 
 mute-stream@0.0.7:
   version "0.0.7"


### PR DESCRIPTION
### Commit 1: `Update mustache to 4.0.1`

Despite being a "major" version upgrade, [the changelog](https://github.com/janl/mustache.js/blob/master/CHANGELOG.md) mainly lists internal improvements. There aren't any breaking api changes, at least the ones we're using. They also mention

> Majority of using projects don't have to worry by this being a new major version.

Overall, I felt a slight (maybe subjective) performance improvements locally. There are no changes to any of the generated fixtures (as expected).

The second one is the more interesting:

### Commit 2: `Add support for mustache partials`

[Partials](https://github.com/janl/mustache.js/#partials) are now supported in the two exported methods of `mustacheUtils`.

This also lifts some unnecessary restrictions that were previously enforced in `ern-api-impl-gen`: It was processing the resource directory under the assumption that _all_ `*.mustache` files have to have a mapping to a file in the output directory. That is obviously not applicable for partials. I removed throwing an Error, and instead only render the mustache file into the output directory if there is a mapping. Changed the `warn` log to `info` if there is no mapping.

We will need this new capability for the hull improvements in #1600