### PR TITLE
Fix JS API implementations injection in composite

### DIFF
--- a/ern-composite-gen/src/createIndexJs.ts
+++ b/ern-composite-gen/src/createIndexJs.ts
@@ -4,28 +4,31 @@ import { readPackageJson, PackagePath } from 'ern-core';
 
 export async function createIndexJs({
   cwd,
+  jsApiImplDependencies = [],
   miniApps,
 }: {
   cwd: string;
+  jsApiImplDependencies: PackagePath[];
   miniApps: PackagePath[];
 }) {
   let entryIndexJsContent = '';
 
   const compositePackageJson = await readPackageJson(cwd);
-  for (const miniApp of miniApps) {
-    // Add miniapp imports strictly matching miniapps array order
-    // For git based miniapps we have to rely on some trickery to
+
+  for (const dependency of [...jsApiImplDependencies, ...miniApps]) {
+    // Add dependency imports strictly matching miniapps array order
+    // For git based dependencies we have to rely on some trickery to
     // find the package name, as it won't be set in the PackagePath
     // We just look in the composite package.json for a match on
     // the path, and get the package name from there.
     //
     // Sample git package in package.json:
     // "bar": "git+ssh://github.com/foo/bar.git#master"
-    const pkgName = miniApp.isGitPath
+    const pkgName = dependency.isGitPath
       ? Object.entries(compositePackageJson.dependencies).find(
-          ([, v]) => v === miniApp.fullPath,
+          ([, v]) => v === dependency.fullPath,
         )![0]
-      : miniApp.name;
+      : dependency.name;
     entryIndexJsContent += `import '${pkgName}'\n`;
   }
 

--- a/ern-composite-gen/src/generateComposite.ts
+++ b/ern-composite-gen/src/generateComposite.ts
@@ -128,7 +128,7 @@ async function generateFullComposite(
   outDir: string,
   {
     extraJsDependencies = [],
-    jsApiImplDependencies,
+    jsApiImplDependencies = [],
     pathToYarnLock,
     resolutions,
   }: {
@@ -192,12 +192,14 @@ async function generateFullComposite(
       extraJsDependencies.push(
         PackagePath.fromString(`react-native-electrode-bridge`),
       );
+      extraJsDependencies = [...extraJsDependencies, ...jsApiImplDependencies];
     }
 
     await addRNStartScriptToPjson({ cwd: outDir });
 
     await createIndexJs({
       cwd: outDir,
+      jsApiImplDependencies,
       miniApps,
     });
 


### PR DESCRIPTION
Looks like when we introduced faster composite generation back in 0.41.0, we forgot about JS API implementations ...

We are not using any JS API implementations internally, that's probably why this problem has not surfaced earlier and been only [recently reported](https://github.com/electrode-io/electrode-native/issues/1710).

The issue only impacts container/composite generation when using one or more JS API implementations and only local MiniApps _(i.e not git or registry urls for the MiniApps, only file based path)_. In that case the JS API implementations provided to the composite generator are just plain ignored _(not installed in the composite, nor imported in composite index.js. entry file)._

This PR fixes this, by properly handling JS API implementation(s) in this specific context _(installing them in the composite + importing them in the composite index.js)._

Fixes https://github.com/electrode-io/electrode-native/issues/1710