### PR TITLE
Pass extraNodeModules to compositeGen in runner

### DIFF
--- a/ern-orchestrator/src/generateContainerForRunner.ts
+++ b/ern-orchestrator/src/generateContainerForRunner.ts
@@ -48,6 +48,7 @@ export async function generateContainerForRunner(
       runLocalCompositeGen({
         baseComposite,
         jsApiImpls,
+        metroExtraNodeModules: extra?.compositeGenerator?.metroExtraNodeModules,
         miniApps,
         outDir: createTmpDir(),
       }),

--- a/ern-orchestrator/src/runMiniApp.ts
+++ b/ern-orchestrator/src/runMiniApp.ts
@@ -155,6 +155,17 @@ export async function runMiniApp(
       [];
   }
 
+  if (extra?.compositeGenerator?.metroExtraNodeModules) {
+    Object.keys(extra.compositeGenerator.metroExtraNodeModules).map((value) => {
+      const moduleValue = extra.compositeGenerator.metroExtraNodeModules[value];
+      extra.compositeGenerator.metroExtraNodeModules[value] = path.isAbsolute(
+        moduleValue,
+      )
+        ? moduleValue
+        : path.join(cwd!!, 'node_modules', moduleValue);
+    });
+  }
+
   const outDir = Platform.getContainerGenOutDirectory(platform);
   const containerGenResult = await generateContainerForRunner(platform, {
     baseComposite,

--- a/ern-orchestrator/test/generateContainerForRunner-test.ts
+++ b/ern-orchestrator/test/generateContainerForRunner-test.ts
@@ -82,4 +82,27 @@ describe('generateContainerForRunner', () => {
       },
     );
   });
+
+  it('should call runLocalCompositeGen with extra arguments if no descriptor is provided', async () => {
+    const metroExtraNodeModules = [
+      'dependency-a',
+      '/home/user/path/to/dependency-b',
+    ];
+    const extra = { androidConfig: { compileSdkVersion: '28' } };
+    await generateContainerForRunner('android', {
+      extra: {
+        compositeGenerator: {
+          metroExtraNodeModules,
+        },
+      },
+      outDir: '/home/user/test',
+    });
+    sinon.assert.calledWith(compositeStub.runLocalCompositeGen, {
+      baseComposite: undefined,
+      jsApiImpls: sinon.match.array,
+      metroExtraNodeModules,
+      miniApps: sinon.match.array,
+      outDir: sinon.match.string,
+    });
+  });
 });

--- a/ern-orchestrator/test/runMiniApp-test.ts
+++ b/ern-orchestrator/test/runMiniApp-test.ts
@@ -195,6 +195,39 @@ describe('runMiniApp', () => {
     });
   });
 
+  it('should prepend local path to relative extraNodeModules passed to composite generator', async () => {
+    prepareStubs();
+    const cwd = process.cwd();
+    await runMiniApp('android', {
+      cwd,
+      extra: {
+        compositeGenerator: {
+          metroExtraNodeModules: [
+            'dependency-a',
+            '/home/user/path/to/dependency-b',
+          ],
+        },
+      },
+    });
+    sandbox.assert.calledWith(generateContainerForRunnerStub, 'android', {
+      baseComposite: undefined,
+      extra: {
+        androidConfig: sinon.match.object,
+        compositeGenerator: {
+          metroExtraNodeModules: [
+            path.join(cwd, 'node_modules', 'dependency-a'),
+            '/home/user/path/to/dependency-b',
+          ],
+        },
+      },
+      jsApiImpls: undefined,
+      jsMainModuleName: 'index.android',
+      miniApps: sinon.match.array,
+      napDescriptor: undefined,
+      outDir: sinon.match.string,
+    });
+  });
+
   it('should publish the container to maven local [local single miniapp - android]', async () => {
     prepareStubs();
     await runMiniApp('android');


### PR DESCRIPTION
With this change, `metroExtraNodeModules` are now also passed and taken into account for `ern run-android` and `ern run-ios`.