### PR TITLE
Add packagingOptions to android runner build

### DIFF
--- a/ern-runner-gen-android/src/hull/app/build.gradle
+++ b/ern-runner-gen-android/src/hull/app/build.gradle
@@ -57,8 +57,16 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+
+    packagingOptions {
+        pickFirst "lib/armeabi-v7a/libc++_shared.so"
+        pickFirst "lib/arm64-v8a/libc++_shared.so"
+        pickFirst "lib/x86/libc++_shared.so"
+        pickFirst "lib/x86_64/libc++_shared.so"
+    }
+
     // applicationVariants are e.g. debug, release
-   applicationVariants.all { variant ->
+    applicationVariants.all { variant ->
        variant.outputs.each { output ->
            // For each separate APK per architecture, set a unique version code as described here:
            // http://tools.android.com/tech-docs/new-build-system/user-guide/apk-splits

--- a/ern-runner-gen-android/test/fixtures/simple-android-runner/app/build.gradle
+++ b/ern-runner-gen-android/test/fixtures/simple-android-runner/app/build.gradle
@@ -47,8 +47,16 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+
+    packagingOptions {
+        pickFirst "lib/armeabi-v7a/libc++_shared.so"
+        pickFirst "lib/arm64-v8a/libc++_shared.so"
+        pickFirst "lib/x86/libc++_shared.so"
+        pickFirst "lib/x86_64/libc++_shared.so"
+    }
+
     // applicationVariants are e.g. debug, release
-   applicationVariants.all { variant ->
+    applicationVariants.all { variant ->
        variant.outputs.each { output ->
            // For each separate APK per architecture, set a unique version code as described here:
            // http://tools.android.com/tech-docs/new-build-system/user-guide/apk-splits


### PR DESCRIPTION
These `packagingOptions` are part of the default RN 0.62.2 template:

https://github.com/facebook/react-native/blob/v0.62.2/template/android/app/build.gradle#L167

Without them `ern run-android` in a miniapp may fail, forcing repo owners to modify and commit the generated `android` folder to source control.