### PR TITLE
Fix RN61+ iOS container issue with scoped packages

### DIFF
--- a/ern-container-gen-ios/src/IosGenerator.ts
+++ b/ern-container-gen-ios/src/IosGenerator.ts
@@ -225,6 +225,7 @@ Make sure to run these commands before building the container.`,
           ...dependencies.thirdPartyInManifest,
           ...dependencies.thirdPartyNotInManifest,
         ];
+
         const addDependencies: any = {};
         resDependencies.forEach((p) => {
           addDependencies[p.name!] = p.version;
@@ -253,7 +254,10 @@ Make sure to run these commands before building the container.`,
           );
           shell.mkdir('-p', containerNodeModulesPath);
           resDependencies.forEach((p) => {
-            shell.cp('-rf', p.basePath!, containerNodeModulesPath);
+            const depPath = p.basePath!.match(/node_modules\/(.+)/)![1];
+            const targetPath = path.join(containerNodeModulesPath, depPath);
+            shell.mkdir('-p', targetPath);
+            shell.cp('-rf', path.join(p.basePath!, '{.*,*}'), targetPath);
           });
         } else {
           shell.rm('-rf', 'node_modules');


### PR DESCRIPTION
Scoped native modules packages are not copied to the proper destination in iOS container `node_modules` directory. 

For example `node_modules/@foo/bar` is currently copied into `node_modules/bar`

This issue doesn't cause container generation to fail _(which explains in part why it was only noticed now),_ but the CocoaPods of all such scoped modules are just not injected in the generated container.

This PR fixes this problem.