### PR TITLE
Guarantee miniapps import order in composite

### DIFF
--- a/ern-composite-gen/src/generateComposite.ts
+++ b/ern-composite-gen/src/generateComposite.ts
@@ -151,11 +151,6 @@ async function generateFullComposite(
   const remoteMiniapps = miniApps.filter((p) => !p.isFilePath);
   const localMiniApps = miniApps.filter((p) => p.isFilePath);
   const localMiniAppsPaths = localMiniApps.map((m) => m.basePath);
-  const localMiniAppsPkgNames = [];
-  for (const x of localMiniApps) {
-    const pJson = await readPackageJson(x.basePath);
-    localMiniAppsPkgNames.push(pJson.name);
-  }
   const extraNodeModules: { [pkg: string]: string } = {};
 
   try {
@@ -201,7 +196,10 @@ async function generateFullComposite(
 
     await addRNStartScriptToPjson({ cwd: outDir });
 
-    await createIndexJs({ cwd: outDir, extraImports: localMiniAppsPkgNames });
+    await createIndexJs({
+      cwd: outDir,
+      miniApps,
+    });
 
     await createWatchmanConfig({ cwd: outDir });
 


### PR DESCRIPTION
The order of miniapps imports in composite `index.js` was not deterministic, which could lead to some issues in the case of miniapps having to be imported before other ones (should never be the case, still).

This PR achieves the necessary to guarantee deterministic miniapps imports order.

To avoid introducing any additional configuration complexity, the order of imports will exactly match the order of the miniapps as defined in cauldron (when generating a composite from cauldron), or the order of the miniapps provided on command line (when generating a composite with a command taking arbitrary miniapps paths).
