### PR TITLE
Fix hermes default version for RN63+

### DIFF
--- a/ern-core/src/android.ts
+++ b/ern-core/src/android.ts
@@ -433,13 +433,13 @@ export function androidEmulatorPath(): string {
 export function getDefaultHermesVersion(
   reactNativeVersion: string,
 ): string | never {
-  if (semver.gte(reactNativeVersion, '0.62.0')) {
+  if (semver.gte(reactNativeVersion, '0.63.0')) {
+    // https://github.com/facebook/react-native/blob/v0.63.0/package.json#L98
+    return '~0.5.0';
+  } else if (semver.gte(reactNativeVersion, '0.62.0')) {
     return '~0.4.0';
   } else if (semver.gte(reactNativeVersion, '0.60.0')) {
     return '^0.2.1';
-  } else if (semver.gte(reactNativeVersion, '0.63.0')) {
-    // https://github.com/facebook/react-native/blob/v0.63.0/package.json#L98
-    return '~0.5.0';
   } else {
     throw new Error(
       'This function can only be called for versions of React Native >= 0.60.0',

--- a/ern-core/test/android-test.ts
+++ b/ern-core/test/android-test.ts
@@ -300,4 +300,40 @@ describe('android.js', () => {
       });
     });
   });
+
+  describe('getDefaultHermesVersion', () => {
+    it('should return ~0.5.0 for react native versions >= 0.63.0', () => {
+      ['0.63.0', '0.63.1'].forEach((rnVersion) => {
+        const hermesVersion = android.getDefaultHermesVersion(rnVersion);
+        expect(hermesVersion).eql(
+          '~0.5.0',
+          `Fail for react native version ${rnVersion}. ${hermesVersion} != '~0.5.0'`,
+        );
+      });
+    });
+
+    it('should return ~0.4.0 for react native versions >= 0.62.0 && < 0.63.0', () => {
+      ['0.62.0', '0.62.1', '0.62.2'].forEach((rnVersion) => {
+        const hermesVersion = android.getDefaultHermesVersion(rnVersion);
+        expect(hermesVersion).eql(
+          '~0.4.0',
+          `Fail for react native version ${rnVersion}. ${hermesVersion} != '~0.4.0'`,
+        );
+      });
+    });
+
+    it('should return ^0.2.1 for react native versions >= 0.60.0 && < 0.62.0', () => {
+      ['0.60.0', '0.60.1', '0.61.0', '0.61.1'].forEach((rnVersion) => {
+        const hermesVersion = android.getDefaultHermesVersion(rnVersion);
+        expect(hermesVersion).eql(
+          '^0.2.1',
+          `Fail for react native version ${rnVersion}. ${hermesVersion} != '^0.2.1'`,
+        );
+      });
+    });
+
+    it('should throw if react native version < 0.60.0', () => {
+      expect(() => android.getDefaultHermesVersion('0.59.0')).to.throw();
+    });
+  });
 });


### PR DESCRIPTION
Fix very silly bug introduced in https://github.com/electrode-io/electrode-native/pull/1688 that could have been caught easily by unit tests. But there was no unit tests for this function, so adding some as well so that this does not happen again next time ;)