### PR TITLE
Fix "platform config set" command for object values

### DIFF
--- a/ern-local-cli/src/commands/platform/config/set.ts
+++ b/ern-local-cli/src/commands/platform/config/set.ts
@@ -31,7 +31,11 @@ export const commandHandler = async ({
   if (!isNaN(+value!)) {
     valueToset = +value!;
   } else {
-    valueToset = value === 'true' ? true : value === 'false' ? false : value;
+    try {
+      valueToset = JSON.parse(valueToset);
+    } catch (e) {
+      // swallow
+    }
   }
   ernConfig.set(key, valueToset);
   log.info(`Successfully set ${key} value to ${ernConfig.get(key)}`);


### PR DESCRIPTION
Fix `platform config set` command when setting object values.

For example, running in `ern platform config set manifest '{"override": {"url": "/Users/foo/bar"}}'` currently results in a stringified version of the object to be set as the value:

```json
{ "manifest": "{\"overrride\": { \"url\": \"/Users/foo/bar\"}}" }
```

With this PR fix, the object itself will be properly set as the value:

```json
{
  "manifest": {
    "override": {
      "url": "/Users/foo/bar"
    }
  }
}
```
