### PR TITLE
Fixes

### DIFF
--- a/ern-composite-gen/src/generateComposite.ts
+++ b/ern-composite-gen/src/generateComposite.ts
@@ -184,16 +184,17 @@ async function generateFullComposite(
       extraJsDependencies.push(
         PackagePath.fromString(`react@${miniAppReactVersion}`),
       );
-      // Explicitly add react as an extra node module in metro config
-      // Because its not a native module, it will not be auto added
-      // later on as done for native modules
-      extraNodeModules.react = path.join(outDir, 'node_modules/react');
       // Also add latest version of the bridge
       extraJsDependencies.push(
         PackagePath.fromString(`react-native-electrode-bridge`),
       );
       extraJsDependencies = [...extraJsDependencies, ...jsApiImplDependencies];
     }
+
+    // Explicitly add react as an extra node module in metro config
+    // Because its not a native module, it will not be auto added
+    // later on as done for native modules
+    extraNodeModules.react = path.join(outDir, 'node_modules/react');
 
     await addRNStartScriptToPjson({ cwd: outDir });
 

--- a/ern-core/src/Manifest.ts
+++ b/ern-core/src/Manifest.ts
@@ -210,6 +210,14 @@ export interface IosPluginConfig extends CommonPluginConfig {
    * will be processed
    */
   requiresManualLinking?: boolean;
+  /**
+   * Indicates whether to ignore the podspec
+   * This can be used in case of manually linking a plugin with
+   * requiresManualLinking, if the plugin has a podspec
+   * Otherwise the plugin will both be manually linked by ern
+   * but also auto linked by RN63 due to the precense of the podsepc
+   */
+  ignorePodSpec?: boolean;
 }
 
 /**


### PR DESCRIPTION
Addresses a few issues experienced in `0.44.0`. Fixes to be shipped in `0.44.1`.

- Fix issue with composite not resolving `react` dependency when mixing git and local miniapps *(impacting composite generation and start command)*
- Fix issue with `podspec` iOS directive *(not working in `0.44.0`)*
- Add new iOS directive `ignorePodSpec` *(not a fix per se but needs to be shipped for internal needs)*