### PR TITLE
Fix azure system tests

### DIFF
--- a/azure/templates/system-tests.yml
+++ b/azure/templates/system-tests.yml
@@ -8,17 +8,11 @@ steps:
       git config --global user.name "Electrode Native"
     displayName: 'Set git user'
   - script: |
-      npm install -g electrode-native;
+      npm install -g electrode-native
     displayName: 'Install ern global CLI'
-  - script: |
-      ern
-    displayName: 'Install ern local CLI'
   - script: |
       node setup-dev
     displayName: 'Setup dev version of ern'
-  - script: |
-      ern platform use 1000.0.0
-    displayName: 'Use dev version of ern'
   - script: |
       yarn coverage
       yarn coverage:upload


### PR DESCRIPTION
Forgot to take out these steps 🤦 

With 1.1.0 of global-cli it is no longer necessary to explicitly install the local cli. `ern` without arguments will now _always_ return 1 (including the very first time it is called).