### PR TITLE
Remove strong references for delegates

### DIFF
--- a/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeBridgeDelegate.m
+++ b/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeBridgeDelegate.m
@@ -18,9 +18,9 @@
 
 @interface ElectrodeBridgeDelegate ()
 @property (nonatomic, copy) NSURL *sourceURL;
-@property (nonatomic, strong) NSArray *extraModules;
-@property(nonatomic, strong) id<ElectrodePluginConfig> containerConfig;
-@property(nonatomic, strong) id<ElectrodePluginConfig> codePushConfig;
+@property (nonatomic, copy) NSArray *extraModules;
+@property (nonatomic, weak) id<ElectrodePluginConfig> containerConfig;
+@property (nonatomic, weak) id<ElectrodePluginConfig> codePushConfig;
 @end
 
 @implementation ElectrodeBridgeDelegate

--- a/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeBridgeDelegate.m
+++ b/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeBridgeDelegate.m
@@ -18,9 +18,9 @@
 
 @interface ElectrodeBridgeDelegate ()
 @property (nonatomic, copy) NSURL *sourceURL;
-@property (nonatomic, strong) NSArray *extraModules;
-@property(nonatomic, strong) id<ElectrodePluginConfig> containerConfig;
-@property(nonatomic, strong) id<ElectrodePluginConfig> codePushConfig;
+@property (nonatomic, copy) NSArray *extraModules;
+@property (nonatomic, weak) id<ElectrodePluginConfig> containerConfig;
+@property (nonatomic, weak) id<ElectrodePluginConfig> codePushConfig;
 @end
 
 @implementation ElectrodeBridgeDelegate


### PR DESCRIPTION
Using weak reference for delegate properties is standard Objective C practice. Also, copy for immutable arrays.