### PR TITLE
Revert "Set Android container Gradle plugin to 3.5.2"

### DIFF
--- a/ern-container-gen-android/src/hull/build.gradle
+++ b/ern-container-gen-android/src/hull/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:{{{androidGradlePlugin}}}'
     }
 }
 

--- a/ern-core/src/android.ts
+++ b/ern-core/src/android.ts
@@ -12,7 +12,7 @@ import semver from 'semver';
 // Default value for android build config
 // ==============================================================================
 
-export const DEFAULT_ANDROID_GRADLE_PLUGIN_VERSION = '3.4.0';
+export const DEFAULT_ANDROID_GRADLE_PLUGIN_VERSION = '3.4.2';
 export const DEFAULT_ANDROIDX_APPCOMPACT_VERSION = '1.1.0';
 export const DEFAULT_ANDROIDX_LIFECYCLE_EXTENSIONS_VERSION = '2.1.0';
 export const DEFAULT_BUILD_TOOLS_VERSION = '28.0.3';

--- a/system-tests/fixtures/android-container/build.gradle
+++ b/system-tests/fixtures/android-container/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:3.4.2'
     }
 }
 

--- a/system-tests/fixtures/android-container/build.gradle
+++ b/system-tests/fixtures/android-container/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:3.4.0'
     }
 }
 


### PR DESCRIPTION
The update of the Android Gradle plugin in the container from `3.4.0` to `3.5.2` is causing some unexpected regressions. In certain project setups, it might result in the following container build error:

```
More than one file was found with OS independent path 'classes.jar'
```

Other people have faced similar issues, and there is no simple fix available.

https://stackoverflow.com/questions/57725323/more-than-one-file-was-found-with-os-independent-path-classes-jar-com-andro
https://github.com/gradle/gradle/issues/10882

It will most likely require some extended investigation to figure out exactly what's going wrong and what the proper fix will look like.

This reverts the update, and instead changes the default version from `3.4.0` to `3.4.2`, keeping the container plugin at the `3.4.x` series. `3.4.2` is confirmed to work as expected.