### PR TITLE
Fix watch folder path escaping on Windows

### DIFF
--- a/ern-composite-gen/src/createMetroConfig.ts
+++ b/ern-composite-gen/src/createMetroConfig.ts
@@ -24,7 +24,7 @@ module.exports = {
   ${
     watchFolders
       ? `watchFolders: [ 
-        ${watchFolders.map(x => `"${x}"`).join(`,${os.EOL}`)} 
+        ${watchFolders.map(x => `"${x.replace(/\\/g, '\\\\')}"`).join(`,${os.EOL}`)} 
       ],`
       : ''
   }


### PR DESCRIPTION
Path names on Windows that contain backslashes need to be escaped before they are put in `metro.config.js`, otherwise they are interpreted as control characters.

Verified this locally generating a new miniapp and composite on Windows 10.

Fixes #1586