### PR TITLE
Allow "cauldron repo add" to overwrite alias

### DIFF
--- a/docs/cli/cauldron/repo/add.md
+++ b/docs/cli/cauldron/repo/add.md
@@ -24,10 +24,14 @@
 
 **Options**
 
-`--current true|false`
+- `--current true|false`
 
-- Set the repository as the active repository after adding it to the collection of repositories.
-- If this option is not provided, you are prompted to choose if you want to set the repository as the active repository.
+  - Set the repository as the active repository after adding it to the collection of repositories.
+  - If this option is not provided, you are prompted to choose if you want to set the repository as the active repository.
+
+- `--force/-f true|false`
+
+  Overwrite an existing alias with the same name
 
 **Example**
 
@@ -40,6 +44,9 @@ Add a new Cauldron repository with alias `my-local-cauldron` and url pointing to
 `ern cauldron repo add my-other-cauldron git@github.com:username/other-cauldron#development --current`  
 Add a new Cauldron repository, with alias `my-other-cauldron`, and url `git@github.com:username/other-cauldron`, to the local collection of Cauldron repositories and set it at the current activated Cauldron. The branch that will be used for this Cauldron will be `development` as it was explicitly specified in the Cauldron url.
 
+`ern cauldron repo add -f my-local-cauldron ~/path/to/local/cauldron`\
+Adds the `my-local-cauldron` alias, and overwrites it if it already exists.
+
 #### Remarks
 
-- If the `alias` already exists, this command will fail.
+- If the `alias` already exists, this command will fail, unless `--force/-f` is used.

--- a/ern-cauldron-api/src/CauldronRepositories.ts
+++ b/ern-cauldron-api/src/CauldronRepositories.ts
@@ -7,11 +7,15 @@ export class CauldronRepositories {
     url: string,
     {
       activate,
+      force,
     }: {
       activate?: boolean
+      force?: boolean
     }
   ): CauldronRepository {
-    this.throwIfAliasExist({ alias })
+    if (!force) {
+      this.throwIfAliasExist({ alias })
+    }
 
     const supportedGitHttpsSchemeRe = /(^https:\/\/.+:.+@.+$)|(^https:\/\/.+@.+$)/
     if (url.startsWith('https')) {

--- a/ern-core/src/createProxyAgent.ts
+++ b/ern-core/src/createProxyAgent.ts
@@ -41,8 +41,12 @@ export function createProxyAgentFromErnConfig(
   if (proxyUrl) {
     return createProxyAgentFromUrl(new url.URL(proxyUrl), { https })
   } else if (process.env.http_proxy) {
-    return createProxyAgentFromUrl(new url.URL(process.env.http_proxy), { https })
+    return createProxyAgentFromUrl(new url.URL(process.env.http_proxy), {
+      https,
+    })
   } else if (process.env.https_proxy) {
-    return createProxyAgentFromUrl(new url.URL(process.env.https_proxy), { https })
+    return createProxyAgentFromUrl(new url.URL(process.env.https_proxy), {
+      https,
+    })
   }
 }

--- a/ern-local-cli/src/commands/cauldron/repo/add.ts
+++ b/ern-local-cli/src/commands/cauldron/repo/add.ts
@@ -13,25 +13,30 @@ export const builder = (argv: Argv) => {
       describe: 'Set repo as the current Cauldron repository',
       type: 'boolean',
     })
+    .option('force', {
+      alias: 'f',
+      describe: 'Overwrite an existing alias with the same name',
+      type: 'boolean',
+    })
     .epilog(epilog(exports))
 }
 
 export const commandHandler = async ({
   alias,
   current,
+  force,
   url,
 }: {
   alias: string
   current: boolean
+  force: boolean
   url: string
 }) => {
-  if (current === undefined) {
-    current = await askUserConfirmation(
-      `Set ${alias} as current Cauldron repository ?`
-    )
-  }
+  const activate =
+    current ??
+    (await askUserConfirmation(`Set ${alias} as current Cauldron repository?`))
 
-  cauldronRepositories.add(alias, url, { activate: current })
+  cauldronRepositories.add(alias, url, { activate, force })
 
   log.info(`Added Cauldron repository ${url} with alias ${alias}`)
 }


### PR DESCRIPTION
This adds a new `--force`/`-f` option to the `ern cauldron repo add` command, allowing the user to overwrite an existing alias with a new value, without the need to remove it first.

### Example

```
// ('test-cauldron' alias already exists)

$ ern cauldron repo add test-cauldron /tmp/cauldron
✖ An error occurred: A Cauldron repository already exists with test-cauldron alias

$ ern cauldron repo add -f test-cauldron /tmp/cauldron
ℹ Added Cauldron repository /tmp/cauldron with alias test-cauldron
```
