### PR TITLE
Fix typo in miniappview interface

### DIFF
--- a/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeReactNative.h
+++ b/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeReactNative.h
@@ -149,7 +149,8 @@ without the extension.
 */
 - (UIView *)miniAppViewWithName:(NSString *)name
                      properties:(NSDictionary *_Nullable)properties
-                        overlay:(BOOL)overlay
+                        overlay:(BOOL)overlay;
+
 /**
  Returns a react native miniapp (from a JSBundle).
 

--- a/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeReactNative.m
+++ b/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeReactNative.m
@@ -201,14 +201,14 @@ static NSString *enableBundleStore = @"enableBundleStore";
 - (UIView *)miniAppViewWithName:(NSString *)name properties:(NSDictionary *_Nullable)properties {
     // Use the bridge to generate the view
     RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:self.bridge moduleName:name initialProperties:properties];
-    rootView.backgroundColor = [self rootViewColor overlay:NO];
+    rootView.backgroundColor = [self rootViewColorWithOverlay:NO];
     return rootView;
 }
 
 - (UIView *)miniAppViewWithName:(NSString *)name properties:(NSDictionary *_Nullable)properties overlay:(BOOL)overlay {
     // Use the bridge to generate the view
     RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:self.bridge moduleName:name initialProperties:properties];
-    rootView.backgroundColor = [self rootViewColor overlay:overlay];
+    rootView.backgroundColor = [self rootViewColorWithOverlay:overlay];
     return rootView;
 }
 
@@ -217,7 +217,7 @@ static NSString *enableBundleStore = @"enableBundleStore";
                 sizeFlexibility:(NSInteger)sizeFlexibilty {
     RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:self.bridge moduleName:name initialProperties:properties];
     rootView.sizeFlexibility = (RCTRootViewSizeFlexibility)sizeFlexibilty;
-    rootView.backgroundColor = [self rootViewColor overlay:NO];
+    rootView.backgroundColor = [self rootViewColorWithOverlay:NO];
     return rootView;
 }
 
@@ -227,12 +227,12 @@ static NSString *enableBundleStore = @"enableBundleStore";
                        delegate:(id<MiniAppViewDelegate> _Nullable)delegate {
     RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:self.bridge moduleName:name initialProperties:properties];
     rootView.sizeFlexibility = (RCTRootViewSizeFlexibility)sizeFlexibilty;
-    rootView.backgroundColor = [self rootViewColor overlay:NO];
+    rootView.backgroundColor = [self rootViewColorWithOverlay:NO];
     rootView.delegate = delegate;
     return rootView;
 }
 
-- (UIColor *)rootViewColor overlay:(BOOL)overlay {
+- (UIColor *)rootViewColorWithOverlay:(BOOL)overlay {
     if (overlay) {
         return [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:0.5];
     }

--- a/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeReactNative.h
+++ b/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeReactNative.h
@@ -113,7 +113,8 @@ without the extension.
 */
 - (UIView *)miniAppViewWithName:(NSString *)name
                      properties:(NSDictionary *_Nullable)properties
-                        overlay:(BOOL)overlay
+                        overlay:(BOOL)overlay;
+
 /**
  Returns a react native miniapp (from a JSBundle).
 

--- a/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeReactNative.m
+++ b/system-tests/fixtures/ios-container/ElectrodeContainer/ElectrodeReactNative.m
@@ -171,14 +171,14 @@ static NSString *enableBundleStore = @"enableBundleStore";
 - (UIView *)miniAppViewWithName:(NSString *)name properties:(NSDictionary *_Nullable)properties {
     // Use the bridge to generate the view
     RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:self.bridge moduleName:name initialProperties:properties];
-    rootView.backgroundColor = [self rootViewColor overlay:NO];
+    rootView.backgroundColor = [self rootViewColorWithOverlay:NO];
     return rootView;
 }
 
 - (UIView *)miniAppViewWithName:(NSString *)name properties:(NSDictionary *_Nullable)properties overlay:(BOOL)overlay {
     // Use the bridge to generate the view
     RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:self.bridge moduleName:name initialProperties:properties];
-    rootView.backgroundColor = [self rootViewColor overlay:overlay];
+    rootView.backgroundColor = [self rootViewColorWithOverlay:overlay];
     return rootView;
 }
 
@@ -187,7 +187,7 @@ static NSString *enableBundleStore = @"enableBundleStore";
                 sizeFlexibility:(NSInteger)sizeFlexibilty {
     RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:self.bridge moduleName:name initialProperties:properties];
     rootView.sizeFlexibility = (RCTRootViewSizeFlexibility)sizeFlexibilty;
-    rootView.backgroundColor = [self rootViewColor overlay:NO];
+    rootView.backgroundColor = [self rootViewColorWithOverlay:NO];
     return rootView;
 }
 
@@ -197,12 +197,12 @@ static NSString *enableBundleStore = @"enableBundleStore";
                        delegate:(id<MiniAppViewDelegate> _Nullable)delegate {
     RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:self.bridge moduleName:name initialProperties:properties];
     rootView.sizeFlexibility = (RCTRootViewSizeFlexibility)sizeFlexibilty;
-    rootView.backgroundColor = [self rootViewColor overlay:NO];
+    rootView.backgroundColor = [self rootViewColorWithOverlay:NO];
     rootView.delegate = delegate;
     return rootView;
 }
 
-- (UIColor *)rootViewColor overlay:(BOOL)overlay {
+- (UIColor *)rootViewColorWithOverlay:(BOOL)overlay {
     if (overlay) {
         return [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:0.5];
     }


### PR DESCRIPTION
Fixes missing semicolon in miniappview interface.
Also improper syntax is color method signature.