### PR TITLE
Remove Pods directory from iOS container gitignore

### DIFF
--- a/ern-container-gen-ios/src/hull/.gitignore
+++ b/ern-container-gen-ios/src/hull/.gitignore
@@ -11,5 +11,4 @@ xcuserdata/
 
 # Third-party dependencies
 #
-Pods/
 Carthage/


### PR DESCRIPTION
When generating a complete (installed) container with ern (pod install being run), we don't want to exclude the Pods directory when publishing the container to a git repository.

Indeed, a complete iOS container published to git, should be 'buildable' fresh from a git clone, without having to run `yarn install` nor `pod install`.

Having this directory in the .gitignore of the iOS container, was causing such containers to fail building out of the box when cloned from the git repository.