### PR TITLE
Reorder iOS container generator steps

### DIFF
--- a/ern-container-gen-ios/src/IosGenerator.ts
+++ b/ern-container-gen-ios/src/IosGenerator.ts
@@ -172,21 +172,6 @@ Make sure to run these commands before building the container.`,
           projectSpec,
         ),
       );
-    const { iosProject, projectPath } = await iosUtil.fillProjectHull(
-      pathSpec,
-      projectSpec,
-      config.plugins,
-      mustacheView,
-      config.composite,
-    );
-
-    await kax
-      .task('Adding Native Dependencies Hooks')
-      .run(
-        this.addiOSPluginHookClasses(iosProject, config.plugins, config.outDir),
-      );
-
-    fs.writeFileSync(projectPath, iosProject.writeSync());
 
     if (semver.gte(reactNativePlugin.version!, '0.61.0')) {
       shell.pushd(config.outDir);
@@ -265,7 +250,25 @@ Make sure to run these commands before building the container.`,
       } finally {
         shell.popd();
       }
+    }
 
+    const { iosProject, projectPath } = await iosUtil.fillProjectHull(
+      pathSpec,
+      projectSpec,
+      config.plugins,
+      mustacheView,
+      config.composite,
+    );
+
+    await kax
+      .task('Adding Native Dependencies Hooks')
+      .run(
+        this.addiOSPluginHookClasses(iosProject, config.plugins, config.outDir),
+      );
+
+    fs.writeFileSync(projectPath, iosProject.writeSync());
+
+    if (semver.gte(reactNativePlugin.version!, '0.61.0')) {
       // For full iOS container generation, run 'pod install'
       // and also add all essential node_modules (needed for the build)
       // to the container


### PR DESCRIPTION
Reorder a step of iOS container generation, just so that in case of an RN 61+ container, the plugin injection phase _(injecting native modules based on configuration defined in the manifest)_ is performed AFTER copying the composite `node_modules` _(containing the native module pods)_ to the container output directory and not BEFORE (as it is currently).

This is done because, in very specific cases, the native code and supporting pods of native modules could need to be altered or used in some ways during plugin injection, based on some plugin configuration directives, but can't currently happen because of the fact that this copy happens after the plugin configuration is evaluated.