### PR TITLE
Keep cauldron repositories sorted

### DIFF
--- a/ern-cauldron-api/src/CauldronRepositories.ts
+++ b/ern-cauldron-api/src/CauldronRepositories.ts
@@ -1,4 +1,4 @@
-import { config, Platform, shell } from 'ern-core';
+import { config, Platform, sortObjectByKeys, shell } from 'ern-core';
 import { CauldronRepository } from './types';
 
 export class CauldronRepositories {
@@ -29,7 +29,7 @@ https://[token]@[repourl]`);
 
     const cauldronRepositories = config.get('cauldronRepositories', {});
     cauldronRepositories[alias] = url;
-    config.set('cauldronRepositories', cauldronRepositories);
+    config.set('cauldronRepositories', sortObjectByKeys(cauldronRepositories));
     if (activate) {
       this.activate({ alias });
     }
@@ -46,7 +46,7 @@ https://[token]@[repourl]`);
     const cauldronRepositories = config.get('cauldronRepositories');
     const result = { alias, url: cauldronRepositories[alias] };
     delete cauldronRepositories[alias];
-    config.set('cauldronRepositories', cauldronRepositories);
+    config.set('cauldronRepositories', sortObjectByKeys(cauldronRepositories));
     const cauldronRepoInUse = config.get('cauldronRepoInUse');
     if (cauldronRepoInUse === alias) {
       config.set('cauldronRepoInUse', null);

--- a/ern-core/src/index.ts
+++ b/ern-core/src/index.ts
@@ -55,6 +55,7 @@ export * from './config';
 export * from './gitApply';
 export * from './createProxyAgent';
 export * from './bugsnagUpload';
+export * from './sortObjectByKeys';
 
 export const config = _config;
 export const Platform = _Platform;

--- a/ern-core/src/sortObjectByKeys.ts
+++ b/ern-core/src/sortObjectByKeys.ts
@@ -1,0 +1,11 @@
+export function sortObjectByKeys(obj: {
+  [key: string]: any;
+}): { [key: string]: any } {
+  const res: { [key: string]: any } = {};
+  Object.keys(obj)
+    .sort()
+    .forEach((k: string) => {
+      res[k] = obj[k];
+    });
+  return res;
+}

--- a/ern-core/test/sortObjectByKey-test.ts
+++ b/ern-core/test/sortObjectByKey-test.ts
@@ -1,0 +1,17 @@
+// tslint:disable:object-literal-sort-keys
+
+import { sortObjectByKeys } from '../src/sortObjectByKeys';
+import { expect } from 'chai';
+
+describe('sortObjectByKey', () => {
+  it('should sort an object by its keys', () => {
+    const obj = {
+      c: 1,
+      a: 2,
+      b: 3,
+    };
+    const sortedObj = sortObjectByKeys(obj);
+    expect(Object.keys(sortedObj)).deep.equal(['a', 'b', 'c']);
+    expect(obj).deep.equal(sortedObj);
+  });
+});


### PR DESCRIPTION
I have a lot of cauldron repositories in my local setup and when using `ern cauldron repo list` I started having some difficulty finding a particular cauldron repo alias, as they are not sorted.

This PR keep the `cauldronRepositories` object (in `.ernrc`) sorted (prior to object update, its keys get sorted), so that `ern cauldron repo list` now list the repositories sorted by alias. Because the logic is sorting the object keys prior to writing it to `.ernrc`, the `.ernrc` file will also contain the `cauldronRepositories` object with its keys sorted.