### PR TITLE
Increase mocha test timeout

### DIFF
--- a/ern-util-dev/bin/ern-mocha.js
+++ b/ern-util-dev/bin/ern-mocha.js
@@ -14,5 +14,6 @@ process.argv.push('-r', 'ts-node/register');
 process.argv.push('-r', 'tsconfig-paths/register');
 process.argv.push('-r', 'source-map-support/register');
 process.argv.push('--file', '../ern-core/test/mocha-root-level-hooks.ts');
+process.argv.push('--timeout', '5000');
 process.argv.push('test/**/*-test.{ts,js}');
 require('mocha/bin/_mocha');


### PR DESCRIPTION
We have noticed some tests randomly failing, running into timeout, when run on GitHub actions agents.
This PR increase mocha test timeout to 5s _(from the default of 2s)_ which should greatly reduce the amount of random failures due to timeouts (let's keep an eye on this after merge).
