### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,2 @@
-system-tests/fixtures/* linguist-vendored=true
-ern-api-gen/test/fixtures/* linguist-vendored=true
-ern-runner-gen-android/test/fixtures/* linguist-vendored=true
-ern-runner-gen-ios/test/fixtures/* linguist-vendored=true
+**/fixtures/* linguist-vendored
+ern-api-gen/resources/* linguist-vendored


### PR DESCRIPTION
Update `.gitattributes` file to exclude [ern-api-gen/resources](https://github.com/electrode-io/electrode-native/tree/master/ern-api-gen/resources) directory from GitHub repository language statistics. This directory mostly contains mustache templates showing up as HTML in our repo language statistic.

<img width="985" alt="Screen Shot 2020-05-27 at 10 52 07 AM" src="https://user-images.githubusercontent.com/1390588/83055088-3b1a8e00-a008-11ea-9531-f6a540aabe2c.png">
