### PR TITLE
Reuse yarn lock files instead of creating new ones

### DIFF
--- a/ern-cauldron-api/src/CauldronApi.ts
+++ b/ern-cauldron-api/src/CauldronApi.ts
@@ -941,15 +941,9 @@ export default class CauldronApi {
     const version = await this.getVersion(descriptor)
     const fileName = version.yarnLocks[key]
     if (fileName) {
-      const pathToOldYarnLock = this.getRelativePathToYarnLock(fileName)
-      await this.fileStore.removeFile(pathToOldYarnLock)
-      const newYarnLockFileName = uuidv4()
-      const pathToNewYarnLock = this.getRelativePathToYarnLock(
-        newYarnLockFileName
-      )
-      await this.fileStore.storeFile(pathToNewYarnLock, yarnlock)
-      version.yarnLocks[key] = newYarnLockFileName
-      await this.commit(`Updated yarn.lock for ${descriptor.toString()} ${key}`)
+      const yarnLockPath = this.getRelativePathToYarnLock(fileName)
+      await this.fileStore.storeFile(yarnLockPath, yarnlock)
+      await this.commit(`Update yarn.lock for ${descriptor.toString()} ${key}`)
       return true
     }
     return false
@@ -967,9 +961,7 @@ export default class CauldronApi {
       await this.fileStore.removeFile(pathToYarnLock)
     }
     version.yarnLocks[key] = id
-    await this.commit(
-      `Updated yarn.lock id for ${descriptor.toString()} ${key}`
-    )
+    await this.commit(`Update yarn.lock id for ${descriptor.toString()} ${key}`)
   }
 
   public async setYarnLocks(descriptor: AppVersionDescriptor, yarnLocks: any) {


### PR DESCRIPTION
Not much in this PR in term of code changes actually but it will improve tracking of `yarn.lock` files.

This PR updates the `updateYarnLock` method, for it not to create a new yarn lock file in the cauldron but instead reuse the existing one (by just overwriting it).

I am not sure why in the first place this method was implemented this way, but it was a mistake.

Just to give some context here ... 

When Electrode Native generates a container using a cauldron, it stores the resulting `yarn.lock` file inside the cauldron (under `yarnlocks` directory). The filename that is used to store this `yarn.lock` is a generated UUID, for example `0b3877c3-51d2-4090-95cb-2e8547258d9b`. The problem with current `updateYarnLock` method is that it first removes the previous yarn lock file (UUID) associated to a descriptor and create a new one with a new UUID (which git probably maps to a rename).

This is problematic, as a container yarn lock filename for a given descriptor will go through multiple renames (one new filename for each new container version generated), while absolutely unnecessary.

I checked the whole logic and there is nowhere in Electrode Native where we expect to a different yarn lock filename (UUID) for each container version, so it's just better to move this way, with a yarn lock filename that is associated to each descriptor and remain the same for the lifetime of the descriptor.