### PR TITLE
Add support for configurable pod binary version

### DIFF
--- a/docs/cli/platform/config/del.md
+++ b/docs/cli/platform/config/del.md
@@ -26,6 +26,7 @@
 - `manifest`
 - `max-package-cache-size`
 - `package-cache-enabled`
+- `podVersion`
 - `retain-tmp-dir`
 - `showBanner`
 - `sourceMapStoreProxy`

--- a/docs/cli/platform/config/get.md
+++ b/docs/cli/platform/config/get.md
@@ -26,6 +26,7 @@
 - `manifest`
 - `max-package-cache-size`
 - `package-cache-enabled`
+- `podVersion`
 - `retain-tmp-dir`
 - `showBanner`
 - `sourceMapStoreProxy`

--- a/docs/cli/platform/config/set.md
+++ b/docs/cli/platform/config/set.md
@@ -20,62 +20,67 @@
 
 **Configurable properties**
 
-- `codePushAccessKey` [string]  
+- `codePushAccessKey` [string]\
   Code push access key associated with your account
 
-- `codePushCustomHeaders`
+- `codePushCustomHeaders` [string]\
   CodePush custom extra http headers.
 
-- `codePushCustomServerUrl` [string]  
+- `codePushCustomServerUrl` [string]\
   CodePush custom server url, in case you are not using the Microsoft CodePush server.
 
-- `codePushProxy`
+- `codePushProxy` [string]\
   CodePush proxy server url.
 
-- `ignore-required-ern-version` [boolean]
-  Indicates whether any Cauldron ern version requirement should be ignored.
-  This is mostly used for Electrode Native development and should not be set to true otherwise.
+- `ignore-required-ern-version` [boolean]\
+  Indicates whether any Cauldron ern version requirement should be ignored.\
+  This is mostly used for Electrode Native development and should not be set to true otherwise.\
   **default** : false
 
-- `logLevel` [trace|debug|info|error|fatal]  
-  Set the log level to use for all commands.  
+- `logLevel` [trace|debug|info|error|fatal]\
+  Set the log level to use for all commands.\
   **default** : info
 
-- `max-package-cache-size` [number]
-  The maximum disk space to use for the package cache, in Bytes.  
-  Only apply if the package cache is enabled (`package-cache-enabled` configuration key set to `true`).
+- `max-package-cache-size` [number]\
+  The maximum disk space to use for the package cache, in Bytes.\
+  Only apply if the package cache is enabled (`package-cache-enabled` configuration key set to `true`).\
   **default** : 2GB
 
-- `package-cache-enabled` [boolean]
-  Indicates whether the package cache should be enabled.  
-  Enabling the package cache will lead to faster Containers generation, given that all packages versions used for a Container generation, will be retrieved from the cache if available rather than being downloaded upon every generation.
+- `package-cache-enabled` [boolean]\
+  Indicates whether the package cache should be enabled.\
+  Enabling the package cache will lead to faster Containers generation, given that all packages versions used for a Container generation, will be retrieved from the cache if available rather than being downloaded upon every generation.\
   **default** : true
 
-- `retain-tmp-dir` [boolean]  
-  If set to `true`, the temporary directories created during some commands execution, won't be destroyed after the command execution.  
+- `podVersion` [string]\
+  Version of CocoaPods (pod command) to use for iOS container generation.\
+  **The version must be available (installed) locally**\
+  **default** : default CocoaPods version for environment
+
+- `retain-tmp-dir` [boolean]\
+  If set to `true`, the temporary directories created during some commands execution, won't be destroyed after the command execution.\
   **default** : false
 
-- `showBanner` [boolean]  
-  Show the Electrode Native ASCII banner for all commands.  
+- `showBanner` [boolean]\
+  Show the Electrode Native ASCII banner for all commands.\
   **default** : true
 
-- `tmp-dir` [string]
-  Temporary directory to use during commands execution.  
+- `tmp-dir` [string]\
+  Temporary directory to use during commands execution.\
   **default** : system default
 
-- `bundleStoreProxy` [string]  
-  HTTP/HTTPS proxy to use to connect to the bundle store server.  
-  Should be the full url to the proxy, including the port. For example `http://10.0.0.0:9089`.  
+- `bundleStoreProxy` [string]\
+  HTTP/HTTPS proxy to use to connect to the bundle store server.\
+  Should be the full url to the proxy, including the port. For example `http://10.0.0.0:9089`.\
   **default** : no proxy
 
-- `sourceMapStoreProxy` [string]
-  HTTP/HTTPS proxy to use to connect to the source map store server.  
-  Should be the full url to the proxy, including the port. For example `http://10.0.0.0:9089`.  
+- `sourceMapStoreProxy` [string]\
+  HTTP/HTTPS proxy to use to connect to the source map store server.\
+  Should be the full url to the proxy, including the port. For example `http://10.0.0.0:9089`.\
   **default** : no proxy
 
-- `binaryStoreProxy` [string]  
-  HTTP/HTTPS proxy to use to connect to the binary store server.  
-  Should be the full url to the proxy, including the port. For example `http://10.0.0.0:9089`.  
+- `binaryStoreProxy` [string]
+  HTTP/HTTPS proxy to use to connect to the binary store server.\
+  Should be the full url to the proxy, including the port. For example `http://10.0.0.0:9089`.\
   **default** : no proxy
 
 - `manifest` [object]\

--- a/ern-container-gen-ios/src/IosGenerator.ts
+++ b/ern-container-gen-ios/src/IosGenerator.ts
@@ -13,6 +13,7 @@ import {
   utils,
   writePackageJson,
   yarn,
+  config as ernConfig,
 } from 'ern-core';
 import {
   ContainerGenerator,
@@ -278,13 +279,20 @@ Make sure to run these commands before building the container.`,
       // and also add all essential node_modules (needed for the build)
       // to the container
       if (!config?.iosConfig?.skipInstall) {
-        //
-        // Run pod install
+        const podVersionArg = ernConfig.get('podVersion')
+          ? `_${ernConfig.get('podVersion')}_`
+          : '';
+
+        const podCmdArgs = [podVersionArg, 'install', '--verbose'].filter(
+          (x: string) => x !== '',
+        );
+
         shell.pushd(config.outDir);
+
         try {
           await kax
-            .task('Running pod install')
-            .run(childProcess.spawnp('pod', ['install', '--verbose']));
+            .task(`Running pod ${podCmdArgs.join(' ')}`)
+            .run(childProcess.spawnp('pod', podCmdArgs));
         } finally {
           shell.popd();
         }

--- a/ern-orchestrator/src/constants.ts
+++ b/ern-orchestrator/src/constants.ts
@@ -87,4 +87,10 @@ export const availableUserConfigKeys = [
     name: 'manifest',
     values: ['object'],
   },
+  {
+    desc:
+      'Version of CocoaPods to use for iOS container generation (version must be available locally)',
+    name: 'podVersion',
+    values: ['string'],
+  },
 ];


### PR DESCRIPTION
CocoaPods support side-by-side installation of multiple versions of the `pod` executable.
If multiple versions are installed, it will by default pick the latest version (afaik).
It is possible to select a specific version of the executable for running pod commands, as indicated in [this SO post](https://stackoverflow.com/questions/20487849/how-to-downgrade-or-install-an-older-version-of-cocoapods).

When generating an iOS container, ern will run `pod install` as-is without specifying any version, so it will use the latest.

In some fringe cases, or for conducting some experimentation, it might be needed to use a specific version of the pod executable for running `pod install`.

This PR adds a new configuration property `podVersion` to ern global config, so that a specific pod executable version can be used when running `pod install` during iOS container generation, rather than using the default resolved version.

For example, if two versions of the pod executable are installed locally, `1.10.1` and `1.9.3`, `pod install` will by default use `1.10.1`. To force ern iOS container generator to use `1.9.3` instead, the following command can be run:

`ern platform config set podVersion 1.9.3`

And to reset to default version:

`ern platform config del podVersion`