### PR TITLE
Use extraPods array in mustache template

### DIFF
--- a/ern-core/src/iosUtil.ts
+++ b/ern-core/src/iosUtil.ts
@@ -480,10 +480,7 @@ ${JSON.stringify(options.staticLibs, null, 2)}
       await mustacheUtils.mustacheRenderToOutputFileUsingTemplateFile(
         destPodfilePath,
         {
-          extraPods: additionalPods.reduce(
-            (acc, cur) => `${acc}\n  ${cur}`,
-            '',
-          ),
+          extraPods: additionalPods,
           iosDeploymentTarget: projectSpec.deploymentTarget,
           nodeModulesRelativePath:
             projectSpec.nodeModulesRelativePath || './node_modules',


### PR DESCRIPTION
Instead of using `reduce` to manually construct the string for extraPods with linebreaks and two space indentation after the first line, we can pass the array and let mustache iterate over it:

```
{{#extraPods}}
  {{{.}}}
{{/extraPods}}
```

This is already part of the upcoming **ern 0.45 plugin config**: https://github.com/electrode-io/electrode-native-manifest/pull/193

It makes the code here slightly shorter, and also avoids the whitespace error in Podfile if there are _no_ additional pods to include.