### PR TITLE
Update runner-gen tests

### DIFF
--- a/ern-runner-gen-android/test/AndroidRunnerGenerator-test.ts
+++ b/ern-runner-gen-android/test/AndroidRunnerGenerator-test.ts
@@ -1,73 +1,46 @@
 import path from 'path'
-import shell from 'shelljs'
+import tmp from 'tmp'
 import { assert } from 'chai'
 import { sameDirContent } from 'ern-util-dev'
-import { getRunnerGeneratorForPlatform } from 'ern-orchestrator'
+import { AndroidRunnerGenerator } from 'ern-runner-gen-android'
+import { RunnerGeneratorConfig } from 'ern-runner-gen'
 
 describe('AndroidRunnerGenerator', () => {
-  const simpleAndroidRunnerTestGeneratedPath = path.join(
-    __dirname,
-    'generated',
-    'simple-android-runner'
-  )
-  const simpleAndroidRunnerFixturePath = path.join(
+  const fixtureRunnerPath = path.join(
     __dirname,
     'fixtures',
     'simple-android-runner'
   )
+  const generatedRunnerPath = tmp.dirSync({ unsafeCleanup: true }).name
+  process.chdir(generatedRunnerPath)
 
-  before(() => {
-    // Recreate the directory where tests will generate the runner
-    shell.rm('-rf', simpleAndroidRunnerTestGeneratedPath)
-    shell.mkdir('-p', simpleAndroidRunnerTestGeneratedPath)
-  })
-
-  it('should generate simple-android-runner fixture given same configuration ', async () => {
-    await getRunnerGeneratorForPlatform('android').generate({
-      extra: {
-        androidConfig: {
-          artifactId: 'runner-ern-container-dummy',
-          groupId: 'com.walmartlabs.ern',
-          packageFilePath: 'com/walmartlabs/ern/dummy',
-          packageName: 'com.walmartlabs.ern.dummy',
-        },
+  const generatorConfig: RunnerGeneratorConfig = {
+    extra: {
+      androidConfig: {
+        artifactId: 'runner-ern-container-dummy',
+        groupId: 'com.walmartlabs.ern',
+        packageFilePath: 'com/walmartlabs/ern/dummy',
+        packageName: 'com.walmartlabs.ern.dummy',
       },
-      mainMiniAppName: 'dummy',
-      outDir: simpleAndroidRunnerTestGeneratedPath,
-      reactNativeVersion: '0.59.8',
-      targetPlatform: 'android',
-    })
+    },
+    mainMiniAppName: 'dummy',
+    outDir: generatedRunnerPath,
+    reactNativeVersion: '0.59.8',
+    targetPlatform: 'android',
+  }
+
+  it('should generate simple-android-runner fixture given same configuration', async () => {
+    await new AndroidRunnerGenerator().generate(generatorConfig)
     assert(
-      sameDirContent(
-        simpleAndroidRunnerFixturePath,
-        simpleAndroidRunnerTestGeneratedPath,
-        []
-      ),
+      sameDirContent(fixtureRunnerPath, generatedRunnerPath),
       'Generated Android Runner project differs from simple-android-runner fixture'
     )
   })
 
-  it('should re-generate configuration of simple-android-runner fixture given same configuration ', async () => {
-    await getRunnerGeneratorForPlatform('android').regenerateRunnerConfig({
-      extra: {
-        androidConfig: {
-          artifactId: 'runner-ern-container-dummy',
-          groupId: 'com.walmartlabs.ern',
-          packageFilePath: 'com/walmartlabs/ern/dummy',
-          packageName: 'com.walmartlabs.ern.dummy',
-        },
-      },
-      mainMiniAppName: 'dummy',
-      outDir: simpleAndroidRunnerTestGeneratedPath,
-      reactNativeVersion: '0.59.8',
-      targetPlatform: 'android',
-    })
+  it('should re-generate configuration of simple-android-runner fixture given same configuration', async () => {
+    await new AndroidRunnerGenerator().regenerateRunnerConfig(generatorConfig)
     assert(
-      sameDirContent(
-        simpleAndroidRunnerFixturePath,
-        simpleAndroidRunnerTestGeneratedPath,
-        []
-      ),
+      sameDirContent(fixtureRunnerPath, generatedRunnerPath),
       'Generated Android Runner project differs from simple-android-runner fixture'
     )
   })

--- a/ern-runner-gen-android/test/regen-fixtures.ts
+++ b/ern-runner-gen-android/test/regen-fixtures.ts
@@ -1,28 +1,20 @@
 import shell from 'shelljs'
 import chalk from 'chalk'
 import path from 'path'
-import { getRunnerGeneratorForPlatform } from 'ern-orchestrator'
+import { AndroidRunnerGenerator } from 'ern-runner-gen-android'
 
-const pathToTestFixtures = path.join(__dirname, 'fixtures')
-const pathToGeneratedFixtures = path.join(
-  __dirname,
-  'generated/simple-android-runner'
-)
-logHeader('Regenerating Android Runner Fixture')
-getRunnerGeneratorForPlatform('android')
-  .regenerateRunnerConfig({
+async function regenAndroidRunnerFixture() {
+  console.log('Regenerating Android Runner Fixture...')
+  const fixturesPath = path.join(__dirname, 'fixtures', 'simple-android-runner')
+  shell.rm('-rf', fixturesPath)
+  shell.mkdir('-p', fixturesPath)
+  await new AndroidRunnerGenerator().generate({
     mainMiniAppName: 'dummy',
-    outDir: pathToGeneratedFixtures,
-    reactNativeVersion: '0.60.5',
+    outDir: fixturesPath,
+    reactNativeVersion: '0.62.2',
     targetPlatform: 'android',
   })
-  .then(() => {
-    shell.cp('-Rf', pathToGeneratedFixtures, pathToTestFixtures)
-    console.log(chalk.green('Done!'))
-  })
-
-function logHeader(message) {
-  console.log('======================================================')
-  console.log(message)
-  console.log('======================================================')
+  console.log(chalk.green('Done!'))
 }
+
+regenAndroidRunnerFixture().catch(e => console.error(e))

--- a/ern-runner-gen-ios/test/IosRunnerGenerator-test.ts
+++ b/ern-runner-gen-ios/test/IosRunnerGenerator-test.ts
@@ -1,66 +1,49 @@
 import path from 'path'
-import shell from 'shelljs'
 import { assert } from 'chai'
 import { sameDirContent } from 'ern-util-dev'
 import os from 'os'
-import { getRunnerGeneratorForPlatform } from 'ern-orchestrator'
+import { RunnerGeneratorConfig } from 'ern-runner-gen'
+import { IosRunnerGenerator } from 'ern-runner-gen-ios'
+import tmp from 'tmp'
 
 describe('IosRunnerGenerator', () => {
-  const simpleIosRunnerTestGeneratedPath = path.join(
+  const fixtureRunnerPath = path.join(
     __dirname,
-    'generated/simple-ios-runner'
+    'fixtures',
+    'simple-ios-runner'
   )
-  const simpleIosRunnerFixturePath = path.join(
-    __dirname,
-    'fixtures/simple-ios-runner'
-  )
+  const generatedRunnerPath = tmp.dirSync({ unsafeCleanup: true }).name
+  process.chdir(generatedRunnerPath)
+
+  const runnerConfig: RunnerGeneratorConfig = {
+    extra: {
+      containerGenWorkingDir: '/path/to/container',
+    },
+    mainMiniAppName: 'dummy',
+    outDir: generatedRunnerPath,
+    reactNativeVersion: '0.59.8',
+    targetPlatform: 'ios',
+  }
 
   before(function() {
-    if (os.platform() === 'win32') {
+    if (os.platform() !== 'darwin') {
       this.skip()
       return
     }
-    // Recreate the directory where tests will generate the runner
-    shell.rm('-rf', simpleIosRunnerTestGeneratedPath)
-    shell.mkdir('-p', simpleIosRunnerTestGeneratedPath)
   })
 
   it('should generate simple-ios-runner fixture given same configuration ', async () => {
-    await getRunnerGeneratorForPlatform('ios').generate({
-      extra: {
-        containerGenWorkingDir: '/path/to/container',
-      },
-      mainMiniAppName: 'dummy',
-      outDir: simpleIosRunnerTestGeneratedPath,
-      reactNativeVersion: '0.59.8',
-      targetPlatform: 'ios',
-    })
+    await new IosRunnerGenerator().generate(runnerConfig)
     assert(
-      sameDirContent(
-        simpleIosRunnerFixturePath,
-        simpleIosRunnerTestGeneratedPath,
-        []
-      ),
+      sameDirContent(fixtureRunnerPath, generatedRunnerPath),
       'Generated iOS Runner project differs from simple-ios-runner fixture'
     )
   })
 
   it('should re-generate configuration of simple-ios-runner fixture given same configuration ', async () => {
-    await getRunnerGeneratorForPlatform('ios').regenerateRunnerConfig({
-      extra: {
-        containerGenWorkingDir: '/path/to/container',
-      },
-      mainMiniAppName: 'dummy',
-      outDir: simpleIosRunnerTestGeneratedPath,
-      reactNativeVersion: '0.59.8',
-      targetPlatform: 'ios',
-    })
+    await new IosRunnerGenerator().regenerateRunnerConfig(runnerConfig)
     assert(
-      sameDirContent(
-        simpleIosRunnerFixturePath,
-        simpleIosRunnerTestGeneratedPath,
-        []
-      ),
+      sameDirContent(fixtureRunnerPath, generatedRunnerPath),
       'Generated iOS Runner project differs from simple-ios-runner fixture'
     )
   })

--- a/ern-runner-gen-ios/test/regen-fixtures.ts
+++ b/ern-runner-gen-ios/test/regen-fixtures.ts
@@ -1,31 +1,23 @@
 import shell from 'shelljs'
 import chalk from 'chalk'
 import path from 'path'
-import { getRunnerGeneratorForPlatform } from 'ern-orchestrator'
+import { IosRunnerGenerator } from 'ern-runner-gen-ios'
 
-const pathToTestFixtures = path.join(__dirname, 'fixtures')
-const pathToGeneratedFixtures = path.join(
-  __dirname,
-  'generated/simple-ios-runner'
-)
-logHeader('Regenerating iOS Runner Fixture')
-getRunnerGeneratorForPlatform('ios')
-  .regenerateRunnerConfig({
+async function regenIosRunnerFixture() {
+  console.log('Regenerating iOS Runner Fixture...')
+  const fixturesPath = path.join(__dirname, 'fixtures', 'simple-ios-runner')
+  shell.rm('-rf', fixturesPath)
+  shell.mkdir('-p', fixturesPath)
+  await new IosRunnerGenerator().generate({
     extra: {
       containerGenWorkingDir: '/path/to/container',
     },
     mainMiniAppName: 'dummy',
-    outDir: pathToGeneratedFixtures,
-    reactNativeVersion: '0.60.5',
+    outDir: fixturesPath,
+    reactNativeVersion: '0.62.2',
     targetPlatform: 'ios',
   })
-  .then(() => {
-    shell.cp('-Rf', pathToGeneratedFixtures, pathToTestFixtures)
-    console.log(chalk.green('Done!'))
-  })
-
-function logHeader(message: string) {
-  console.log('======================================================')
-  console.log(message)
-  console.log('======================================================')
+  console.log(chalk.green('Done!'))
 }
+
+regenIosRunnerFixture().catch(e => console.error(e))


### PR DESCRIPTION
Major simplifications and partial rewrite of both test cases and `regen-fixtures` scripts of `ern-runner-gen-android` and `ern-runner-gen-ios`.

In preparation for the hull updates in the runner projects.