### PR TITLE
Regenerate system test fixtures

### DIFF
--- a/system-tests/fixtures/android-container/container-metadata.json
+++ b/system-tests/fixtures/android-container/container-metadata.json
@@ -7,7 +7,7 @@
   ],
   "nativeDeps": [
     "react-native@0.62.2",
-    "react-native-electrode-bridge@1.5.24",
+    "react-native-electrode-bridge@1.5.25",
     "react-native-ernmovie-api@0.0.11",
     "react-native-ernnavigation-api@0.0.5"
   ],

--- a/system-tests/fixtures/api-impl-native/ern-movie-api-impl/ios/ElectrodeApiImpl/ElectrodeReactNativeBridge/ElectrodeBridgeHolder.h
+++ b/system-tests/fixtures/api-impl-native/ern-movie-api-impl/ios/ElectrodeApiImpl/ElectrodeReactNativeBridge/ElectrodeBridgeHolder.h
@@ -32,6 +32,8 @@ NS_ASSUME_NONNULL_BEGIN
  * Handles queuing every method calls until react native is ready.
  */
 
+extern NSString * const ElectrodeBridgeDidStartObservingNotification;
+
 @interface ElectrodeBridgeHolder : NSObject
 
 + (void)sendEvent:(ElectrodeBridgeEvent *)event;

--- a/system-tests/fixtures/api-impl-native/ern-movie-api-impl/ios/ElectrodeApiImpl/ElectrodeReactNativeBridge/ElectrodeBridgeHolder.m
+++ b/system-tests/fixtures/api-impl-native/ern-movie-api-impl/ios/ElectrodeApiImpl/ElectrodeReactNativeBridge/ElectrodeBridgeHolder.m
@@ -21,6 +21,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+NSString * const ElectrodeBridgeDidStartObservingNotification = @"ElectrodeBridgeDidStartObservingNotification";
+
 @interface ElectrodeQueuedEventListener: NSObject
 @property (nonatomic, strong) NSUUID *uuid;
 @property (copy) ElectrodeBridgeEventListener listener;

--- a/system-tests/fixtures/api-impl-native/ern-movie-api-impl/ios/ElectrodeApiImpl/ElectrodeReactNativeBridge/ElectrodeBridgeTransceiver.m
+++ b/system-tests/fixtures/api-impl-native/ern-movie-api-impl/ios/ElectrodeApiImpl/ElectrodeReactNativeBridge/ElectrodeBridgeTransceiver.m
@@ -22,6 +22,7 @@
 #import "ElectrodeEventRegistrar.h"
 #import "ElectrodeRequestRegistrar.h"
 #import "ElectrodeLogger.h"
+#import "ElectrodeBridgeHolder.h"
 
 #if __has_include(<React/RCTLog.h>)
 #import <React/RCTLog.h>
@@ -435,6 +436,10 @@ createTransactionWithRequest:(ElectrodeBridgeRequest *)request
   if (reactNativeTransceiver) {
     reactNativeTransceiver(self);
   }
+}
+
+- (void)startObserving {
+    [[NSNotificationCenter defaultCenter] postNotificationName:ElectrodeBridgeDidStartObservingNotification object:self];
 }
 
 @end

--- a/system-tests/fixtures/api-impl-native/ern-movie-api-impl/ios/ElectrodeApiImpl/ElectrodeReactNativeBridge/ElectrodeLogger.m
+++ b/system-tests/fixtures/api-impl-native/ern-movie-api-impl/ios/ElectrodeApiImpl/ElectrodeReactNativeBridge/ElectrodeLogger.m
@@ -71,12 +71,14 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation ElectrodeLoggerObjc
 
 + (void)loglevel:(ElectrodeLogLevel)level format:(NSString *)format, ... {
+#if DEBUG
   va_list argp;
   va_start(argp, format);
   NSString *message = [[NSString alloc] initWithFormat:format arguments:argp];
   va_end(argp);
 
   [[ElectrodeConsoleLogger sharedInstance] log:level message:message];
+#endif
 }
 
 @end

--- a/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeReactNativeBridge/ElectrodeBridgeHolder.h
+++ b/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeReactNativeBridge/ElectrodeBridgeHolder.h
@@ -32,6 +32,8 @@ NS_ASSUME_NONNULL_BEGIN
  * Handles queuing every method calls until react native is ready.
  */
 
+extern NSString * const ElectrodeBridgeDidStartObservingNotification;
+
 @interface ElectrodeBridgeHolder : NSObject
 
 + (void)sendEvent:(ElectrodeBridgeEvent *)event;

--- a/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeReactNativeBridge/ElectrodeBridgeHolder.m
+++ b/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeReactNativeBridge/ElectrodeBridgeHolder.m
@@ -21,6 +21,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+NSString * const ElectrodeBridgeDidStartObservingNotification = @"ElectrodeBridgeDidStartObservingNotification";
+
 @interface ElectrodeQueuedEventListener: NSObject
 @property (nonatomic, strong) NSUUID *uuid;
 @property (copy) ElectrodeBridgeEventListener listener;

--- a/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeReactNativeBridge/ElectrodeBridgeTransceiver.m
+++ b/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeReactNativeBridge/ElectrodeBridgeTransceiver.m
@@ -22,6 +22,7 @@
 #import "ElectrodeEventRegistrar.h"
 #import "ElectrodeRequestRegistrar.h"
 #import "ElectrodeLogger.h"
+#import "ElectrodeBridgeHolder.h"
 
 #if __has_include(<React/RCTLog.h>)
 #import <React/RCTLog.h>
@@ -435,6 +436,10 @@ createTransactionWithRequest:(ElectrodeBridgeRequest *)request
   if (reactNativeTransceiver) {
     reactNativeTransceiver(self);
   }
+}
+
+- (void)startObserving {
+    [[NSNotificationCenter defaultCenter] postNotificationName:ElectrodeBridgeDidStartObservingNotification object:self];
 }
 
 @end

--- a/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeReactNativeBridge/ElectrodeLogger.m
+++ b/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeReactNativeBridge/ElectrodeLogger.m
@@ -71,12 +71,14 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation ElectrodeLoggerObjc
 
 + (void)loglevel:(ElectrodeLogLevel)level format:(NSString *)format, ... {
+#if DEBUG
   va_list argp;
   va_start(argp, format);
   NSString *message = [[NSString alloc] initWithFormat:format arguments:argp];
   va_end(argp);
 
   [[ElectrodeConsoleLogger sharedInstance] log:level message:message];
+#endif
 }
 
 @end

--- a/system-tests/fixtures/ios-container/container-metadata.json
+++ b/system-tests/fixtures/ios-container/container-metadata.json
@@ -7,7 +7,7 @@
   ],
   "nativeDeps": [
     "react-native@0.62.2",
-    "react-native-electrode-bridge@1.5.24",
+    "react-native-electrode-bridge@1.5.25",
     "react-native-ernmovie-api@0.0.11",
     "react-native-ernnavigation-api@0.0.5"
   ],

--- a/system-tests/fixtures/ios-container/package.json
+++ b/system-tests/fixtures/ios-container/package.json
@@ -1,8 +1,7 @@
 {
   "dependencies": {
-    "@react-native-community/cli-platform-ios": "4.8.0",
     "react-native": "0.62.2",
-    "react-native-electrode-bridge": "1.5.24"
+    "react-native-electrode-bridge": "1.5.25"
   },
   "name": "container"
 }


### PR DESCRIPTION
Following `react-native-electrode-bridge` version update to [v1.5.25](https://github.com/electrode-io/react-native-electrode-bridge/releases/tag/v1.5.25)