### PR TITLE
Fix an issue with ios container deployment target

### DIFF
--- a/ern-container-gen-ios/src/IosGenerator.ts
+++ b/ern-container-gen-ios/src/IosGenerator.ts
@@ -150,7 +150,7 @@ Make sure to run these commands before building the container.`,
     const mustacheView: any = {};
     mustacheView.jsMainModuleName = config.jsMainModuleName || 'index';
     mustacheView.iosDeploymentTarget =
-      config.iosConfig.deploymentTarget ??
+      config.iosConfig?.deploymentTarget ??
       iosUtil.getDefaultIosDeploymentTarget(reactNativePlugin.version);
 
     injectReactNativeVersionKeysInObject(


### PR DESCRIPTION
Fix an issue with ios container deployment target caught by system tests.
In case no explicit extra ios configuration is supplied to the container generator, this LOC would throw an error.
To be merged prior to 0.45.0 release.