### PR TITLE
Include dependency type in generated plugin config

### DIFF
--- a/ern-core/src/AndroidPluginConfigGenerator.ts
+++ b/ern-core/src/AndroidPluginConfigGenerator.ts
@@ -32,7 +32,7 @@ export class AndroidPluginConfigGenerator {
   private readonly excludedDirectoriesRe = new RegExp(/sample|demo|example/i);
   private readonly exclusions: string[] = [
     'com.facebook.react:react-native',
-    'fileTree(include',
+    'fileTree(',
   ];
 
   private constructor(p: string) {
@@ -94,7 +94,7 @@ export class AndroidPluginConfigGenerator {
         .filter((x: any) => !this.exclusions.some((y) => x.name.includes(y)))
         .map(async (x: any) => {
           if (x.group) {
-            return `${x.group}:${x.name}:${x.version}`;
+            return `${x.type} '${x.group}:${x.name}:${x.version}'`;
           } else {
             // Handle this kind of string where version is dynamically retrieved
             // "com.android.support:exifinterface:${safeExtGet('supportLibVersion', '28.0.0')}"
@@ -103,14 +103,14 @@ export class AndroidPluginConfigGenerator {
               const [, group, name, version] = match;
               const versionMatch = version.match(/\d+.\d+.\d+/);
               if (versionMatch) {
-                return `${group}:${name}:${versionMatch[0]}`;
+                return `${x.type} '${group}:${name}:${versionMatch[0]}'`;
               } else {
                 // Handle this kind of string where version cannot be found inline
                 // com.google.android.gms:play-services-vision:$googlePlayServicesVisionVersion
                 const resolvedVersion = await resolveDependencyVersion(
                   `${group}:${name}`,
                 );
-                return `${group}:${name}:${resolvedVersion}`;
+                return `${x.type} '${group}:${name}:${resolvedVersion}'`;
               }
             }
             log.debug(`Ignoring ${x.name}`);

--- a/ern-core/test/AndroidPluginConfigGenerator-test.ts
+++ b/ern-core/test/AndroidPluginConfigGenerator-test.ts
@@ -3,12 +3,12 @@ import path from 'path';
 import { expect } from 'chai';
 
 describe('AndroidPluginConfigGenerator', () => {
-  const fixutresPath = path.join(
+  const fixturesPath = path.join(
     __dirname,
     'fixtures/PluginConfigGenerator/android',
   );
 
-  const dependenciesFixturePath = path.join(fixutresPath, 'dependencies');
+  const dependenciesFixturePath = path.join(fixturesPath, 'dependencies');
   const dependenciesBuildGradlePath = path.join(
     dependenciesFixturePath,
     'build.gradle',
@@ -24,11 +24,11 @@ describe('AndroidPluginConfigGenerator', () => {
         () => Promise.resolve('1.0.0'),
       );
       expect(dependencies).deep.equal([
-        'com.google.zxing:core:3.3.3',
-        'com.drewnoakes:metadata-extractor:2.11.0',
-        'com.android.support:exifinterface:28.0.0',
-        'com.android.support:support-annotations:28.0.0',
-        'com.android.support:support-v4:28.0.0',
+        "implementation 'com.android.support:support-v4:28.0.0'",
+        "annotationProcessor 'com.example:annotation-processor:1.0.0'",
+        "api 'com.example:api:1.0.0'",
+        "compileOnly 'com.example:compile-only:1.0.0'",
+        "implementation 'com.example:aar-dep:1.0.0'", // gradle-to-js currently does not support closure blocks and artifact type selectors (@aar)
       ]);
     });
   });

--- a/ern-core/test/fixtures/PluginConfigGenerator/android/dependencies/build.gradle
+++ b/ern-core/test/fixtures/PluginConfigGenerator/android/dependencies/build.gradle
@@ -5,9 +5,6 @@ def safeExtGet(prop, fallback) {
 buildscript {
   repositories {
     google()
-    maven {
-      url 'https://maven.google.com'
-    }
     jcenter()
   }
 
@@ -21,12 +18,10 @@ apply plugin: 'com.android.library'
 android {
   compileSdkVersion safeExtGet('compileSdkVersion', 28)
   buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
-
   defaultConfig {
     minSdkVersion safeExtGet('minSdkVersion', 16)
     targetSdkVersion safeExtGet('targetSdkVersion', 28)
   }
-
   lintOptions {
     abortOnError false
     warning 'InvalidPackage'
@@ -36,9 +31,6 @@ android {
 repositories {
   google()
   jcenter()
-  maven {
-   url 'https://maven.google.com'
-  }
   maven { url "https://jitpack.io" }
   maven {
     // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
@@ -47,12 +39,12 @@ repositories {
 }
 
 dependencies {
-  def googlePlayServicesVisionVersion = safeExtGet('googlePlayServicesVisionVersion', safeExtGet('googlePlayServicesVersion', '17.0.2'))
-
+  implementation fileTree(include: ['*.jar'], dir: 'libs1')
+  implementation fileTree(dir: 'libs2', include: ['*.jar'])
   implementation 'com.facebook.react:react-native:+'
-  implementation "com.google.zxing:core:3.3.3"
-  implementation "com.drewnoakes:metadata-extractor:2.11.0"
-  implementation "com.android.support:exifinterface:${safeExtGet('supportLibVersion', '28.0.0')}"
-  implementation "com.android.support:support-annotations:${safeExtGet('supportLibVersion', '28.0.0')}"
   implementation "com.android.support:support-v4:${safeExtGet('supportLibVersion', '28.0.0')}"
+  annotationProcessor 'com.example:annotation-processor:1.0.0'
+  api 'com.example:api:1.0.0'
+  compileOnly 'com.example:compile-only:1.0.0'
+  implementation('com.example:aar-dep:1.0.0@aar') { transitive = true }
 }

--- a/ern-local-cli/src/commands/create-plugin-config.ts
+++ b/ern-local-cli/src/commands/create-plugin-config.ts
@@ -21,7 +21,7 @@ export const builder = (argv: Argv) => {
 
 // Bump this version whenever Electrode Native plugin configuration
 // offers new features or has structural changes
-const manifestBaseErnVersion = '0.14.0';
+const manifestBaseErnVersion = '0.46.0';
 
 export const commandHandler = async ({ plugin }: { plugin: PackagePath }) => {
   if (!(await fs.pathExists('manifest.json'))) {


### PR DESCRIPTION
**Update**:

This PR also increases `manifestBaseErnVersion` for `create-plugin-config` to `0.46.0`.

---

ERN started supporting "raw" dependency types in plugin configs with version 0.44 (see #1712). However, `ern create-plugin-config` did not include the dependency type in the generated file. With this small change, it will now correctly support and recognize additional types (e.g. `compileOnly`, `api`, ..) and not just add the dependency to a plain list (which would then _all_ be added using `implementation` to the container).

Example before:

```
{
  "android": {
    "root": "android",
    "dependencies": [
      "com.example:impl:1.0.0",
      "com.example:api:1.0.0",
      "com.example:annotation-processor:1.0.0",
      "com.example.compile-only:1.0.0"
    ]
  },
  "ios": {}
}
```

Now:

```
{
  "android": {
    "root": "android",
    "dependencies": [
      "implementation 'com.example:impl:1.0.0'",
      "api 'com.example:api:1.0.0'",
      "annotationProcessor 'com.example:annotation-processor:1.0.0'",
      "compileOnly 'com.example.compile-only:1.0.0'"
    ]
  },
  "ios": {}
}
```

It also includes a small fix to prevent the command from asking:
```
? Cannot resolve version for fileTree(dir: 'libs', include. Enter the version to use
```
This could happen when a `fileTree` dependency was written in different order (and result in a broken manifest config that needs to be cleaned up manually).
