### PR TITLE
Improve an error message in iOS container generator

### DIFF
--- a/ern-core/src/iosUtil.ts
+++ b/ern-core/src/iosUtil.ts
@@ -349,12 +349,34 @@ export async function fillProjectHull(
                 projectAbsolutePath,
                 staticLibs: project.staticLibs,
               };
-              iosProject.addProject(
-                project.path,
-                project.group,
-                target,
-                options,
-              );
+              try {
+                iosProject.addProject(
+                  project.path,
+                  project.group,
+                  target,
+                  options,
+                );
+              } catch (e) {
+                if (
+                  e.message.includes(
+                    "Cannot read property 'productReference'",
+                  ) &&
+                  options.staticLibs?.length >= 1
+                ) {
+                  throw new Error(
+                    `Error when trying to inject ${
+                      plugin.name
+                    } in iOS container.
+This error is typically due to a plugin misconfiguration in the manifest.
+Please make sure that the following static lib(s) reference(s) (name and target) in your configuration ...
+${JSON.stringify(options.staticLibs, null, 2)}
+... are matching the values defined in the native module pbxproj located in ${projectAbsolutePath}.
+`,
+                  );
+                } else {
+                  throw e;
+                }
+              }
             }
           }
 


### PR DESCRIPTION
Some users have reported the following obscure error when generating an iOS container 

`✖ An error occurred: TypeError: Cannot read property 'productReference' of null`

This error is coming from the library we use to parse iOS project files _(.pbxproj)_ and is usually caused by a plugin misconfiguration in manifest. Unfortunately this error is not very informative and does not clearly point to the cause of the problem.

This PR improves the error message in such a scenario, to throw this error instead _(sample)_

```
✖ An error occurred: Error when trying to inject react-native-reanimated in iOS container.
✖ This error is typically due to a plugin misconfiguration in manifest.
✖ Please make sure that the following static lib(s) reference(s) (name and target) in your configuration ...
✖ [
✖   {
✖     "name": "libRNReanimate.a",
✖     "target": "RNeanimated"
✖   }
✖ ]
✖ ... are matching the values defined in the native module pbxproj located in RNReanimated.xcodeproj/project.pbxproj.
```