### PR TITLE
Add more properties to system test api schema

### DIFF
--- a/system-tests/fixtures/api/complex-api/IOS/ErnObject.swift
+++ b/system-tests/fixtures/api/complex-api/IOS/ErnObject.swift
@@ -22,8 +22,11 @@
      specify merge type
      */
     public let mergeType: Int?
+    public let stringArray: [String]?
+    public let integerArray: [Int]?
+    public let booleanArray: [Bool]?
 
-    public init(name: String, value: String?, domain: String?, path: String?, uri: String?, version: Double, expiry: Int64?, leftButton: NavBarButton?, rightButtons: [NavBarButton]?, isGuestUser: Bool?, mergeType: Int?) {
+    public init(name: String, value: String?, domain: String?, path: String?, uri: String?, version: Double, expiry: Int64?, leftButton: NavBarButton?, rightButtons: [NavBarButton]?, isGuestUser: Bool?, mergeType: Int?, stringArray: [String]?, integerArray: [Int]?, booleanArray: [Bool]?) {
         self.name = name
         self.value = value
         self.domain = domain
@@ -35,6 +38,9 @@
         self.rightButtons = rightButtons
         self.isGuestUser = isGuestUser
         self.mergeType = mergeType
+        self.stringArray = stringArray
+        self.integerArray = integerArray
+        self.booleanArray = booleanArray
         super.init()
     }
 
@@ -50,6 +56,9 @@
         self.rightButtons = nil
         self.isGuestUser = nil
         self.mergeType = nil
+        self.stringArray = nil
+        self.integerArray = nil
+        self.booleanArray = nil
         super.init()
     }
 
@@ -113,6 +122,24 @@
         } else {
             self.mergeType = nil
         }
+        if let validStringArray = try? NSObject.generateObject(data: dictionary["stringArray"], classType: [Any].self, itemType: String.self),
+            let stringArrayList = validStringArray as? [String] {
+            self.stringArray = stringArrayList
+        } else {
+            self.stringArray = nil
+        }
+        if let validIntegerArray = try? NSObject.generateObject(data: dictionary["integerArray"], classType: [Any].self, itemType: Int.self),
+            let integerArrayList = validIntegerArray as? [Int] {
+            self.integerArray = integerArrayList
+        } else {
+            self.integerArray = nil
+        }
+        if let validBooleanArray = try? NSObject.generateObject(data: dictionary["booleanArray"], classType: [Any].self, itemType: Bool.self),
+            let booleanArrayList = validBooleanArray as? [Bool] {
+            self.booleanArray = booleanArrayList
+        } else {
+            self.booleanArray = nil
+        }
 
         super.init(dictionary: dictionary)
     }
@@ -149,6 +176,15 @@
         }
         if let nonNullMergeType = self.mergeType {
             dict["mergeType"] = nonNullMergeType
+        }
+        if let nonNullStringArray = self.stringArray {
+            dict["stringArray"] = nonNullStringArray
+        }
+        if let nonNullIntegerArray = self.integerArray {
+            dict["integerArray"] = nonNullIntegerArray
+        }
+        if let nonNullBooleanArray = self.booleanArray {
+            dict["booleanArray"] = nonNullBooleanArray
         }
         return dict as NSDictionary
     }
@@ -179,8 +215,11 @@ public class ErnObject: ElectrodeObject, Bridgeable {
      specify merge type
      */
     public let mergeType: Int?
+    public let stringArray: [String]?
+    public let integerArray: [Int]?
+    public let booleanArray: [Bool]?
 
-    public init(name: String, value: String?, domain: String?, path: String?, uri: String?, version: Double, expiry: Int64?, leftButton: NavBarButton?, rightButtons: [NavBarButton]?, isGuestUser: Bool?, mergeType: Int?) {
+    public init(name: String, value: String?, domain: String?, path: String?, uri: String?, version: Double, expiry: Int64?, leftButton: NavBarButton?, rightButtons: [NavBarButton]?, isGuestUser: Bool?, mergeType: Int?, stringArray: [String]?, integerArray: [Int]?, booleanArray: [Bool]?) {
         self.name = name
         self.value = value
         self.domain = domain
@@ -192,6 +231,9 @@ public class ErnObject: ElectrodeObject, Bridgeable {
         self.rightButtons = rightButtons
         self.isGuestUser = isGuestUser
         self.mergeType = mergeType
+        self.stringArray = stringArray
+        self.integerArray = integerArray
+        self.booleanArray = booleanArray
         super.init()
     }
 
@@ -207,6 +249,9 @@ public class ErnObject: ElectrodeObject, Bridgeable {
         self.rightButtons = nil
         self.isGuestUser = nil
         self.mergeType = nil
+        self.stringArray = nil
+        self.integerArray = nil
+        self.booleanArray = nil
         super.init()
     }
 
@@ -270,6 +315,24 @@ public class ErnObject: ElectrodeObject, Bridgeable {
         } else {
             self.mergeType = nil
         }
+        if let validStringArray = try? NSObject.generateObject(data: dictionary["stringArray"], classType: [Any].self, itemType: String.self),
+            let stringArrayList = validStringArray as? [String] {
+            self.stringArray = stringArrayList
+        } else {
+            self.stringArray = nil
+        }
+        if let validIntegerArray = try? NSObject.generateObject(data: dictionary["integerArray"], classType: [Any].self, itemType: Int.self),
+            let integerArrayList = validIntegerArray as? [Int] {
+            self.integerArray = integerArrayList
+        } else {
+            self.integerArray = nil
+        }
+        if let validBooleanArray = try? NSObject.generateObject(data: dictionary["booleanArray"], classType: [Any].self, itemType: Bool.self),
+            let booleanArrayList = validBooleanArray as? [Bool] {
+            self.booleanArray = booleanArrayList
+        } else {
+            self.booleanArray = nil
+        }
 
         super.init(dictionary: dictionary)
     }
@@ -306,6 +369,15 @@ public class ErnObject: ElectrodeObject, Bridgeable {
         }
         if let nonNullMergeType = self.mergeType {
             dict["mergeType"] = nonNullMergeType
+        }
+        if let nonNullStringArray = self.stringArray {
+            dict["stringArray"] = nonNullStringArray
+        }
+        if let nonNullIntegerArray = self.integerArray {
+            dict["integerArray"] = nonNullIntegerArray
+        }
+        if let nonNullBooleanArray = self.booleanArray {
+            dict["booleanArray"] = nonNullBooleanArray
         }
         return dict as NSDictionary
     }

--- a/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complexapi/ern/model/ErnObject.java
+++ b/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complexapi/ern/model/ErnObject.java
@@ -52,6 +52,9 @@ public class ErnObject implements Parcelable, Bridgeable {
     private List<NavBarButton> rightButtons;
     private Boolean isGuestUser;
     private Integer mergeType;
+    private List<String> stringArray;
+    private List<Integer> integerArray;
+    private List<Boolean> booleanArray;
 
     private ErnObject() {
     }
@@ -68,6 +71,9 @@ public class ErnObject implements Parcelable, Bridgeable {
         this.rightButtons = builder.rightButtons;
         this.isGuestUser = builder.isGuestUser;
         this.mergeType = builder.mergeType;
+        this.stringArray = builder.stringArray;
+        this.integerArray = builder.integerArray;
+        this.booleanArray = builder.booleanArray;
     }
 
     private ErnObject(Parcel in) {
@@ -94,6 +100,9 @@ public class ErnObject implements Parcelable, Bridgeable {
         this.rightButtons = bundle.containsKey("rightButtons") ? getList(bundle.getParcelableArray("rightButtons"), NavBarButton.class) : null;
         this.isGuestUser = bundle.containsKey("isGuestUser") ? bundle.getBoolean("isGuestUser") : null;
         this.mergeType = getNumberValue(bundle, "mergeType") == null ? null : getNumberValue(bundle, "mergeType").intValue();
+        this.stringArray = bundle.containsKey("stringArray") ? getList(bundle.getStringArray("stringArray"), String.class) : null;
+        this.integerArray = bundle.containsKey("integerArray") ? getList(bundle.getIntArray("integerArray"), Integer.class) : null;
+        this.booleanArray = bundle.containsKey("booleanArray") ? getList(bundle.getBooleanArray("booleanArray"), Boolean.class) : null;
     }
 
     @NonNull
@@ -166,6 +175,21 @@ public class ErnObject implements Parcelable, Bridgeable {
         return mergeType;
     }
 
+    @Nullable
+    public List<String> getStringArray() {
+        return stringArray;
+    }
+
+    @Nullable
+    public List<Integer> getIntegerArray() {
+        return integerArray;
+    }
+
+    @Nullable
+    public List<Boolean> getBooleanArray() {
+        return booleanArray;
+    }
+
     @Override
     public int describeContents() {
         return 0;
@@ -209,6 +233,15 @@ public class ErnObject implements Parcelable, Bridgeable {
         if (this.mergeType != null) {
             bundle.putInt("mergeType", this.mergeType);
         }
+        if (this.stringArray != null) {
+            updateBundleWithList(this.stringArray, bundle, "stringArray");
+        }
+        if (this.integerArray != null) {
+            updateBundleWithList(this.integerArray, bundle, "integerArray");
+        }
+        if (this.booleanArray != null) {
+            updateBundleWithList(this.booleanArray, bundle, "booleanArray");
+        }
         return bundle;
     }
 
@@ -225,7 +258,10 @@ public class ErnObject implements Parcelable, Bridgeable {
                 + "leftButton:" + (leftButton != null ? leftButton.toString() : null) + ","
                 + "rightButtons:" + (rightButtons != null ? rightButtons.toString() : null) + ","
                 + "isGuestUser:" + isGuestUser + ","
-                + "mergeType:" + mergeType
+                + "mergeType:" + mergeType + ","
+                + "stringArray:" + (stringArray != null ? stringArray.toString() : null) + ","
+                + "integerArray:" + (integerArray != null ? integerArray.toString() : null) + ","
+                + "booleanArray:" + (booleanArray != null ? booleanArray.toString() : null)
                 + "}";
     }
 
@@ -241,6 +277,9 @@ public class ErnObject implements Parcelable, Bridgeable {
         private List<NavBarButton> rightButtons;
         private Boolean isGuestUser;
         private Integer mergeType;
+        private List<String> stringArray;
+        private List<Integer> integerArray;
+        private List<Boolean> booleanArray;
 
         public Builder(@NonNull String name, @NonNull Double version) {
             this.name = name;
@@ -298,6 +337,24 @@ public class ErnObject implements Parcelable, Bridgeable {
         @NonNull
         public Builder mergeType(@Nullable Integer mergeType) {
             this.mergeType = mergeType;
+            return this;
+        }
+
+        @NonNull
+        public Builder stringArray(@Nullable List<String> stringArray) {
+            this.stringArray = stringArray;
+            return this;
+        }
+
+        @NonNull
+        public Builder integerArray(@Nullable List<Integer> integerArray) {
+            this.integerArray = integerArray;
+            return this;
+        }
+
+        @NonNull
+        public Builder booleanArray(@Nullable List<Boolean> booleanArray) {
+            this.booleanArray = booleanArray;
             return this;
         }
 

--- a/system-tests/fixtures/api/complex-api/schema.json
+++ b/system-tests/fixtures/api/complex-api/schema.json
@@ -157,6 +157,24 @@
         "mergeType": {
           "type": "integer",
           "description": "specify merge type"
+        },
+        "stringArray": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "integerArray": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "booleanArray": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
         }
       },
       "required": [

--- a/system-tests/fixtures/api/complexapi-schema.json
+++ b/system-tests/fixtures/api/complexapi-schema.json
@@ -157,6 +157,24 @@
         "mergeType": {
           "type": "integer",
           "description": "specify merge type"
+        },
+        "stringArray": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "integerArray": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "booleanArray": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
         }
       },
       "required": [


### PR DESCRIPTION
Follow up to https://github.com/electrode-io/electrode-native/pull/1707

Add the following properties to `ERNObject` to complex API schema  

- `stringArray`
- `integerArray`
- `booleanArray`

to properly cover generation of some basic arrays of primitive types.

Obviously,  also regenerate system test fixtures 😉 