### PR TITLE
Fix default iOS deployment target for RN<0.61

### DIFF
--- a/ern-core/src/iosUtil.ts
+++ b/ern-core/src/iosUtil.ts
@@ -532,10 +532,12 @@ function switchToOldDirectoryStructure(
 
 export const getDefaultIosDeploymentTarget = (
   rnVersion: string,
-): string | undefined => {
+): string => {
   if (semver.gte(rnVersion, '0.63.0')) {
     return '10.0';
-  } else if (semver.gte(rnVersion, '0.61.0')) {
+  } else if (semver.gte(rnVersion, '0.56.0')) {
     return '9.0';
+  } else {
+    return '8.0';
   }
 };


### PR DESCRIPTION
Related to #1737 #1739 #1741, usage of `getDefaultIosDeploymentTarget` in projects with a version of React Native **lower than 0.61** leads to a bug which leaves the deployment target undefined. This causes the generated container to defaults to the latest in Xcode (e.g. 13.2), and fail the build.

With this small patch, the method now supports practically all versions of RN: Versions before 0.56.0 had a deployment target set to `8.0` (tested all the way down to 0.41). The change from 8.0 to 9.0 happened in RN 0.56 (not 0.61, which is what the method previously assumed).

Thanks @jw2175 for helping to investigate!