### PR TITLE
Run basic system test on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: ci
-on: [push, pull_request]
+on:
+  push:
+    branches: '*'
+  pull_request:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -18,7 +21,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-      - run: yarn
+      - run: yarn --frozen-lockfile
       - run: yarn build
       - run: yarn test:unit
   lint:
@@ -26,5 +29,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
-      - run: yarn
+      - run: yarn --frozen-lockfile
       - run: yarn check:lint
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      - run: yarn --frozen-lockfile
+      - run: yarn test:system basic

--- a/system-tests/src/tests/basic.js
+++ b/system-tests/src/tests/basic.js
@@ -1,0 +1,21 @@
+const chalk = require('chalk');
+const path = require('path');
+
+const run = require('../utils/run');
+
+console.log(chalk.bold.blue(`Working directory: ${process.cwd()}`));
+
+const miniAppName = 'BasicMiniApp';
+run(`create-miniapp ${miniAppName} --packageName basic-miniapp --skipNpmCheck --skipInstall`);
+
+const miniAppPath = path.join(process.cwd(), miniAppName);
+
+// Escape backslashes on Windows
+const miniApp = `file:${
+  process.platform === 'win32'
+    ? miniAppPath.replace(/\\/g, '\\\\')
+    : miniAppPath
+}`;
+
+run(`create-container -m ${miniApp} -p android`);
+run(`create-container -m ${miniApp} -p ios --skipInstall`);

--- a/system-tests/src/tests/misc.js
+++ b/system-tests/src/tests/misc.js
@@ -133,9 +133,15 @@ run(
   { expectedExitCode: 1 },
 );
 
+// Escape backslashes on Windows
+const miniApp = `file:${
+  process.platform === 'win32'
+    ? miniAppPath.replace(/\\/g, '\\\\')
+    : miniAppPath
+}`;
 // Container gen should be successful for the two following commands
-run(`create-container --miniapps file:${miniAppPath} -p android`);
-run(`create-container --miniapps file:${miniAppPath} -p ios --skipInstall`);
+run(`create-container --miniapps ${miniApp} -p android`);
+run(`create-container --miniapps ${miniApp} -p ios --skipInstall`);
 
 // transform-container / publish-container should be successful
 run(


### PR DESCRIPTION
This adds a "basic" system test (creating a miniapp, and generating both Android and iOS containers). While this test is of course not as comprehensive as the full suite, it will help us catch a large number of potential bugs **much earlier**. It has already happened several times in the past that we were surprised by a 9pm system test failure.

Also fixed a few issues with command line args running tests on Windows.

To run the test:

```sh
yarn test:system basic
```

It takes around 3 minutes on my local machine. Since it will run _in parallel_ with other jobs on CI, it _should_ be fast enough to run with every PR. We can test this out for a week or two and see how it goes.

This is one more step towards fully migrating to GitHub Actions CI, and if this proves to be reliable, we can (finally) remove the Azure tests in the near future (after running the full system test suite on schedule).