### PR TITLE
Fix CodePush MiniApps import ordering

### DIFF
--- a/ern-orchestrator/src/codepush.ts
+++ b/ern-orchestrator/src/codepush.ts
@@ -376,14 +376,14 @@ export async function performCodePushOtaUpdate(
     }
 
     const miniAppsToBeCodePushed = _.unionBy(
-      miniApps,
       referenceMiniAppsToCodePush,
+      miniApps,
       (x) => x.basePath,
     );
 
     const jsApiImplsToBeCodePushed = _.unionBy(
-      jsApiImpls,
       referenceJsApiImplsToCodePush,
+      jsApiImpls,
       (x) => x.basePath,
     );
 


### PR DESCRIPTION
Follow up to https://github.com/electrode-io/electrode-native/pull/1687

CodePush is not guaranteeing MiniApps import order based on Cauldron because of a [`unionBy`](https://lodash.com/docs/#unionBy) call that uses user provided MiniApps to CodePush as first parameter of the union call, and the complete list of MiniApps from Cauldron as the second parameter. Because lodash [`unionBy`](https://lodash.com/docs/#unionBy) order elements based on the first array, this causes the order guarantee based on Cauldron not to be honored.

The fix is just to switch the two parameters, so that ordering will match the order from Cauldron, as for all other commands generating a composite from Cauldron.
