### PR TITLE
Add --skipInstall option to create-miniapp

### DIFF
--- a/docs/cli/create-miniapp.md
+++ b/docs/cli/create-miniapp.md
@@ -55,6 +55,11 @@ The `android` and `ios` directories are not created by this command. They will b
 - This option is rarely used.
 - **Default** Will use the currently activated platform version.
 
+`--skipInstall`
+
+- Skip the installation of dependencies after project creation.
+- **Default** The value defaults to false.
+
 `--skipNpmCheck`
 
 - Skip the check ensuring package does not already exists in npm registry.

--- a/ern-core/src/MiniApp.ts
+++ b/ern-core/src/MiniApp.ts
@@ -104,6 +104,7 @@ export class MiniApp extends BaseMiniApp {
       packageManager,
       platformVersion = Platform.currentVersion,
       scope,
+      skipInstall,
       template,
     }: {
       language?: 'JavaScript' | 'TypeScript'
@@ -111,6 +112,7 @@ export class MiniApp extends BaseMiniApp {
       packageManager?: 'npm' | 'yarn'
       platformVersion?: string
       scope?: string
+      skipInstall?: boolean
       template?: string
     } = {}
   ) {
@@ -179,6 +181,7 @@ You can find instructions to install CocoaPods @ https://cocoapods.org`)
       )
       .run(
         reactnative.init(miniAppName, reactNativeVersion, {
+          skipInstall,
           template: template
             ? template
             : language === 'TypeScript'

--- a/ern-core/src/ReactNativeCli.ts
+++ b/ern-core/src/ReactNativeCli.ts
@@ -38,7 +38,13 @@ export default class ReactNativeCli {
   public async init(
     appName: string,
     rnVersion: string,
-    { template }: { template?: string } = {}
+    {
+      skipInstall,
+      template
+    }: {
+      skipInstall?: boolean,
+      template?: string
+    } = {},
   ) {
     const dir = path.join(process.cwd(), appName)
 
@@ -46,8 +52,9 @@ export default class ReactNativeCli {
       throw new Error(`Path already exists will not override ${dir}`)
     }
 
+    const skipInstallArg = skipInstall ? ` --skip-install` : ''
     const templateArg = template !== undefined ? ` --template ${template}` : ''
-    const initCmd = `init ${appName} --version ${rnVersion}${templateArg}`
+    const initCmd = `init ${appName} --version ${rnVersion}${templateArg}${skipInstallArg}`
 
     if (semver.gte(rnVersion, '0.60.0')) {
       return execp(`npx --ignore-existing react-native@${rnVersion} ${initCmd}`)

--- a/ern-local-cli/src/commands/create-miniapp.ts
+++ b/ern-local-cli/src/commands/create-miniapp.ts
@@ -50,6 +50,11 @@ export const builder = (argv: Argv) => {
       alias: 's',
       describe: 'Scope to use for the MiniApp NPM package',
     })
+    .option('skipInstall', {
+      describe:
+        'Skip the installation of dependencies after project creation',
+      type: 'boolean',
+    })
     .option('skipNpmCheck', {
       describe:
         'Skip the check ensuring package does not already exists in npm registry',
@@ -77,6 +82,7 @@ export const commandHandler = async ({
   packageName,
   platformVersion,
   scope,
+  skipInstall,
   skipNpmCheck,
   template,
 }: {
@@ -88,6 +94,7 @@ export const commandHandler = async ({
   packageManager?: 'npm' | 'yarn'
   platformVersion: string
   scope?: string
+  skipInstall?: boolean
   skipNpmCheck?: boolean
   template?: string
 }) => {
@@ -155,6 +162,7 @@ export const commandHandler = async ({
       packageManager,
       platformVersion: platformVersion && platformVersion.replace('v', ''),
       scope,
+      skipInstall,
       template,
     })
   )


### PR DESCRIPTION
Similar to how we now have a `--skipInstall` for `create-container` (#1662), this adds the `--skipInstall` to `create-miniapp`. Does a similar thing, and in this case, simply passes through the `--skip-install` flag to the React Native CLI.