### PR TITLE
Align composite gen config parameters

### DIFF
--- a/ern-local-cli/src/commands/create-container.ts
+++ b/ern-local-cli/src/commands/create-container.ts
@@ -183,14 +183,15 @@ Output directory should either not exist (it will be created) or should be empty
           'You cannot create a container for a non-existing native application version.',
       },
     });
-    const compositeGenConfig = await cauldron.getCompositeGeneratorConfig(
-      descriptor,
-    );
-    baseComposite =
-      baseComposite ||
-      (compositeGenConfig?.baseComposite &&
-        PackagePath.fromString(compositeGenConfig.baseComposite));
   }
+
+  const compositeGenConfig = await cauldron.getCompositeGeneratorConfig(
+    descriptor,
+  );
+  baseComposite =
+    baseComposite ||
+    (compositeGenConfig?.baseComposite &&
+      PackagePath.fromString(compositeGenConfig.baseComposite));
 
   if (!descriptor && miniapps) {
     platform = platform || (await askUserToSelectAPlatform());
@@ -205,6 +206,7 @@ Output directory should either not exist (it will be created) or should be empty
       runLocalCompositeGen({
         baseComposite,
         jsApiImpls,
+        metroExtraNodeModules: compositeGenConfig?.metroExtraNodeModules,
         miniApps: miniapps,
         outDir: compositeDir,
       }),

--- a/ern-local-cli/src/commands/create-container.ts
+++ b/ern-local-cli/src/commands/create-container.ts
@@ -202,9 +202,10 @@ Output directory should either not exist (it will be created) or should be empty
     }
 
     const composite = await kax.task('Generating Composite locally').run(
-      runLocalCompositeGen(miniapps, {
+      runLocalCompositeGen({
         baseComposite,
         jsApiImpls,
+        miniApps: miniapps,
         outDir: compositeDir,
       }),
     );

--- a/ern-orchestrator/src/composite.ts
+++ b/ern-orchestrator/src/composite.ts
@@ -15,12 +15,14 @@ export async function runLocalCompositeGen(
   {
     baseComposite,
     jsApiImpls,
+    metroExtraNodeModules,
     miniApps,
     outDir,
     resolutions,
   }: {
     baseComposite?: PackagePath;
     jsApiImpls?: PackagePath[];
+    metroExtraNodeModules?: { [pkg: string]: string };
     miniApps: PackagePath[];
     outDir: string;
     resolutions?: { [pkg: string]: string };
@@ -31,6 +33,7 @@ export async function runLocalCompositeGen(
       GeneratedComposite.generate({
         baseComposite,
         jsApiImplDependencies: jsApiImpls,
+        metroExtraNodeModules,
         miniApps,
         outDir,
         resolutions,

--- a/ern-orchestrator/src/composite.ts
+++ b/ern-orchestrator/src/composite.ts
@@ -1,7 +1,6 @@
 import { Composite, GeneratedComposite } from 'ern-composite-gen';
 import {
   AppVersionDescriptor,
-  createTmpDir,
   kax,
   log,
   PackagePath,
@@ -13,16 +12,17 @@ import * as constants from './constants';
 import path from 'path';
 
 export async function runLocalCompositeGen(
-  miniappPackagesPaths: PackagePath[],
   {
     baseComposite,
     jsApiImpls,
+    miniApps,
     outDir,
     resolutions,
   }: {
     baseComposite?: PackagePath;
     jsApiImpls?: PackagePath[];
-    outDir?: string;
+    miniApps: PackagePath[];
+    outDir: string;
     resolutions?: { [pkg: string]: string };
   },
 ): Promise<GeneratedComposite> {
@@ -31,8 +31,8 @@ export async function runLocalCompositeGen(
       GeneratedComposite.generate({
         baseComposite,
         jsApiImplDependencies: jsApiImpls,
-        miniApps: miniappPackagesPaths,
-        outDir: outDir || createTmpDir(),
+        miniApps,
+        outDir,
         resolutions,
       }),
     );
@@ -55,9 +55,9 @@ export async function runCauldronCompositeGen(
     favorGitBranches,
   }: {
     baseComposite?: PackagePath;
-    outDir?: string;
+    outDir: string;
     favorGitBranches?: boolean;
-  } = {},
+  },
 ): Promise<GeneratedComposite> {
   try {
     const cauldron = await getActiveCauldron();
@@ -95,7 +95,7 @@ export async function runCauldronCompositeGen(
         baseComposite,
         jsApiImplDependencies: jsApiImpls,
         miniApps: miniapps,
-        outDir: outDir || createTmpDir(),
+        outDir,
         pathToYarnLock,
         resolutions: compositeGenConfig && compositeGenConfig.resolutions,
       }),

--- a/ern-orchestrator/src/generateContainerForRunner.ts
+++ b/ern-orchestrator/src/generateContainerForRunner.ts
@@ -1,5 +1,6 @@
 import {
   AppVersionDescriptor,
+  createTmpDir,
   kax,
   NativePlatform,
   PackagePath,
@@ -32,6 +33,7 @@ export async function generateContainerForRunner(
     const composite = await kax.task('Generating Composite from Cauldron').run(
       runCauldronCompositeGen(napDescriptor, {
         baseComposite,
+        outDir: createTmpDir(),
       }),
     );
 
@@ -43,9 +45,11 @@ export async function generateContainerForRunner(
     );
   } else {
     const composite = await kax.task('Generating Composite locally').run(
-      runLocalCompositeGen(miniApps, {
+      runLocalCompositeGen({
         baseComposite,
         jsApiImpls,
+        miniApps,
+        outDir: createTmpDir(),
       }),
     );
 


### PR DESCRIPTION
Two small commits related to passing custom metro config parameters to the composite generator. Best reviewed individually:

The first commit only aligns some minor inconsistencies in parameter naming and structure (no functional changes). The second commit is the one with the actual change: `create-container` now supports the optional `metroExtraNodeModules` in a Cauldron's `compositeGenerator` config added in #1743.