### PR TITLE
Use generalized names for paths, packages, urls

### DIFF
--- a/docs/cli/create-container.md
+++ b/docs/cli/create-container.md
@@ -62,10 +62,10 @@
     or
     `--extra '{"iosConfig": {"deploymentTarget": "11.0"}}'`
   - **As a file path**
-    For example `--extra /Users/username/my-container-config.json`
+    For example `--extra <path>/container-config.json`
     In that case, the configuration will be read from the file.
   - **As a Cauldron file path**
-    For example `--extra cauldron://config/container/my-container-config.json`
+    For example `--extra cauldron://config/container/container-config.json`
     In that case, the configuration will be read from the file stored in Cauldron.
     For this way to work, the file must exist in Cauldron (you can add a file to the cauldron by using the [ern cauldron add file] command).
 

--- a/docs/cli/publish-container.md
+++ b/docs/cli/publish-container.md
@@ -59,10 +59,10 @@
   - **As a json string**  
     For example `--extra '{"configKey": "configValue"}'`
   - **As a file path**  
-    For example `--extra /Users/username/my-publisher-config.json`  
+    For example `--extra <path>/publisher-config.json`  
     In that case, the configuration will be read from the file.
   - **As a Cauldron file path**  
-    For example `--extra cauldron://config/publishers/my-publisher-config.json`  
+    For example `--extra cauldron://config/publishers/publisher-config.json`  
     In that case, the configuration will be read from the file stored in Cauldron.  
     For this way to work, the file must exist in Cauldron (you can add a file to the cauldron by using the [ern cauldron add file] command).
 

--- a/docs/cli/transform-container.md
+++ b/docs/cli/transform-container.md
@@ -50,10 +50,10 @@
   - **As a json string**  
     For example `--extra '{"configKey": "configValue"}'`
   - **As a file path**  
-    For example `--extra /Users/username/my-transformer-config.json`  
+    For example `--extra <path>/transformer-config.json`  
     In that case, the configuration will be read from the file
   - **As a Cauldron file path**  
-    For example `--extra cauldron://config/publishers/my-transformer-config.json`  
+    For example `--extra cauldron://config/publishers/transformer-config.json`  
     In that case, the configuration will be read from the file stored in Cauldron.  
     For this way to work, the file must exist in Cauldron (you can add a file to the cauldron by using the [ern cauldron add file] command).
 

--- a/docs/platform-parts/cauldron/structure.md
+++ b/docs/platform-parts/cauldron/structure.md
@@ -146,7 +146,7 @@ At this time there is no way to set or update configuration through commands. Co
       },
       {
         "name": "maven",
-        "url": "http://repository.example.com:8081/nexus/content/repositories"
+        "url": "https://repo.example.org/content/repositories"
       }
     ]
   }

--- a/docs/platform-parts/container/container-publication.md
+++ b/docs/platform-parts/container/container-publication.md
@@ -50,7 +50,7 @@ The following illustrate such a configuration:
       },
       {
          "name":"ern-container-publisher-maven",
-         "url": "http://repository.example.com:8081/nexus/content/repositories"
+         "url": "https://repo.example.org/content/repositories"
       },
       {
          "name":"ern-container-publisher-jcenter"

--- a/ern-api-gen/test/fixtures/android/build.gradle
+++ b/ern-api-gen/test/fixtures/android/build.gradle
@@ -14,7 +14,6 @@ buildscript {
 allprojects {
     repositories {
         mavenLocal()
-        maven { url 'http://mobilebuild.homeoffice.wal-mart.com:8081/nexus/content/repositories/hosted' }
         jcenter()
     }
 }

--- a/ern-api-gen/test/fixtures/event-op/ERNAndroid/build.gradle
+++ b/ern-api-gen/test/fixtures/event-op/ERNAndroid/build.gradle
@@ -10,7 +10,6 @@ classpath 'com.android.tools.build:gradle:2.3.3'
 allprojects {
 repositories {
 mavenLocal()
-maven { url 'http://mobilebuild.homeoffice.wal-mart.com:8081/nexus/content/repositories/hosted' }
 jcenter()
 }
 }

--- a/ern-api-gen/test/fixtures/petstore/android/build.gradle
+++ b/ern-api-gen/test/fixtures/petstore/android/build.gradle
@@ -14,7 +14,6 @@ buildscript {
 allprojects {
     repositories {
         mavenLocal()
-        maven { url 'http://mobilebuild.homeoffice.wal-mart.com:8081/nexus/content/repositories/hosted' }
         jcenter()
     }
 }

--- a/ern-api-gen/test/fixtures/petstore/ern-android/build.gradle
+++ b/ern-api-gen/test/fixtures/petstore/ern-android/build.gradle
@@ -14,7 +14,6 @@ buildscript {
 allprojects {
     repositories {
         mavenLocal()
-        maven { url 'http://mobilebuild.homeoffice.wal-mart.com:8081/nexus/content/repositories/hosted' }
         jcenter()
     }
 }

--- a/ern-api-gen/test/fixtures/uber/android/build.gradle
+++ b/ern-api-gen/test/fixtures/uber/android/build.gradle
@@ -14,7 +14,6 @@ buildscript {
 allprojects {
     repositories {
         mavenLocal()
-        maven { url 'http://mobilebuild.homeoffice.wal-mart.com:8081/nexus/content/repositories/hosted' }
         jcenter()
     }
 }

--- a/ern-cauldron-api/test/CauldronApi-test.ts
+++ b/ern-cauldron-api/test/CauldronApi-test.ts
@@ -65,9 +65,6 @@ describe('CauldronApi.js', () => {
     sandbox.restore();
   });
 
-  // ==========================================================
-  // upgradeCauldronSchema
-  // ==========================================================
   describe('upgradeCauldronSchema', () => {
     it('should properly upgrade a cauldron [schema 0.0.0 => 3.0.0]', async () => {
       sandbox.stub(utils, 'isGitBranch').resolves(true);
@@ -88,9 +85,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // commit
-  // ==========================================================
   describe('commit', () => {
     it('should call commit on the document store', async () => {
       const api = cauldronApi();
@@ -107,9 +101,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // getCauldron
-  // ==========================================================
   describe('getCauldron', () => {
     it('should return the Cauldron document', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -118,9 +109,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // getCauldronSchemaVersion
-  // ==========================================================
   describe('getCauldronSchemaVersion', () => {
     it('should return the Cauldron schema version', async () => {
       const schemaVersion = await cauldronApi().getCauldronSchemaVersion();
@@ -137,9 +125,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // beginTransaction
-  // ==========================================================
   describe('beginTransaction', () => {
     it('should call beginTransaction on the document store', async () => {
       const api = cauldronApi();
@@ -159,9 +144,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // discardTransaction
-  // ==========================================================
   describe('discardTransaction', () => {
     it('should call discardTransaction on the document store', async () => {
       const api = cauldronApi();
@@ -184,9 +166,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // commitTransaction
-  // ==========================================================
   describe('commitTransaction', () => {
     it('should call commitTransaction on the document store', async () => {
       const api = cauldronApi();
@@ -229,9 +208,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // getNativeApplications
-  // ==========================================================
   describe('getNativeApplications', () => {
     it('should return the native applications', async () => {
       const nativeApps = await cauldronApi().getNativeApplications();
@@ -239,9 +215,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // getNativeApplication
-  // ==========================================================
   describe('getNativeApplication', () => {
     it('should return the native applications array', async () => {
       const nativeApp = await cauldronApi().getNativeApplication(
@@ -266,9 +239,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // getPlatforms
-  // ==========================================================
   describe('getPlatforms', () => {
     it('should return the platforms array', async () => {
       const platforms = await cauldronApi().getPlatforms(
@@ -285,9 +255,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // getPlatform
-  // ==========================================================
   describe('getPlatform', () => {
     it('should return the platform object given its name', async () => {
       const platformObj = await cauldronApi().getPlatform(
@@ -323,9 +290,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // getVersions
-  // ==========================================================
   describe('getVersions', () => {
     it('should return the versions array', async () => {
       const versionsArr = await cauldronApi().getVersions(
@@ -361,9 +325,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // getVersion
-  // ==========================================================
   describe('getVersion', () => {
     it('should return the version object', async () => {
       const versionObj = await cauldronApi().getVersion(
@@ -410,9 +371,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // getCodePushEntries
-  // ==========================================================
   describe('getCodePushEntries', () => {
     it('should return the code push Production entries', async () => {
       const entries = await cauldronApi().getCodePushEntries(
@@ -467,9 +425,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // setCodePushEntries
-  // ==========================================================
   describe('setCodePushEntries', () => {
     it('should set the code push entries', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -501,9 +456,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // getContainerMiniApps
-  // ==========================================================
   describe('getContainerMiniApps', () => {
     it('should return the MiniApps array of a native application version Container', async () => {
       const containerMiniApps = await cauldronApi().getContainerMiniApps(
@@ -546,9 +498,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // getNativeDependencies
-  // ==========================================================
   describe('getNativeDependencies', () => {
     it('should return the native dependencies of a native application version Container', async () => {
       const containerDependencies = await cauldronApi().getNativeDependencies(
@@ -591,9 +540,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // getContainerJsApiImpls
-  // ==========================================================
   describe('getContainerJsApiImpls', () => {
     it('should throw an error if the native application version does not exist', async () => {
       const api = cauldronApi();
@@ -615,9 +561,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // getContainerJsApiImpl
-  // ==========================================================
   describe('getContainerJsApiImpl', () => {
     it('should throw an error if the native application version does not exist', async () => {
       const api = cauldronApi();
@@ -648,9 +591,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // getNativeDependency
-  // ==========================================================
   describe('getNativeDependency', () => {
     it('should return the native dependency string if no version is provided', async () => {
       const dependency = await cauldronApi().getContainerNativeDependency(
@@ -729,9 +669,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // getConfig
-  // ==========================================================
   describe('getConfig', () => {
     it('[get application version config] should return the native application version config', async () => {
       const configObj = await cauldronApi({
@@ -797,9 +734,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // clearCauldron
-  // ==========================================================
   describe('clearCauldron', () => {
     it('should empty the Cauldron', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -808,9 +742,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // addDescriptor
-  // ==========================================================
   describe('addDescriptor', () => {
     it('should add a native application entry', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -846,9 +777,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // removeDescriptor
-  // ==========================================================
   describe('removeDescriptor', () => {
     it('should remove a top level native app', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -884,9 +812,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // createNativeApplication
-  // ==========================================================
   describe('createNativeApplication', () => {
     it('should create the native application object', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -914,9 +839,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // removeNativeApplication
-  // ==========================================================
   describe('removeNativeApplication', () => {
     it('should remove the native application given its name', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -950,9 +872,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // createPlatform
-  // ==========================================================
   describe('createPlatform', () => {
     it('should create the platform object', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -989,9 +908,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // removePlatform
-  // ==========================================================
   describe('removePlatform', () => {
     it('should remove the native application platform given its name', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -1038,9 +954,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // createVersion
-  // ==========================================================
   describe('createVersion', () => {
     it('should create the version object', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -1092,9 +1005,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // removeVersion
-  // ==========================================================
   describe('removeVersion', () => {
     it('should remove the native application version given its name', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -1141,9 +1051,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // updateVersion
-  // ==========================================================
   describe('updateVersion', () => {
     it('should perform the update', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -1183,9 +1090,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // addOrUpdateDescription
-  // ==========================================================
 
   describe('addOrUpdateDescription', () => {
     it('should add a description if it does not exist yet', async () => {
@@ -1256,9 +1160,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // removePackageFromContainer [native dependency]
-  // ==========================================================
   describe('removePackageFromContainer [Native Dependency]', () => {
     it('should remove the native dependency', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -1316,9 +1217,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // updatePackageInContainer [MiniApp]
-  // ==========================================================
   describe('updatePackageInContainer [MiniApp]', () => {
     it('should update the MiniApp version', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -1376,9 +1274,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // updateTopLevelContainerVersion
-  // ==========================================================
   describe('updateTopLevelContainerVersion', () => {
     it('should update the top level container version', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -1407,9 +1302,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // updateContainerVersion
-  // ==========================================================
   describe('updateContainerVersion', () => {
     it('should update the container version of the given native application version', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -1450,9 +1342,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // getTopLevelContainerVersion
-  // ==========================================================
   describe('getTopLevelContainerVersion', () => {
     it('should return the top level container version', async () => {
       const result = await cauldronApi().getTopLevelContainerVersion(
@@ -1462,9 +1351,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // getContainerVersion
-  // ==========================================================
   describe('getContainerVersion', () => {
     it('should return the container version of the given native application version', async () => {
       const result = await cauldronApi().getContainerVersion(
@@ -1485,9 +1371,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // removePackageFromContainer
-  // ==========================================================
   describe('removePackageFromContainer [MiniApp]', () => {
     it('should remove the MiniApp from the container of the native application version', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -1544,9 +1427,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // addPackageToContainer [MiniApp]
-  // ==========================================================
   describe('addPackageToContainer [MiniApp]', () => {
     it('should add the MiniApp to the container of the native application version', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -1601,9 +1481,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // addPackageToContainer [Native Dependency]
-  // ==========================================================
   describe('addPackageToContainer [Native Dependency]', () => {
     it('should add the native dependency to the container of the native application version', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -1660,9 +1537,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // addPackageToContainer [JS API Implementation]
-  // ==========================================================
   describe('addPackageToContainer [JS API Implementation]', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi();
@@ -1720,9 +1594,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  //  removePackageFromContainer [JS API Implementation]
-  // ==========================================================
   describe('removePackageFromContainer [JS API Implementation]', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi();
@@ -1808,9 +1679,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // updatePackageInContainer [JS API Implementation]
-  // ==========================================================
   describe('updatePackageInContainer [JS API Implementation]', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi();
@@ -1867,9 +1735,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // addCodePushEntry
-  // ==========================================================
   describe('addCodePushEntry', () => {
     it('should add the code push entry to QA', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -1926,9 +1791,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // addFile
-  // ==========================================================
   describe('addFile', () => {
     it('should throw if cauldronFilePath is undefined', async () => {
       const api = cauldronApi();
@@ -1985,9 +1847,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // updateFile
-  // ==========================================================
   describe('updateFile', () => {
     it('should throw if cauldronFilePath is undefined', async () => {
       const api = cauldronApi();
@@ -2054,9 +1913,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // removeFile
-  // ==========================================================
   describe('removeFile', () => {
     it('should throw if cauldronFilePath is undefined', async () => {
       const api = cauldronApi();
@@ -2110,9 +1966,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // getFile
-  // ==========================================================
   describe('getFile', () => {
     it('should throw if cauldronFilePath is undefined', async () => {
       const api = cauldronApi();
@@ -2164,9 +2017,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // hasYarnLock
-  // ==========================================================
   describe('hasYarnLock', () => {
     it('should return true if the native application version has the given yarn lock key', async () => {
       const hasYarnLock = await cauldronApi().hasYarnLock(
@@ -2198,9 +2048,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // addYarnLock
-  // ==========================================================
   describe('addYarnLock', () => {
     it('should properly add the yarn lock', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -2242,9 +2089,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // getYarnLockId
-  // ==========================================================
   describe('getYarnLockId', () => {
     it('should properly return the yarn lock id if it exists', async () => {
       const id = await cauldronApi().getYarnLockId(
@@ -2275,9 +2119,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // getYarnLock
-  // ==========================================================
   describe('getYarnLock', () => {
     it('should throw if the native application version is not found', async () => {
       const newId = '30bf4eff61586d71fe5d52e31a2cfabcbb31e33e';
@@ -2293,9 +2134,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // getPathToYarnLock
-  // ==========================================================
   describe('getPathToYarnLock', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi();
@@ -2310,9 +2148,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // removeYarnLock
-  // ==========================================================
   describe('removeYarnLock', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi();
@@ -2327,9 +2162,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // updateYarnLock
-  // ==========================================================
   describe('updateYarnLock', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi();
@@ -2345,9 +2177,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // updateYarnLockId
-  // ==========================================================
   describe('updateYarnLockId', () => {
     it('should properly update the yarn lock id of an existing key', async () => {
       const newId = '30bf4eff61586d71fe5d52e31a2cfabcbb31e33e';
@@ -2393,9 +2222,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // setYarnLocks
-  // ==========================================================
   describe('setYarnLocks', () => {
     it('should set the yarn locks', async () => {
       const yarnLocks = { test: '30bf4eff61586d71fe5d52e31a2cfabcbb31e33e' };
@@ -2436,9 +2262,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // addBundle
-  // ==========================================================
   describe('addBundle', () => {
     it('should properly add the bundle', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -2449,9 +2272,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // hasBundle
-  // ==========================================================
   describe('hasBundle', () => {
     it('should return true if there is a stored bundle for the given native application descriptor', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -2478,9 +2298,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // getBundle
-  // ==========================================================
   describe('getBundle', () => {
     it('should throw if the native application descriptor is partial', async () => {
       const api = cauldronApi();
@@ -2519,9 +2336,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // addPackageToContainer [MiniApp Branch]
-  // ==========================================================
   describe('addPackageToContainer [MiniApp Branch]', () => {
     it('should throw if the native application descriptor is partial', async () => {
       const api = cauldronApi();
@@ -2588,9 +2402,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // addPackageToContainer [JS API Implementation branch]
-  // ==========================================================
   describe('addPackageToContainer [JS API Implementation branch]', () => {
     it('should throw if the native application descriptor is partial', async () => {
       const api = cauldronApi();
@@ -2660,9 +2471,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // updatePackageInContainer [MiniApp branch]
-  // ==========================================================
   describe('updatePackageInContainer [MiniApp branch]', () => {
     it('should throw if the native application descriptor is partial', async () => {
       const api = cauldronApi();
@@ -2718,9 +2526,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // updatePackageInContainer [JS API Implementation branch]
-  // ==========================================================
   describe('updateJsApiImplBranchInContainer', () => {
     it('should throw if the native application descriptor is partial', async () => {
       const api = cauldronApi();
@@ -2778,9 +2583,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // removePackageFromContainer [MiniApp branch]
-  // ==========================================================
   describe('removePackageFromContainer [MiniApp branch]', () => {
     it('should throw if the native application descriptor is partial', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -2869,9 +2671,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // removePackageFromContainer [JS API Implementation branch]
-  // ==========================================================
   describe('removePackageFromContainer [JS API Implementation branch]', () => {
     it('should throw if the native application descriptor is partial', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -2960,9 +2759,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // hasJsPackageBranchInContainer [JS API Implementation branch]
-  // ==========================================================
   describe('hasJsPackageBranchInContainer [JS API Implementation branch]', () => {
     it('should throw if the native application descriptor is partial', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
@@ -3011,9 +2807,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // getConfigFilePath
-  // ==========================================================
   describe('getConfigFilePath', () => {
     it('should return default config path if no descriptor is provided', () => {
       const cauldron = cauldronApi();
@@ -3043,9 +2836,6 @@ describe('CauldronApi.js', () => {
     });
   });
 
-  // ==========================================================
-  // emptyContainer
-  // ==========================================================
   describe('emptyContainer', () => {
     it('should throw if provided a partial native application desscriptor', async () => {
       const cauldron = cauldronApi();

--- a/ern-cauldron-api/test/CauldronHelper-test.ts
+++ b/ern-cauldron-api/test/CauldronHelper-test.ts
@@ -199,12 +199,12 @@ describe('CauldronHelper.js', () => {
       sandbox.stub(utils, 'isGitBranch').resolves(false);
       await cauldronHelper.addMiniAppToContainer(
         AppVersionDescriptor.fromString('test:android:17.8.0'),
-        PackagePath.fromString('https://github.com/foo/test-miniapp.git#tag'),
+        PackagePath.fromString('https://github.com/org/test-miniapp.git#tag'),
       );
       const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0];
       expect(
         nativeAppVersion.container.miniApps.includes(
-          'https://github.com/foo/test-miniapp.git#tag',
+          'https://github.com/org/test-miniapp.git#tag',
         ),
       ).true;
     });
@@ -217,12 +217,12 @@ describe('CauldronHelper.js', () => {
       sandbox.stub(utils, 'isGitBranch').resolves(false);
       await cauldronHelper.addMiniAppToContainer(
         AppVersionDescriptor.fromString('test:android:17.8.0'),
-        PackagePath.fromString('https://github.com/foo/test-miniapp.git#tag'),
+        PackagePath.fromString('https://github.com/org/test-miniapp.git#tag'),
       );
       const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0];
       expect(
         nativeAppVersion.container.miniAppsBranches.includes(
-          'https://github.com/foo/test-miniapp.git#tag',
+          'https://github.com/org/test-miniapp.git#tag',
         ),
       ).false;
     });
@@ -239,13 +239,13 @@ describe('CauldronHelper.js', () => {
       await cauldronHelper.addMiniAppToContainer(
         AppVersionDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString(
-          'https://github.com/foo/test-miniapp.git#master',
+          'https://github.com/org/test-miniapp.git#master',
         ),
       );
       const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0];
       expect(
         nativeAppVersion.container.miniApps.includes(
-          'https://github.com/foo/test-miniapp.git#6319d9ef0c237907c784a8c472b000d5ff83b49a',
+          'https://github.com/org/test-miniapp.git#6319d9ef0c237907c784a8c472b000d5ff83b49a',
         ),
       ).true;
     });
@@ -262,13 +262,13 @@ describe('CauldronHelper.js', () => {
       await cauldronHelper.addMiniAppToContainer(
         AppVersionDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString(
-          'https://github.com/foo/test-miniapp.git#master',
+          'https://github.com/org/test-miniapp.git#master',
         ),
       );
       const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0];
       expect(
         nativeAppVersion.container.miniAppsBranches.includes(
-          'https://github.com/foo/test-miniapp.git#master',
+          'https://github.com/org/test-miniapp.git#master',
         ),
       ).true;
     });
@@ -301,13 +301,13 @@ describe('CauldronHelper.js', () => {
       await cauldronHelper.updateMiniAppVersionInContainer(
         AppVersionDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString(
-          'git+ssh://git@github.com:electrode-io/gitMiniApp.git#0.0.10',
+          'git+ssh://git@github.com:org/test-miniapp.git#0.0.10',
         ),
       );
       const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0];
       expect(
         nativeAppVersion.container.miniApps.includes(
-          'git+ssh://git@github.com:electrode-io/gitMiniApp.git#0.0.10',
+          'git+ssh://git@github.com:org/test-miniapp.git#0.0.10',
         ),
       ).true;
     });
@@ -324,13 +324,13 @@ describe('CauldronHelper.js', () => {
       await cauldronHelper.updateMiniAppVersionInContainer(
         AppVersionDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString(
-          'git+ssh://git@github.com:electrode-io/gitMiniApp.git#master',
+          'git+ssh://git@github.com:org/test-miniapp.git#master',
         ),
       );
       const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0];
       expect(
         nativeAppVersion.container.miniApps.includes(
-          'git+ssh://git@github.com:electrode-io/gitMiniApp.git#6319d9ef0c237907c784a8c472b000d5ff83b49a',
+          'git+ssh://git@github.com:org/test-miniapp.git#6319d9ef0c237907c784a8c472b000d5ff83b49a',
         ),
       ).true;
     });
@@ -347,13 +347,13 @@ describe('CauldronHelper.js', () => {
       await cauldronHelper.updateMiniAppVersionInContainer(
         AppVersionDescriptor.fromString('test:android:17.8.0'),
         PackagePath.fromString(
-          'git+ssh://git@github.com:electrode-io/gitMiniApp.git#master',
+          'git+ssh://git@github.com:org/test-miniapp.git#master',
         ),
       );
       const nativeAppVersion = jp.query(fixture, testAndroid1780Path)[0];
       expect(
         nativeAppVersion.container.miniAppsBranches.includes(
-          'git+ssh://git@github.com:electrode-io/gitMiniApp.git#master',
+          'git+ssh://git@github.com:org/test-miniapp.git#master',
         ),
       ).true;
     });
@@ -1737,6 +1737,7 @@ describe('CauldronHelper.js', () => {
       expect(result.basePath).eql('react-native-electrode-bridge');
     });
   });
+
   describe('syncContainerMiniApps', () => {
     it('should not update anything if miniapps versions are the same', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
@@ -1749,7 +1750,7 @@ describe('CauldronHelper.js', () => {
           PackagePath.fromString('@test/react-native-foo@5.0.0'),
           PackagePath.fromString('react-native-bar@3.0.0'),
           PackagePath.fromString(
-            'git+ssh://git@github.com:electrode-io/gitMiniApp.git#0.0.9',
+            'git+ssh://git@github.com:org/test-miniapp.git#0.0.9',
           ),
         ],
       );
@@ -1762,7 +1763,7 @@ describe('CauldronHelper.js', () => {
         'react-native-bar@3.0.0',
       );
       expect(nativeAppVersion.container.miniApps).includes(
-        'git+ssh://git@github.com:electrode-io/gitMiniApp.git#0.0.9',
+        'git+ssh://git@github.com:org/test-miniapp.git#0.0.9',
       );
     });
 
@@ -1777,7 +1778,7 @@ describe('CauldronHelper.js', () => {
           PackagePath.fromString('@test/react-native-foo@5.0.0'),
           PackagePath.fromString('react-native-bar@3.0.0'),
           PackagePath.fromString(
-            'git+ssh://git@github.com:electrode-io/gitMiniApp.git#0.0.9',
+            'git+ssh://git@github.com:org/test-miniapp.git#0.0.9',
           ),
           PackagePath.fromString('new-miniapp@0.0.1'),
         ],
@@ -1791,7 +1792,7 @@ describe('CauldronHelper.js', () => {
         'react-native-bar@3.0.0',
       );
       expect(nativeAppVersion.container.miniApps).includes(
-        'git+ssh://git@github.com:electrode-io/gitMiniApp.git#0.0.9',
+        'git+ssh://git@github.com:org/test-miniapp.git#0.0.9',
       );
       expect(nativeAppVersion.container.miniApps).includes('new-miniapp@0.0.1');
     });
@@ -1808,7 +1809,7 @@ describe('CauldronHelper.js', () => {
           PackagePath.fromString('@test/react-native-foo@6.0.0'),
           PackagePath.fromString('react-native-bar@3.0.0'),
           PackagePath.fromString(
-            'git+ssh://git@github.com:electrode-io/gitMiniApp.git#1.0.0',
+            'git+ssh://git@github.com:org/test-miniapp.git#1.0.0',
           ),
         ],
       );
@@ -1821,7 +1822,7 @@ describe('CauldronHelper.js', () => {
         'react-native-bar@3.0.0',
       );
       expect(nativeAppVersion.container.miniApps).includes(
-        'git+ssh://git@github.com:electrode-io/gitMiniApp.git#1.0.0',
+        'git+ssh://git@github.com:org/test-miniapp.git#1.0.0',
       );
     });
 
@@ -1837,7 +1838,7 @@ describe('CauldronHelper.js', () => {
           PackagePath.fromString('@test/react-native-foo@6.0.0'),
           PackagePath.fromString('react-native-bar@3.0.0'),
           PackagePath.fromString(
-            'git+ssh://git@github.com:electrode-io/gitMiniApp.git#1.0.0',
+            'git+ssh://git@github.com:org/test-miniapp.git#1.0.0',
           ),
           PackagePath.fromString('new-miniapp@0.0.1'),
         ],
@@ -1851,7 +1852,7 @@ describe('CauldronHelper.js', () => {
         'react-native-bar@3.0.0',
       );
       expect(nativeAppVersion.container.miniApps).includes(
-        'git+ssh://git@github.com:electrode-io/gitMiniApp.git#1.0.0',
+        'git+ssh://git@github.com:org/test-miniapp.git#1.0.0',
       );
       expect(nativeAppVersion.container.miniApps).includes('new-miniapp@0.0.1');
     });
@@ -2518,7 +2519,7 @@ describe('CauldronHelper.js', () => {
       );
       expect(result).to.be.an('array').of.length(4);
       expect(result.map((m) => m.toString())).contains(
-        'https://github.com/foo/foo.git#6319d9ef0c237907c784a8c472b000d5ff83b49a',
+        'https://github.com/org/foo-miniapp.git#6319d9ef0c237907c784a8c472b000d5ff83b49a',
       );
     });
 
@@ -2533,7 +2534,7 @@ describe('CauldronHelper.js', () => {
       );
       expect(result).to.be.an('array').of.length(4);
       expect(result.map((m) => m.toString())).contains(
-        'https://github.com/foo/foo.git#master',
+        'https://github.com/org/foo-miniapp.git#master',
       );
     });
   });

--- a/ern-cauldron-api/test/CauldronHelper-test.ts
+++ b/ern-cauldron-api/test/CauldronHelper-test.ts
@@ -3129,9 +3129,6 @@ describe('CauldronHelper.js', () => {
     });
   });
 
-  // ==========================================================
-  // getNapDescriptorStrings
-  // ==========================================================
   describe('getNapDescriptorStrings', () => {
     it('should return an empty array if no match', async () => {
       const fixture = cloneFixture(fixtures.emptyCauldron);
@@ -3222,9 +3219,6 @@ describe('CauldronHelper.js', () => {
     });
   });
 
-  // ==========================================================
-  // getDescriptorsMatchingSemVerDescriptor
-  // ==========================================================
   describe('getDescriptorsMatchingSemVerDescriptor', () => {
     it('should throw if the descriptor does not contain a platform', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);

--- a/ern-cauldron-api/test/fixtures/cauldron-0.0.0.json
+++ b/ern-cauldron-api/test/fixtures/cauldron-0.0.0.json
@@ -3,7 +3,7 @@
   "config": {
     "manifest": {
       "override": {
-        "url": "git@gecgithub01.test.com:react-native/ern-test-manifest.git",
+        "url": "https://github.com/org/ern-test-manifest.git",
         "type": "partial"
       }
     }
@@ -43,7 +43,7 @@
                 "container": [
                   "@test/react-native-foo@4.0.0",
                   "react-native-bar@2.0.0",
-                  "git+ssh://git@github.com/myminiapp.git#master"
+                  "git+ssh://git@github.com/org/test-miniapp.git#master"
                 ]
               },
               "codePush": {

--- a/ern-cauldron-api/test/fixtures/cauldron-1.0.0.json
+++ b/ern-cauldron-api/test/fixtures/cauldron-1.0.0.json
@@ -3,7 +3,7 @@
   "config": {
     "manifest": {
       "override": {
-        "url": "git@gecgithub01.test.com:react-native/ern-test-manifest.git",
+        "url": "https://github.com/org/ern-test-manifest.git",
         "type": "partial"
       }
     }
@@ -43,7 +43,7 @@
                 "miniApps": [
                   "@test/react-native-foo@4.0.0",
                   "react-native-bar@2.0.0",
-                  "git+ssh://git@github.com/myminiapp.git#master"
+                  "git+ssh://git@github.com/org/test-miniapp.git#master"
                 ],
                 "jsApiImpls": []
               },

--- a/ern-cauldron-api/test/fixtures/cauldron-2.0.0.json
+++ b/ern-cauldron-api/test/fixtures/cauldron-2.0.0.json
@@ -3,7 +3,7 @@
   "config": {
     "manifest": {
       "override": {
-        "url": "git@gecgithub01.test.com:react-native/ern-test-manifest.git",
+        "url": "https://github.com/org/ern-test-manifest.git",
         "type": "partial"
       }
     }
@@ -41,12 +41,12 @@
                   "react-native-code-push@1.17.1-beta"
                 ],
                 "miniAppsBranches": [
-                  "git+ssh://git@github.com/myminiapp.git#master"
+                  "git+ssh://git@github.com/org/test-miniapp.git#master"
                 ],
                 "miniApps": [
                   "@test/react-native-foo@4.0.0",
                   "react-native-bar@2.0.0",
-                  "git+ssh://git@github.com/myminiapp.git#master"
+                  "git+ssh://git@github.com/org/test-miniapp.git#master"
                 ],
                 "jsApiImplsBranches": [],
                 "jsApiImpls": []

--- a/ern-cauldron-api/test/fixtures/cauldron-3.0.0.json
+++ b/ern-cauldron-api/test/fixtures/cauldron-3.0.0.json
@@ -26,12 +26,12 @@
                   "react-native-code-push@1.17.1-beta"
                 ],
                 "miniAppsBranches": [
-                  "git+ssh://git@github.com/myminiapp.git#master"
+                  "git+ssh://git@github.com/org/test-miniapp.git#master"
                 ],
                 "miniApps": [
                   "@test/react-native-foo@4.0.0",
                   "react-native-bar@2.0.0",
-                  "git+ssh://git@github.com/myminiapp.git#master"
+                  "git+ssh://git@github.com/org/test-miniapp.git#master"
                 ],
                 "jsApiImplsBranches": [],
                 "jsApiImpls": []

--- a/ern-cauldron-api/test/fixtures/filestore/config/default.json
+++ b/ern-cauldron-api/test/fixtures/filestore/config/default.json
@@ -8,7 +8,7 @@
   },
   "manifest": {
     "override": {
-      "url": "git@gecgithub01.test.com:react-native/ern-test-manifest.git",
+      "url": "https://github.com/org/ern-test-manifest.git",
       "type": "partial"
     }
   }

--- a/ern-cauldron-api/test/fixtures/filestore/config/test-android-17.8.0.json
+++ b/ern-cauldron-api/test/fixtures/filestore/config/test-android-17.8.0.json
@@ -1,6 +1,6 @@
 {
   "codePush": {
-    "appName": "walmart-android",
+    "appName": "app-android",
     "versionModifiers": [
       {
         "deploymentName": "QA",

--- a/ern-cauldron-api/test/fixtures/filestore/config/test-android.json
+++ b/ern-cauldron-api/test/fixtures/filestore/config/test-android.json
@@ -4,11 +4,11 @@
     "publishers": [
       {
         "name": "git",
-        "url": "git@gecgithub01.test.com:react-native/test-react-container-android.git"
+        "url": "https://github.com:org/test-react-container-android.git"
       },
       {
         "name": "maven",
-        "url": "http://mobilebuild.homeoffice.test.com:8081/nexus/content/repositories/hosted",
+        "url": "https://repo.example.org/content/repositories/hosted",
         "disabled": false
       },
       {

--- a/ern-cauldron-api/test/util-test.ts
+++ b/ern-cauldron-api/test/util-test.ts
@@ -40,17 +40,13 @@ describe('util.js', () => {
 
   describe('buildNativeBinaryFileName', () => {
     it('should return the correct file name of Android binary', () => {
-      const result = util.buildNativeBinaryFileName(
-        'walmart',
-        'android',
-        '17.7.0',
-      );
-      expect(result).eql('walmart-android@17.7.0.apk');
+      const result = util.buildNativeBinaryFileName('app', 'android', '17.7.0');
+      expect(result).eql('app-android@17.7.0.apk');
     });
 
     it('should return the correct file name of iOS binary', () => {
-      const result = util.buildNativeBinaryFileName('walmart', 'ios', '17.7.0');
-      expect(result).eql('walmart-ios@17.7.0.app');
+      const result = util.buildNativeBinaryFileName('app', 'ios', '17.7.0');
+      expect(result).eql('app-ios@17.7.0.app');
     });
   });
 

--- a/ern-composite-gen/src/miniAppsDeltasUtils.ts
+++ b/ern-composite-gen/src/miniAppsDeltasUtils.ts
@@ -66,7 +66,7 @@ export function getPackageJsonDependenciesUsingMiniAppDeltas(
     for (const m of miniAppsDeltas.same) {
       if (m.isRegistryPath) {
         // Sample package.json entry :
-        // "my-miniapp": "0.8.3"
+        // "test-miniapp": "0.8.3"
         result[m.basePath] = m.version!;
       } else if (m.isGitPath) {
         // For a git based dependency, the name of the dependency as
@@ -77,7 +77,7 @@ export function getPackageJsonDependenciesUsingMiniAppDeltas(
           yarnlock,
         )![1 /*name*/];
         // Sample package.json entry :
-        // "my-miniapp": "https://github.com/org/MyMiniApp.git#master"
+        // "test-miniapp": "https://github.com/org/test-miniapp.git#master"
         result[name] = m.fullPath;
       }
     }

--- a/ern-composite-gen/src/yarnLockUtils.ts
+++ b/ern-composite-gen/src/yarnLockUtils.ts
@@ -9,8 +9,8 @@ import _ from 'lodash';
  * - 2: Version of the dependency (as seen in package.json)
  *
  * Sample yarn.lock entry:
- * my-miniapp@0.8.3:
- * groups[1] : my-miniapp
+ * test-miniapp@0.8.3:
+ * groups[1] : test-miniapp
  * groups[2] : 0.8.3
  * @param dep The dependency to build a Regular Expression for
  */
@@ -28,8 +28,8 @@ export function getYarnLockTopLevelRegistryDependencyRe(
  * - 2: Version of the dependency (as seen in package.json)
  *
  * Sample yarn.lock entry:
- * "my-miniapp@https://github.com/org/MyMiniApp.git#master":
- * groups[1] : my-miniapp
+ * "test-miniapp@https://github.com/org/test-miniapp.git#master":
+ * groups[1] : test-miniapp
  * groups[2] : master
  * @param dep The dependency to build a Regular Expression for
  */

--- a/ern-composite-gen/test/compositegen-test.ts
+++ b/ern-composite-gen/test/compositegen-test.ts
@@ -46,9 +46,6 @@ describe('ern-container-gen utils.js', () => {
     sandbox.restore();
   });
 
-  // ==========================================================
-  // getMiniAppsDeltas
-  // ==========================================================
   describe('getMiniAppsDeltas', () => {
     it('should compute new deltas', () => {
       const miniApps = [
@@ -96,9 +93,6 @@ describe('ern-container-gen utils.js', () => {
     });
   });
 
-  // ==========================================================
-  // runYarnUsingMiniAppDeltas
-  // ==========================================================
   describe('runYarnUsingMiniAppDeltas', () => {
     it('should yarn add new MiniApps', async () => {
       const miniAppsDeltas = {
@@ -150,9 +144,6 @@ describe('ern-container-gen utils.js', () => {
     });
   });
 
-  // ==========================================================
-  // getPackageJsonDependenciesBasedOnMiniAppDeltas
-  // ==========================================================
   describe('getPackageJsonDependenciesBasedOnMiniAppDeltas', () => {
     it('should inject MiniApps that have same version as previous', () => {
       const miniAppsDeltas = {
@@ -239,9 +230,6 @@ describe('ern-container-gen utils.js', () => {
     );
   };
 
-  // ==========================================================
-  // generateComposite [with yarn lock]
-  // ==========================================================
   describe('generateComposite [with yarn lock]', () => {
     it('should throw an exception if at least one of the MiniApp path is using a file scheme [1]', async () => {
       const miniApps = [
@@ -390,9 +378,6 @@ describe('ern-container-gen utils.js', () => {
     });
   });
 
-  // ==========================================================
-  // generateComposite [without yarn lock]
-  // ==========================================================
   const fakeYarnInit = (rootDir: string, rnVersion: string) => {
     fs.writeFileSync(
       path.join(tmpOutDir, 'package.json'),
@@ -452,9 +437,6 @@ describe('ern-container-gen utils.js', () => {
     });
   });
 
-  // ==========================================================
-  // applyYarnResolutions
-  // ==========================================================
   describe('applyYarnResolutions', () => {
     it('should add resolutions field to the package.json', async () => {
       const packageJsonPath = path.join(tmpOutDir, 'package.json');
@@ -496,9 +478,6 @@ describe('ern-container-gen utils.js', () => {
     });
   });
 
-  // ==========================================================
-  // generateComposite [with custom extraNodeModules]
-  // ==========================================================
   describe('generateComposite [with custom extraNodeModules]', () => {
     it('should create custom extraNodeModules in Metro config', async () => {
       yarnCliStub.init.callsFake(() => fakeYarnInit(tmpOutDir, '0.57.0'));

--- a/ern-composite-gen/test/compositegen-test.ts
+++ b/ern-composite-gen/test/compositegen-test.ts
@@ -52,8 +52,8 @@ describe('ern-container-gen utils.js', () => {
   describe('getMiniAppsDeltas', () => {
     it('should compute new deltas', () => {
       const miniApps = [
-        PackagePath.fromString('MiniAppFour@1.0.0'),
-        PackagePath.fromString('MiniAppFive@1.0.0'),
+        PackagePath.fromString('fourth-miniapp@1.0.0'),
+        PackagePath.fromString('fifth-miniapp@1.0.0'),
       ];
       const result = getMiniAppsDeltas(miniApps, sampleYarnLock);
       expect(result).to.have.property('new').that.is.a('array').lengthOf(2);
@@ -61,8 +61,8 @@ describe('ern-container-gen utils.js', () => {
 
     it('should compute same deltas', () => {
       const miniApps = [
-        PackagePath.fromString('MiniAppOne@6.0.0'),
-        PackagePath.fromString('MiniAppTwo@3.0.0'),
+        PackagePath.fromString('first-miniapp@6.0.0'),
+        PackagePath.fromString('second-miniapp@3.0.0'),
       ];
       const result = getMiniAppsDeltas(miniApps, sampleYarnLock);
       expect(result).to.have.property('same').that.is.a('array').lengthOf(2);
@@ -70,8 +70,8 @@ describe('ern-container-gen utils.js', () => {
 
     it('should compute upgraded deltas', () => {
       const miniApps = [
-        PackagePath.fromString('MiniAppOne@7.0.0'),
-        PackagePath.fromString('MiniAppTwo@4.0.0'),
+        PackagePath.fromString('first-miniapp@7.0.0'),
+        PackagePath.fromString('second-miniapp@4.0.0'),
       ];
       const result = getMiniAppsDeltas(miniApps, sampleYarnLock);
       expect(result)
@@ -82,9 +82,9 @@ describe('ern-container-gen utils.js', () => {
 
     it('should compute deltas', () => {
       const miniApps = [
-        PackagePath.fromString('MiniAppOne@1.0.0'),
-        PackagePath.fromString('MiniAppTwo@3.0.0'),
-        PackagePath.fromString('MiniAppFour@1.0.0'),
+        PackagePath.fromString('first-miniapp@1.0.0'),
+        PackagePath.fromString('second-miniapp@3.0.0'),
+        PackagePath.fromString('fourth-miniapp@1.0.0'),
       ];
       const result = getMiniAppsDeltas(miniApps, sampleYarnLock);
       expect(result).to.have.property('new').that.is.a('array').lengthOf(1);
@@ -103,8 +103,8 @@ describe('ern-container-gen utils.js', () => {
     it('should yarn add new MiniApps', async () => {
       const miniAppsDeltas = {
         new: [
-          PackagePath.fromString('MiniAppFour@7.0.0'),
-          PackagePath.fromString('MiniAppFive@4.0.0'),
+          PackagePath.fromString('fourth-miniapp@7.0.0'),
+          PackagePath.fromString('fifth-miniapp@4.0.0'),
         ],
       };
       await runYarnUsingMiniAppDeltas(miniAppsDeltas);
@@ -114,8 +114,8 @@ describe('ern-container-gen utils.js', () => {
     it('should yarn add upgraded MiniApps', async () => {
       const miniAppsDeltas = {
         upgraded: [
-          PackagePath.fromString('MiniAppOne@7.0.0'),
-          PackagePath.fromString('MiniAppTwo@4.0.0'),
+          PackagePath.fromString('first-miniapp@7.0.0'),
+          PackagePath.fromString('second-miniapp@4.0.0'),
         ],
       };
       await runYarnUsingMiniAppDeltas(miniAppsDeltas);
@@ -125,8 +125,8 @@ describe('ern-container-gen utils.js', () => {
     it('should not yarn add same MiniApps versions', async () => {
       const miniAppsDeltas = {
         same: [
-          PackagePath.fromString('MiniAppOne@6.0.0'),
-          PackagePath.fromString('MiniAppTwo@3.0.0'),
+          PackagePath.fromString('first-miniapp@6.0.0'),
+          PackagePath.fromString('second-miniapp@3.0.0'),
         ],
       };
       await runYarnUsingMiniAppDeltas(miniAppsDeltas);
@@ -135,14 +135,14 @@ describe('ern-container-gen utils.js', () => {
 
     it('should work correctly with mixed deltas', async () => {
       const miniAppsDeltas = {
-        new: [PackagePath.fromString('MiniAppFour@7.0.0')],
+        new: [PackagePath.fromString('fourth-miniapp@7.0.0')],
         same: [
-          PackagePath.fromString('MiniAppOne@6.0.0'),
-          PackagePath.fromString('MiniAppTwo@3.0.0'),
+          PackagePath.fromString('first-miniapp@6.0.0'),
+          PackagePath.fromString('second-miniapp@3.0.0'),
         ],
         upgraded: [
-          PackagePath.fromString('MiniAppOne@7.0.0'),
-          PackagePath.fromString('MiniAppTwo@4.0.0'),
+          PackagePath.fromString('first-miniapp@7.0.0'),
+          PackagePath.fromString('second-miniapp@4.0.0'),
         ],
       };
       await runYarnUsingMiniAppDeltas(miniAppsDeltas);
@@ -157,38 +157,38 @@ describe('ern-container-gen utils.js', () => {
     it('should inject MiniApps that have same version as previous', () => {
       const miniAppsDeltas = {
         same: [
-          PackagePath.fromString('MiniAppOne@6.0.0'),
-          PackagePath.fromString('MiniAppTwo@3.0.0'),
+          PackagePath.fromString('first-miniapp@6.0.0'),
+          PackagePath.fromString('second-miniapp@3.0.0'),
         ],
       };
       const result = getPackageJsonDependenciesUsingMiniAppDeltas(
         miniAppsDeltas,
         sampleYarnLock,
       );
-      expect(result).to.have.property('MiniAppOne', '6.0.0');
-      expect(result).to.have.property('MiniAppTwo', '3.0.0');
+      expect(result).to.have.property('first-miniapp', '6.0.0');
+      expect(result).to.have.property('second-miniapp', '3.0.0');
     });
 
     it('should inject MiniApps that have upgraded versions', () => {
       const miniAppsDeltas = {
         upgraded: [
-          PackagePath.fromString('MiniAppOne@7.0.0'),
-          PackagePath.fromString('MiniAppTwo@4.0.0'),
+          PackagePath.fromString('first-miniapp@7.0.0'),
+          PackagePath.fromString('second-miniapp@4.0.0'),
         ],
       };
       const result = getPackageJsonDependenciesUsingMiniAppDeltas(
         miniAppsDeltas,
         sampleYarnLock,
       );
-      expect(result).to.have.property('MiniAppOne', '6.0.0');
-      expect(result).to.have.property('MiniAppTwo', '3.0.0');
+      expect(result).to.have.property('first-miniapp', '6.0.0');
+      expect(result).to.have.property('second-miniapp', '3.0.0');
     });
 
     it('should not inject MiniApps that are new', () => {
       const miniAppsDeltas = {
         new: [
-          PackagePath.fromString('MiniAppFour@7.0.0'),
-          PackagePath.fromString('MiniAppFive@4.0.0'),
+          PackagePath.fromString('fourth-miniapp@7.0.0'),
+          PackagePath.fromString('fifth-miniapp@4.0.0'),
         ],
       };
       const result = getPackageJsonDependenciesUsingMiniAppDeltas(
@@ -200,16 +200,16 @@ describe('ern-container-gen utils.js', () => {
 
     it('should inject proper MiniApps', () => {
       const miniAppsDeltas = {
-        new: [PackagePath.fromString('MiniAppFour@7.0.0')],
-        same: [PackagePath.fromString('MiniAppOne@6.0.0')],
-        upgraded: [PackagePath.fromString('MiniAppTwo@4.0.0')],
+        new: [PackagePath.fromString('fourth-miniapp@7.0.0')],
+        same: [PackagePath.fromString('first-miniapp@6.0.0')],
+        upgraded: [PackagePath.fromString('second-miniapp@4.0.0')],
       };
       const result = getPackageJsonDependenciesUsingMiniAppDeltas(
         miniAppsDeltas,
         sampleYarnLock,
       );
-      expect(result).to.have.property('MiniAppOne', '6.0.0');
-      expect(result).to.have.property('MiniAppTwo', '3.0.0');
+      expect(result).to.have.property('first-miniapp', '6.0.0');
+      expect(result).to.have.property('second-miniapp', '3.0.0');
     });
   });
 
@@ -259,7 +259,7 @@ describe('ern-container-gen utils.js', () => {
 
     it('should throw an exception if at least one of the MiniApp path is using a file scheme [2]', async () => {
       const miniApps = [
-        PackagePath.fromString('MiniAppOne@1.0.0'),
+        PackagePath.fromString('first-miniapp@1.0.0'),
         PackagePath.fromString(path.join(__dirname, 'fixtures', 'miniapp')),
       ];
       assert(
@@ -286,7 +286,7 @@ describe('ern-container-gen utils.js', () => {
 
     it('should throw an exception if at least one of the MiniApp path is using a git scheme [2]', async () => {
       const miniApps = [
-        PackagePath.fromString('MiniAppOne@1.0.0'),
+        PackagePath.fromString('first-miniapp@1.0.0'),
         PackagePath.fromString('git://github.com:org/repo'),
       ];
       assert(
@@ -300,7 +300,7 @@ describe('ern-container-gen utils.js', () => {
     });
 
     it('should throw an exception if one of the MiniApp is not using an explicit version [1]', async () => {
-      const miniApps = [PackagePath.fromString('MiniAppOne')];
+      const miniApps = [PackagePath.fromString('first-miniapp')];
       assert(
         await doesThrow(generateComposite, null, {
           miniApps,
@@ -313,8 +313,8 @@ describe('ern-container-gen utils.js', () => {
 
     it('should throw an exception if one of the MiniApp is not using an explicit version [1]', async () => {
       const miniApps = [
-        PackagePath.fromString('MiniAppOne'),
-        PackagePath.fromString('MiniAppTwo@1.0.0'),
+        PackagePath.fromString('first-miniapp'),
+        PackagePath.fromString('second-miniapp@1.0.0'),
       ];
       assert(
         await doesThrow(generateComposite, null, {
@@ -328,8 +328,8 @@ describe('ern-container-gen utils.js', () => {
 
     it('should throw an exception if path to yarn.lock does not exists', async () => {
       const miniApps = [
-        PackagePath.fromString('MiniAppOne@1.0.0'),
-        PackagePath.fromString('MiniAppTwo@1.0.0'),
+        PackagePath.fromString('first-miniapp@1.0.0'),
+        PackagePath.fromString('second-miniapp@1.0.0'),
       ];
       assert(
         await doesThrow(generateComposite, null, {
@@ -361,9 +361,9 @@ describe('ern-container-gen utils.js', () => {
         createCompositeNodeModulesReactNativePackageJson(tmpOutDir, '0.56.0'),
       );
       const miniApps = [
-        PackagePath.fromString('MiniAppOne@6.0.0'), // same
-        PackagePath.fromString('MiniAppTwo@4.0.0'), // upgraded
-        PackagePath.fromString('MiniAppFour@1.0.0'), // new
+        PackagePath.fromString('first-miniapp@6.0.0'), // same
+        PackagePath.fromString('second-miniapp@4.0.0'), // upgraded
+        PackagePath.fromString('fourth-miniapp@1.0.0'), // new
       ];
       await generateComposite({
         miniApps,
@@ -380,7 +380,7 @@ describe('ern-container-gen utils.js', () => {
       yarnCliStub.install.callsFake(() =>
         createCompositeNodeModulesReactNativePackageJson(tmpOutDir, '0.56.0'),
       );
-      const miniApps = [PackagePath.fromString('MiniAppOne@6.0.0')];
+      const miniApps = [PackagePath.fromString('first-miniapp@6.0.0')];
       await generateComposite({
         miniApps,
         outDir: tmpOutDir,
@@ -408,9 +408,9 @@ describe('ern-container-gen utils.js', () => {
     // expected package.json beforehand
     it('should call yarn add for each MiniApp', async () => {
       const miniApps = [
-        PackagePath.fromString('MiniAppOne@6.0.0'), // same
-        PackagePath.fromString('MiniAppTwo@4.0.0'), // upgraded
-        PackagePath.fromString('MiniAppFour@1.0.0'), // new
+        PackagePath.fromString('first-miniapp@6.0.0'), // same
+        PackagePath.fromString('second-miniapp@4.0.0'), // upgraded
+        PackagePath.fromString('fourth-miniapp@1.0.0'), // new
       ];
       yarnCliStub.init.callsFake(() => fakeYarnInit(tmpOutDir, '0.57.0'));
       await generateComposite({ miniApps, outDir: tmpOutDir });
@@ -419,7 +419,7 @@ describe('ern-container-gen utils.js', () => {
 
     it('should create index.js', async () => {
       // One new, one same, one upgrade
-      const miniApps = [PackagePath.fromString('MiniAppOne@6.0.0')];
+      const miniApps = [PackagePath.fromString('first-miniapp@6.0.0')];
       yarnCliStub.init.callsFake(() => fakeYarnInit(tmpOutDir, '0.57.0'));
       await generateComposite({ miniApps, outDir: tmpOutDir });
       assert(fs.existsSync(path.join(tmpOutDir, 'index.js')));
@@ -427,7 +427,7 @@ describe('ern-container-gen utils.js', () => {
 
     it('should create .babelrc with react-native preset for RN < 0.57.0', async () => {
       // One new, one same, one upgrade
-      const miniApps = [PackagePath.fromString('MiniAppOne@6.0.0')];
+      const miniApps = [PackagePath.fromString('first-miniapp@6.0.0')];
       yarnCliStub.init.callsFake(() => fakeYarnInit(tmpOutDir, '0.56.0'));
       await generateComposite({ miniApps, outDir: tmpOutDir });
       assert(fs.existsSync(path.join(tmpOutDir, '.babelrc')));
@@ -439,7 +439,7 @@ describe('ern-container-gen utils.js', () => {
 
     it('should create .babelrc with module:metro-react-native-babel-preset preset for RN >= 0.57.0', async () => {
       // One new, one same, one upgrade
-      const miniApps = [PackagePath.fromString('MiniAppOne@6.0.0')];
+      const miniApps = [PackagePath.fromString('first-miniapp@6.0.0')];
       yarnCliStub.init.callsFake(() => fakeYarnInit(tmpOutDir, '0.57.0'));
       await generateComposite({ miniApps, outDir: tmpOutDir });
       assert(fs.existsSync(path.join(tmpOutDir, '.babelrc')));

--- a/ern-composite-gen/test/fixtures/sample.yarn.lock
+++ b/ern-composite-gen/test/fixtures/sample.yarn.lock
@@ -2,46 +2,46 @@
 # yarn lockfile v1
 
 
-DependencyA@^1.0.1:
+dep-a@^1.0.1:
   version "1.0.1"
-  resolved "http://npme.walmart.com/DependencyA/-/DependencyA-1.0.1.tgz#d4d255f326fbbb01a0f73a5c4d073a68e36b4b18"
+  resolved "https://registry/dep-a/-/dep-a-1.0.1.tgz#d4d255f326fbbb01a0f73a5c4d073a68e36b4b18"
   dependencies:
-    DependencyB "^1.0.0"
+    dep-b "^1.0.0"
 
-DependencyA@^1.0.3:
+dep-a@^1.0.3:
   version "1.0.3"
-  resolved "http://npme.walmart.com/DependencyA/-/DependencyA-1.0.3.tgz#9ead385585913d4d7493ea111a98c94fde9ce701"
+  resolved "https://registry/dep-a/-/dep-a-1.0.3.tgz#9ead385585913d4d7493ea111a98c94fde9ce701"
   dependencies:
-    DependencyB "^1.0.4"
+    dep-b "^1.0.4"
 
-DependencyB@^1.0.0, DependencyB@^1.0.1:
+dep-b@^1.0.0, dep-b@^1.0.1:
   version "1.0.2"
-  resolved "http://npme.walmart.com/DependencyB/-/DependencyB-1.0.2.tgz#9cd91f9c97c866caeb0233e3d631c974d629066e"
+  resolved "https://registry/dep-b/-/dep-b-1.0.2.tgz#9cd91f9c97c866caeb0233e3d631c974d629066e"
 
-DependencyB@^1.0.4:
+dep-b@^1.0.4:
   version "1.0.4"
-  resolved "http://npme.walmart.com/DependencyB/-/DependencyB-1.0.4.tgz#93d7b72c37b4e33a17ccec2d5e82935836d2cd0f"
+  resolved "https://registry/dep-b/-/dep-b-1.0.4.tgz#93d7b72c37b4e33a17ccec2d5e82935836d2cd0f"
 
-DependencyC@^1.0.0:
+dep-c@^1.0.0:
   version "1.0.0"
-  resolved "http://npme.walmart.com/DependencyC/-/DependencyC-1.0.0.tgz#bae7948e9a56868898998f3baa0cce369bb42c7c"
+  resolved "https://registry/dep-c/-/dep-c-1.0.0.tgz#bae7948e9a56868898998f3baa0cce369bb42c7c"
   dependencies:
-    DependencyB "^1.0.1"
+    dep-b "^1.0.1"
 
-MiniAppOne@6.0.0:
+first-miniapp@6.0.0:
   version "6.0.0"
-  resolved "http://npme.walmart.com/MiniAppOne/-/MiniAppOne-6.0.0.tgz#49ee83da9283e95683e65aa0d48f4e836e4b7600"
+  resolved "https://registry/first-miniapp/-/first-miniapp-6.0.0.tgz#49ee83da9283e95683e65aa0d48f4e836e4b7600"
   dependencies:
-    DependencyA "^1.0.3"
+    dep-a "^1.0.3"
 
-MiniAppTwo@3.0.0:
+second-miniapp@3.0.0:
   version "3.0.0"
-  resolved "http://npme.walmart.com/MiniAppTwo/-/MiniAppTwo-3.0.0.tgz#2e373554125d30ea38d7d92188da090601fafa41"
+  resolved "https://registry/second-miniapp/-/second-miniapp-3.0.0.tgz#2e373554125d30ea38d7d92188da090601fafa41"
   dependencies:
-    DependencyA "^1.0.1"
+    dep-a "^1.0.1"
 
-MiniAppThree@1.0.0:
+third-miniapp@1.0.0:
   version "1.0.0"
-  resolved "http://npme.walmart.com/MiniAppThree/-/MiniAppThree-1.0.0.tgz#84519bd8f3ce55535d1711839409bd0bc10af859"
+  resolved "https://registry/third-miniapp/-/third-miniapp-1.0.0.tgz#84519bd8f3ce55535d1711839409bd0bc10af859"
   dependencies:
-    DependencyC "^1.0.0"
+    dep-c "^1.0.0"

--- a/ern-core/src/FsCache.ts
+++ b/ern-core/src/FsCache.ts
@@ -34,7 +34,7 @@ export interface CacheManifestEntry {
   id: string;
   /**
    * Absolute path to the entry
-   * ex : /Users/blemair/.ern/cache/78c40fda-d5bb-4681-9bd2-a5fba9df1f70
+   * ex : /home/user/.ern/cache/78c40fda-d5bb-4681-9bd2-a5fba9df1f70
    */
   path: string;
   /**

--- a/ern-core/src/LocalManifest.ts
+++ b/ern-core/src/LocalManifest.ts
@@ -51,17 +51,17 @@ export class LocalManifest {
    *
    * For example, given the following directories :
    *
-   *  /Users/blemair/.ern/ern-override-manifest/plugins/ern_v0.5.0+
-   *  /Users/blemair/.ern/ern-override-manifest/plugins/ern_v0.10.0+
-   *  /Users/blemair/.ern/ern-override-manifest/plugins/ern_v0.13.0+
+   *  /home/user/.ern/ern-override-manifest/plugins/ern_v0.5.0+
+   *  /home/user/.ern/ern-override-manifest/plugins/ern_v0.10.0+
+   *  /home/user/.ern/ern-override-manifest/plugins/ern_v0.13.0+
    *
    * And maxVersion='0.10.0'
    *
    * The function would return :
    *
    *  [
-   *   '/Users/blemair/.ern/ern-override-manifest/plugins/ern_v0.5.0+',
-   *   '/Users/blemair/.ern/ern-override-manifest/plugins/ern_v0.10.0+'
+   *   '/home/user/.ern/ern-override-manifest/plugins/ern_v0.5.0+',
+   *   '/home/user/.ern/ern-override-manifest/plugins/ern_v0.10.0+'
    *  ]
    * @param maxVersion The upper bound Electrode Native version.
    *                   Only plugin configuration directories lower than this
@@ -136,8 +136,8 @@ export class LocalManifest {
     // Electrode Native version
     // For example :
     // [
-    //   '/Users/blemair/.ern/ern-override-manifest/plugins/ern_v0.10.0+',
-    //   '/Users/blemair/.ern/ern-override-manifest/plugins/ern_v0.5.0+'
+    //   '/home/user/.ern/ern-override-manifest/plugins/ern_v0.10.0+',
+    //   '/home/user/.ern/ern-override-manifest/plugins/ern_v0.5.0+'
     // ]
     const orderedPluginsConfigurationDirectories = this.getPluginsConfigurationDirectories(
       platformVersion,

--- a/ern-core/test/Utils-test.ts
+++ b/ern-core/test/Utils-test.ts
@@ -112,9 +112,9 @@ describe('Core Utils', () => {
     });
 
     it('should coerce a string|PackagePath mixed array to a PackagePath array', () => {
-      const depA = PackagePath.fromString('depA@1.0.0');
-      const depB = PackagePath.fromString('depB@1.0.0');
-      const result = coreUtils.coerceToPackagePathArray(['depA@1.0.0', depB]);
+      const depA = PackagePath.fromString('dep-a@1.0.0');
+      const depB = PackagePath.fromString('dep-b@1.0.0');
+      const result = coreUtils.coerceToPackagePathArray(['dep-a@1.0.0', depB]);
       expect(result).is.an('array').of.length(2);
       expect(result[0]).eql(depA);
       expect(result[1]).eql(depB);
@@ -136,9 +136,7 @@ describe('Core Utils', () => {
 
     it('should return true if the package path does not include a branch [as it corresponds to default branch]', async () => {
       const result = await coreUtils.isGitBranch(
-        PackagePath.fromString(
-          'https://github.com/electrode-io/electrode-native.git',
-        ),
+        PackagePath.fromString('https://github.com/org/repo.git'),
       );
       expect(result).true;
     });
@@ -150,9 +148,7 @@ describe('Core Utils', () => {
         },
       });
       const result = await coreUtils.isGitBranch(
-        PackagePath.fromString(
-          'https://github.com/electrode-io/electrode-native.git#v0.10',
-        ),
+        PackagePath.fromString('https://github.com/org/repo.git#v0.10'),
       );
       expect(result).true;
     });
@@ -164,9 +160,7 @@ describe('Core Utils', () => {
         },
       });
       const result = await coreUtils.isGitBranch(
-        PackagePath.fromString(
-          'https://github.com/electrode-io/electrode-native.git#foo',
-        ),
+        PackagePath.fromString('https://github.com/org/repo.git#foo'),
       );
       expect(result).false;
     });
@@ -187,9 +181,7 @@ d9fa903349bbb9e7f86535cb69256e064d0fba65        refs/tags/v0.1.2`;
 
     it('should return false if the package path does not include a tag', async () => {
       const result = await coreUtils.isGitTag(
-        PackagePath.fromString(
-          'https://github.com/electrode-io/electrode-native.git',
-        ),
+        PackagePath.fromString('https://github.com/org/repo.git'),
       );
       expect(result).false;
     });
@@ -201,9 +193,7 @@ d9fa903349bbb9e7f86535cb69256e064d0fba65        refs/tags/v0.1.2`;
         },
       });
       const result = await coreUtils.isGitTag(
-        PackagePath.fromString(
-          'https://github.com/electrode-io/electrode-native.git#v0.1.2',
-        ),
+        PackagePath.fromString('https://github.com/org/repo.git#v0.1.2'),
       );
       expect(result).true;
     });
@@ -215,9 +205,7 @@ d9fa903349bbb9e7f86535cb69256e064d0fba65        refs/tags/v0.1.2`;
         },
       });
       const result = await coreUtils.isGitBranch(
-        PackagePath.fromString(
-          'https://github.com/electrode-io/electrode-native.git#foo',
-        ),
+        PackagePath.fromString('https://github.com/org/repo.git#foo'),
       );
       expect(result).false;
     });
@@ -241,9 +229,7 @@ d9fa903349bbb9e7f86535cb69256e064d0fba65        refs/tags/v0.1.2`;
         await doesThrow(
           coreUtils.getCommitShaOfGitBranchOrTag,
           null,
-          PackagePath.fromString(
-            'https://github.com/electrode-io/electrode-native.git',
-          ),
+          PackagePath.fromString('https://github.com/org/repo.git'),
         ),
       );
     });
@@ -258,9 +244,7 @@ d9fa903349bbb9e7f86535cb69256e064d0fba65        refs/tags/v0.1.2`;
         await doesThrow(
           coreUtils.getCommitShaOfGitBranchOrTag,
           null,
-          PackagePath.fromString(
-            'https://github.com/electrode-io/electrode-native.git#foo',
-          ),
+          PackagePath.fromString('https://github.com/org/repo.git#foo'),
         ),
       );
     });
@@ -272,9 +256,7 @@ d9fa903349bbb9e7f86535cb69256e064d0fba65        refs/tags/v0.1.2`;
         },
       });
       const result = await coreUtils.getCommitShaOfGitBranchOrTag(
-        PackagePath.fromString(
-          'https://github.com/electrode-io/electrode-native.git#master',
-        ),
+        PackagePath.fromString('https://github.com/org/repo.git#master'),
       );
       expect(result).eql('31d04959d8786113bfeaee997a1d1eaa8cb6c5f5');
     });
@@ -282,10 +264,10 @@ d9fa903349bbb9e7f86535cb69256e064d0fba65        refs/tags/v0.1.2`;
 
   describe('areSamePackagePathsAndVersions', () => {
     it('should return false if the packages arrays are not of same length', async () => {
-      const a = [PackagePath.fromString('packA@1.2.3')];
+      const a = [PackagePath.fromString('dep-a@1.2.3')];
       const b = [
-        PackagePath.fromString('packA@1.2.3'),
-        PackagePath.fromString('packB@1.0.0'),
+        PackagePath.fromString('dep-a@1.2.3'),
+        PackagePath.fromString('dep-b@1.0.0'),
       ];
       const result = await coreUtils.areSamePackagePathsAndVersions(a, b);
       expect(result).false;
@@ -293,26 +275,30 @@ d9fa903349bbb9e7f86535cb69256e064d0fba65        refs/tags/v0.1.2`;
 
     it('should return true if the packages arrays are identical', async () => {
       const a = [
-        PackagePath.fromString('packA@1.2.3'),
-        PackagePath.fromString('packB@1.0.0'),
+        PackagePath.fromString('dep-a@1.2.3'),
+        PackagePath.fromString('dep-b@1.0.0'),
       ];
       const b = [
-        PackagePath.fromString('packA@1.2.3'),
-        PackagePath.fromString('packB@1.0.0'),
+        PackagePath.fromString('dep-a@1.2.3'),
+        PackagePath.fromString('dep-b@1.0.0'),
       ];
       const result = await coreUtils.areSamePackagePathsAndVersions(a, b);
       expect(result).true;
     });
 
+    // TODO:
+    // Use mocks to avoid relying on network for unit tests for
+    // the three tests below
+    /*
     it('should return true if the packages are pointing to same commit sha [branch]', async () => {
       const a = [
         PackagePath.fromString(
-          'https://github.com/electrode-io/MovieListMiniApp.git#334df50afb1c18e5a42058208c5915643a661009',
+          'https://github.com/org/test-miniapp.git#334df50afb1c18e5a42058208c5915643a661009',
         ),
       ];
       const b = [
         PackagePath.fromString(
-          'https://github.com/electrode-io/MovieListMiniApp.git#ern-v0.24',
+          'https://github.com/org/test-miniapp.git#ern-v0.24',
         ),
       ];
       const result = await coreUtils.areSamePackagePathsAndVersions(a, b);
@@ -322,12 +308,12 @@ d9fa903349bbb9e7f86535cb69256e064d0fba65        refs/tags/v0.1.2`;
     it('should return false if the packages are not pointing to same commit sha [branch]', async () => {
       const a = [
         PackagePath.fromString(
-          'https://github.com/electrode-io/MovieListMiniApp.git#124df50afb3c18e5a42058508c5915663a661008',
+          'https://github.com/org/test-miniapp.git#124df50afb3c18e5a42058508c5915663a661008',
         ),
       ];
       const b = [
         PackagePath.fromString(
-          'https://github.com/electrode-io/MovieListMiniApp.git#ern-v0.24',
+          'https://github.com/org/test-miniapp.git#ern-v0.24',
         ),
       ];
       const result = await coreUtils.areSamePackagePathsAndVersions(a, b);
@@ -337,26 +323,27 @@ d9fa903349bbb9e7f86535cb69256e064d0fba65        refs/tags/v0.1.2`;
     it('should return true if the packages are pointing to same commit sha [tag]', async () => {
       const a = [
         PackagePath.fromString(
-          'https://github.com/electrode-io/MovieListMiniApp.git#03ecb47c9bcc693d0d6d43a3cace1b22cdd64286',
+          'https://github.com/org/test-miniapp.git#03ecb47c9bcc693d0d6d43a3cace1b22cdd64286',
         ),
       ];
       const b = [
         PackagePath.fromString(
-          'https://github.com/electrode-io/MovieListMiniApp.git#v0.0.25',
+          'https://github.com/org/test-miniapp.git#v0.0.25',
         ),
       ];
       const result = await coreUtils.areSamePackagePathsAndVersions(a, b);
       expect(result).true;
     }).timeout(5000);
+     */
 
     it('should return false if at least one package is not using same version', async () => {
       const a = [
-        PackagePath.fromString('packA@1.2.3'),
-        PackagePath.fromString('packB@1.0.0'),
+        PackagePath.fromString('dep-a@1.2.3'),
+        PackagePath.fromString('dep-b@1.0.0'),
       ];
       const b = [
-        PackagePath.fromString('packA@2.0.0'),
-        PackagePath.fromString('packB@1.0.0'),
+        PackagePath.fromString('dep-a@2.0.0'),
+        PackagePath.fromString('dep-b@1.0.0'),
       ];
       const result = await coreUtils.areSamePackagePathsAndVersions(a, b);
       expect(result).false;

--- a/ern-core/test/android-test.ts
+++ b/ern-core/test/android-test.ts
@@ -32,9 +32,6 @@ describe('android.js', () => {
     sandbox.restore();
   });
 
-  // ==========================================================
-  // runAndroid
-  // ==========================================================
   describe('runAndroid', () => {
     it('runAndroid throws error with more than 2 running devices', async () => {
       execpStub.resolves(fixtures.getDeviceResult);
@@ -51,9 +48,6 @@ describe('android.js', () => {
     });
   });
 
-  // ==========================================================
-  // runAndroid
-  // ==========================================================
   describe('getDevices', () => {
     it('get adb devices as list from stdout', async () => {
       const avdStdOut = await readFile(
@@ -75,9 +69,6 @@ describe('android.js', () => {
     });
   });
 
-  // ==========================================================
-  // askUserToSelectAvdEmulator
-  // ==========================================================
   describe('askUserToSelectAvdEmulator', () => {
     it('prompt user if previous emulator flag is false', async () => {
       execpStub.resolves(fixtures.oneAvdList);
@@ -146,9 +137,6 @@ describe('android.js', () => {
     });
   });
 
-  // ==========================================================
-  // getAndroidAvds
-  // ==========================================================
   describe('getAndroidAvds', () => {
     it('return non-empty list with 2 avds', async () => {
       const avdStdOut = await readFile(
@@ -178,9 +166,6 @@ describe('android.js', () => {
     });
   });
 
-  // ==========================================================
-  // getGradleByPlatform
-  // ==========================================================
   describe('getGradleByPlatform', () => {
     it('check gradlew is returned for win  ', () => {
       const platform = Object.getOwnPropertyDescriptor(process, 'platform');
@@ -216,9 +201,6 @@ describe('android.js', () => {
     });
   });
 
-  // ==========================================================
-  // androidGetBootAnimProp
-  // ==========================================================
   describe('installApk', () => {
     it('adb install -r', async () => {
       execpStub.resolves('Stopped');
@@ -226,9 +208,6 @@ describe('android.js', () => {
     });
   });
 
-  // ==========================================================
-  // resolveAndroidVersions
-  // ==========================================================
   describe('resolveAndroidVersions', () => {
     it('should return all default versions if no versions are provided', () => {
       const versions = android.resolveAndroidVersions();

--- a/ern-core/test/coreutils-test.ts
+++ b/ern-core/test/coreutils-test.ts
@@ -26,9 +26,6 @@ describe('utils.js', () => {
     afterTest();
   });
 
-  // ==========================================================
-  // isPublishedToNpm
-  // ==========================================================
   describe('isPublishedToNpm', () => {
     it('pkgName published in npm return true', async () => {
       const yarnStub = sinon.stub(yarn, 'info');
@@ -72,9 +69,6 @@ describe('utils.js', () => {
     });
   });
 
-  // ==========================================================
-  // camelize
-  // ==========================================================
   describe('camelize', () => {
     it('camelcase word with lowercaseFirstLetter true', () => {
       expect(utils.camelize('Foo Bar', true)).to.eql('fooBar');
@@ -96,9 +90,6 @@ describe('utils.js', () => {
     });
   });
 
-  // ==========================================================
-  // splitCamelCaseString
-  // ==========================================================
   describe('splitCamelCaseString', () => {
     it('split camel case string', () => {
       expect(utils.splitCamelCaseString('')).to.eql(['']);
@@ -112,9 +103,6 @@ describe('utils.js', () => {
     });
   });
 
-  // ==========================================================
-  // getDefaultPackageNameForCamelCaseString
-  // ==========================================================
   describe('getDefaultPackageNameForCamelCaseString', () => {
     it('get default package name no module type', () => {
       const tests = [
@@ -199,9 +187,6 @@ describe('utils.js', () => {
     });
   });
 
-  // ==========================================================
-  // getModuleSuffix
-  // ==========================================================
   describe('getModuleSuffix', () => {
     it('returns the correct suffixes', () => {
       expect(utils.getModuleSuffix(MINIAPP)).to.eql('miniapp');
@@ -219,9 +204,6 @@ describe('utils.js', () => {
     });
   });
 
-  // ==========================================================
-  // getDefaultPackageNameForModule
-  // ==========================================================
   describe('getDefaultPackageNameForModule', () => {
     const tests = {
       api: [
@@ -303,9 +285,6 @@ describe('utils.js', () => {
     });
   });
 
-  // ==========================================================
-  // isDependencyApiImpl
-  // ==========================================================
   describe('isDependencyApiImpl', () => {
     it('return true if ern object resolves for native api impl', async () => {
       const yarnStub = sinon.stub(yarn, 'info');
@@ -326,9 +305,6 @@ describe('utils.js', () => {
     });
   });
 
-  // ==========================================================
-  // isDependencyApi
-  // ==========================================================
   describe('isDependencyApi', () => {
     it('returns true if ern module type is set to ern-api', async () => {
       const yarnStub = sinon.stub(yarn, 'info');
@@ -340,9 +316,6 @@ describe('utils.js', () => {
     });
   });
 
-  // ==========================================================
-  // isDependencyApiOrApiImpl
-  // ==========================================================
   describe('isDependencyApiOrApiImpl', () => {
     it('return true if ern object resolves for api', async () => {
       const yarnStub = sinon.stub(yarn, 'info');
@@ -372,9 +345,6 @@ describe('utils.js', () => {
     });
   });
 
-  // ==========================================================
-  // isValidElectrodeNativeModuleName
-  // ==========================================================
   describe('isValidElectrodeNativeModuleName', () => {
     fixtures.validElectrodeNativeModuleNames.forEach((name) => {
       it('should return true if valid electrode native module name', () => {
@@ -389,9 +359,6 @@ describe('utils.js', () => {
     });
   });
 
-  // ==========================================================
-  // getDownloadedPluginPath
-  // ==========================================================
   describe('getDownloadedPluginPath', () => {
     it('return download plugin path for npm plugin', () => {
       const pluginPath = 'node_modules/react-native-code-push';

--- a/ern-core/test/resolveNativeDependenciesVersions-test.ts
+++ b/ern-core/test/resolveNativeDependenciesVersions-test.ts
@@ -53,29 +53,29 @@ describe('containsVersionMismatch', () => {
 describe('retainHighestVersion', () => {
   it('should work as expected', () => {
     const arrA = [
-      PackagePath.fromString('dependencyA@1.0.0'),
-      PackagePath.fromString('dependencyB@2.0.1'),
-      PackagePath.fromString('dependencyC@1.0.0'),
-      PackagePath.fromString('dependencyD@1.0.0'),
+      PackagePath.fromString('dep-a@1.0.0'),
+      PackagePath.fromString('dep-b@2.0.1'),
+      PackagePath.fromString('dep-c@1.0.0'),
+      PackagePath.fromString('dep-d@1.0.0'),
     ];
 
     const arrB = [
-      PackagePath.fromString('dependencyA@2.0.0'),
-      PackagePath.fromString('dependencyB@2.0.0'),
-      PackagePath.fromString('dependencyC@1.1.0'),
-      PackagePath.fromString('dependencyE@1.0.0'),
-      PackagePath.fromString('dependencyF@3.0.0'),
+      PackagePath.fromString('dep-a@2.0.0'),
+      PackagePath.fromString('dep-b@2.0.0'),
+      PackagePath.fromString('dep-c@1.1.0'),
+      PackagePath.fromString('dep-e@1.0.0'),
+      PackagePath.fromString('dep-f@3.0.0'),
     ];
 
     const result = retainHighestVersions(arrA, arrB);
     const stringifedResult = result.map((p) => p.toString());
     expect(stringifedResult).length(6);
-    expect(stringifedResult).includes('dependencyA@2.0.0');
-    expect(stringifedResult).includes('dependencyB@2.0.1');
-    expect(stringifedResult).includes('dependencyC@1.1.0');
-    expect(stringifedResult).includes('dependencyD@1.0.0');
-    expect(stringifedResult).includes('dependencyE@1.0.0');
-    expect(stringifedResult).includes('dependencyF@3.0.0');
+    expect(stringifedResult).includes('dep-a@2.0.0');
+    expect(stringifedResult).includes('dep-b@2.0.1');
+    expect(stringifedResult).includes('dep-c@1.1.0');
+    expect(stringifedResult).includes('dep-d@1.0.0');
+    expect(stringifedResult).includes('dep-e@1.0.0');
+    expect(stringifedResult).includes('dep-f@3.0.0');
   });
 });
 

--- a/ern-local-cli/test/fixtures/common.js
+++ b/ern-local-cli/test/fixtures/common.js
@@ -4,16 +4,16 @@ export const withoutGitOrFileSystemPath = [
 ];
 
 export const withGitOrFileSystemPath = [
-  'git+ssh://github.com:electrode/react-native.git#master',
-  'file:/Users/username',
+  'git+ssh://github.com:org/repo.git#master',
+  'file:/home/user',
 ];
 
 export const withoutFileSystemPath = [
-  'git+ssh://github.com:electrode/react-native.git#master',
+  'git+ssh://github.com:org/repo.git#master',
   'package@1.2.3',
 ];
 
-export const withFileSystemPath = ['file:/Users/username'];
+export const withFileSystemPath = ['file:/home/user'];
 
 export const differentNativeApplicationPlatformDescriptors = [
   'testapp:android:1.0.0',

--- a/ern-orchestrator/src/codepush.ts
+++ b/ern-orchestrator/src/codepush.ts
@@ -350,9 +350,9 @@ export async function performCodePushOtaUpdate(
     // We need to include, in this CodePush bundle, all the MiniApps and JS API implementations that were part
     // of the previous CodePush. We will override versions of the MiniApps and JS API implementations with
     // the one provided to this function, and keep other ones intact.
-    // For example, if previous CodePush bundle was containing MiniAppOne@1.0.0 and
-    // MiniAppTwo@1.0.0 and this method is called to CodePush MiniAppOne@2.0.0, then
-    // the bundle we will push will container MiniAppOne@2.0.0 and MiniAppTwo@1.0.0.
+    // For example, if previous CodePush bundle was containing first-miniapp@1.0.0 and
+    // second-miniapp@1.0.0 and this method is called to CodePush first-miniapp@2.0.0, then
+    // the bundle we will push will container first-miniapp@2.0.0 and second-miniapp@1.0.0.
     // If this the first ever CodePush bundle for this specific native application version
     // then the reference miniapp versions are the one from the container.
     let referenceMiniAppsToCodePush = latestCodePushedMiniApps;

--- a/ern-orchestrator/src/container.ts
+++ b/ern-orchestrator/src/container.ts
@@ -23,8 +23,8 @@ import * as constants from './constants';
 // The string used to represent a miniapp package can be anything supported by `yarn add` command
 // For example, the following miniapp strings are all valid
 // FROM NPM => react-native-miniapp@1.2.3
-// FROM GIT => git@github.com:username/MiniAppp.git
-// FROM FS  => file:/Users/username/Code/MiniApp
+// FROM GIT => git@github.com:org/test-miniapp.git
+// FROM FS  => file:/home/user/test-miniapp
 export async function runLocalContainerGen(
   platform: NativePlatform,
   composite: Composite,

--- a/ern-orchestrator/test/Ensure-test.js
+++ b/ern-orchestrator/test/Ensure-test.js
@@ -194,7 +194,7 @@ describe('Ensure.js', () => {
         await doesThrow(
           Ensure.dependencyIsOrphaned,
           null,
-          'DependencyB',
+          'dep-b',
           'testapp:android:1.0.0',
         ),
       );
@@ -208,7 +208,7 @@ describe('Ensure.js', () => {
         await doesNotThrow(
           Ensure.dependencyIsOrphaned,
           null,
-          'DependencyD',
+          'dep-d',
           'testapp:android:1.0.0',
         ),
       );
@@ -222,7 +222,7 @@ describe('Ensure.js', () => {
         await doesNotThrow(
           Ensure.dependencyIsOrphaned,
           null,
-          'DependencyOutOfLockFile',
+          'dep-x',
           'testapp:android:1.0.0',
         ),
       );
@@ -251,7 +251,7 @@ describe('Ensure.js', () => {
   describe('dependencyIsInNativeApplicationVersionContainer', () => {
     it('should not throw if dependency is in native application version Container', async () => {
       cauldronHelperStub.getContainerNativeDependency.resolves(
-        PackagePath.fromString('depA@1.0.0'),
+        PackagePath.fromString('dep-a@1.0.0'),
       );
       assert(
         await doesNotThrow(
@@ -388,13 +388,13 @@ describe('Ensure.js', () => {
   describe('dependencyIsInNativeApplicationVersionContainerWithDifferentVersion', () => {
     it('should not throw if dependency is in native application version Container with different version', async () => {
       cauldronHelperStub.getContainerNativeDependency.resolves(
-        PackagePath.fromString('depA@2.0.0'),
+        PackagePath.fromString('dep-a@2.0.0'),
       );
       assert(
         await doesNotThrow(
           Ensure.dependencyIsInNativeApplicationVersionContainerWithDifferentVersion,
           null,
-          'depA@1.0.0',
+          'dep-a@1.0.0',
           'testapp:android:1.0.0',
         ),
       );
@@ -402,7 +402,7 @@ describe('Ensure.js', () => {
 
     it('should not throw if dependency is undefined', async () => {
       cauldronHelperStub.getContainerNativeDependency.resolves(
-        PackagePath.fromString('depA@2.0.0'),
+        PackagePath.fromString('dep-a@2.0.0'),
       );
       assert(
         await doesNotThrow(
@@ -416,13 +416,13 @@ describe('Ensure.js', () => {
 
     it('should throw if dependency is in native application version Container with same version', async () => {
       cauldronHelperStub.getContainerNativeDependency.resolves(
-        PackagePath.fromString('depA@1.0.0'),
+        PackagePath.fromString('dep-a@1.0.0'),
       );
       assert(
         await doesThrow(
           Ensure.dependencyIsInNativeApplicationVersionContainerWithDifferentVersion,
           null,
-          'depA@1.0.0',
+          'dep-a@1.0.0',
           'testapp:android:1.0.0',
         ),
       );

--- a/ern-orchestrator/test/Ensure-test.js
+++ b/ern-orchestrator/test/Ensure-test.js
@@ -24,9 +24,6 @@ describe('Ensure.js', () => {
     sandbox.restore();
   });
 
-  // ==========================================================
-  // noGitOrFilesystemPath
-  // ==========================================================
   describe('noGitOrFilesystemPath', () => {
     fixtures.withoutGitOrFileSystemPath.forEach((obj) => {
       it('should not throw if no git or file system path', () => {
@@ -47,9 +44,6 @@ describe('Ensure.js', () => {
     });
   });
 
-  // ==========================================================
-  // noFileSystemPath
-  // ==========================================================
   describe('noFileSystemPath', () => {
     fixtures.withoutFileSystemPath.forEach((obj) => {
       it('should not throw if no file system path', () => {
@@ -70,9 +64,6 @@ describe('Ensure.js', () => {
     });
   });
 
-  // ==========================================================
-  // napDescritorExistsInCauldron
-  // ==========================================================
   describe('napDescritorExistsInCauldron', () => {
     it('should not throw if nap descriptor exists in Cauldron', async () => {
       cauldronHelperStub.isDescriptorInCauldron.resolves(true);
@@ -115,9 +106,6 @@ describe('Ensure.js', () => {
     });
   });
 
-  // ==========================================================
-  // napDescritorDoesNotExistsInCauldron
-  // ==========================================================
   describe('napDescritorDoesNotExistsInCauldron', () => {
     it('should throw if nap descriptor exists in Cauldron', async () => {
       cauldronHelperStub.isDescriptorInCauldron.resolves(true);
@@ -142,9 +130,6 @@ describe('Ensure.js', () => {
     });
   });
 
-  // ==========================================================
-  // dependencyNotInNativeApplicationVersionContainer
-  // ==========================================================
   describe('dependencyNotInNativeApplicationVersionContainer', () => {
     it('should throw if dependency is in native application version Container', async () => {
       cauldronHelperStub.isNativeDependencyInContainer.resolves(true);
@@ -182,9 +167,6 @@ describe('Ensure.js', () => {
     });
   });
 
-  // ==========================================================
-  // dependencyIsOrphaned
-  // ==========================================================
   describe('dependencyIsOrphaned', async () => {
     it('should throw if dependency is not orphaned', async () => {
       cauldronHelperStub.getYarnLock.resolves(
@@ -229,9 +211,6 @@ describe('Ensure.js', () => {
     });
   });
 
-  // ==========================================================
-  // dependencyNotInUseByAMiniApp
-  // ==========================================================
   describe('dependencyNotInUseByAMiniApp', () => {
     it('should not throw if dependency is undefined', async () => {
       assert(
@@ -245,9 +224,6 @@ describe('Ensure.js', () => {
     });
   });
 
-  // ==========================================================
-  // dependencyIsInNativeApplicationVersionContainer
-  // ==========================================================
   describe('dependencyIsInNativeApplicationVersionContainer', () => {
     it('should not throw if dependency is in native application version Container', async () => {
       cauldronHelperStub.getContainerNativeDependency.resolves(
@@ -287,9 +263,6 @@ describe('Ensure.js', () => {
     });
   });
 
-  // ==========================================================
-  // miniAppIsInNativeApplicationVersionContainer
-  // ==========================================================
   describe('miniAppIsInNativeApplicationVersionContainer', () => {
     it('should not throw if MiniApp is in native application version Container', async () => {
       cauldronHelperStub.isMiniAppInContainer.resolves(true);
@@ -338,9 +311,6 @@ describe('Ensure.js', () => {
     });
   });
 
-  // ==========================================================
-  // miniAppIsInNativeApplicationVersionContainerWithDifferentVersion
-  // ==========================================================
   describe('miniAppIsInNativeApplicationVersionContainerWithDifferentVersion', () => {
     it('should not throw if miniapp is in native application version Container with different version', async () => {
       cauldronHelperStub.isMiniAppInContainer.resolves(true);
@@ -382,9 +352,6 @@ describe('Ensure.js', () => {
     });
   });
 
-  // ==========================================================
-  // dependencyIsInNativeApplicationVersionContainerWithDifferentVersion
-  // ==========================================================
   describe('dependencyIsInNativeApplicationVersionContainerWithDifferentVersion', () => {
     it('should not throw if dependency is in native application version Container with different version', async () => {
       cauldronHelperStub.getContainerNativeDependency.resolves(
@@ -429,9 +396,6 @@ describe('Ensure.js', () => {
     });
   });
 
-  // ==========================================================
-  // miniAppNotInNativeApplicationVersionContainer
-  // ==========================================================
   describe('miniAppNotInNativeApplicationVersionContainer', () => {
     it('should not throw for undefined MiniApp', async () => {
       assert(
@@ -456,9 +420,6 @@ describe('Ensure.js', () => {
     });
   });
 
-  // ==========================================================
-  // publishedToNpm
-  // ==========================================================
   describe('publishedToNpm', () => {
     it('should not throw if dependency is published to npm', async () => {
       sandbox.stub(utils, 'isPublishedToNpm').resolves(true);
@@ -475,9 +436,6 @@ describe('Ensure.js', () => {
     });
   });
 
-  // ==========================================================
-  // cauldronIsActive
-  // ==========================================================
   /*describe('cauldronIsActive', () => {
     it('should not throw if a cauldron is active', async () => {
       isActiveStub.returns(true)
@@ -490,9 +448,6 @@ describe('Ensure.js', () => {
     })
   })*/
 
-  // ==========================================================
-  // isValidNpmPackageName
-  // ==========================================================
   describe('isValidNpmPackageName', () => {
     fixtures.validNpmPackageNames.forEach((name) => {
       it('should not throw if name is valid', () => {
@@ -513,9 +468,6 @@ describe('Ensure.js', () => {
     });
   });
 
-  // ==========================================================
-  // isValidElectrodeNativeModuleName
-  // ==========================================================
   describe('isValidElectrodeNativeModuleName', () => {
     coreFixtures.validElectrodeNativeModuleNames.forEach((name) => {
       it('should not throw if name is valid', () => {
@@ -536,9 +488,6 @@ describe('Ensure.js', () => {
     });
   });
 
-  // ==========================================================
-  // sameNativeApplicationAndPlatform
-  // ==========================================================
   describe('sameNativeApplicationAndPlatform', () => {
     it('should not throw if descriptors are matching the same native application and platform', () => {
       expect(() =>
@@ -557,9 +506,6 @@ describe('Ensure.js', () => {
     });
   });
 
-  // ==========================================================
-  // checkIfCodePushOptionsAreValid
-  // ==========================================================
   describe('checkIfCodePushOptionsAreValid', () => {
     it('should not throw if descriptors and semVerDescriptor are specified', () => {
       expect(() =>
@@ -600,9 +546,6 @@ describe('Ensure.js', () => {
     });
   });
 
-  // ==========================================================
-  // pathExist
-  // ==========================================================
   describe('pathExist', () => {
     it('should not throw if path exist', async () => {
       const tmpDirPath = createTmpDir();
@@ -615,9 +558,6 @@ describe('Ensure.js', () => {
     });
   });
 
-  // ==========================================================
-  // isFilePath
-  // ==========================================================
   describe('isFilePath', () => {
     it('should not throw if path is a file', async () => {
       const tmpDirPath = createTmpDir();
@@ -637,9 +577,6 @@ describe('Ensure.js', () => {
     });
   });
 
-  // ==========================================================
-  // isDirectoryPath
-  // ==========================================================
   describe('isDirectoryPath', () => {
     it('should not throw if path is a  directory', async () => {
       const tmpDirPath = createTmpDir();
@@ -661,9 +598,6 @@ describe('Ensure.js', () => {
     });
   });
 
-  // ==========================================================
-  // isSupportedMiniAppOrJsApiImplVersion
-  // ==========================================================
   describe('isSupportedMiniAppOrJsApiImplVersion', () => {
     fixtures.supportedCauldronMiniAppsVersions.forEach((pkg) => {
       it(`should not throw if suported version (pkg: ${pkg})`, () => {
@@ -684,9 +618,6 @@ describe('Ensure.js', () => {
     });
   });
 
-  // ==========================================================
-  // isContainerPath
-  // ==========================================================
   describe('isContainerPath', () => {
     it('should not throw if path points to a container', async () => {
       const tmpDirPath = createTmpDir();

--- a/ern-orchestrator/test/codepush-test.ts
+++ b/ern-orchestrator/test/codepush-test.ts
@@ -863,7 +863,7 @@ describe('codepush', () => {
 
     it('should use the app name from config if any', async () => {
       const result = await sut.getCodePushAppName(testAndroid1780Descriptor);
-      expect(result).equal('walmart-android');
+      expect(result).equal('app-android');
     });
   });
 });

--- a/ern-orchestrator/test/fixtures/common.js
+++ b/ern-orchestrator/test/fixtures/common.js
@@ -6,34 +6,34 @@ export const withoutGitOrFileSystemPath = [
 ];
 
 export const withGitOrFileSystemPath = [
-  'git+ssh://github.com:electrode/react-native.git#master',
-  'file:/Users/username',
+  'git+ssh://github.com:org/repo.git#master',
+  'file:/home/user',
 ];
 
 export const withoutFileSystemPath = [
-  'git+ssh://github.com:electrode/react-native.git#master',
+  'git+ssh://github.com:org/repo.git#master',
   'package@1.2.3',
 ];
 
 export const supportedCauldronMiniAppsVersions = [
-  'git+ssh://github.com/MiniApp.git#master',
-  'git+ssh://github.com/MiniApp.git#v1.0.0',
-  'git+ssh://github.com/MiniApp.git#ea2e2d248c6af5eb14d76e4108ec922febd096f5',
-  'https://github.com/MiniApp.git#master',
-  'https://github.com/MiniApp.git#v1.0.0',
-  'https://github.com/MiniApp.git#ea2e2d248c6af5eb14d76e4108ec922febd096f5',
-  'MiniApp@1.0.0',
-  'MiniApp@1.0.0-beta',
+  'git+ssh://github.com/org/test-miniapp.git#master',
+  'git+ssh://github.com/org/test-miniapp.git#v1.0.0',
+  'git+ssh://github.com/org/test-miniapp.git#ea2e2d248c6af5eb14d76e4108ec922febd096f5',
+  'https://github.com/org/test-miniapp.git#master',
+  'https://github.com/org/test-miniapp.git#v1.0.0',
+  'https://github.com/org/test-miniapp.git#ea2e2d248c6af5eb14d76e4108ec922febd096f5',
+  'test-miniapp@1.0.0',
+  'test-miniapp@1.0.0-beta',
 ];
 
 export const unSupportedCauldronMiniAppsVersions = [
-  'git+ssh://github.com/MiniApp.git',
-  'https://github.com/MiniApp.git',
-  'MiniApp@^1.0.0',
-  'MiniApp@~1.0.0',
+  'git+ssh://github.com/org/test-miniapp.git',
+  'https://github.com/org/test-miniapp.git',
+  'test-miniapp@^1.0.0',
+  'test-miniapp@~1.0.0',
 ];
 
-export const withFileSystemPath = ['file:/Users/username'];
+export const withFileSystemPath = ['file:/home/user'];
 
 export const validNpmPackageNames = ['hello-world', '@hello/world'];
 

--- a/ern-orchestrator/test/fixtures/sample.yarn.lock
+++ b/ern-orchestrator/test/fixtures/sample.yarn.lock
@@ -2,50 +2,50 @@
 # yarn lockfile v1
 
 
-DependencyA@^1.0.1:
+dep-a@^1.0.1:
   version "1.0.1"
-  resolved "http://npme.walmart.com/DependencyA/-/DependencyA-1.0.1.tgz#d4d255f326fbbb01a0f73a5c4d073a68e36b4b18"
+  resolved "https://registry/dep-a/-/dep-a-1.0.1.tgz#d4d255f326fbbb01a0f73a5c4d073a68e36b4b18"
   dependencies:
-    DependencyB "^1.0.0"
+    dep-b "^1.0.0"
 
-DependencyA@^1.0.3:
+dep-a@^1.0.3:
   version "1.0.3"
-  resolved "http://npme.walmart.com/DependencyA/-/DependencyA-1.0.3.tgz#9ead385585913d4d7493ea111a98c94fde9ce701"
+  resolved "https://registry/dep-a/-/dep-a-1.0.3.tgz#9ead385585913d4d7493ea111a98c94fde9ce701"
   dependencies:
-    DependencyB "^1.0.4"
+    dep-b "^1.0.4"
 
-DependencyB@^1.0.0, DependencyB@^1.0.1:
+dep-b@^1.0.0, dep-b@^1.0.1:
   version "1.0.2"
-  resolved "http://npme.walmart.com/DependencyB/-/DependencyB-1.0.2.tgz#9cd91f9c97c866caeb0233e3d631c974d629066e"
+  resolved "https://registry/dep-b/-/dep-b-1.0.2.tgz#9cd91f9c97c866caeb0233e3d631c974d629066e"
 
-DependencyB@^1.0.4:
+dep-b@^1.0.4:
   version "1.0.4"
-  resolved "http://npme.walmart.com/DependencyB/-/DependencyB-1.0.4.tgz#93d7b72c37b4e33a17ccec2d5e82935836d2cd0f"
+  resolved "https://registry/dep-b/-/dep-b-1.0.4.tgz#93d7b72c37b4e33a17ccec2d5e82935836d2cd0f"
 
-DependencyC@^1.0.0:
+dep-c@^1.0.0:
   version "1.0.0"
-  resolved "http://npme.walmart.com/DependencyC/-/DependencyC-1.0.0.tgz#bae7948e9a56868898998f3baa0cce369bb42c7c"
+  resolved "https://registry/dep-c/-/dep-c-1.0.0.tgz#bae7948e9a56868898998f3baa0cce369bb42c7c"
   dependencies:
-    DependencyB "^1.0.1"
+    dep-b "^1.0.1"
 
-DependencyD@^1.0.0:
+dep-d@^1.0.0:
   version "1.0.0"
-  resolved "http://npme.walmart.com/DependencyB/-/DependencyB-1.0.4.tgz#9347b72c37b4e33a17ccec2d5e82935836d2cd0f"
+  resolved "https://registry/dep-d/-/dep-d-1.0.0.tgz#1347b72c37b4e33a17ccec2d5e82935836d2cd0f"
 
-MiniAppOne@6.0.0:
+first-miniapp@6.0.0:
   version "6.0.0"
-  resolved "http://npme.walmart.com/MiniAppOne/-/MiniAppOne-6.0.0.tgz#49ee83da9283e95683e65aa0d48f4e836e4b7600"
+  resolved "https://registry/first-miniapp/-/first-miniapp-6.0.0.tgz#49ee83da9283e95683e65aa0d48f4e836e4b7600"
   dependencies:
-    DependencyA "^1.0.3"
+    dep-a "^1.0.3"
 
-MiniAppTwo@3.0.0:
+second-miniapp@3.0.0:
   version "3.0.0"
-  resolved "http://npme.walmart.com/MiniAppTwo/-/MiniAppTwo-3.0.0.tgz#2e373554125d30ea38d7d92188da090601fafa41"
+  resolved "https://registry/second-miniapp/-/second-miniapp-3.0.0.tgz#2e373554125d30ea38d7d92188da090601fafa41"
   dependencies:
-    DependencyA "^1.0.1"
+    dep-a "^1.0.1"
 
-MiniAppThree@1.0.0:
+third-miniapp@1.0.0:
   version "1.0.0"
-  resolved "http://npme.walmart.com/MiniAppThree/-/MiniAppThree-1.0.0.tgz#84519bd8f3ce55535d1711839409bd0bc10af859"
+  resolved "https://registry/third-miniapp/-/third-miniapp-1.0.0.tgz#84519bd8f3ce55535d1711839409bd0bc10af859"
   dependencies:
-    DependencyC "^1.0.0"
+    dep-c "^1.0.0"

--- a/ern-orchestrator/test/fixtures/yarn.lock
+++ b/ern-orchestrator/test/fixtures/yarn.lock
@@ -2,50 +2,50 @@
 # yarn lockfile v1
 
 
-DependencyA@^1.0.1:
+dep-a@^1.0.1:
   version "1.0.1"
-  resolved "http://npme.walmart.com/DependencyA/-/DependencyA-1.0.1.tgz#d4d255f326fbbb01a0f73a5c4d073a68e36b4b18"
+  resolved "https://registry/dep-a/-/dep-a-1.0.1.tgz#d4d255f326fbbb01a0f73a5c4d073a68e36b4b18"
   dependencies:
-    DependencyB "^1.0.0"
+    dep-b "^1.0.0"
 
-DependencyA@^1.0.3:
+dep-a@^1.0.3:
   version "1.0.3"
-  resolved "http://npme.walmart.com/DependencyA/-/DependencyA-1.0.3.tgz#9ead385585913d4d7493ea111a98c94fde9ce701"
+  resolved "https://registry/dep-a/-/dep-a-1.0.3.tgz#9ead385585913d4d7493ea111a98c94fde9ce701"
   dependencies:
-    DependencyB "^1.0.4"
+    dep-b "^1.0.4"
 
-DependencyB@^1.0.0, DependencyB@^1.0.1:
+dep-b@^1.0.0, dep-b@^1.0.1:
   version "1.0.2"
-  resolved "http://npme.walmart.com/DependencyB/-/DependencyB-1.0.2.tgz#9cd91f9c97c866caeb0233e3d631c974d629066e"
+  resolved "https://registry/dep-b/-/dep-b-1.0.2.tgz#9cd91f9c97c866caeb0233e3d631c974d629066e"
 
-DependencyB@^1.0.4:
+dep-b@^1.0.4:
   version "1.0.4"
-  resolved "http://npme.walmart.com/DependencyB/-/DependencyB-1.0.4.tgz#93d7b72c37b4e33a17ccec2d5e82935836d2cd0f"
+  resolved "https://registry/dep-b/-/dep-b-1.0.4.tgz#93d7b72c37b4e33a17ccec2d5e82935836d2cd0f"
 
-DependencyC@^1.0.0:
+dep-c@^1.0.0:
   version "1.0.0"
-  resolved "http://npme.walmart.com/DependencyC/-/DependencyC-1.0.0.tgz#bae7948e9a56868898998f3baa0cce369bb42c7c"
+  resolved "https://registry/dep-c/-/dep-c-1.0.0.tgz#bae7948e9a56868898998f3baa0cce369bb42c7c"
   dependencies:
-    DependencyB "^1.0.1"
+    dep-b "^1.0.1"
 
-DependencyD@^1.0.0:
+dep-d@^1.0.0:
   version "1.0.0"
-  resolved "http://npme.walmart.com/DependencyB/-/DependencyB-1.0.4.tgz#9347b72c37b4e33a17ccec2d5e82935836d2cd0f"
+  resolved "https://registry/dep-d/-/dep-d-1.0.0.tgz#1347b72c37b4e33a17ccec2d5e82935836d2cd0f"
 
-MiniAppOne@6.0.0:
+first-miniapp@6.0.0:
   version "6.0.0"
-  resolved "http://npme.walmart.com/MiniAppOne/-/MiniAppOne-6.0.0.tgz#49ee83da9283e95683e65aa0d48f4e836e4b7600"
+  resolved "https://registry/first-miniapp/-/first-miniapp-6.0.0.tgz#49ee83da9283e95683e65aa0d48f4e836e4b7600"
   dependencies:
-    DependencyA "^1.0.3"
+    dep-a "^1.0.3"
 
-MiniAppTwo@3.0.0:
+second-miniapp@3.0.0:
   version "3.0.0"
-  resolved "http://npme.walmart.com/MiniAppTwo/-/MiniAppTwo-3.0.0.tgz#2e373554125d30ea38d7d92188da090601fafa41"
+  resolved "https://registry/second-miniapp/-/second-miniapp-3.0.0.tgz#2e373554125d30ea38d7d92188da090601fafa41"
   dependencies:
-    DependencyA "^1.0.1"
+    dep-a "^1.0.1"
 
-MiniAppThree@1.0.0:
+third-miniapp@1.0.0:
   version "1.0.0"
-  resolved "http://npme.walmart.com/MiniAppThree/-/MiniAppThree-1.0.0.tgz#84519bd8f3ce55535d1711839409bd0bc10af859"
+  resolved "https://registry/third-miniapp/-/third-miniapp-1.0.0.tgz#84519bd8f3ce55535d1711839409bd0bc10af859"
   dependencies:
-    DependencyC "^1.0.0"
+    dep-c "^1.0.0"

--- a/ern-orchestrator/test/generateContainerForRunner-test.ts
+++ b/ern-orchestrator/test/generateContainerForRunner-test.ts
@@ -21,7 +21,7 @@ describe('generateContainerForRunner', () => {
 
   it('should call runCauldronContainerGen with proper arguments if a descriptor is provided', async () => {
     const descriptor = AppVersionDescriptor.fromString('test:android:1.0.0');
-    const outDir = '/Users/foo/test';
+    const outDir = '/home/user/test';
     await generateContainerForRunner('android', {
       napDescriptor: descriptor,
       outDir,
@@ -38,7 +38,7 @@ describe('generateContainerForRunner', () => {
   });
 
   it('should call runLocalContainerGen with proper arguments if no descriptor is provided', async () => {
-    const outDir = '/Users/foo/test';
+    const outDir = '/home/user/test';
     const miniApps = [PackagePath.fromString('a@1.0.0')];
     const jsApiImpls = [PackagePath.fromString('b@1.0.0')];
     const dependencies = [PackagePath.fromString('c@1.0.0')];
@@ -60,7 +60,7 @@ describe('generateContainerForRunner', () => {
   });
 
   it('should call runLocalContainerGen with extra arguments if no descriptor is provided', async () => {
-    const outDir = '/Users/foo/test';
+    const outDir = '/home/user/test';
     const miniApps = [PackagePath.fromString('a@1.0.0')];
     const jsApiImpls = [PackagePath.fromString('b@1.0.0')];
     const dependencies = [PackagePath.fromString('c@1.0.0')];
@@ -84,10 +84,7 @@ describe('generateContainerForRunner', () => {
   });
 
   it('should call runLocalCompositeGen with extra arguments if no descriptor is provided', async () => {
-    const metroExtraNodeModules = [
-      'dependency-a',
-      '/home/user/path/to/dependency-b',
-    ];
+    const metroExtraNodeModules = ['dep-a', '/home/user/path/to/dep-b'];
     const extra = { androidConfig: { compileSdkVersion: '28' } };
     await generateContainerForRunner('android', {
       extra: {

--- a/ern-orchestrator/test/launchOnDevice-test.ts
+++ b/ern-orchestrator/test/launchOnDevice-test.ts
@@ -31,16 +31,16 @@ describe('launchOnDevice', () => {
 
   it('should ask the user to select an iOS device', async () => {
     spawnStub = sandbox.stub(childProcess, 'spawnSync').returns({});
-    await launchOnDevice('/Users/foo/test', devices);
+    await launchOnDevice('/home/user/test', devices);
     sandbox.assert.calledWith(askUserDeviceStub, devices);
   });
 
   it('should call ios-deploy with correct arguments', async () => {
     sandbox.stub(childProcess, 'spawnSync').returns({});
-    await launchOnDevice('/Users/foo/test', devices);
+    await launchOnDevice('/home/user/test', devices);
     const expectedIosDeployArgs = [
       '--bundle',
-      '/Users/foo/test/build/Debug-iphoneos/ErnRunner.app',
+      '/home/user/test/build/Debug-iphoneos/ErnRunner.app',
       '--id',
       'DB3D6BC0-BB08-4340-8D03-A87D69E5BEA6',
       '--justlaunch',
@@ -55,6 +55,6 @@ describe('launchOnDevice', () => {
 
   it('should throw if ios-deploy fails', async () => {
     sandbox.stub(childProcess, 'spawnSync').throws(new Error('fail'));
-    assert(await doesThrow(launchOnDevice, '/Users/foo/test', devices));
+    assert(await doesThrow(launchOnDevice, '/home/user/test', devices));
   });
 });

--- a/ern-orchestrator/test/launchOnSimulator-test.ts
+++ b/ern-orchestrator/test/launchOnSimulator-test.ts
@@ -41,17 +41,17 @@ describe('launchOnSimulator', () => {
   });
 
   it('should ask the user to select an iOS device', async () => {
-    await launchOnSimulator('/Users/foo/test');
+    await launchOnSimulator('/home/user/test');
     sandbox.assert.calledOnce(askUserDeviceStub);
   });
 
   it('should kill all running simulators', async () => {
-    await launchOnSimulator('/Users/foo/test');
+    await launchOnSimulator('/home/user/test');
     sandbox.assert.calledOnce(killAllRunningSimulatorsStub);
   });
 
   it('should launch the simulator', async () => {
-    await launchOnSimulator('/Users/foo/test');
+    await launchOnSimulator('/home/user/test');
     sandbox.assert.calledWith(
       launchSimulatorStub,
       'DB3D6BC0-BB08-4340-8D03-A87D69E5BEA6',
@@ -59,25 +59,25 @@ describe('launchOnSimulator', () => {
   });
 
   it('should build the iOS runner', async () => {
-    await launchOnSimulator('/Users/foo/test');
+    await launchOnSimulator('/home/user/test');
     sandbox.assert.calledWith(
       buildIosRunnerStub,
-      '/Users/foo/test',
+      '/home/user/test',
       'DB3D6BC0-BB08-4340-8D03-A87D69E5BEA6',
     );
   });
 
   it('should install the iOS runner on the simulator', async () => {
-    await launchOnSimulator('/Users/foo/test');
+    await launchOnSimulator('/home/user/test');
     sandbox.assert.calledWith(
       installApplicationOnSimulatorStub,
       'DB3D6BC0-BB08-4340-8D03-A87D69E5BEA6',
-      '/Users/foo/test/build/Debug-iphonesimulator/ErnRunner.app',
+      '/home/user/test/build/Debug-iphonesimulator/ErnRunner.app',
     );
   });
 
   it('should launch the iOS runner on the simulator', async () => {
-    await launchOnSimulator('/Users/foo/test');
+    await launchOnSimulator('/home/user/test');
     sandbox.assert.calledWith(
       launchApplicationStub,
       'DB3D6BC0-BB08-4340-8D03-A87D69E5BEA6',

--- a/ern-orchestrator/test/launchRunner-test.ts
+++ b/ern-orchestrator/test/launchRunner-test.ts
@@ -24,13 +24,13 @@ describe('launchRunner', () => {
   it('should call runAndroidProject to launch the Android runner [android]', async () => {
     await launchRunner({
       extra: { packageName: 'com.walmartlabs.ern' },
-      pathToRunner: '/Users/foo/test',
+      pathToRunner: '/home/user/test',
       platform: 'android',
     });
     sandbox.assert.calledWith(runAndroidProjectStub, {
       launchFlags: undefined,
       packageName: 'com.walmartlabs.ern',
-      projectPath: '/Users/foo/test',
+      projectPath: '/home/user/test',
     });
   });
 
@@ -43,17 +43,17 @@ describe('launchRunner', () => {
       },
     ];
     sandbox.stub(core.ios, 'getiPhoneRealDevices').returns(iosDevices);
-    await launchRunner({ platform: 'ios', pathToRunner: '/Users/foo/test' });
+    await launchRunner({ platform: 'ios', pathToRunner: '/home/user/test' });
     sandbox.assert.calledWith(
       launchOnDeviceStub as any,
-      '/Users/foo/test',
+      '/home/user/test',
       iosDevices,
     );
   });
 
   it('should call launchOnSimulator if there are no iOS device connected [iOS]', async () => {
     sandbox.stub(core.ios, 'getiPhoneRealDevices').returns([]);
-    await launchRunner({ platform: 'ios', pathToRunner: '/Users/foo/test' });
-    sandbox.assert.calledWith(launchOnSimulatorStub as any, '/Users/foo/test');
+    await launchRunner({ platform: 'ios', pathToRunner: '/home/user/test' });
+    sandbox.assert.calledWith(launchOnSimulatorStub as any, '/home/user/test');
   });
 });

--- a/ern-orchestrator/test/runMiniApp-test.ts
+++ b/ern-orchestrator/test/runMiniApp-test.ts
@@ -52,10 +52,8 @@ describe('runMiniApp', () => {
     sandbox
       .stub(cauldronApi, 'getActiveCauldron')
       .resolves(createCauldronHelper(fixtures.defaultCauldron));
-    sandbox
-      .stub(core.MiniApp, 'fromCurrentPath')
-      .returns({ name: 'myMiniApp' });
-    sandbox.stub(core.MiniApp, 'fromPath').returns({ name: 'myMiniApp' });
+    sandbox.stub(core.MiniApp, 'fromCurrentPath').returns({ name: 'test' });
+    sandbox.stub(core.MiniApp, 'fromPath').returns({ name: 'test' });
     startPackagerStub = sandbox.stub(
       core.reactnative,
       'startPackagerInNewWindow',
@@ -118,8 +116,8 @@ describe('runMiniApp', () => {
     assert(
       await doesThrow(runMiniApp, null, 'android', {
         miniapps: [
-          PackagePath.fromString('myMiniAppA@1.0.0'),
-          PackagePath.fromString('myMiniAppB@1.0.0'),
+          PackagePath.fromString('first-miniapp@1.0.0'),
+          PackagePath.fromString('second-miniapp@1.0.0'),
         ],
       }),
     );
@@ -140,10 +138,10 @@ describe('runMiniApp', () => {
     assert(
       await doesThrow(runMiniApp, null, 'android', {
         descriptor: testAndroid1770Descriptor,
-        mainMiniAppName: 'myMiniAppA',
+        mainMiniAppName: 'first-miniapp',
         miniapps: [
-          PackagePath.fromString('myMiniAppA@1.0.0'),
-          PackagePath.fromString('myMiniAppB@1.0.0'),
+          PackagePath.fromString('first-miniapp@1.0.0'),
+          PackagePath.fromString('second-miniapp@1.0.0'),
         ],
       }),
     );
@@ -202,10 +200,7 @@ describe('runMiniApp', () => {
       cwd,
       extra: {
         compositeGenerator: {
-          metroExtraNodeModules: [
-            'dependency-a',
-            '/home/user/path/to/dependency-b',
-          ],
+          metroExtraNodeModules: ['dep-a', '/home/user/path/to/dep-b'],
         },
       },
     });
@@ -215,8 +210,8 @@ describe('runMiniApp', () => {
         androidConfig: sinon.match.object,
         compositeGenerator: {
           metroExtraNodeModules: [
-            path.join(cwd, 'node_modules', 'dependency-a'),
-            '/home/user/path/to/dependency-b',
+            path.join(cwd, 'node_modules', 'dep-a'),
+            '/home/user/path/to/dep-b',
           ],
         },
       },
@@ -235,10 +230,10 @@ describe('runMiniApp', () => {
       containerPath: sinon.match.string,
       containerVersion: '1.0.0',
       extra: {
-        artifactId: 'runner-ern-container-myminiapp',
+        artifactId: 'runner-ern-container-test',
         groupId: 'com.walmartlabs.ern',
-        packageFilePath: 'com/walmartlabs/ern/myminiapp',
-        packageName: 'com.walmartlabs.ern.myminiapp',
+        packageFilePath: 'com/walmartlabs/ern/test',
+        packageName: 'com.walmartlabs.ern.test',
       },
       platform: 'android',
       publisher: sinon.match.any,
@@ -252,15 +247,15 @@ describe('runMiniApp', () => {
     sandbox.assert.calledWith(androidRunnerGenStub.regenerateRunnerConfig, {
       extra: {
         androidConfig: {
-          artifactId: 'runner-ern-container-myminiapp',
+          artifactId: 'runner-ern-container-test',
           groupId: 'com.walmartlabs.ern',
-          packageFilePath: 'com/walmartlabs/ern/myminiapp',
-          packageName: 'com.walmartlabs.ern.myminiapp',
+          packageFilePath: 'com/walmartlabs/ern/test',
+          packageName: 'com.walmartlabs.ern.test',
         },
         containerGenWorkingDir: Platform.containerGenDirectory,
         iosConfig: {},
       },
-      mainMiniAppName: 'myMiniApp',
+      mainMiniAppName: 'test',
       outDir: sinon.match.string,
       reactNativeDevSupportEnabled: undefined,
       reactNativePackagerHost: undefined,
@@ -275,27 +270,27 @@ describe('runMiniApp', () => {
     await runMiniApp('android', {
       extra: {
         androidConfig: {
-          artifactId: 'runner-ern-container-myminiapp',
+          artifactId: 'runner-ern-container-test',
           compileSdkVersion: '28',
           groupId: 'com.walmartlabs.ern',
-          packageFilePath: 'com/walmartlabs/ern/myminiapp',
-          packageName: 'com.walmartlabs.ern.myminiapp',
+          packageFilePath: 'com/walmartlabs/ern/test',
+          packageName: 'com.walmartlabs.ern.test',
         },
       },
     });
     sandbox.assert.calledWith(androidRunnerGenStub.regenerateRunnerConfig, {
       extra: {
         androidConfig: {
-          artifactId: 'runner-ern-container-myminiapp',
+          artifactId: 'runner-ern-container-test',
           compileSdkVersion: '28',
           groupId: 'com.walmartlabs.ern',
-          packageFilePath: 'com/walmartlabs/ern/myminiapp',
-          packageName: 'com.walmartlabs.ern.myminiapp',
+          packageFilePath: 'com/walmartlabs/ern/test',
+          packageName: 'com.walmartlabs.ern.test',
         },
         containerGenWorkingDir: Platform.containerGenDirectory,
         iosConfig: {},
       },
-      mainMiniAppName: 'myMiniApp',
+      mainMiniAppName: 'test',
       outDir: sinon.match.string,
       reactNativeDevSupportEnabled: undefined,
       reactNativePackagerHost: undefined,
@@ -310,25 +305,25 @@ describe('runMiniApp', () => {
 
     await runMiniApp('android', {
       dev: true,
-      mainMiniAppName: 'myMiniAppA',
+      mainMiniAppName: 'first-miniapp',
       miniapps: [
-        PackagePath.fromString('myMiniAppA@1.0.0'),
-        PackagePath.fromString('myMiniAppB@1.0.0'),
+        PackagePath.fromString('first-miniapp@1.0.0'),
+        PackagePath.fromString('second-miniapp@1.0.0'),
       ],
     });
 
     sandbox.assert.calledWith(androidRunnerGenStub.regenerateRunnerConfig, {
       extra: {
         androidConfig: {
-          artifactId: 'runner-ern-container-myminiappa',
+          artifactId: 'runner-ern-container-first-miniapp',
           groupId: 'com.walmartlabs.ern',
-          packageFilePath: 'com/walmartlabs/ern/myminiappa',
-          packageName: 'com.walmartlabs.ern.myminiappa',
+          packageFilePath: 'com/walmartlabs/ern/first-miniapp',
+          packageName: 'com.walmartlabs.ern.first-miniapp',
         },
         containerGenWorkingDir: Platform.containerGenDirectory,
         iosConfig: {},
       },
-      mainMiniAppName: 'myMiniAppA',
+      mainMiniAppName: 'first-miniapp',
       outDir: sinon.match.string,
       reactNativeDevSupportEnabled: false,
       reactNativePackagerHost: undefined,
@@ -343,23 +338,23 @@ describe('runMiniApp', () => {
 
     await runMiniApp('android', {
       miniapps: [
-        PackagePath.fromString('myMiniAppA@1.0.0'),
-        PackagePath.fromString('myMiniAppB@1.0.0'),
+        PackagePath.fromString('first-miniapp@1.0.0'),
+        PackagePath.fromString('second-miniapp@1.0.0'),
       ],
     });
 
     sandbox.assert.calledWith(androidRunnerGenStub.regenerateRunnerConfig, {
       extra: {
         androidConfig: {
-          artifactId: 'runner-ern-container-myminiapp',
+          artifactId: 'runner-ern-container-test',
           groupId: 'com.walmartlabs.ern',
-          packageFilePath: 'com/walmartlabs/ern/myminiapp',
-          packageName: 'com.walmartlabs.ern.myminiapp',
+          packageFilePath: 'com/walmartlabs/ern/test',
+          packageName: 'com.walmartlabs.ern.test',
         },
         containerGenWorkingDir: Platform.containerGenDirectory,
         iosConfig: {},
       },
-      mainMiniAppName: 'myMiniApp',
+      mainMiniAppName: 'test',
       outDir: sinon.match.string,
       reactNativeDevSupportEnabled: undefined,
       reactNativePackagerHost: undefined,

--- a/ern-orchestrator/test/utils-test.js
+++ b/ern-orchestrator/test/utils-test.js
@@ -66,9 +66,6 @@ describe('utils.js', () => {
     sandbox.restore();
   });
 
-  // ==========================================================
-  // syncCauldronContainer
-  // ==========================================================
   describe('syncCauldronContainer', () => {
     beforeEach(() => {
       cauldronHelperStub.getContainerMiniApps.resolves([]);
@@ -160,10 +157,6 @@ describe('utils.js', () => {
     });
   });
 
-  // ==========================================================
-  // getDefaultExtraConfigurationOfPublisherFromCauldron
-  // ==========================================================
-
   describe('getDefaultExtraConfigurationOfPublisherFromCauldron', () => {
     it('should return the correct default configuration for a maven publisher [1]', () => {
       const conf = getDefaultExtraConfigurationOfPublisherFromCauldron({
@@ -241,9 +234,6 @@ describe('utils.js', () => {
     });
   });
 
-  // ==========================================================
-  // parseJsonFromStringOrFile
-  // ==========================================================
   describe('parseJsonFromStringOrFile', () => {
     it('should throw if the passed string is not valid json', async () => {
       assert(await doesThrow(parseJsonFromStringOrFile, null, 'invalidjson'));

--- a/ern-util-dev/fixtures/default-cauldron-fixture.json
+++ b/ern-util-dev/fixtures/default-cauldron-fixture.json
@@ -104,12 +104,14 @@
                   "react-native@0.42.0",
                   "react-native-code-push@1.17.1-beta"
                 ],
-                "miniAppsBranches": ["https://github.com/foo/foo.git#master"],
+                "miniAppsBranches": [
+                  "https://github.com/org/foo-miniapp.git#master"
+                ],
                 "miniApps": [
                   "@test/react-native-foo@5.0.0",
                   "react-native-bar@3.0.0",
-                  "git+ssh://git@github.com:electrode-io/gitMiniApp.git#0.0.9",
-                  "https://github.com/foo/foo.git#6319d9ef0c237907c784a8c472b000d5ff83b49a"
+                  "git+ssh://git@github.com:org/test-miniapp.git#0.0.9",
+                  "https://github.com/org/foo-miniapp.git#6319d9ef0c237907c784a8c472b000d5ff83b49a"
                 ],
                 "jsApiImpls": ["react-native-my-api-impl@1.0.0"],
                 "ernVersion": "1000.0.0"


### PR DESCRIPTION
This also removes a bunch of leftover internal Walmart urls (npme, gecgithub, homeoffice.wal-mart, etc.).