### PR TITLE
Add support for http_proxy env variables

### DIFF
--- a/ern-core/src/createProxyAgent.ts
+++ b/ern-core/src/createProxyAgent.ts
@@ -40,5 +40,9 @@ export function createProxyAgentFromErnConfig(
   const proxyUrl = config.get(configKey)
   if (proxyUrl) {
     return createProxyAgentFromUrl(new url.URL(proxyUrl), { https })
+  } else if (process.env.http_proxy) {
+    return createProxyAgentFromUrl(new url.URL(process.env.http_proxy), { https })
+  } else if (process.env.https_proxy) {
+    return createProxyAgentFromUrl(new url.URL(process.env.https_proxy), { https })
   }
 }


### PR DESCRIPTION
With this small change, the `createProxyAgentFromErnConfig` function now supports the `http_proxy` and `https_proxy` environment variables in addition to the existing support for config keys from the ern config (currently `bundleStoreProxy`, `bugsnagProxy`, or `sourceMapStoreProxy`).

The config keys still take precedence, so if one is set, this PR won't affect the existing behavior.
