### PR TITLE
Improve error message of extra option

### DIFF
--- a/ern-local-cli/src/commands/cauldron/add/nativeapp.ts
+++ b/ern-local-cli/src/commands/cauldron/add/nativeapp.ts
@@ -85,7 +85,11 @@ export const commandHandler = async ({
     }
   }
 
-  config = config && (await parseJsonFromStringOrFile(config));
+  try {
+    config = config && (await parseJsonFromStringOrFile(config));
+  } catch (e) {
+    throw new Error('(--config option): Invalid input');
+  }
 
   await kax.task(`Adding ${descriptor}`).run(
     cauldron.addNativeApplicationVersion(descriptor, {

--- a/ern-local-cli/src/commands/create-container.ts
+++ b/ern-local-cli/src/commands/create-container.ts
@@ -158,7 +158,12 @@ Output directory should either not exist (it will be created) or should be empty
     );
   }
 
-  const extraObj = (extra && (await parseJsonFromStringOrFile(extra))) || {};
+  let extraObj;
+  try {
+    extraObj = (extra && (await parseJsonFromStringOrFile(extra))) || {};
+  } catch (e) {
+    throw new Error('(--extra/-e option): Invalid input');
+  }
 
   // Full native application selector was not provided.
   // Ask the user to select a completeNapDescriptor from a list

--- a/ern-local-cli/src/commands/publish-container.ts
+++ b/ern-local-cli/src/commands/publish-container.ts
@@ -83,7 +83,12 @@ export const commandHandler = async ({
     },
   });
 
-  const extraObj = extra && (await parseJsonFromStringOrFile(extra));
+  let extraObj;
+  try {
+    extraObj = (extra && (await parseJsonFromStringOrFile(extra))) || {};
+  } catch (e) {
+    throw new Error('(--extra/-e option): Invalid input');
+  }
 
   if (
     publisher.isRegistryPath &&

--- a/ern-local-cli/src/commands/run-android.ts
+++ b/ern-local-cli/src/commands/run-android.ts
@@ -95,11 +95,14 @@ export const commandHandler = async ({
   deviceConfig.updateDeviceConfig('android', usePreviousDevice);
 
   const miniAppPackageJson = await readPackageJson(process.cwd());
-  const extraObj =
-    (extra && (await parseJsonFromStringOrFile(extra))) ||
-    miniAppPackageJson.ern
-      ? miniAppPackageJson.ern
-      : {};
+
+  let extraObj;
+  try {
+    extraObj = (extra && (await parseJsonFromStringOrFile(extra))) || {};
+  } catch (e) {
+    throw new Error('(--extra/-e option): Invalid input');
+  }
+  extraObj = extraObj ?? (miniAppPackageJson.ern ? miniAppPackageJson.ern : {});
 
   await runMiniApp('android', {
     baseComposite,

--- a/ern-local-cli/src/commands/transform-container.ts
+++ b/ern-local-cli/src/commands/transform-container.ts
@@ -58,7 +58,12 @@ export const commandHandler = async ({
     },
   });
 
-  const extraObj = extra && (await parseJsonFromStringOrFile(extra));
+  let extraObj;
+  try {
+    extraObj = (extra && (await parseJsonFromStringOrFile(extra))) || {};
+  } catch (e) {
+    throw new Error('(--extra/-e option): Invalid input');
+  }
 
   if (
     transformer.isRegistryPath &&


### PR DESCRIPTION
`--extra/-e` option of some commands is highly prone to errors as its value can a JSON literal or a JSON file, that can be easily malformatted in some way. 

In that case, `ern` currently fails with somewhat obscure error `An error occurred: [parseJsonFromStringOrFile] Invalid JSON or file` which might not immediately lead the user to understand that something is wrong with the `extra` option value being provided.

This PR just improves the error message in case of an issue parsing the `extra` option value. 