### PR TITLE
Fix bugsnag upload issue

### DIFF
--- a/ern-orchestrator/src/codepush.ts
+++ b/ern-orchestrator/src/codepush.ts
@@ -564,8 +564,8 @@ export async function performCodePushOtaUpdate(
             minifiedUrl,
             projectRoot,
             sourceMap,
-            uploadNodeModules: true,
-            uploadSources: !!bundlingResult.isHermesBundle,
+            uploadNodeModules: false,
+            uploadSources: false,
           })
         } catch (e) {
           log.error(`Bugsnag upload failed : ${e}`)

--- a/ern-orchestrator/src/syncCauldronContainer.ts
+++ b/ern-orchestrator/src/syncCauldronContainer.ts
@@ -187,8 +187,8 @@ Please set the new container version through command options.`)
           minifiedUrl,
           projectRoot,
           sourceMap,
-          uploadNodeModules: true,
-          uploadSources: !!containerGenRes.bundlingResult.isHermesBundle,
+          uploadNodeModules: false,
+          uploadSources: false,
         })
       } catch (e) {
         log.error(`Bugsnag upload failed : ${e}`)


### PR DESCRIPTION
Do not upload sources for Android Hermes bundles.

Recently this started causing huge payload sizes, ultimately failing to be uploaded to BugSnag with and HTTP 500 error.

Looking at the source map, I can see that it references a bunch of files that are not sources (images, json ...). Given that all sources files referenced by the source map are uploaded, this is what probably causes the huge resulting payload size. Not sure why the generated source map references such non source files (sure they are imported in the code, but should not be accounted for in the source map), maybe it's some kind of issue with react native source map generation for Hermes bundles, or just some configuration issue.

This is a hotfix directly targeting 0.41. branch, to be released in 0.41.5. Not targeting master and cherry-picking for this one, because we recently changed on master the bugsnag library (from our fork to official one). 

Will create an issue with a milestone set to 0.42.0 to make sure that we don't forget about it, investigate further and make the necessary changes on master as well if needed.