### PR TITLE
Fix iOS skipInstall

### DIFF
--- a/ern-container-gen-ios/src/IosGenerator.ts
+++ b/ern-container-gen-ios/src/IosGenerator.ts
@@ -123,7 +123,7 @@ Or set --skipInstall if using the create-container command.`
       )
     }
 
-    if (config.iosConfig.skipInstall) {
+    if (config?.iosConfig?.skipInstall) {
       log.info(
         `skipInstall option is set. 'yarn install' and 'pod install' won't be run after container generation.
 Make sure to run these commands before building the container.`

--- a/ern-orchestrator/src/container.ts
+++ b/ern-orchestrator/src/container.ts
@@ -120,6 +120,7 @@ export async function runCauldronContainerGen(
           ignoreRnpmAssets:
             containerGeneratorConfig &&
             containerGeneratorConfig.ignoreRnpmAssets,
+          iosConfig: containerGeneratorConfig?.iosConfig,
           jsMainModuleName,
           outDir: outDir || Platform.getContainerGenOutDirectory(platform),
           plugins,


### PR DESCRIPTION
Follow up to https://github.com/electrode-io/electrode-native/pull/1662
Late changes to this PR were not tested before merge (my bad)
There was a bug in case the iOS extra configuration is not provided, were the code would fail (trying to access skipInstall property on undefined object).
Also in case of container generation from Cauldron, the extra iOS configuration was not retrieved from Cauldron.
This PR addresses these two issues.