### PR TITLE
Remove mkdirp

### DIFF
--- a/ern-api-gen/package.json
+++ b/ern-api-gen/package.json
@@ -42,7 +42,6 @@
     "json-stable-stringify": "^1.0.1",
     "lodash": "^4.17.19",
     "minimatch": "^3.0.4",
-    "mkdirp": "^0.5.1",
     "mustache": "^4.0.1",
     "semver": "^5.5.0",
     "shelljs": "^0.8.4",

--- a/ern-api-gen/src/java/File.ts
+++ b/ern-api-gen/src/java/File.ts
@@ -1,7 +1,6 @@
 /* tslint:disable:variable-name */
 import fs from 'fs';
 import path from 'path';
-import { sync as mkdirsSync } from 'mkdirp';
 
 function canAccess(file) {
   try {
@@ -109,7 +108,7 @@ export default class File {
   }
 
   public mkdirs() {
-    return mkdirsSync(this._filename);
+    return fs.mkdirSync(this._filename, { recursive: true });
   }
 
   public toString() {


### PR DESCRIPTION
There was only a _single_ (direct) dependency on `mkdirp` left in our code base. This removes it and replaces it with (now) built-in functionality of `fs`.