### PR TITLE
Exclude yarn.lock from container fixtures check

### DIFF
--- a/system-tests/src/tests/create-container-android-fixture.js
+++ b/system-tests/src/tests/create-container-android-fixture.js
@@ -12,6 +12,7 @@ const excludeFilter = [
   'index.android.bundle',
   'index.android.bundle.meta',
   'jniLibs/**',
+  'yarn.lock',
 ]
   .map(s => `**/${s}`)
   .join(',')

--- a/system-tests/src/tests/create-container-ios-fixture.js
+++ b/system-tests/src/tests/create-container-ios-fixture.js
@@ -14,6 +14,7 @@ const excludeFilter = [
   'node_modules/**',
   'Pods/**',
   'Podfile.lock',
+  'yarn.lock',
 ]
   .map(s => `**/${s}`)
   .join(',')


### PR DESCRIPTION
Tiny PR, just adding `yarn.lock` to the exclude list of the container fixture tests. 4 of the 6 fixture tests already had the file in the ignore list. Without this, it could lead to local test failures.