### PR TITLE
Remove strict cauldron https check

### DIFF
--- a/ern-cauldron-api/src/CauldronRepositories.ts
+++ b/ern-cauldron-api/src/CauldronRepositories.ts
@@ -17,16 +17,6 @@ export class CauldronRepositories {
       this.throwIfAliasExist({ alias });
     }
 
-    const supportedGitHttpsSchemeRe = /(^https:\/\/.+:.+@.+$)|(^https:\/\/.+@.+$)/;
-    if (url.startsWith('https')) {
-      if (!supportedGitHttpsSchemeRe.test(url)) {
-        throw new Error(`Cauldron https urls have to be formatted as:
-https://[username]:[password]@[repourl]
-OR
-https://[token]@[repourl]`);
-      }
-    }
-
     const cauldronRepositories = config.get('cauldronRepositories', {});
     cauldronRepositories[alias] = url;
     config.set('cauldronRepositories', sortObjectByKeys(cauldronRepositories));


### PR DESCRIPTION
Allow regular https-style urls with the `ern cauldron repo add` command.

1. There is no technical reason to only allow ssh urls or https with user/pass/token
2. Using a native credentials helper of the operating system is preferred over embedding credentials in the url
3. ERN works just fine with plain https url (no other changes needed)
4. It's not ERN's job to mandate/enforce a certain local Git setup