### PR TITLE
Fix two bugs in resolveNativeDependenciesVersions

### DIFF
--- a/ern-core/src/resolveNativeDependenciesVersions.ts
+++ b/ern-core/src/resolveNativeDependenciesVersions.ts
@@ -63,7 +63,7 @@ export function resolvePackageVersionsGivenMismatchLevel(
 
   for (const name of Object.keys(pluginsByName)) {
     const entry = pluginsByName[name]
-    const pluginVersions = _.map(entry, 'version')
+    const pluginVersions = _.uniq(_.map(entry, 'version'))
     if (pluginVersions.length > 1) {
       // If there are multiple versions of the dependency
       if (
@@ -114,11 +114,9 @@ export function resolveNativeDependenciesVersions(
     aggregateNativeDependencies.thirdPartyInManifest.push(
       ...nativeDependencies.thirdPartyInManifest
     )
-    if (aggregateNativeDependencies.thirdPartyNotInManifest.length > 0) {
-      aggregateNativeDependencies.thirdPartyNotInManifest.push(
-        ...nativeDependencies.thirdPartyNotInManifest
-      )
-    }
+    aggregateNativeDependencies.thirdPartyNotInManifest.push(
+      ...nativeDependencies.thirdPartyNotInManifest
+    )
   }
 
   return resolveNativeDependenciesVersionsEx(aggregateNativeDependencies)


### PR DESCRIPTION
First bug is that under some circumstances, electrode native would behave incorrectly, leading to an error when generating a composite. The problem was the use of `_.map(entry, 'version')` to map an array of packages to their versions. In case of a package used across multiple miniapps with the same version, the resulting array looked like `['1.0.0', '1.0.0']` for example, going into the conditional block handling multiple different versions of the dependency, instead of going through the conditional where only one version is used. The fix here is just to apply `_.uniq` on the array, to only keep unique versions (so `['1.0.0,  '1.0.0']` collapse to `['1.0.0']` and the right conditional is entered). 

```
 if (pluginVersions.length > 1) {
  // If there are multiple versions of the dependency
  [...]
} else {
  // Only one version is used across all MiniApps, just use this version
  [...]
}
```

The second bug is just about some code that could never have been run:

```javascript
if (aggregateNativeDependencies.thirdPartyNotInManifest.length > 0) {
  aggregateNativeDependencies.thirdPartyNotInManifest.push( ...nativeDependencies.thirdPartyNotInManifest)
}
```

Looking at the code, the `if` conditional was always returning false. This is probably the remnant of some logic that was valid before but not valid anymore post some refactoring and forgotten about.

