### PR TITLE
Update shelljs to 0.8.4

### DIFF
--- a/ern-api-gen/package.json
+++ b/ern-api-gen/package.json
@@ -46,7 +46,7 @@
     "mkdirp": "^0.5.1",
     "mustache": "^4.0.1",
     "semver": "^5.5.0",
-    "shelljs": "^0.8.2",
+    "shelljs": "^0.8.4",
     "swagger-methods": "^1.0.4",
     "sway": "^1.0.0"
   },

--- a/ern-core/package.json
+++ b/ern-core/package.json
@@ -62,7 +62,7 @@
     "node-simctl": "^5.1.1",
     "react-native-cli": "^2.0.1",
     "semver": "^5.5.0",
-    "shelljs": "^0.8.2",
+    "shelljs": "^0.8.4",
     "simple-git": "^1.106.0",
     "tmp": "^0.0.33",
     "treeify": "^1.1.0",

--- a/ern-util-dev/package.json
+++ b/ern-util-dev/package.json
@@ -43,7 +43,7 @@
     "dir-compare": "^1.4.0",
     "fs-readdir-recursive": "^1.1.0",
     "istanbul": "^0.4.5",
-    "shelljs": "^0.8.2",
+    "shelljs": "^0.8.4",
     "tmp": "^0.0.33"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@types/node": "^11.15.12",
     "chalk": "^2.4.2",
-    "shelljs": "^0.8.3"
+    "shelljs": "^0.8.4"
   },
   "devDependencies": {
     "@types/archiver": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7308,10 +7308,10 @@ shell-quote@^1.4.3:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
 
-shelljs@^0.8.2, shelljs@^0.8.3:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
-  integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
+shelljs@^0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
+  integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"


### PR DESCRIPTION
0.8.4 includes https://github.com/shelljs/shelljs/commit/05374a749992969bb6b853095f4c9308df69aa82 which fixes a bunch of warnings we keep getting when using Node.js 14:

```
(node:54809) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
(Use `node --trace-warnings ...` to show where the warning was created)
(node:54809) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
(node:54809) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
```

There are not other changes compared to 0.8.3

More details:
https://github.com/shelljs/shelljs/issues/991

Fixes #1558 