### PR TITLE
Improve initial installation process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ If you want to contribute code to the Electrode Native platform, you'll first ne
 1. If you have not already installed the platform, install by running the following command:
 
     ```bash
-    npm install -g electrode-native && ern
+    npm install -g electrode-native
     ```
 
 1. Fork and clone the `electrode-native` repository.

--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@
 
 ### Prerequisites
 
-- Node.js >= 8.3
-- NPM >= 3.0
+- Node.js >= 10
+- npm >= 5.6.0
 - Android Studio (for Android apps)
 - Xcode >= 10 (for iOS apps)
-- CocoaPods (for iOS apps using a version of React Native >= 0.60)
+- CocoaPods (if using a version of React Native >= 0.60)
 
 ### Install
 
-```console
-$ npm install -g electrode-native && ern
+```sh
+npm install -g electrode-native
 ```
 
 ## Documentation

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,8 +9,8 @@
 
 - Install the platform by running the following command in a terminal :
 
-```bash
-$ npm install -g electrode-native && ern
+```sh
+npm install -g electrode-native
 ```
 
 ## Getting Started

--- a/setup-dev.js
+++ b/setup-dev.js
@@ -5,32 +5,42 @@
 const childProcess = require('child_process')
 const execSync = childProcess.execSync
 
-console.log('Performing Electrode Native development setup. Please wait.')
-execSync(`yarn install`)
+console.log('Performing Electrode Native development setup. Please wait...')
+execSync(`yarn`)
 
 const chalk = require('chalk')
 const shell = require('shelljs')
 const os = require('os')
 const path = require('path')
+const fs = require('fs')
 
-// Path to ern platform root directory
-const ERN_PATH = process.env.ERN_HOME || path.join(os.homedir(), '.ern')
-// Path to ern platform cache directory (containing all installed cached versions of the platform)
-const ERN_VERSIONS_CACHE_PATH = path.join(ERN_PATH, 'versions')
-// Path from where this script is run (wherever the user cloned the repo locally)
-const WORKING_DIR = process.cwd()
-// Create the cache directory for this version as a symlink to current working directory
-shell.cd(ERN_VERSIONS_CACHE_PATH)
-shell.ln('-sf', WORKING_DIR, '1000.0.0')
+// Ensure directory structure exists and create symlink
+const ERN_HOME = process.env.ERN_HOME || path.join(os.homedir(), '.ern')
+shell.mkdir('-p', path.join(ERN_HOME, 'versions'))
+shell.ln('-sf', process.cwd(), path.join(ERN_HOME, 'versions', '1000.0.0'))
+
+// Create initial .ernrc if necessary
+const ERN_RC = path.join(ERN_HOME, '.ernrc')
+if (!fs.existsSync(ERN_RC)) {
+  const ernRc = {
+    platformVersion: '1000.0.0',
+  }
+  fs.writeFileSync(ERN_RC, JSON.stringify(ernRc, null, 2).concat('\n'))
+}
 
 console.log(
   chalk.green(`
-=================================================================
-Development environment is now setup !
-Version v1000.0.0 has been created and points to your working directory.
-You can switch to this version by running :
+==============================================================================
+Development environment setup complete!
+Version ${chalk.bold(`1000.0.0`)} has been symlinked to the current directory.
+
+You can switch to the latest release version by running:
+${chalk.yellow(`ern platform use latest`)}
+
+Switch to the development version:
 ${chalk.yellow(`ern platform use 1000.0.0`)}
+
 Enjoï.
-=================================================================
+==============================================================================
 `)
 )


### PR DESCRIPTION
This simplifies the initial installation process with two small but significant improvements:

### Support for `ERN_INITIAL_VERSION` 

Now it is possible to override the initial version of ERN (i.e. `ern-local-cli`) that is downloaded on a new system (no previous `.ern` folder) using the environment variable `ERN_INITIAL_VERSION`. This is especially useful on CI systems and/or in combination with specifying a custom `ERN_HOME`.

### Remove the requirement to run `ern` once

Previously, we had the rather unusual requirement to run `ern` (without arguments) at least once after globally installing `electrode-native`:

```
npm install -g electrode-native && ern
```

This is no longer necessary. Any arguments passed to the first invocation of `ern` are now automatically passed to `ern-local-cli` _after_ the initial install. This reduces first time use friction and standardizes usage/installation with many other Node.js command line tools.

Also simplified and enhanced the `setup-dev.js` script. It now automatically creates initial directories/.ernrc if necessary, as well as activates `1000.0.0` (unless a different version has already been set).