### PR TITLE
Set default hermes version for RN63+

### DIFF
--- a/ern-core/src/android.ts
+++ b/ern-core/src/android.ts
@@ -437,6 +437,9 @@ export function getDefaultHermesVersion(
     return '~0.4.0';
   } else if (semver.gte(reactNativeVersion, '0.60.0')) {
     return '^0.2.1';
+  } else if (semver.gte(reactNativeVersion, '0.63.0')) {
+    // https://github.com/facebook/react-native/blob/v0.63.0/package.json#L98
+    return '~0.5.0';
   } else {
     throw new Error(
       'This function can only be called for versions of React Native >= 0.60.0',


### PR DESCRIPTION
Prep work for React Native 0.63 support

[Hermes engine was updated to 0.5.0 in React Native 0.63.0](
https://github.com/facebook/react-native/commit/4305a291a9408ca65847994bbec42f1fbc97071d)

This PR updated the default version of Hermes used by Electrode Native for RN63+, to `~0.5.0` matching [range used by React Native](https://github.com/facebook/react-native/blob/v0.63.0/package.json#L98).