### PR TITLE
Set verbose flag for pod install command

### DIFF
--- a/ern-container-gen-ios/src/IosGenerator.ts
+++ b/ern-container-gen-ios/src/IosGenerator.ts
@@ -279,7 +279,7 @@ Make sure to run these commands before building the container.`,
         try {
           await kax
             .task('Running pod install')
-            .run(childProcess.spawnp('pod', ['install']));
+            .run(childProcess.spawnp('pod', ['install', '--verbose']));
         } finally {
           shell.popd();
         }


### PR DESCRIPTION
Add `verbose` flag to `pod install` command, to get more details, especially in the case of the command failing.