### PR TITLE
Fix copyRnConfigAssets for iOS on RN61+

### DIFF
--- a/ern-container-gen/test/fixtures/CompositeWithRnConfigs/package.json
+++ b/ern-container-gen/test/fixtures/CompositeWithRnConfigs/package.json
@@ -1,4 +1,7 @@
 {
   "name": "composite",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "dependencies": {
+    "react-native": "0.63.1"
+  }
 }


### PR DESCRIPTION
An issue was found in `copyRnConfigAssets` function on iOS, that would cause assets injection to be done twice (first by ern, adding the resources directly to Container resources, and second, during pod install, as podspec contains resources injection statements), leading in some edge cases to container build failing because of resource duplication.

Fix here only applies for iOS and if a version of React Native >= 0.61 is used. If that's the case, ern will skip copying assets of packages that contain a podspec file, as they will be copied over by pod install.