### PR TITLE
Fix an issue with linked registry miniapps

### DIFF
--- a/ern-orchestrator/src/start.ts
+++ b/ern-orchestrator/src/start.ts
@@ -111,7 +111,7 @@ export default async function start({
   );
   _.remove(miniapps, (m) => npmMiniAppsLinkedPkgNames.includes(m.name!));
   npmMiniAppsLinkedPkgNames.forEach((pkgName) =>
-    miniapps.push(miniAppsLinksObj[pkgName]),
+    miniapps.push(PackagePath.fromString(miniAppsLinksObj[pkgName])),
   );
 
   const composite = await kax.task('Generating MiniApps composite').run(


### PR DESCRIPTION
Fix an issue causing linked registry based miniapps _(miniapps linked using `ern link` and retrieved from a registry url instead of git)_ to be improperly imported in the composite index.

Fixes https://github.com/electrode-io/electrode-native/issues/1713