### PR TITLE
Fix cauldron requirement for create-container command

### DIFF
--- a/ern-cauldron-api/src/getActiveCauldron.ts
+++ b/ern-cauldron-api/src/getActiveCauldron.ts
@@ -12,7 +12,33 @@ let currentCauldronHelperInstance: CauldronHelper;
 let currentCauldronRepoInUse: string;
 const ernPlatformUseCmdMsg = 'ern platform use <version> command';
 
-export default async function getActiveCauldron({
+export async function getActiveCauldron({
+  ignoreRequiredErnVersionMismatch,
+  ignoreSchemaVersionMismatch,
+  localRepoPath,
+  throwIfNoActiveCauldron,
+  silent,
+}?: {
+  ignoreRequiredErnVersionMismatch?: boolean;
+  ignoreSchemaVersionMismatch?: boolean;
+  localRepoPath?: string;
+  throwIfNoActiveCauldron: true;
+  silent?: boolean;
+}): Promise<CauldronHelper>;
+export async function getActiveCauldron({
+  ignoreRequiredErnVersionMismatch,
+  ignoreSchemaVersionMismatch,
+  localRepoPath,
+  throwIfNoActiveCauldron,
+  silent,
+}: {
+  ignoreRequiredErnVersionMismatch?: boolean;
+  ignoreSchemaVersionMismatch?: boolean;
+  localRepoPath?: string;
+  throwIfNoActiveCauldron: false;
+  silent?: boolean;
+}): Promise<CauldronHelper | undefined>;
+export async function getActiveCauldron({
   ignoreRequiredErnVersionMismatch,
   ignoreSchemaVersionMismatch,
   localRepoPath,
@@ -24,7 +50,7 @@ export default async function getActiveCauldron({
   localRepoPath?: string;
   throwIfNoActiveCauldron?: boolean;
   silent?: boolean;
-} = {}): Promise<CauldronHelper> {
+} = {}): Promise<CauldronHelper | undefined> {
   const repoInUse = config.get('cauldronRepoInUse');
   ignoreRequiredErnVersionMismatch =
     ignoreRequiredErnVersionMismatch ||

--- a/ern-cauldron-api/src/index.ts
+++ b/ern-cauldron-api/src/index.ts
@@ -3,7 +3,6 @@ import _EphemeralFileStore from './EphemeralFileStore';
 import _InMemoryDocumentStore from './InMemoryDocumentStore';
 import _GitFileStore from './GitFileStore';
 import _GitDocumentStore from './GitDocumentStore';
-import _getActiveCauldron from './getActiveCauldron';
 import { CauldronRepositories } from './CauldronRepositories';
 
 export { CauldronHelper } from './CauldronHelper';
@@ -13,9 +12,9 @@ export const EphemeralFileStore = _EphemeralFileStore;
 export const InMemoryDocumentStore = _InMemoryDocumentStore;
 export const GitFileStore = _GitFileStore;
 export const GitDocumentStore = _GitDocumentStore;
-export const getActiveCauldron = _getActiveCauldron;
 
 export * from './types';
+export * from './getActiveCauldron';
 
 export {
   getSchemaVersionMatchingCauldronApiVersion,

--- a/ern-local-cli/src/commands/cauldron/config/get.ts
+++ b/ern-local-cli/src/commands/cauldron/config/get.ts
@@ -44,6 +44,7 @@ export const commandHandler = async ({
 }) => {
   const cauldron = await getActiveCauldron({
     ignoreRequiredErnVersionMismatch: true,
+    throwIfNoActiveCauldron: true,
   });
   let result: any;
   if (key && strict) {

--- a/ern-local-cli/src/commands/cauldron/upgrade.ts
+++ b/ern-local-cli/src/commands/cauldron/upgrade.ts
@@ -12,6 +12,7 @@ export const commandHandler = async () => {
   const cauldron = await getActiveCauldron({
     ignoreRequiredErnVersionMismatch: true,
     ignoreSchemaVersionMismatch: true,
+    throwIfNoActiveCauldron: true,
   });
   await cauldron.upgradeCauldronSchema();
   log.info('Cauldron was successfully upgraded');

--- a/ern-local-cli/src/commands/create-composite.ts
+++ b/ern-local-cli/src/commands/create-composite.ts
@@ -111,7 +111,7 @@ Output directory should either not exist (it will be created) or should be empty
   let pathToYarnLock;
   let resolutions;
   let metroExtraNodeModules;
-  if (descriptor) {
+  if (descriptor && cauldron) {
     await logErrorAndExitIfNotSatisfied({
       napDescriptorExistInCauldron: {
         descriptor,

--- a/ern-local-cli/src/commands/create-container.ts
+++ b/ern-local-cli/src/commands/create-container.ts
@@ -185,7 +185,7 @@ Output directory should either not exist (it will be created) or should be empty
     });
   }
 
-  const compositeGenConfig = await cauldron.getCompositeGeneratorConfig(
+  const compositeGenConfig = await cauldron?.getCompositeGeneratorConfig(
     descriptor,
   );
   baseComposite =

--- a/ern-local-cli/src/index.ts
+++ b/ern-local-cli/src/index.ts
@@ -148,8 +148,7 @@ Manifest.getOverrideManifestConfig = async (): Promise<OverrideManifestConfig | 
       silent: true,
       throwIfNoActiveCauldron: false,
     });
-    manifestConfig =
-      cauldronInstance && (await cauldronInstance.getManifestConfig());
+    manifestConfig = await cauldronInstance?.getManifestConfig();
     if (manifestConfig) {
       return {
         source: 'cauldron',

--- a/ern-orchestrator/src/start.ts
+++ b/ern-orchestrator/src/start.ts
@@ -76,7 +76,7 @@ export default async function start({
   }
 
   let resolutions;
-  if (descriptor) {
+  if (descriptor && cauldron) {
     miniapps = await cauldron.getContainerMiniApps(descriptor, {
       favorGitBranches: true,
     });
@@ -205,7 +205,7 @@ export default async function start({
     resetCache,
   });
 
-  if (descriptor && !disableBinaryStore) {
+  if (cauldron && descriptor && !disableBinaryStore) {
     const binaryStoreConfig = await cauldron.getBinaryStoreConfig();
     if (binaryStoreConfig) {
       const cauldronStartCommandConfig = await cauldron.getStartCommandConfig(


### PR DESCRIPTION
Fix a `create-container` command bug introduced in`0.45.2` through #1745

The issue is on [this line](https://github.com/electrode-io/electrode-native/pull/1745/files#diff-21660d33eebc3be34c32e7b9851feab3c24608a6e00935391811d967c2f95782R188) where `cauldron` instance can be `undefined` _(if not connected to a cauldron, which is allowed if miniapps are explicitly provided to the command)_, leading to the command failing with `Cannot read property 'getCompositeGeneratorConfig' of undefined` in this case.

The fix here is only to replace `cauldron.getCompositeGeneratorConfig` with `cauldron?.getCompositeGeneratorConfig`.

The additional code updates in this PR is just due diligence to enhance type safety to catch such errors on cauldron instances retrieved via `getActiveCauldron` way earlier. Basically, instead of returning a `Promise<Cauldron>` the method will now return `Promise<Cauldron>` or `Promise<Cauldron | undefined>` based on the value of the `throwIfNoActiveCauldron` flag. Had this been implemented before, TypeScript would have caught this bug at build time.

