### PR TITLE
Fix system tests on Windows/Linux

### DIFF
--- a/system-tests/src/tests/create-container-ios-fixture.js
+++ b/system-tests/src/tests/create-container-ios-fixture.js
@@ -32,5 +32,5 @@ if (process.platform === 'darwin') {
     'Generated IOS Container differ from reference fixture !'
   )
 } else {
-  run(command, { expectedExitCode: 1 })
+  run(command)
 }


### PR DESCRIPTION
Remove expected failure exit code now that we use `--skipInstall` flag for the iOS `create-container` command, which will cause it to end with success even on Windows/Linux.