### PR TITLE
Set node engine restriction in global-cli to >=8

### DIFF
--- a/global-cli/package.json
+++ b/global-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrode-native",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Electrode Native Global CLI",
   "main": "src/index.js",
   "files": [

--- a/global-cli/package.json
+++ b/global-cli/package.json
@@ -39,6 +39,6 @@
     "update-notifier": "^4.1.0"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=8"
   }
 }


### PR DESCRIPTION
Lower node engine restriction in `global-cli` from 10 to 8.

Reason: The global CLI is a standalone package (with currently no strict requirement for Node 10+), and it can also be used by people still using an _older_ version of ERN (using `ERN_INITIAL_VERSION` on first install). This improves backwards compatibility on CI.