### PR TITLE
Use yarn add instead of upgrade when reusing yarn.lock

### DIFF
--- a/ern-composite-gen/src/installPackagesUsingYarnLock.ts
+++ b/ern-composite-gen/src/installPackagesUsingYarnLock.ts
@@ -18,40 +18,48 @@ export async function installPackagesUsingYarnLock({
   pathToYarnLock: string
   jsPackages: PackagePath[]
 }) {
-  const compositePackageJson: any = {}
+  shell.pushd(cwd)
+  try {
+    const compositePackageJson: any = {}
 
-  if (_.some(jsPackages, m => !m.version)) {
-    throw new Error(
-      '[generateComposite] When providing a yarn lock you cannot pass MiniApps without an explicit version'
+    if (_.some(jsPackages, m => !m.version)) {
+      throw new Error(
+        '[generateComposite] When providing a yarn lock you cannot pass MiniApps without an explicit version'
+      )
+    }
+
+    if (!(await fs.pathExists(pathToYarnLock))) {
+      throw new Error(
+        `[generateComposite] Path to yarn.lock does not exist (${pathToYarnLock})`
+      )
+    }
+
+    log.debug(`Copying yarn.lock to ${cwd}`)
+    shell.cp(pathToYarnLock, path.join(cwd, 'yarn.lock'))
+
+    const yarnLock = await fs.readFile(pathToYarnLock, 'utf8')
+    const miniAppsDeltas: MiniAppsDeltas = getMiniAppsDeltas(
+      jsPackages,
+      yarnLock
     )
-  }
 
-  if (!(await fs.pathExists(pathToYarnLock))) {
-    throw new Error(
-      `[generateComposite] Path to yarn.lock does not exist (${pathToYarnLock})`
+    log.debug(
+      `[generateComposite] miniAppsDeltas: ${JSON.stringify(miniAppsDeltas)}`
     )
+
+    compositePackageJson.dependencies = getPackageJsonDependenciesUsingMiniAppDeltas(
+      miniAppsDeltas,
+      yarnLock
+    )
+
+    await writePackageJson(cwd, compositePackageJson)
+
+    // Now that the composite package.json is similar to the one used to generated yarn.lock
+    // we can run yarn install to get back to the exact same dependency graph as the previously
+    // generated composite
+    await kax.task('Running yarn install').run(yarn.install())
+    return runYarnUsingMiniAppDeltas(miniAppsDeltas)
+  } finally {
+    shell.popd()
   }
-
-  log.debug(`Copying yarn.lock to ${cwd}`)
-  shell.cp(pathToYarnLock, path.join(cwd, 'yarn.lock'))
-
-  const yarnLock = await fs.readFile(pathToYarnLock, 'utf8')
-  const miniAppsDeltas: MiniAppsDeltas = getMiniAppsDeltas(jsPackages, yarnLock)
-
-  log.debug(
-    `[generateComposite] miniAppsDeltas: ${JSON.stringify(miniAppsDeltas)}`
-  )
-
-  compositePackageJson.dependencies = getPackageJsonDependenciesUsingMiniAppDeltas(
-    miniAppsDeltas,
-    yarnLock
-  )
-
-  await writePackageJson(cwd, compositePackageJson)
-
-  // Now that the composite package.json is similar to the one used to generated yarn.lock
-  // we can run yarn install to get back to the exact same dependency graph as the previously
-  // generated composite
-  await kax.task('Running yarn install').run(yarn.install())
-  await runYarnUsingMiniAppDeltas(miniAppsDeltas)
 }

--- a/ern-composite-gen/src/miniAppsDeltasUtils.ts
+++ b/ern-composite-gen/src/miniAppsDeltasUtils.ts
@@ -117,23 +117,17 @@ export async function runYarnUsingMiniAppDeltas(
     }
   }
 
-  // !!! TODO !!!
-  // We run `yarn upgrade` here but that might not be the safest solution
-  // as `yarn upgrade` will run a full upgrade of all dependencies of the
-  // MiniApp, transitively, which might not be desired.
-  // Indeed if we want to be as close to the yarn.lock as possible, running
-  // `yarn add` for upgraded dependencies will only upgrade the MiniApp
-  // version but will leave its dependency graph untouched, based
-  // on yarn.lock.
-  // It might be better to given more control to the MiniApp team on
-  // dependency control.
+  //
+  // We also run `yarn add` for any upgraded MiniApps insead of
+  // `yarn upgrade`, to ensure that the dependency graph of the
+  // MiniApp will remain as close to the existing yarn.lock as
+  // possible
   if (miniAppsDeltas.upgraded) {
     for (const upgradedMiniAppVersion of miniAppsDeltas.upgraded) {
       log.debug(`Upgrading MiniApp ${upgradedMiniAppVersion.toString()}`)
-      // TODO : Once again ... Do we really want upgrade here ?
       await kax
         .task(`Upgrading ${upgradedMiniAppVersion}`)
-        .run(yarn.upgrade(upgradedMiniAppVersion))
+        .run(yarn.add(upgradedMiniAppVersion))
     }
   }
 

--- a/ern-composite-gen/test/compositegen-test.ts
+++ b/ern-composite-gen/test/compositegen-test.ts
@@ -123,7 +123,7 @@ describe('ern-container-gen utils.js', () => {
       assert(yarnCliStub.add.calledTwice)
     })
 
-    it('should yarn upgrade upgraded MiniApps', async () => {
+    it('should yarn add upgraded MiniApps', async () => {
       const miniAppsDeltas = {
         upgraded: [
           PackagePath.fromString('MiniAppOne@7.0.0'),
@@ -131,10 +131,10 @@ describe('ern-container-gen utils.js', () => {
         ],
       }
       await runYarnUsingMiniAppDeltas(miniAppsDeltas)
-      assert(yarnCliStub.upgrade.calledTwice)
+      assert(yarnCliStub.add.calledTwice)
     })
 
-    it('should not yarn upgrade nor yarn add same MiniApps versions', async () => {
+    it('should not yarn add same MiniApps versions', async () => {
       const miniAppsDeltas = {
         same: [
           PackagePath.fromString('MiniAppOne@6.0.0'),
@@ -142,7 +142,6 @@ describe('ern-container-gen utils.js', () => {
         ],
       }
       await runYarnUsingMiniAppDeltas(miniAppsDeltas)
-      assert(yarnCliStub.upgrade.notCalled)
       assert(yarnCliStub.add.notCalled)
     })
 
@@ -159,8 +158,7 @@ describe('ern-container-gen utils.js', () => {
         ],
       }
       await runYarnUsingMiniAppDeltas(miniAppsDeltas)
-      assert(yarnCliStub.upgrade.calledTwice)
-      assert(yarnCliStub.add.calledOnce)
+      assert(yarnCliStub.add.calledThrice)
     })
   })
 
@@ -371,7 +369,7 @@ describe('ern-container-gen utils.js', () => {
       )
     })
 
-    it('should call yarn install prior to calling yarn add or yarn upgrade for each MiniApp', async () => {
+    it('should call yarn install prior to calling yarn add for each MiniApp', async () => {
       // One new, one same, one upgrade
       yarnCliStub.install.callsFake(() =>
         createCompositeNodeModulesReactNativePackageJson(tmpOutDir, '0.56.0')
@@ -387,10 +385,8 @@ describe('ern-container-gen utils.js', () => {
         pathToYarnLock: pathToSampleYarnLock,
       })
       assert(yarnCliStub.install.calledOnce)
-      assert(yarnCliStub.upgrade.calledOnce)
-      assert(yarnCliStub.add.calledTwice)
+      assert(yarnCliStub.add.calledThrice)
       assert(yarnCliStub.install.calledBefore(yarnCliStub.add))
-      assert(yarnCliStub.install.calledBefore(yarnCliStub.upgrade))
     })
 
     it('should create index.js', async () => {


### PR DESCRIPTION
When reusing a composite `yarn.lock` _(`bypassYarnLock=false`)_ use `yarn add` instead of `yarn upgrade` to update MiniApp versions.

When reusing `yarn.lock` we want to ensure that the new composite dependency graph remains as close to the previous one as possible. The problem with `yarn upgrade` is that it will refresh the whole dependency graph of the miniapp updated to a new version; retrieving latest versions of dependencies matching the defined ranges, even if no top level dependencies (in the miniapp package.json) were explicitly updated.

For example, assuming a miniapp has the following dependencies in its package.json:

```
"dependencies": {
  "depA": "^1.0.0",
  "depC": "^1.0.0"
}
```

The resulting resolved dependency tree might look like this (assuming depA is having a dependency on depB and that at the time of the yarn.lock creating, only 1.0.0 versions of the dependencies were published):

```
miniapp@1.0.0
├── depA@1.0.0
│   └── depB@1.0.0
└── depC@1.0.0
```

Now, without touching the miniapp package.json, but releasing a new version of the miniapp (2.0.0 let's say), and assuming a new version 1.1.0 of depB got released meanwhile ...
Running `yarn upgrade miniapp@2.0.0` will produce the following dependency tree (assuming depA used a ^ range for depB):

```
miniapp@2.0.0
├── depA@1.0.0
│   └── depB@1.1.0
└── depC@1.0.0
```

So depB is getting updated under the hood, even though there was no change at all in the package.json of the miniapp.
Using `yarn add` in that case would preserve the initial captured dependency tree.

`yarn add` will keep the dependency tree as close to the `yarn.lock` as possible and will only update top level or transitive dependencies if strictly needed.

For example, still assuming that depB@1.1.0 got released, and assuming that depA@2.0.0 is still having a dependency on depB@^1.0.0 ... if the miniapp@2.0.0 is explicitly updating depA@^2.0.0 in its package.json, then `yarn add miniapp@2.0.0` will only refresh depA in the tree, but will leave depB untouched (as 1.0.0 still match ^1.0.0, even if 1.1.0 is available), as shown below. 

```
miniapp@2.0.0
├── depA@2.0.0
│   └── depB@1.0.0
└── depC@1.0.0
```

Only if depA@2.0.0 was now depending on depB@^1.1.0, would it update to depB@1.1.0.

This is a bit of a simplification. In practice a miniapp is depending on dozen of dependencies, ending up in hundreds of transitive dependencies, quickly diverging from the original yarn lock. Given that with yarn.lock reuse we want to remain as close as possible to the captured yarn.lock, and only update dependencies if strictly needed, `yarn add` should be used here instead of `yarn upgrade`.