### PR TITLE
Fix iOS API generator for arrays of primitives

### DIFF
--- a/ern-api-gen/resources/swift/libraries/ern/model.mustache
+++ b/ern-api-gen/resources/swift/libraries/ern/model.mustache
@@ -58,7 +58,7 @@
 {{/isPrimitiveType}}
 {{/isNotContainer}}
 {{^isNotContainer}}
-        if let valid{{nameInCamelCase}} = try? NSObject.generateObject(data: dictionary["{{name}}"], classType: Array<Any>.self, itemType: {{complexType}}.self),
+        if let valid{{nameInCamelCase}} = try? NSObject.generateObject(data: dictionary["{{name}}"], classType: Array<Any>.self, itemType: {{#items}}{{baseType}}{{/items}}.self),
              let {{baseName}}List = valid{{nameInCamelCase}} as? {{datatype}}  {
                  self.{{name}} = {{baseName}}List
              } else {
@@ -77,7 +77,7 @@
         }
 {{/isNotContainer}}
 {{^isNotContainer}}
-        if let valid{{nameInCamelCase}} = try? NSObject.generateObject(data: dictionary["{{name}}"], classType: [Any].self, itemType: {{complexType}}.self),
+        if let valid{{nameInCamelCase}} = try? NSObject.generateObject(data: dictionary["{{name}}"], classType: [Any].self, itemType: {{#items}}{{baseType}}{{/items}}.self),
             let {{baseName}}List = valid{{nameInCamelCase}} as? {{datatype}} {
             self.{{name}} = {{baseName}}List
         } else {
@@ -168,7 +168,7 @@ public class {{classname}}: ElectrodeObject, Bridgeable {
 {{/isPrimitiveType}}
 {{/isNotContainer}}
 {{^isNotContainer}}
-        if let valid{{nameInCamelCase}} = try? NSObject.generateObject(data: dictionary["{{name}}"], classType: [Any].self, itemType: {{complexType}}.self),
+        if let valid{{nameInCamelCase}} = try? NSObject.generateObject(data: dictionary["{{name}}"], classType: [Any].self, itemType: {{#items}}{{baseType}}{{/items}}.self),
              let {{baseName}}List = valid{{nameInCamelCase}} as? {{datatype}}  {
                  self.{{name}} = {{baseName}}List
              } else {
@@ -187,7 +187,7 @@ public class {{classname}}: ElectrodeObject, Bridgeable {
         }
 {{/isNotContainer}}
 {{^isNotContainer}}
-        if let valid{{nameInCamelCase}} = try? NSObject.generateObject(data: dictionary["{{name}}"], classType: [Any].self, itemType: {{complexType}}.self),
+        if let valid{{nameInCamelCase}} = try? NSObject.generateObject(data: dictionary["{{name}}"], classType: [Any].self, itemType: {{#items}}{{baseType}}{{/items}}.self),
             let {{baseName}}List = valid{{nameInCamelCase}} as? {{datatype}} {
             self.{{name}} = {{baseName}}List
         } else {


### PR DESCRIPTION
Fix a bug in iOS API generator that is producing invalid swift file when using an array of primitives as an object property type.

For example, defining an object `foo` with a `bar` property being a string array, as depicted by the following schema:

```json
{
  "foo": {
    "type": "object",
    "properties": {
       "bar": {
         "type": "array",
         "items": {
           "type": "string"
         }
       }
     }
  }
}
```

Is currently resulting in the following Swift code to be generated :

```objc
NSObject.generateObject(data: dictionary["bar"], classType: [Any].self, itemType: .self)
```

Instead of 

```objc
NSObject.generateObject(data: dictionary["bar"], classType: [Any].self, itemType: String.self)
```

The issue is not limited to string array type, but any array of primitive type is resulting in the same invalid generation.

This PR fixes that issue.

Related relevant code that is populating the mustache template can be found here in [DefaultCodegen.ts](https://github.com/electrode-io/electrode-native/blob/master/ern-api-gen/src/DefaultCodegen.ts#L1553-L1570)
