### PR TITLE
Add svg import support

### DIFF
--- a/ern-composite-gen/src/createMetroConfig.ts
+++ b/ern-composite-gen/src/createMetroConfig.ts
@@ -23,10 +23,10 @@ module.exports = {
   ${projectRoot ? `projectRoot: "${projectRoot}",` : ''}
   ${
     watchFolders
-      ? `watchFolders: [ 
+      ? `watchFolders: [
         ${watchFolders
           .map((x) => `"${x.replace(/\\/g, '\\\\')}"`)
-          .join(`,${os.EOL}`)} 
+          .join(`,${os.EOL}`)}
       ],`
       : ''
   }
@@ -53,31 +53,31 @@ module.exports = {
       "jpeg",
       "png",
       "psd",
-      "svg",
-      "webp", 
+      "webp",
       // Video formats
       "m4v",
       "mov",
       "mp4",
       "mpeg",
       "mpg",
-      "webm", 
+      "webm",
       // Audio formats
       "aac",
       "aiff",
       "caf",
       "m4a",
       "mp3",
-      "wav", 
+      "wav",
       // Document formats
       "html",
       "pdf",
       // Font formats
       "otf",
-      "ttf", 
+      "ttf",
       // Archives (virtual files)
       "zip"
-    ]
+    ],
+    sourceExts: ["js", "json", "ts", "tsx", "svg"],
   },
   transformer: {
     getTransformOptions: async () => ({
@@ -87,6 +87,7 @@ module.exports = {
       },
     }),
     assetPlugins: ['ern-bundle-store-metro-asset-plugin'],
+    babelTransformerPath: require.resolve("react-native-svg-transformer"),
   },
 };
 `),

--- a/ern-composite-gen/src/generateComposite.ts
+++ b/ern-composite-gen/src/generateComposite.ts
@@ -210,6 +210,7 @@ async function generateFullComposite(
         cwd: outDir,
         extraJsDependencies: [
           PackagePath.fromString('ern-bundle-store-metro-asset-plugin'),
+          PackagePath.fromString('react-native-svg-transformer'),
           ...extraJsDependencies,
         ],
       }),

--- a/ern-composite-gen/test/compositegen-test.ts
+++ b/ern-composite-gen/test/compositegen-test.ts
@@ -373,7 +373,7 @@ describe('ern-container-gen utils.js', () => {
         pathToYarnLock: pathToSampleYarnLock,
       });
       assert(yarnCliStub.install.calledOnce);
-      assert(yarnCliStub.add.calledThrice);
+      sinon.assert.callCount(yarnCliStub.add, 4);
       assert(yarnCliStub.install.calledBefore(yarnCliStub.add));
     });
 
@@ -416,7 +416,7 @@ describe('ern-container-gen utils.js', () => {
       ];
       yarnCliStub.init.callsFake(() => fakeYarnInit(tmpOutDir, '0.57.0'));
       await generateComposite({ miniApps, outDir: tmpOutDir });
-      assert(yarnCliStub.add.callCount === 4);
+      sinon.assert.callCount(yarnCliStub.add, 5);
     });
 
     it('should create index.js', async () => {


### PR DESCRIPTION
Add out of the box `svg` file import support for full composites, using [react-native-svg-transformer](https://github.com/kristerkari/react-native-svg-transformer).

Also includes a formatting fixes to the changed file (minimal, not using two commits here).