### PR TITLE
Do not try to regen iOS fixtures on non-darwin

### DIFF
--- a/system-tests/src/regen-fixtures.js
+++ b/system-tests/src/regen-fixtures.js
@@ -64,6 +64,10 @@ function regenAndroidContainerFixture() {
 }
 
 function regenIosContainerFixture() {
+  if (process.platform !== 'darwin') {
+    console.log("The iOS Container Fixture can only be regenerated on macOS")
+    return;
+  }
   logHeader('Regenerating iOS Container Fixture')
   shell.rm('-rf', pathsToFixtures['ios-container'])
   shell.exec(


### PR DESCRIPTION
Trying to regenerate all fixtures (including the iOS container fixture) on Linux or Windows results in the whole directory being deleted. iOS container generation is only supported on macOS, so this avoids running the command on non-macOS.