### PR TITLE
Fix metro config blacklistRe generation on Windows

### DIFF
--- a/ern-composite-gen/src/generateComposite.ts
+++ b/ern-composite-gen/src/generateComposite.ts
@@ -282,7 +282,14 @@ You should resolve the following version mismatches prior to retrying.${os.EOL}`
         .concat(
           ...localMiniAppsPaths.map(p => path.join(p, 'node_modules/react'))
         )
-        .map(l => new RegExp(`${l}\/.*`))
+        .map(
+          l =>
+            new RegExp(
+              os.platform() === 'win32'
+                ? `${l}\\.*`.replace(/\\/g, '\\\\')
+                : `${l}\/.*`
+            )
+        )
     }
 
     await patchCompositeBabelRcRoots({

--- a/ern-orchestrator/src/start.ts
+++ b/ern-orchestrator/src/start.ts
@@ -21,6 +21,7 @@ import {
 import _ from 'lodash'
 import path from 'path'
 import fs from 'fs-extra'
+import os from 'os'
 
 export default async function start({
   baseComposite,
@@ -167,7 +168,14 @@ export default async function start({
     const blacklistRe = _.difference(
       allNativeModules.map(d => d.basePath),
       dedupedNativeModules.resolved.map(d => d.basePath)
-    ).map(l => new RegExp(`${l}\/.*`))
+    ).map(
+      l =>
+        new RegExp(
+          os.platform() === 'win32'
+            ? `${l}\\.*`.replace(/\\/g, '\\\\')
+            : `${l}\/.*`
+        )
+    )
 
     const compositeLocalMiniappsPaths = compositeMiniApps
       .filter(m => m.packagePath.isFilePath)


### PR DESCRIPTION
Kinda follow up to https://github.com/electrode-io/electrode-native/pull/1666

`blacklistRe` paths in `metro.config.js` are not generated properly on Windows.

For example, this is how a path will currently look like when generated `/C:\foo\node_modules\react-native\/.*/`, while valid path should instead be `/C:\\foo\\node_modules\\react-native\\.*/`

To be noted that there is some duplication here (in `start` and `generateComposite`), not limited to this line. Some refactoring should be done. Not part of this PR only addressing this issue with minimum changes, for patch release.