### PR TITLE
Add custom Metro config extraNodeModules support

### DIFF
--- a/docs/platform-parts/composite/index.md
+++ b/docs/platform-parts/composite/index.md
@@ -58,6 +58,26 @@ Resolutions configuration can be done in the `compositeGenerator` config in the 
 
 Please note that this configuration will be ignored if you are using a custom composite. Because a custom composite offers full control of the Composite project, it is the responsibility of the custom composite project maintainer to manually add `resolutions` to the `package.json` of the custom composite.
 
+### Custom `extraNodeModules` in Metro config
+
+Custom entries to the `resolver.extraNodeModules` property in `metro.config.json` can be added via the
+`metroExtraNodeModules` field. It supports both relative and absolute paths. Relative paths will resolve to
+`node_modules` inside the Composite project.
+
+```json
+"config": {
+  "compositeGenerator": {
+    "metroExtraNodeModules": {
+      "pkg-a": "@scope/new-pkg-a",
+      "pkg-b": "/absolute/path/to/new-pkg-b"
+    }
+  }
+}
+```
+
+Similar to selective dependency resolutions described above, custom extraNodeModules are only supported for a full
+composite. When using a custom composite, `metro.config.json` should be modified directly.
+
 ## Note in regards to local `.npmrc`
 
 When generating a Composite, Electrode Native will not consider any local `.npmrc` file present in the root of a MiniApp.  
@@ -70,7 +90,7 @@ In the majority of cases, there is no need to create a custom composite, as Elec
 
 Setting up a custom Composite project (also known as a base Composite) for Electrode Native is relatively straightforward.
 
-This can be achived in two steps:
+This can be achieved in two steps:
 
 1. Create the Composite git repository
 2. Configure Electrode Native to use custom Composite rather than the one built-in

--- a/ern-composite-gen/src/types/CompositeGeneratorConfig.ts
+++ b/ern-composite-gen/src/types/CompositeGeneratorConfig.ts
@@ -31,4 +31,10 @@ export interface CompositeGeneratorConfig {
    * Can be used to force the version of selected packages
    */
   resolutions?: { [pkg: string]: string };
+  /**
+   * Which other node_modules to include besides the ones relative to the
+   * project directory. This is keyed by dependency name.
+   * https://facebook.github.io/metro/docs/configuration/#extranodemodules
+   */
+  metroExtraNodeModules?: { [pkg: string]: string };
 }

--- a/ern-container-gen/src/bundleMiniApps.ts
+++ b/ern-container-gen/src/bundleMiniApps.ts
@@ -17,6 +17,7 @@ export async function bundleMiniApps(
     baseComposite,
     jsApiImplDependencies,
     resolutions,
+    metroExtraNodeModules,
     extraJsDependencies,
     resetCache,
   }: {
@@ -27,6 +28,7 @@ export async function bundleMiniApps(
     baseComposite?: PackagePath;
     jsApiImplDependencies?: PackagePath[];
     resolutions?: { [pkg: string]: string };
+    metroExtraNodeModules?: { [pkg: string]: string };
     extraJsDependencies?: PackagePath[];
     resetCache?: boolean;
   } = {},
@@ -36,6 +38,7 @@ export async function bundleMiniApps(
       baseComposite,
       extraJsDependencies,
       jsApiImplDependencies,
+      metroExtraNodeModules,
       miniApps,
       outDir: compositeDir,
       pathToYarnLock,

--- a/ern-local-cli/src/commands/bundlestore/upload.ts
+++ b/ern-local-cli/src/commands/bundlestore/upload.ts
@@ -138,6 +138,7 @@ export const commandHandler = async ({
 
     let pathToYarnLock;
     let resolutions;
+    let metroExtraNodeModules;
     if (descriptor) {
       await logErrorAndExitIfNotSatisfied({
         napDescriptorExistInCauldron: {
@@ -171,6 +172,8 @@ export const commandHandler = async ({
         (compositeGenConfig?.baseComposite &&
           PackagePath.fromString(compositeGenConfig.baseComposite));
       resolutions = compositeGenConfig && compositeGenConfig.resolutions;
+      metroExtraNodeModules =
+        compositeGenConfig && compositeGenConfig.metroExtraNodeModules;
     }
 
     const compositeDir = createTmpDir();
@@ -179,6 +182,7 @@ export const commandHandler = async ({
         baseComposite,
         extraJsDependencies,
         jsApiImplDependencies: jsApiImpls,
+        metroExtraNodeModules,
         miniApps: miniapps!,
         outDir: compositeDir,
         pathToYarnLock,

--- a/ern-local-cli/src/commands/create-composite.ts
+++ b/ern-local-cli/src/commands/create-composite.ts
@@ -110,6 +110,7 @@ Output directory should either not exist (it will be created) or should be empty
 
   let pathToYarnLock;
   let resolutions;
+  let metroExtraNodeModules;
   if (descriptor) {
     await logErrorAndExitIfNotSatisfied({
       napDescriptorExistInCauldron: {
@@ -143,6 +144,8 @@ Output directory should either not exist (it will be created) or should be empty
       (compositeGenConfig?.baseComposite &&
         PackagePath.fromString(compositeGenConfig.baseComposite));
     resolutions = compositeGenConfig && compositeGenConfig.resolutions;
+    metroExtraNodeModules =
+      compositeGenConfig && compositeGenConfig.metroExtraNodeModules;
   }
 
   await kax.task('Generating Composite').run(
@@ -150,6 +153,7 @@ Output directory should either not exist (it will be created) or should be empty
       baseComposite,
       extraJsDependencies,
       jsApiImplDependencies: jsApiImpls,
+      metroExtraNodeModules,
       miniApps: miniapps!,
       outDir,
       pathToYarnLock,


### PR DESCRIPTION
This adds support for custom `extraNodeModules` entries in `metro.config.json` of the Composite project.

Docs have been updated and a test case was added. The diff is pretty short and straightforward, so I won't put any additional description here.

I'm not exactly sure if something identical can be done with the existing Babel support - If that's the case then we might not need this.