### PR TITLE
Fix iOS deployment target for native api impls

### DIFF
--- a/ern-api-impl-gen/src/generators/ios/ApiImplIosGenerator.ts
+++ b/ern-api-impl-gen/src/generators/ios/ApiImplIosGenerator.ts
@@ -48,10 +48,15 @@ export default class ApiImplIosGenerator implements ApiImplGeneratable {
   ) {
     log.debug(`Starting project generation for ${this.platform}`);
     this.regenerateApiImpl = regen;
-    await this.fillHull(paths, plugins, apis);
+    await this.fillHull(paths, plugins, apis, reactNativeVersion);
   }
 
-  public async fillHull(paths: any, plugins: PackagePath[], apis: any[]) {
+  public async fillHull(
+    paths: any,
+    plugins: PackagePath[],
+    apis: any[],
+    reactNativeVersion: string,
+  ) {
     try {
       const pathSpec = {
         outputDir: path.join(paths.outDirectory, 'ios'),
@@ -60,6 +65,9 @@ export default class ApiImplIosGenerator implements ApiImplGeneratable {
       };
 
       const projectSpec = {
+        deploymentTarget: iosUtil.getDefaultIosDeploymentTarget(
+          reactNativeVersion,
+        ),
         nodeModulesRelativePath: '../node_modules',
         projectName: 'ElectrodeApiImpl',
       };

--- a/ern-container-gen-ios/src/IosGenerator.ts
+++ b/ern-container-gen-ios/src/IosGenerator.ts
@@ -151,7 +151,7 @@ Make sure to run these commands before building the container.`,
     mustacheView.jsMainModuleName = config.jsMainModuleName || 'index';
     mustacheView.iosDeploymentTarget =
       config.iosConfig.deploymentTarget ??
-      getDefaultIosDeploymentTarget(reactNativePlugin.version);
+      iosUtil.getDefaultIosDeploymentTarget(reactNativePlugin.version);
 
     injectReactNativeVersionKeysInObject(
       mustacheView,
@@ -479,13 +479,3 @@ Make sure to run these commands before building the container.`,
     }
   }
 }
-
-const getDefaultIosDeploymentTarget = (rnVersion: string): string | null => {
-  if (semver.gte(rnVersion, '0.63.0')) {
-    return '10.0';
-  } else if (semver.gte(rnVersion, '0.61.0')) {
-    return '9.0';
-  } else {
-    return null;
-  }
-};

--- a/ern-core/src/iosUtil.ts
+++ b/ern-core/src/iosUtil.ts
@@ -529,3 +529,13 @@ function switchToOldDirectoryStructure(
   }
   return false;
 }
+
+export const getDefaultIosDeploymentTarget = (
+  rnVersion: string,
+): string | undefined => {
+  if (semver.gte(rnVersion, '0.63.0')) {
+    return '10.0';
+  } else if (semver.gte(rnVersion, '0.61.0')) {
+    return '9.0';
+  }
+};


### PR DESCRIPTION
Follow up of https://github.com/electrode-io/electrode-native/pull/1737 which missed propagating the iOS deployment target for native api implementation project generation.

Moved `getDefaultIosDeploymentTarget` function to `iosUtil` part of this PR, as being a generic iOS utility function it belongs in this file, making it more accessible to other modules. Also make it return undefined instead of null, to comply with some expected types _(and in a sense it's more meaningful as the pod deployment target is not defined for versions of RN < 61 that are not using any Podfile)._