### PR TITLE
Use files array in global-cli package.json

### DIFF
--- a/global-cli/package.json
+++ b/global-cli/package.json
@@ -2,7 +2,11 @@
   "name": "electrode-native",
   "version": "1.1.0",
   "description": "Electrode Native Global CLI",
-  "main": "./src/index.js",
+  "main": "src/index.js",
+  "files": [
+    "bin/",
+    "src/"
+  ],
   "bin": {
     "ern": "bin/ern.js"
   },


### PR DESCRIPTION
A couple of small updates in preparation for `global-cli@1.1.0`:

- Update `main` value (should _not_ start with `./`, otherwise the default npm packing method won't automatically include the file)
- Add `files` array to explicitly declare items to be published (this guards against the possibility of accidentally publishing untracked files in the directory)