### PR TITLE
Fix a bug causing local miniapps to be included twice in container

### DIFF
--- a/ern-composite-gen/src/GeneratedComposite.ts
+++ b/ern-composite-gen/src/GeneratedComposite.ts
@@ -115,7 +115,7 @@ export class GeneratedComposite implements Composite {
       const ppKey = PackagePath.fromString(key);
 
       if (
-        ppValue.isFilePath ||
+        !ppValue.isFilePath &&
         this.config.miniApps.some((p) => p.basePath === ppValue.basePath)
       ) {
         result.push({


### PR DESCRIPTION
Some code was added recently to this function to deal with local MiniApps separately, due to the refactoring of full composite generation. In the case of non full composite (using base composite), we noticed that. each local miniapps gets injected twice  in the container, resulting in container build failure.
Fix is just not to update the conditional not to consider file based path.