### PR TITLE
Fix podspec ios directive

### DIFF
--- a/ern-core/src/iosUtil.ts
+++ b/ern-core/src/iosUtil.ts
@@ -404,7 +404,7 @@ export async function fillProjectHull(
 
         if (podspec) {
           const sourcePodspecPath = path.join(pluginConfig!.path!, podspec)
-          const destPodspecPath = path.join(pathSpec.outputDir, podspec)
+          const destPodspecPath = path.join(pluginSourcePath, podspec)
           shell.cp(sourcePodspecPath, destPodspecPath)
         }
 


### PR DESCRIPTION
Noticed that the iOS plugin configuration `podspec` directive wasn't properly working.

Two problems here:

- The `podspec` file was copied to the wrong directory (container dir instead of plugin directory in composite node modules). Fixed by updating destination directory with proper one.
- When generating the container, `yarn add` of the community cli in container dir was done after the copy of all composite native modules to the `node_modules` directory of container dir. Because we are adding all native modules to container package.json prior to running this `yarn add`, this was reinstalling all modules, including the ones that were patched with podspec directive (so overwriting the changes). The fix here is just to reorder things, and run any `yarn add` in the container prior to copying composite native modules node modules to container directory. This also speeds up container generation a bit as it won't reinstall all the native modules.