### PR TITLE
Replace doesThrow with rejects

### DIFF
--- a/ern-cauldron-api/test/CauldronApi-test.ts
+++ b/ern-cauldron-api/test/CauldronApi-test.ts
@@ -7,7 +7,8 @@ import {
   PackagePath,
   utils,
 } from 'ern-core';
-import { doesNotThrow, doesThrow, fixtures } from 'ern-util-dev';
+import { fixtures } from 'ern-util-dev';
+import { doesNotReject, rejects } from 'assert';
 import {
   CauldronCodePushEntry,
   ICauldronDocumentStore,
@@ -229,13 +230,7 @@ describe('CauldronApi.js', () => {
 
     it('should throw if the application name is not found', async () => {
       const api = cauldronApi();
-      assert(
-        await doesThrow(
-          api.getNativeApplication,
-          api,
-          'unexisting'.toAppDescriptor(),
-        ),
-      );
+      assert(rejects(api.getNativeApplication('missing'.toAppDescriptor())));
     });
   });
 
@@ -249,9 +244,7 @@ describe('CauldronApi.js', () => {
 
     it('should throw if the application name is not found', async () => {
       const api = cauldronApi();
-      assert(
-        await doesThrow(api.getPlatforms, api, 'unexisting'.toAppDescriptor()),
-      );
+      assert(rejects(api.getPlatforms('missing'.toAppDescriptor())));
     });
   });
 
@@ -270,21 +263,15 @@ describe('CauldronApi.js', () => {
     it('should throw if the platform is not found', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getPlatform,
-          api,
-          AppPlatformDescriptor.fromString('test:ios'),
-        ),
+        rejects(api.getPlatform(AppPlatformDescriptor.fromString('test:ios'))),
       );
     });
 
     it('should throw if the native application is not found', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getPlatform,
-          api,
-          AppPlatformDescriptor.fromString('unexisting:android'),
+        rejects(
+          api.getPlatform(AppPlatformDescriptor.fromString('missing:android')),
         ),
       );
     });
@@ -305,21 +292,15 @@ describe('CauldronApi.js', () => {
     it('should throw if the native application platform does not exist', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getVersions,
-          api,
-          AppPlatformDescriptor.fromString('test:ios'),
-        ),
+        rejects(api.getVersions(AppPlatformDescriptor.fromString('test:ios'))),
       );
     });
 
     it('should throw if the native application name does not exist', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getVersions,
-          api,
-          AppPlatformDescriptor.fromString('unexisting:android'),
+        rejects(
+          api.getVersions(AppPlatformDescriptor.fromString('missing:android')),
         ),
       );
     });
@@ -340,10 +321,8 @@ describe('CauldronApi.js', () => {
     it('should throw if the native application version does not exist', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getVersion,
-          api,
-          AppVersionDescriptor.fromString('test:android:0.1.0'),
+        rejects(
+          api.getVersion(AppVersionDescriptor.fromString('test:android:0.1.0')),
         ),
       );
     });
@@ -351,10 +330,8 @@ describe('CauldronApi.js', () => {
     it('should throw if the native application platform does not exist', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getVersion,
-          api,
-          AppVersionDescriptor.fromString('test:ios:0.1.0'),
+        rejects(
+          api.getVersion(AppVersionDescriptor.fromString('test:ios:0.1.0')),
         ),
       );
     });
@@ -362,10 +339,10 @@ describe('CauldronApi.js', () => {
     it('should throw if the native application name does not exist', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getVersion,
-          api,
-          AppVersionDescriptor.fromString('unexisting:android:17.7.0'),
+        rejects(
+          api.getVersion(
+            AppVersionDescriptor.fromString('missing:android:17.7.0'),
+          ),
         ),
       );
     });
@@ -391,11 +368,11 @@ describe('CauldronApi.js', () => {
     it('should throw if native application version is not found', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getCodePushEntries,
-          api,
-          AppVersionDescriptor.fromString('test:android:1.0.0'),
-          'QA',
+        rejects(
+          api.getCodePushEntries(
+            AppVersionDescriptor.fromString('test:android:1.0.0'),
+            'QA',
+          ),
         ),
       );
     });
@@ -403,11 +380,11 @@ describe('CauldronApi.js', () => {
     it('should throw if native application platform does not exist', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getCodePushEntries,
-          api,
-          AppVersionDescriptor.fromString('test:ios:1.0.0'),
-          'QA',
+        rejects(
+          api.getCodePushEntries(
+            AppVersionDescriptor.fromString('test:ios:1.0.0'),
+            'QA',
+          ),
         ),
       );
     });
@@ -415,11 +392,11 @@ describe('CauldronApi.js', () => {
     it('should throw if native application name does not exist', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getCodePushEntries,
-          api,
-          AppVersionDescriptor.fromString('unexisting:android:17.7.0'),
-          'QA',
+        rejects(
+          api.getCodePushEntries(
+            AppVersionDescriptor.fromString('missing:android:17.7.0'),
+            'QA',
+          ),
         ),
       );
     });
@@ -445,12 +422,12 @@ describe('CauldronApi.js', () => {
     it('should throw if the native application version does not exists', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.setCodePushEntries,
-          api,
-          AppVersionDescriptor.fromString('test:android:1.0.0'),
-          'QA',
-          [codePushNewEntryFixture],
+        rejects(
+          api.setCodePushEntries(
+            AppVersionDescriptor.fromString('test:android:1.0.0'),
+            'QA',
+            [codePushNewEntryFixture],
+          ),
         ),
       );
     });
@@ -467,10 +444,10 @@ describe('CauldronApi.js', () => {
     it('should throw if native application version does not exist', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getContainerMiniApps,
-          api,
-          AppVersionDescriptor.fromString('test:android:1.0.0'),
+        rejects(
+          api.getContainerMiniApps(
+            AppVersionDescriptor.fromString('test:android:1.0.0'),
+          ),
         ),
       );
     });
@@ -478,10 +455,10 @@ describe('CauldronApi.js', () => {
     it('should throw if native application platform does not exist', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getContainerMiniApps,
-          api,
-          AppVersionDescriptor.fromString('test:ios:17.7.0'),
+        rejects(
+          api.getContainerMiniApps(
+            AppVersionDescriptor.fromString('test:ios:17.7.0'),
+          ),
         ),
       );
     });
@@ -489,10 +466,10 @@ describe('CauldronApi.js', () => {
     it('should throw if native application name does not exist', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getContainerMiniApps,
-          api,
-          AppVersionDescriptor.fromString('unexisting:android:17.7.0'),
+        rejects(
+          api.getContainerMiniApps(
+            AppVersionDescriptor.fromString('missing:android:17.7.0'),
+          ),
         ),
       );
     });
@@ -509,10 +486,10 @@ describe('CauldronApi.js', () => {
     it('should throw if native application version does not exist', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getNativeDependencies,
-          api,
-          AppVersionDescriptor.fromString('test:android:1.0.0'),
+        rejects(
+          api.getNativeDependencies(
+            AppVersionDescriptor.fromString('test:android:1.0.0'),
+          ),
         ),
       );
     });
@@ -520,10 +497,10 @@ describe('CauldronApi.js', () => {
     it('should throw if native application platform does not exist', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getNativeDependencies,
-          api,
-          AppVersionDescriptor.fromString('test:ios:17.7.0'),
+        rejects(
+          api.getNativeDependencies(
+            AppVersionDescriptor.fromString('test:ios:17.7.0'),
+          ),
         ),
       );
     });
@@ -531,10 +508,10 @@ describe('CauldronApi.js', () => {
     it('should throw if native application name does not exist', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getNativeDependencies,
-          api,
-          AppVersionDescriptor.fromString('unexisting:android:17.7.0'),
+        rejects(
+          api.getNativeDependencies(
+            AppVersionDescriptor.fromString('missing:android:17.7.0'),
+          ),
         ),
       );
     });
@@ -544,10 +521,10 @@ describe('CauldronApi.js', () => {
     it('should throw an error if the native application version does not exist', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getContainerJsApiImpls,
-          api,
-          AppVersionDescriptor.fromString('test:android:1.0.0'),
+        rejects(
+          api.getContainerJsApiImpls(
+            AppVersionDescriptor.fromString('test:android:1.0.0'),
+          ),
         ),
       );
     });
@@ -565,11 +542,11 @@ describe('CauldronApi.js', () => {
     it('should throw an error if the native application version does not exist', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getContainerJsApiImpl,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.10.0'),
-          'react-native-my-api-impl',
+        rejects(
+          api.getContainerJsApiImpl(
+            AppVersionDescriptor.fromString('test:android:17.10.0'),
+            'react-native-my-api-impl',
+          ),
         ),
       );
     });
@@ -611,11 +588,11 @@ describe('CauldronApi.js', () => {
     it('should throw if incorrect version is provided', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getContainerNativeDependency,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          'react-native-electrode-bridge@0.1.0',
+        rejects(
+          api.getContainerNativeDependency(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            'react-native-electrode-bridge@0.1.0',
+          ),
         ),
       );
     });
@@ -623,11 +600,11 @@ describe('CauldronApi.js', () => {
     it('should throw if dependency does not exist', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getContainerNativeDependency,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          'unexisting',
+        rejects(
+          api.getContainerNativeDependency(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            'missing',
+          ),
         ),
       );
     });
@@ -635,11 +612,11 @@ describe('CauldronApi.js', () => {
     it('should throw if native application version does not exist', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getContainerNativeDependency,
-          api,
-          AppVersionDescriptor.fromString('test:android:0.1.0'),
-          'react-native-electrode-bridge',
+        rejects(
+          api.getContainerNativeDependency(
+            AppVersionDescriptor.fromString('test:android:0.1.0'),
+            'react-native-electrode-bridge',
+          ),
         ),
       );
     });
@@ -647,11 +624,11 @@ describe('CauldronApi.js', () => {
     it('should throw if native application platform does not exist', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getContainerNativeDependency,
-          api,
-          AppVersionDescriptor.fromString('test:ios:17.7.0'),
-          'react-native-electrode-bridge',
+        rejects(
+          api.getContainerNativeDependency(
+            AppVersionDescriptor.fromString('test:ios:17.7.0'),
+            'react-native-electrode-bridge',
+          ),
         ),
       );
     });
@@ -659,11 +636,11 @@ describe('CauldronApi.js', () => {
     it('should throw if native application name does not exist', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getContainerNativeDependency,
-          api,
-          AppVersionDescriptor.fromString('unexisting:android:17.7.0'),
-          'react-native-electrode-bridge',
+        rejects(
+          api.getContainerNativeDependency(
+            AppVersionDescriptor.fromString('missing:android:17.7.0'),
+            'react-native-electrode-bridge',
+          ),
         ),
       );
     });
@@ -683,10 +660,8 @@ describe('CauldronApi.js', () => {
     it('[get application version config] should throw if the native application version does not exist', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getConfig,
-          api,
-          AppVersionDescriptor.fromString('test:android:1.0.0'),
+        rejects(
+          api.getConfig(AppVersionDescriptor.fromString('test:android:1.0.0')),
         ),
       );
     });
@@ -704,11 +679,7 @@ describe('CauldronApi.js', () => {
     it('[get application platform config] should throw if the native application platform does not exist', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getConfig,
-          api,
-          AppPlatformDescriptor.fromString('test:ios'),
-        ),
+        rejects(api.getConfig(AppPlatformDescriptor.fromString('test:ios'))),
       );
     });
 
@@ -724,13 +695,7 @@ describe('CauldronApi.js', () => {
 
     it('[get application config] should throw if native application does not exist', async () => {
       const api = cauldronApi();
-      assert(
-        await doesThrow(
-          api.getConfig,
-          api,
-          AppNameDescriptor.fromString('unexisting'),
-        ),
-      );
+      assert(rejects(api.getConfig(AppNameDescriptor.fromString('missing'))));
     });
   });
 
@@ -833,9 +798,7 @@ describe('CauldronApi.js', () => {
     it('should throw if the native application name already exists', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
       const api = cauldronApi({ cauldronDocument: tmpFixture });
-      assert(
-        await doesThrow(api.createNativeApplication, api, { name: 'test' }),
-      );
+      assert(rejects(api.createNativeApplication({ name: 'test' })));
     });
   });
 
@@ -863,10 +826,8 @@ describe('CauldronApi.js', () => {
     it('should throw if the application name does not exists', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.removeNativeApplication,
-          api,
-          AppNameDescriptor.fromString('unexisting'),
+        rejects(
+          api.removeNativeApplication(AppNameDescriptor.fromString('missing')),
         ),
       );
     });
@@ -898,11 +859,10 @@ describe('CauldronApi.js', () => {
     it('should throw if the application platform already exists', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.createPlatform,
-          api,
-          AppNameDescriptor.fromString('test'),
-          { name: 'android' },
+        rejects(
+          api.createPlatform(AppNameDescriptor.fromString('test'), {
+            name: 'android',
+          }),
         ),
       );
     });
@@ -934,10 +894,10 @@ describe('CauldronApi.js', () => {
     it('should throw if the application name does not exists', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.removePlatform,
-          api,
-          AppPlatformDescriptor.fromString('unexisting:android'),
+        rejects(
+          api.removePlatform(
+            AppPlatformDescriptor.fromString('missing:android'),
+          ),
         ),
       );
     });
@@ -945,10 +905,8 @@ describe('CauldronApi.js', () => {
     it('should throw if the application platform does not exists', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.removePlatform,
-          api,
-          AppPlatformDescriptor.fromString('test:ios'),
+        rejects(
+          api.removePlatform(AppPlatformDescriptor.fromString('test:ios')),
         ),
       );
     });
@@ -983,11 +941,10 @@ describe('CauldronApi.js', () => {
     it('should throw if the platform does not exist', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.createVersion,
-          api,
-          AppPlatformDescriptor.fromString('test:ios'),
-          { name: '17.20.0' },
+        rejects(
+          api.createVersion(AppPlatformDescriptor.fromString('test:ios'), {
+            name: '17.20.0',
+          }),
         ),
       );
     });
@@ -995,11 +952,10 @@ describe('CauldronApi.js', () => {
     it('should throw if the version already exists', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.createVersion,
-          api,
-          AppPlatformDescriptor.fromString('test:android'),
-          { name: '17.7.0' },
+        rejects(
+          api.createVersion(AppPlatformDescriptor.fromString('test:android'), {
+            name: '17.7.0',
+          }),
         ),
       );
     });
@@ -1031,10 +987,8 @@ describe('CauldronApi.js', () => {
     it('should throw if the platform name does not exists', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.removeVersion,
-          api,
-          AppVersionDescriptor.fromString('test:ios:17.7.0'),
+        rejects(
+          api.removeVersion(AppVersionDescriptor.fromString('test:ios:17.7.0')),
         ),
       );
     });
@@ -1042,10 +996,10 @@ describe('CauldronApi.js', () => {
     it('should throw if the version does not exists', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.removeVersion,
-          api,
-          AppVersionDescriptor.fromString('test:android:1.0.0'),
+        rejects(
+          api.removeVersion(
+            AppVersionDescriptor.fromString('test:android:1.0.0'),
+          ),
         ),
       );
     });
@@ -1080,16 +1034,15 @@ describe('CauldronApi.js', () => {
     it('should throw if the version does not exists', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.updateVersion,
-          api,
-          AppVersionDescriptor.fromString('test:android:0.1.0'),
-          { isReleased: false },
+        rejects(
+          api.updateVersion(
+            AppVersionDescriptor.fromString('test:android:0.1.0'),
+            { isReleased: false },
+          ),
         ),
       );
     });
   });
-
 
   describe('addOrUpdateDescription', () => {
     it('should add a description if it does not exist yet', async () => {
@@ -1135,26 +1088,14 @@ describe('CauldronApi.js', () => {
       sinon.assert.calledOnce(commitStub);
     });
 
-    it('should throw if the descriptor is partial', async () => {
-      const api = cauldronApi();
-      assert(
-        await doesThrow(
-          api.addOrUpdateDescription,
-          api,
-          AppPlatformDescriptor.fromString('test:android'),
-          'new description',
-        ),
-      );
-    });
-
     it('should throw if the version does not exists', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.addOrUpdateDescription,
-          api,
-          AppVersionDescriptor.fromString('test:android:0.1.0'),
-          'new description',
+        rejects(
+          api.addOrUpdateDescription(
+            AppVersionDescriptor.fromString('test:android:0.1.0'),
+            'new description',
+          ),
         ),
       );
     });
@@ -1193,12 +1134,12 @@ describe('CauldronApi.js', () => {
     it('should throw if the dependency is not found', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.removePackageFromContainer,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          PackagePath.fromString('unexisting'),
-          'nativeDeps',
+        rejects(
+          api.removePackageFromContainer(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            PackagePath.fromString('missing'),
+            'nativeDeps',
+          ),
         ),
       );
     });
@@ -1206,12 +1147,12 @@ describe('CauldronApi.js', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.removePackageFromContainer,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.20.0'),
-          'react-native-electrode-bridge',
-          'nativeDeps',
+        rejects(
+          api.removePackageFromContainer(
+            AppVersionDescriptor.fromString('test:android:17.20.0'),
+            PackagePath.fromString('react-native-electrode-bridge'),
+            'nativeDeps',
+          ),
         ),
       );
     });
@@ -1250,12 +1191,12 @@ describe('CauldronApi.js', () => {
     it('should throw if the miniapp is not found', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.updatePackageInContainer,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          PackagePath.fromString('react-native-foo@3.0.0'),
-          'miniApps',
+        rejects(
+          api.updatePackageInContainer(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            PackagePath.fromString('react-native-foo@3.0.0'),
+            'miniApps',
+          ),
         ),
       );
     });
@@ -1263,12 +1204,12 @@ describe('CauldronApi.js', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.updatePackageInContainer,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.20.0'),
-          PackagePath.fromString('react-native-bar@3.0.0'),
-          'miniApps',
+        rejects(
+          api.updatePackageInContainer(
+            AppVersionDescriptor.fromString('test:android:17.20.0'),
+            PackagePath.fromString('react-native-bar@3.0.0'),
+            'miniApps',
+          ),
         ),
       );
     });
@@ -1332,11 +1273,11 @@ describe('CauldronApi.js', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.updateContainerVersion,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.20.0'),
-          '2.0.0',
+        rejects(
+          api.updateContainerVersion(
+            AppVersionDescriptor.fromString('test:android:17.20.0'),
+            '2.0.0',
+          ),
         ),
       );
     });
@@ -1362,10 +1303,10 @@ describe('CauldronApi.js', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getContainerVersion,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.20.0'),
+        rejects(
+          api.getContainerVersion(
+            AppVersionDescriptor.fromString('test:android:17.20.0'),
+          ),
         ),
       );
     });
@@ -1403,12 +1344,12 @@ describe('CauldronApi.js', () => {
     it('should throw if the MiniApp is not found', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.removePackageFromContainer,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          PackagePath.fromString('unexisting'),
-          'miniApps',
+        rejects(
+          api.removePackageFromContainer(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            PackagePath.fromString('missing'),
+            'miniApps',
+          ),
         ),
       );
     });
@@ -1416,12 +1357,12 @@ describe('CauldronApi.js', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.removePackageFromContainer,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.20.0'),
-          PackagePath.fromString('react-native-bar'),
-          'miniApps',
+        rejects(
+          api.removePackageFromContainer(
+            AppVersionDescriptor.fromString('test:android:17.20.0'),
+            PackagePath.fromString('react-native-bar'),
+            'miniApps',
+          ),
         ),
       );
     });
@@ -1457,12 +1398,12 @@ describe('CauldronApi.js', () => {
     it('should throw if the MiniApp already exists', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.addPackageToContainer,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          PackagePath.fromString('react-native-bar@2.0.0'),
-          'miniApps',
+        rejects(
+          api.addPackageToContainer(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            PackagePath.fromString('react-native-bar@2.0.0'),
+            'miniApps',
+          ),
         ),
       );
     });
@@ -1470,12 +1411,12 @@ describe('CauldronApi.js', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.addPackageToContainer,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.20.0'),
-          PackagePath.fromString('newMiniApp@1.0.0'),
-          'miniApps',
+        rejects(
+          api.addPackageToContainer(
+            AppVersionDescriptor.fromString('test:android:17.20.0'),
+            PackagePath.fromString('newMiniApp@1.0.0'),
+            'miniApps',
+          ),
         ),
       );
     });
@@ -1513,12 +1454,12 @@ describe('CauldronApi.js', () => {
     it('should throw if the dependency already exists', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.addPackageToContainer,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          PackagePath.fromString('react-native-electrode-bridge@1.4.9'),
-          'nativeDeps',
+        rejects(
+          api.addPackageToContainer(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            PackagePath.fromString('react-native-electrode-bridge@1.4.9'),
+            'nativeDeps',
+          ),
         ),
       );
     });
@@ -1526,12 +1467,12 @@ describe('CauldronApi.js', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.addPackageToContainer,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.20.0'),
-          PackagePath.fromString('testDep@1.0.0'),
-          'nativeDeps',
+        rejects(
+          api.addPackageToContainer(
+            AppVersionDescriptor.fromString('test:android:17.20.0'),
+            PackagePath.fromString('testDep@1.0.0'),
+            'nativeDeps',
+          ),
         ),
       );
     });
@@ -1541,12 +1482,12 @@ describe('CauldronApi.js', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.addPackageToContainer,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.20.0'),
-          PackagePath.fromString('react-native-new-js-api-impl@1.0.0'),
-          'jsApiImpls',
+        rejects(
+          api.addPackageToContainer(
+            AppVersionDescriptor.fromString('test:android:17.20.0'),
+            PackagePath.fromString('react-native-new-js-api-impl@1.0.0'),
+            'jsApiImpls',
+          ),
         ),
       );
     });
@@ -1554,12 +1495,12 @@ describe('CauldronApi.js', () => {
     it('should throw if the js api impl already exists', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.addPackageToContainer,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          PackagePath.fromString('react-native-my-api-impl@1.0.0'),
-          'jsApiImpls',
+        rejects(
+          api.addPackageToContainer(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            PackagePath.fromString('react-native-my-api-impl@1.0.0'),
+            'jsApiImpls',
+          ),
         ),
       );
     });
@@ -1598,12 +1539,12 @@ describe('CauldronApi.js', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.removePackageFromContainer,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.20.0'),
-          PackagePath.fromString('react-native-my-api-impl@1.0.0'),
-          'jsApiImpls',
+        rejects(
+          api.removePackageFromContainer(
+            AppVersionDescriptor.fromString('test:android:17.20.0'),
+            PackagePath.fromString('react-native-my-api-impl@1.0.0'),
+            'jsApiImpls',
+          ),
         ),
       );
     });
@@ -1611,12 +1552,12 @@ describe('CauldronApi.js', () => {
     it('should throw if the js api impl is not found [1]', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.removePackageFromContainer,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          PackagePath.fromString('react-native-unknown-api-impl'),
-          'jsApiImpls',
+        rejects(
+          api.removePackageFromContainer(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            PackagePath.fromString('react-native-unknown-api-impl'),
+            'jsApiImpls',
+          ),
         ),
       );
     });
@@ -1624,12 +1565,12 @@ describe('CauldronApi.js', () => {
     it('should throw if the js api impl is not found [2]', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.removePackageFromContainer,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          PackagePath.fromString('react-native-unknown-api-impl@1.0.0'),
-          'jsApiImpls',
+        rejects(
+          api.removePackageFromContainer(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            PackagePath.fromString('react-native-unknown-api-impl@1.0.0'),
+            'jsApiImpls',
+          ),
         ),
       );
     });
@@ -1683,12 +1624,12 @@ describe('CauldronApi.js', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.updatePackageInContainer,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.20.0'),
-          PackagePath.fromString('react-native-my-api-impl@2.0.0'),
-          'jsApiImpls',
+        rejects(
+          api.updatePackageInContainer(
+            AppVersionDescriptor.fromString('test:android:17.20.0'),
+            PackagePath.fromString('react-native-my-api-impl@2.0.0'),
+            'jsApiImpls',
+          ),
         ),
       );
     });
@@ -1696,12 +1637,12 @@ describe('CauldronApi.js', () => {
     it('should throw if the js api impl is not found', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.updatePackageInContainer,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          PackagePath.fromString('react-native-unknown-api-impl@1.0.0'),
-          'jsApiImpls',
+        rejects(
+          api.updatePackageInContainer(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            PackagePath.fromString('react-native-unknown-api-impl@1.0.0'),
+            'jsApiImpls',
+          ),
         ),
       );
     });
@@ -1781,11 +1722,11 @@ describe('CauldronApi.js', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.addCodePushEntry,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.20.0'),
-          codePushNewEntryFixture,
+        rejects(
+          api.addCodePushEntry(
+            AppVersionDescriptor.fromString('test:android:17.20.0'),
+            codePushNewEntryFixture,
+          ),
         ),
       );
     });
@@ -1794,14 +1735,12 @@ describe('CauldronApi.js', () => {
   describe('addFile', () => {
     it('should throw if cauldronFilePath is undefined', async () => {
       const api = cauldronApi();
-      assert(await doesThrow(api.addFile, api, { fileContent: 'content' }));
+      assert(rejects(api.addFile({ fileContent: 'content' })));
     });
 
     it('should throw if fileContent is undefined', async () => {
       const api = cauldronApi();
-      assert(
-        await doesThrow(api.addFile, api, { cauldronFilePath: 'dir/file' }),
-      );
+      assert(rejects(api.addFile({ cauldronFilePath: 'dir/file' })));
     });
 
     it('should throw if file already exist', async () => {
@@ -1811,20 +1750,24 @@ describe('CauldronApi.js', () => {
         fileContent: 'content',
       });
       assert(
-        await doesThrow(api.addFile, api, {
-          cauldronFilePath: 'dir/file',
-          fileContent: 'newcontent',
-        }),
+        rejects(
+          api.addFile({
+            cauldronFilePath: 'dir/file',
+            fileContent: 'newcontent',
+          }),
+        ),
       );
     });
 
     it('should not throw in nominal proper use case', async () => {
       const api = cauldronApi();
       assert(
-        await doesNotThrow(api.addFile, api, {
-          cauldronFilePath: 'dir/file',
-          fileContent: 'content',
-        }),
+        doesNotReject(
+          api.addFile({
+            cauldronFilePath: 'dir/file',
+            fileContent: 'content',
+          }),
+        ),
       );
     });
 
@@ -1850,23 +1793,23 @@ describe('CauldronApi.js', () => {
   describe('updateFile', () => {
     it('should throw if cauldronFilePath is undefined', async () => {
       const api = cauldronApi();
-      assert(await doesThrow(api.updateFile, api, { fileContent: 'content' }));
+      assert(rejects(api.updateFile({ fileContent: 'content' })));
     });
 
     it('should throw if fileContent is undefined', async () => {
       const api = cauldronApi();
-      assert(
-        await doesThrow(api.updateFile, api, { cauldronFilePath: 'dir/file' }),
-      );
+      assert(rejects(api.updateFile({ cauldronFilePath: 'dir/file' })));
     });
 
     it('should throw if file does not already exist', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(api.updateFile, api, {
-          cauldronFilePath: 'dir/file',
-          fileContent: 'newcontent',
-        }),
+        rejects(
+          api.updateFile({
+            cauldronFilePath: 'dir/file',
+            fileContent: 'newcontent',
+          }),
+        ),
       );
     });
 
@@ -1877,10 +1820,12 @@ describe('CauldronApi.js', () => {
         fileContent: 'content',
       });
       assert(
-        await doesNotThrow(api.updateFile, api, {
-          cauldronFilePath: 'dir/file',
-          fileContent: 'content',
-        }),
+        doesNotReject(
+          api.updateFile({
+            cauldronFilePath: 'dir/file',
+            fileContent: 'content',
+          }),
+        ),
       );
     });
 
@@ -1891,10 +1836,12 @@ describe('CauldronApi.js', () => {
         fileContent: 'content',
       });
       assert(
-        await doesNotThrow(api.updateFile, api, {
-          cauldronFilePath: 'dir/file',
-          fileContent: 'content',
-        }),
+        doesNotReject(
+          api.updateFile({
+            cauldronFilePath: 'dir/file',
+            fileContent: 'content',
+          }),
+        ),
       );
     });
 
@@ -1905,10 +1852,12 @@ describe('CauldronApi.js', () => {
         fileContent: 'content',
       });
       assert(
-        await doesNotThrow(api.updateFile, api, {
-          cauldronFilePath: 'cauldron://dir/file',
-          fileContent: 'content',
-        }),
+        doesNotReject(
+          api.updateFile({
+            cauldronFilePath: 'cauldron://dir/file',
+            fileContent: 'content',
+          }),
+        ),
       );
     });
   });
@@ -1916,15 +1865,17 @@ describe('CauldronApi.js', () => {
   describe('removeFile', () => {
     it('should throw if cauldronFilePath is undefined', async () => {
       const api = cauldronApi();
-      assert(await doesThrow(api.removeFile, api, {}));
+      assert(rejects(api.removeFile({})));
     });
 
     it('should throw if file does not exist', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(api.removeFile, api, {
-          cauldronFilePath: 'dir/file',
-        }),
+        rejects(
+          api.removeFile({
+            cauldronFilePath: 'dir/file',
+          }),
+        ),
       );
     });
 
@@ -1935,9 +1886,11 @@ describe('CauldronApi.js', () => {
         fileContent: 'content',
       });
       assert(
-        await doesNotThrow(api.removeFile, api, {
-          cauldronFilePath: 'dir/file',
-        }),
+        doesNotReject(
+          api.removeFile({
+            cauldronFilePath: 'dir/file',
+          }),
+        ),
       );
     });
 
@@ -1969,15 +1922,17 @@ describe('CauldronApi.js', () => {
   describe('getFile', () => {
     it('should throw if cauldronFilePath is undefined', async () => {
       const api = cauldronApi();
-      assert(await doesThrow(api.getFile, api, {}));
+      assert(rejects(api.getFile({})));
     });
 
     it('should throw if file does not exist', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(api.getFile, api, {
-          cauldronFilePath: 'dir/file',
-        }),
+        rejects(
+          api.getFile({
+            cauldronFilePath: 'dir/file',
+          }),
+        ),
       );
     });
 
@@ -1988,9 +1943,11 @@ describe('CauldronApi.js', () => {
         fileContent: 'content',
       });
       assert(
-        await doesNotThrow(api.getFile, api, {
-          cauldronFilePath: 'dir/file',
-        }),
+        doesNotReject(
+          api.getFile({
+            cauldronFilePath: 'dir/file',
+          }),
+        ),
       );
     });
 
@@ -2037,12 +1994,11 @@ describe('CauldronApi.js', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.hasYarnLock,
-          api,
-          'test',
-          AppVersionDescriptor.fromString('test:android:17.20.0'),
-          'Production',
+        rejects(
+          api.hasYarnLock(
+            AppVersionDescriptor.fromString('test:android:17.20.0'),
+            'Production',
+          ),
         ),
       );
     });
@@ -2078,12 +2034,12 @@ describe('CauldronApi.js', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.addYarnLock,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.20.0'),
-          'YARN_LOCK_KEY',
-          'YARN_LOCK_CONTENT',
+        rejects(
+          api.addYarnLock(
+            AppVersionDescriptor.fromString('test:android:17.20.0'),
+            'YARN_LOCK_KEY',
+            'YARN_LOCK_CONTENT',
+          ),
         ),
       );
     });
@@ -2109,11 +2065,11 @@ describe('CauldronApi.js', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getYarnLockId,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.20.0'),
-          'Production',
+        rejects(
+          api.getYarnLockId(
+            AppVersionDescriptor.fromString('test:android:17.20.0'),
+            'Production',
+          ),
         ),
       );
     });
@@ -2124,11 +2080,11 @@ describe('CauldronApi.js', () => {
       const newId = '30bf4eff61586d71fe5d52e31a2cfabcbb31e33e';
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getYarnLock,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.20.0'),
-          'Production',
+        rejects(
+          api.getYarnLock(
+            AppVersionDescriptor.fromString('test:android:17.20.0'),
+            'Production',
+          ),
         ),
       );
     });
@@ -2138,11 +2094,11 @@ describe('CauldronApi.js', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.getPathToYarnLock,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.20.0'),
-          'Production',
+        rejects(
+          api.getPathToYarnLock(
+            AppVersionDescriptor.fromString('test:android:17.20.0'),
+            'Production',
+          ),
         ),
       );
     });
@@ -2152,11 +2108,11 @@ describe('CauldronApi.js', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.removeYarnLock,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.20.0'),
-          'Production',
+        rejects(
+          api.removeYarnLock(
+            AppVersionDescriptor.fromString('test:android:17.20.0'),
+            'Production',
+          ),
         ),
       );
     });
@@ -2166,12 +2122,12 @@ describe('CauldronApi.js', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.updateYarnLock,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.20.0'),
-          'Production',
-          'NewLock',
+        rejects(
+          api.updateYarnLock(
+            AppVersionDescriptor.fromString('test:android:17.20.0'),
+            'Production',
+            'NewLock',
+          ),
         ),
       );
     });
@@ -2212,11 +2168,12 @@ describe('CauldronApi.js', () => {
       const newId = '30bf4eff61586d71fe5d52e31a2cfabcbb31e33e';
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.updateYarnLockId,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.20.0'),
-          'NewKey',
+        rejects(
+          api.updateYarnLockId(
+            AppVersionDescriptor.fromString('test:android:17.20.0'),
+            'NewKey',
+            newId,
+          ),
         ),
       );
     });
@@ -2252,11 +2209,11 @@ describe('CauldronApi.js', () => {
     it('should throw if the native application version is not found', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.setYarnLocks,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.20.0'),
-          { Test: '30bf4eff61586d71fe5d52e31a2cfabcbb31e33e' },
+        rejects(
+          api.setYarnLocks(
+            AppVersionDescriptor.fromString('test:android:17.20.0'),
+            { Test: '30bf4eff61586d71fe5d52e31a2cfabcbb31e33e' },
+          ),
         ),
       );
     });
@@ -2299,25 +2256,12 @@ describe('CauldronApi.js', () => {
   });
 
   describe('getBundle', () => {
-    it('should throw if the native application descriptor is partial', async () => {
-      const api = cauldronApi();
-      assert(
-        await doesThrow(
-          api.getBundle,
-          api,
-          AppPlatformDescriptor.fromString('test:android'),
-        ),
-      );
-    });
-
     it('should throw if there is no stored bundle for the given native application descriptor', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
       const api = cauldronApi({ cauldronDocument: tmpFixture });
       assert(
-        await doesThrow(
-          api.getBundle,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
+        rejects(
+          api.getBundle(AppVersionDescriptor.fromString('test:android:17.7.0')),
         ),
       );
     });
@@ -2337,28 +2281,15 @@ describe('CauldronApi.js', () => {
   });
 
   describe('addPackageToContainer [MiniApp Branch]', () => {
-    it('should throw if the native application descriptor is partial', async () => {
-      const api = cauldronApi();
-      assert(
-        await doesThrow(
-          api.addPackageToContainer,
-          api,
-          AppPlatformDescriptor.fromString('test:android'),
-          PackagePath.fromString('https://github.com/foo/MiniApp.git#master'),
-          'miniAppsBranches',
-        ),
-      );
-    });
-
     it('should throw if the MiniApp path does not include a branch', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.addPackageToContainer,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          PackagePath.fromString('https://github.com/foo/MiniApp.git'),
-          'miniAppsBranches',
+        rejects(
+          api.addPackageToContainer(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            PackagePath.fromString('https://github.com/org/repo.git'),
+            'miniAppsBranches',
+          ),
         ),
       );
     });
@@ -2369,14 +2300,14 @@ describe('CauldronApi.js', () => {
         cauldronDocument: tmpFixture,
       }).addPackageToContainer(
         AppVersionDescriptor.fromString('test:android:17.7.0'),
-        PackagePath.fromString('https://github.com/foo/MiniApp.git#master'),
+        PackagePath.fromString('https://github.com/org/repo.git#master'),
         'miniAppsBranches',
       );
       const miniAppsArr = jp.query(
         tmpFixture,
         '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].container.miniAppsBranches',
       )[0];
-      expect(miniAppsArr.includes('https://github.com/foo/MiniApp.git#master'))
+      expect(miniAppsArr.includes('https://github.com/org/repo.git#master'))
         .true;
     });
 
@@ -2385,46 +2316,31 @@ describe('CauldronApi.js', () => {
       const api = cauldronApi({ cauldronDocument: tmpFixture });
       await api.addPackageToContainer(
         AppVersionDescriptor.fromString('test:android:17.7.0'),
-        PackagePath.fromString('https://github.com/foo/MiniApp.git#master'),
+        PackagePath.fromString('https://github.com/org/repo.git#master'),
         'miniAppsBranches',
       );
       assert(
-        await doesThrow(
-          api.addPackageToContainer,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          PackagePath.fromString(
-            'https://github.com/foo/MiniApp.git#development',
+        rejects(
+          api.addPackageToContainer(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            PackagePath.fromString('https://github.com/org/repo.git#dev'),
+            'miniAppsBranches',
           ),
-          'miniAppsBranches',
         ),
       );
     });
   });
 
   describe('addPackageToContainer [JS API Implementation branch]', () => {
-    it('should throw if the native application descriptor is partial', async () => {
-      const api = cauldronApi();
-      assert(
-        await doesThrow(
-          api.addPackageToContainer,
-          api,
-          AppPlatformDescriptor.fromString('test:android'),
-          PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master'),
-          'jsApiImplsBranches',
-        ),
-      );
-    });
-
     it('should throw if the JS API Impl path does not include a branch', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.addPackageToContainer,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          PackagePath.fromString('https://github.com/foo/JsApiImpl.git'),
-          'jsApiImplsBranches',
+        rejects(
+          api.addPackageToContainer(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            PackagePath.fromString('https://github.com/org/repo.git'),
+            'jsApiImplsBranches',
+          ),
         ),
       );
     });
@@ -2435,7 +2351,7 @@ describe('CauldronApi.js', () => {
         cauldronDocument: tmpFixture,
       }).addPackageToContainer(
         AppVersionDescriptor.fromString('test:android:17.7.0'),
-        PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master'),
+        PackagePath.fromString('https://github.com/org/repo.git#master'),
         'jsApiImplsBranches',
       );
       const jsApiImplsBranchesArr = jp.query(
@@ -2444,7 +2360,7 @@ describe('CauldronApi.js', () => {
       )[0];
       expect(
         jsApiImplsBranchesArr.includes(
-          'https://github.com/foo/JsApiImpl.git#master',
+          'https://github.com/org/repo.git#master',
         ),
       ).true;
     });
@@ -2454,46 +2370,31 @@ describe('CauldronApi.js', () => {
       const api = cauldronApi({ cauldronDocument: tmpFixture });
       await api.addPackageToContainer(
         AppVersionDescriptor.fromString('test:android:17.7.0'),
-        PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master'),
+        PackagePath.fromString('https://github.com/org/repo.git#master'),
         'jsApiImplsBranches',
       );
       assert(
-        await doesThrow(
-          api.addPackageToContainer,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          PackagePath.fromString(
-            'https://github.com/foo/JsApiImpl.git#development',
+        rejects(
+          api.addPackageToContainer(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            PackagePath.fromString('https://github.com/org/repo.git#dev'),
+            'jsApiImplsBranches',
           ),
-          'jsApiImplsBranches',
         ),
       );
     });
   });
 
   describe('updatePackageInContainer [MiniApp branch]', () => {
-    it('should throw if the native application descriptor is partial', async () => {
-      const api = cauldronApi();
-      assert(
-        await doesThrow(
-          api.updatePackageInContainer,
-          api,
-          AppPlatformDescriptor.fromString('test:android'),
-          PackagePath.fromString('https://github.com/foo/MiniApp.git#master'),
-          'miniAppsBranches',
-        ),
-      );
-    });
-
     it('should throw if the MiniApp path does not include a branch', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.updatePackageInContainer,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          PackagePath.fromString('https://github.com/foo/MiniApp.git'),
-          'miniAppsBranches',
+        rejects(
+          api.updatePackageInContainer(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            PackagePath.fromString('https://github.com/org/repo.git'),
+            'miniAppsBranches',
+          ),
         ),
       );
     });
@@ -2504,51 +2405,34 @@ describe('CauldronApi.js', () => {
         cauldronDocument: tmpFixture,
       }).addPackageToContainer(
         AppVersionDescriptor.fromString('test:android:17.7.0'),
-        PackagePath.fromString('https://github.com/foo/MiniApp.git#master'),
+        PackagePath.fromString('https://github.com/org/repo.git#master'),
         'miniAppsBranches',
       );
       await cauldronApi({
         cauldronDocument: tmpFixture,
       }).updatePackageInContainer(
         AppVersionDescriptor.fromString('test:android:17.7.0'),
-        PackagePath.fromString(
-          'https://github.com/foo/MiniApp.git#development',
-        ),
+        PackagePath.fromString('https://github.com/org/repo.git#dev'),
         'miniAppsBranches',
       );
       const miniAppsArr = jp.query(
         tmpFixture,
         '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].container.miniAppsBranches',
       )[0];
-      expect(
-        miniAppsArr.includes('https://github.com/foo/MiniApp.git#development'),
-      ).true;
+      expect(miniAppsArr.includes('https://github.com/org/repo.git#dev')).true;
     });
   });
 
   describe('updateJsApiImplBranchInContainer', () => {
-    it('should throw if the native application descriptor is partial', async () => {
-      const api = cauldronApi();
-      assert(
-        await doesThrow(
-          api.updatePackageInContainer,
-          api,
-          AppPlatformDescriptor.fromString('test:android'),
-          PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master'),
-          'jsApiImplsBranches',
-        ),
-      );
-    });
-
     it('should throw if the JS API Impl path does not include a branch', async () => {
       const api = cauldronApi();
       assert(
-        await doesThrow(
-          api.updatePackageInContainer,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          PackagePath.fromString('https://github.com/foo/JsApiImpl.git'),
-          'jsApiImplsBranches',
+        rejects(
+          api.updatePackageInContainer(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            PackagePath.fromString('https://github.com/org/repo.git'),
+            'jsApiImplsBranches',
+          ),
         ),
       );
     });
@@ -2559,16 +2443,14 @@ describe('CauldronApi.js', () => {
         cauldronDocument: tmpFixture,
       }).addPackageToContainer(
         AppVersionDescriptor.fromString('test:android:17.7.0'),
-        PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master'),
+        PackagePath.fromString('https://github.com/org/repo.git#master'),
         'jsApiImplsBranches',
       );
       await cauldronApi({
         cauldronDocument: tmpFixture,
       }).updatePackageInContainer(
         AppVersionDescriptor.fromString('test:android:17.7.0'),
-        PackagePath.fromString(
-          'https://github.com/foo/JsApiImpl.git#development',
-        ),
+        PackagePath.fromString('https://github.com/org/repo.git#dev'),
         'jsApiImplsBranches',
       );
       const jsApiImplsBranchesArr = jp.query(
@@ -2576,33 +2458,12 @@ describe('CauldronApi.js', () => {
         '$.nativeApps[?(@.name=="test")].platforms[?(@.name=="android")].versions[?(@.name=="17.7.0")].container.jsApiImplsBranches',
       )[0];
       expect(
-        jsApiImplsBranchesArr.includes(
-          'https://github.com/foo/JsApiImpl.git#development',
-        ),
+        jsApiImplsBranchesArr.includes('https://github.com/org/repo.git#dev'),
       ).true;
     });
   });
 
   describe('removePackageFromContainer [MiniApp branch]', () => {
-    it('should throw if the native application descriptor is partial', async () => {
-      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
-      const api = cauldronApi({ cauldronDocument: tmpFixture });
-      await api.addPackageToContainer(
-        AppVersionDescriptor.fromString('test:android:17.7.0'),
-        PackagePath.fromString('https://github.com/foo/MiniApp.git#master'),
-        'miniAppsBranches',
-      );
-      assert(
-        await doesThrow(
-          api.removePackageFromContainer,
-          api,
-          AppPlatformDescriptor.fromString('test:android'),
-          PackagePath.fromString('https://github.com/foo/MiniApp.git#master'),
-          'miniAppsBranches',
-        ),
-      );
-    });
-
     it('should throw if the MiniApp does not exist in the miniAppsBranches array', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
       const api = cauldronApi({ cauldronDocument: tmpFixture });
@@ -2610,16 +2471,16 @@ describe('CauldronApi.js', () => {
         cauldronDocument: tmpFixture,
       }).addPackageToContainer(
         AppVersionDescriptor.fromString('test:android:17.7.0'),
-        PackagePath.fromString('https://github.com/foo/MiniApp.git#master'),
+        PackagePath.fromString('https://github.com/org/repo.git#master'),
         'miniAppsBranches',
       );
       assert(
-        await doesThrow(
-          api.removePackageFromContainer,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          PackagePath.fromString('https://github.com/foo/foo.git'),
-          'miniAppsBranches',
+        rejects(
+          api.removePackageFromContainer(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            PackagePath.fromString('https://github.com/foo/foo.git'),
+            'miniAppsBranches',
+          ),
         ),
       );
     });
@@ -2630,14 +2491,14 @@ describe('CauldronApi.js', () => {
         cauldronDocument: tmpFixture,
       }).addPackageToContainer(
         AppVersionDescriptor.fromString('test:android:17.7.0'),
-        PackagePath.fromString('https://github.com/foo/MiniApp.git#master'),
+        PackagePath.fromString('https://github.com/org/repo.git#master'),
         'miniAppsBranches',
       );
       await cauldronApi({
         cauldronDocument: tmpFixture,
       }).removePackageFromContainer(
         AppVersionDescriptor.fromString('test:android:17.7.0'),
-        PackagePath.fromString('https://github.com/foo/MiniApp.git#master'),
+        PackagePath.fromString('https://github.com/org/repo.git#master'),
         'miniAppsBranches',
       );
       const miniAppsArr = jp.query(
@@ -2653,14 +2514,14 @@ describe('CauldronApi.js', () => {
         cauldronDocument: tmpFixture,
       }).addPackageToContainer(
         AppVersionDescriptor.fromString('test:android:17.7.0'),
-        PackagePath.fromString('https://github.com/foo/MiniApp.git#master'),
+        PackagePath.fromString('https://github.com/org/repo.git#master'),
         'miniAppsBranches',
       );
       await cauldronApi({
         cauldronDocument: tmpFixture,
       }).removePackageFromContainer(
         AppVersionDescriptor.fromString('test:android:17.7.0'),
-        PackagePath.fromString('https://github.com/foo/MiniApp.git'),
+        PackagePath.fromString('https://github.com/org/repo.git'),
         'miniAppsBranches',
       );
       const miniAppsArr = jp.query(
@@ -2672,25 +2533,6 @@ describe('CauldronApi.js', () => {
   });
 
   describe('removePackageFromContainer [JS API Implementation branch]', () => {
-    it('should throw if the native application descriptor is partial', async () => {
-      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
-      const api = cauldronApi({ cauldronDocument: tmpFixture });
-      await api.addPackageToContainer(
-        AppVersionDescriptor.fromString('test:android:17.7.0'),
-        PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master'),
-        'jsApiImplsBranches',
-      );
-      assert(
-        await doesThrow(
-          api.removePackageFromContainer,
-          api,
-          AppPlatformDescriptor.fromString('test:android'),
-          PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master'),
-          'jsApiImplsBranches',
-        ),
-      );
-    });
-
     it('should throw if the JS API Impl does not exist in the jsApiImplsBranches array', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
       const api = cauldronApi({ cauldronDocument: tmpFixture });
@@ -2698,16 +2540,16 @@ describe('CauldronApi.js', () => {
         cauldronDocument: tmpFixture,
       }).addPackageToContainer(
         AppVersionDescriptor.fromString('test:android:17.7.0'),
-        PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master'),
+        PackagePath.fromString('https://github.com/org/repo.git#master'),
         'jsApiImplsBranches',
       );
       assert(
-        await doesThrow(
-          api.removePackageFromContainer,
-          api,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          PackagePath.fromString('https://github.com/foo/foo.git'),
-          'jsApiImplsBranches',
+        rejects(
+          api.removePackageFromContainer(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            PackagePath.fromString('https://github.com/foo/foo.git'),
+            'jsApiImplsBranches',
+          ),
         ),
       );
     });
@@ -2718,14 +2560,14 @@ describe('CauldronApi.js', () => {
         cauldronDocument: tmpFixture,
       }).addPackageToContainer(
         AppVersionDescriptor.fromString('test:android:17.7.0'),
-        PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master'),
+        PackagePath.fromString('https://github.com/org/repo.git#master'),
         'jsApiImplsBranches',
       );
       await cauldronApi({
         cauldronDocument: tmpFixture,
       }).removePackageFromContainer(
         AppVersionDescriptor.fromString('test:android:17.7.0'),
-        PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master'),
+        PackagePath.fromString('https://github.com/org/repo.git#master'),
         'jsApiImplsBranches',
       );
       const jsApiImplBranchesArr = jp.query(
@@ -2741,14 +2583,14 @@ describe('CauldronApi.js', () => {
         cauldronDocument: tmpFixture,
       }).addPackageToContainer(
         AppVersionDescriptor.fromString('test:android:17.7.0'),
-        PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master'),
+        PackagePath.fromString('https://github.com/org/repo.git#master'),
         'jsApiImplsBranches',
       );
       await cauldronApi({
         cauldronDocument: tmpFixture,
       }).removePackageFromContainer(
         AppVersionDescriptor.fromString('test:android:17.7.0'),
-        PackagePath.fromString('https://github.com/foo/JsApiImpl.git'),
+        PackagePath.fromString('https://github.com/org/repo.git'),
         'jsApiImplsBranches',
       );
       const jsApiImplBranchesArr = jp.query(
@@ -2760,31 +2602,12 @@ describe('CauldronApi.js', () => {
   });
 
   describe('hasJsPackageBranchInContainer [JS API Implementation branch]', () => {
-    it('should throw if the native application descriptor is partial', async () => {
-      const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
-      const api = cauldronApi({ cauldronDocument: tmpFixture });
-      await api.addPackageToContainer(
-        AppVersionDescriptor.fromString('test:android:17.7.0'),
-        PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master'),
-        'jsApiImplsBranches',
-      );
-      assert(
-        await doesThrow(
-          api.hasJsPackageBranchInContainer,
-          api,
-          AppPlatformDescriptor.fromString('test:android'),
-          PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master'),
-          'jsApiImplsBranches',
-        ),
-      );
-    });
-
     it('should return false if there is not git branch for the js api impl', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
       const api = cauldronApi({ cauldronDocument: tmpFixture });
       const result = await api.hasJsPackageBranchInContainer(
         AppVersionDescriptor.fromString('test:android:17.7.0'),
-        PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master'),
+        PackagePath.fromString('https://github.com/org/repo.git#master'),
         'jsApiImplsBranches',
       );
       expect(result).false;
@@ -2795,12 +2618,12 @@ describe('CauldronApi.js', () => {
       const api = cauldronApi({ cauldronDocument: tmpFixture });
       await api.addPackageToContainer(
         AppVersionDescriptor.fromString('test:android:17.7.0'),
-        PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master'),
+        PackagePath.fromString('https://github.com/org/repo.git#master'),
         'jsApiImplsBranches',
       );
       const result = await api.hasJsPackageBranchInContainer(
         AppVersionDescriptor.fromString('test:android:17.7.0'),
-        PackagePath.fromString('https://github.com/foo/JsApiImpl.git#master'),
+        PackagePath.fromString('https://github.com/org/repo.git#master'),
         'jsApiImplsBranches',
       );
       expect(result).true;
@@ -2837,17 +2660,6 @@ describe('CauldronApi.js', () => {
   });
 
   describe('emptyContainer', () => {
-    it('should throw if provided a partial native application desscriptor', async () => {
-      const cauldron = cauldronApi();
-      assert(
-        await doesThrow(
-          cauldron.emptyContainer,
-          cauldron,
-          AppPlatformDescriptor.fromString('test:android'),
-        ),
-      );
-    });
-
     it('should remove all MiniApps from Container of target native application version', async () => {
       const tmpFixture = JSON.parse(JSON.stringify(fixtures.defaultCauldron));
       const cauldron = cauldronApi({ cauldronDocument: tmpFixture });

--- a/ern-cauldron-api/test/CauldronHelper-test.ts
+++ b/ern-cauldron-api/test/CauldronHelper-test.ts
@@ -11,7 +11,8 @@ import {
   shell,
   utils,
 } from 'ern-core';
-import { doesNotThrow, doesThrow, fixtures } from 'ern-util-dev';
+import { fixtures } from 'ern-util-dev';
+import { doesNotReject, rejects } from 'assert';
 import {
   CauldronApi,
   CauldronCodePushEntry,
@@ -360,47 +361,17 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('addJsApiImplToContainer', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.addJsApiImplToContainer,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-          PackagePath.fromString('test@1.0.0'),
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.addJsApiImplToContainer,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
-          PackagePath.fromString('test@1.0.0'),
-        ),
-      );
-    });
-
-    it('should throw if the given native application version is released', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.addJsApiImplToContainer,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          PackagePath.fromString('test@1.0.0'),
+        rejects(
+          cauldronHelper.addJsApiImplToContainer(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+            PackagePath.fromString('test@1.0.0'),
+          ),
         ),
       );
     });
@@ -420,22 +391,6 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('removeMiniAppFromContainer', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      sandbox.stub(utils, 'isGitBranch').resolves(false);
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.removeMiniAppFromContainer,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-          PackagePath.fromString('@test/react-native-foo@5.0.0'),
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       sandbox.stub(utils, 'isGitBranch').resolves(false);
       const fixture = cloneFixture(fixtures.defaultCauldron);
@@ -443,11 +398,11 @@ describe('CauldronHelper.js', () => {
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.removeMiniAppFromContainer,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
-          PackagePath.fromString('@test/react-native-foo@5.0.0'),
+        rejects(
+          cauldronHelper.removeMiniAppFromContainer(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+            PackagePath.fromString('@test/react-native-foo@5.0.0'),
+          ),
         ),
       );
     });
@@ -459,11 +414,11 @@ describe('CauldronHelper.js', () => {
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.removeMiniAppFromContainer,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          PackagePath.fromString('@test/react-native-foo@5.0.0'),
+        rejects(
+          cauldronHelper.removeMiniAppFromContainer(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            PackagePath.fromString('@test/react-native-foo@5.0.0'),
+          ),
         ),
       );
     });
@@ -506,32 +461,17 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('removeJsApiImplFromContainer', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.removeJsApiImplFromContainer,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-          PackagePath.fromString('react-native-my-api-impl@1.0.0'),
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.removeJsApiImplFromContainer,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
-          PackagePath.fromString('react-native-my-api-impl@1.0.0'),
+        rejects(
+          cauldronHelper.removeJsApiImplFromContainer(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+            PackagePath.fromString('react-native-my-api-impl@1.0.0'),
+          ),
         ),
       );
     });
@@ -542,11 +482,11 @@ describe('CauldronHelper.js', () => {
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.removeJsApiImplFromContainer,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          PackagePath.fromString('react-native-my-api-impl@1.0.0'),
+        rejects(
+          cauldronHelper.removeJsApiImplFromContainer(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            PackagePath.fromString('react-native-my-api-impl@1.0.0'),
+          ),
         ),
       );
     });
@@ -593,10 +533,8 @@ describe('CauldronHelper.js', () => {
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.getDescriptor,
-          cauldronHelper,
-          AppNameDescriptor.fromString('foo'),
+        rejects(
+          cauldronHelper.getDescriptor(AppNameDescriptor.fromString('foo')),
         ),
       );
     });
@@ -619,10 +557,10 @@ describe('CauldronHelper.js', () => {
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.getDescriptor,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:ios'),
+        rejects(
+          cauldronHelper.getDescriptor(
+            AppPlatformDescriptor.fromString('test:ios'),
+          ),
         ),
       );
     });
@@ -645,10 +583,10 @@ describe('CauldronHelper.js', () => {
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.getDescriptor,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
+        rejects(
+          cauldronHelper.getDescriptor(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+          ),
         ),
       );
     });
@@ -667,20 +605,6 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('getVersions', () => {
-    it('should throw if the descriptor does not contain a platform', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.getVersions,
-          cauldronHelper,
-          AppNameDescriptor.fromString('test'),
-        ),
-      );
-    });
-
     it('should return all the versions', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
@@ -729,20 +653,6 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('getNativeDependencies', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.getNativeDependencies,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-        ),
-      );
-    });
-
     it('should return the native dependencies', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
@@ -756,32 +666,17 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('hasYarnLock', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.hasYarnLock,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-          'Production',
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.hasYarnLock,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
-          'Production',
+        rejects(
+          cauldronHelper.hasYarnLock(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+            'Production',
+          ),
         ),
       );
     });
@@ -812,32 +707,18 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('addYarnLock', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.addYarnLock,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-          'Production',
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.addYarnLock,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
-          'Production',
+        rejects(
+          cauldronHelper.addYarnLock(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+            'Production',
+            '/path/to/yarn.lock',
+          ),
         ),
       );
     });
@@ -861,32 +742,17 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('getYarnLock', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.getYarnLock,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-          'Production',
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.getYarnLock,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
-          'Production',
+        rejects(
+          cauldronHelper.getYarnLock(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+            'Production',
+          ),
         ),
       );
     });
@@ -926,32 +792,17 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('getPathToYarnLock', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.getPathToYarnLock,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-          'Production',
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.getPathToYarnLock,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
-          'Production',
+        rejects(
+          cauldronHelper.getPathToYarnLock(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+            'Production',
+          ),
         ),
       );
     });
@@ -990,32 +841,17 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('removeYarnLock', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.removeYarnLock,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-          'Production',
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.removeYarnLock,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
-          'Production',
+        rejects(
+          cauldronHelper.removeYarnLock(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+            'Production',
+          ),
         ),
       );
     });
@@ -1043,25 +879,6 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('updateYarnLock', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      mockFs({
-        '/path/to/yarn.lock': 'yarnLockContent',
-      });
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.updateYarnLock,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-          'Production',
-          '/path/to/yarn.lock',
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       mockFs({
         '/path/to/yarn.lock': 'yarnLockContent',
@@ -1071,12 +888,12 @@ describe('CauldronHelper.js', () => {
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.updateYarnLock,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
-          'Production',
-          '/path/to/yarn.lock',
+        rejects(
+          cauldronHelper.updateYarnLock(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+            'Production',
+            '/path/to/yarn.lock',
+          ),
         ),
       );
     });
@@ -1149,38 +966,20 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('setYarnLocks', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.setYarnLocks,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-          {
-            Bar: 'a0112c49-4bbc-47a9-ba45-d43e1e84a1a5',
-            Foo: 'b0112c49-4bbc-47a9-ba45-d43e1e84a1a5',
-          },
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.setYarnLocks,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
-          {
-            Bar: 'a0112c49-4bbc-47a9-ba45-d43e1e84a1a5',
-            Foo: 'b0112c49-4bbc-47a9-ba45-d43e1e84a1a5',
-          },
+        rejects(
+          cauldronHelper.setYarnLocks(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+            {
+              Bar: 'a0112c49-4bbc-47a9-ba45-d43e1e84a1a5',
+              Foo: 'b0112c49-4bbc-47a9-ba45-d43e1e84a1a5',
+            },
+          ),
         ),
       );
     });
@@ -1208,25 +1007,6 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('addOrUpdateYarnLock', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      mockFs({
-        '/path/to/yarn.lock': 'yarnLockContent',
-      });
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.addOrUpdateYarnLock,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-          'Production',
-          '/path/to/yarn.lock',
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       mockFs({
         '/path/to/yarn.lock': 'yarnLockContent',
@@ -1236,12 +1016,12 @@ describe('CauldronHelper.js', () => {
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.addOrUpdateYarnLock,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
-          'Production',
-          '/path/to/yarn.lock',
+        rejects(
+          cauldronHelper.addOrUpdateYarnLock(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+            'Production',
+            '/path/to/yarn.lock',
+          ),
         ),
       );
     });
@@ -1284,32 +1064,17 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('getYarnLockId', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.getYarnLockId,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-          'Production',
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.getYarnLockId,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
-          'Production',
+        rejects(
+          cauldronHelper.getYarnLockId(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+            'Production',
+          ),
         ),
       );
     });
@@ -1328,34 +1093,18 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('updateYarnLockId', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.updateYarnLockId,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-          'Production',
-          'c0112c49-4bbc-47a9-ba45-d43e1e84a1a5',
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.updateYarnLockId,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
-          'Production',
-          'c0112c49-4bbc-47a9-ba45-d43e1e84a1a5',
+        rejects(
+          cauldronHelper.updateYarnLockId(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+            'Production',
+            'c0112c49-4bbc-47a9-ba45-d43e1e84a1a5',
+          ),
         ),
       );
     });
@@ -1401,10 +1150,12 @@ describe('CauldronHelper.js', () => {
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(cauldronHelper.updateFile, cauldronHelper, {
-          cauldronFilePath: 'path/in/cauldron/testfile.ext',
-          localFilePath: path.resolve(__dirname, 'fixtures/testfile.ext'),
-        }),
+        rejects(
+          cauldronHelper.updateFile({
+            cauldronFilePath: 'path/in/cauldron/testfile.ext',
+            localFilePath: path.resolve(__dirname, 'fixtures/testfile.ext'),
+          }),
+        ),
       );
     });
 
@@ -1435,10 +1186,11 @@ describe('CauldronHelper.js', () => {
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(cauldronHelper.removeFile, cauldronHelper, {
-          cauldronFilePath: 'path/in/cauldron/testfile.ext',
-          localFilePath: path.resolve(__dirname, 'fixtures/testfile.ext'),
-        }),
+        rejects(
+          cauldronHelper.removeFile({
+            cauldronFilePath: 'path/in/cauldron/testfile.ext',
+          }),
+        ),
       );
     });
 
@@ -1494,9 +1246,11 @@ describe('CauldronHelper.js', () => {
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(cauldronHelper.getFile, cauldronHelper, {
-          cauldronFilePath: '/non/existing/file',
-        }),
+        rejects(
+          cauldronHelper.getFile({
+            cauldronFilePath: '/non/existing/file',
+          }),
+        ),
       );
     });
 
@@ -1517,36 +1271,6 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('addBundle', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.addBundle,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-          'bundleContent',
-        ),
-      );
-    });
-
-    it('should throw if the given native application descriptor is not in Cauldron', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.addBundle,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
-          'bundleContent',
-        ),
-      );
-    });
-
     it('should add the bundle', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
@@ -1564,20 +1288,6 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('hasBundle', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.hasBundle,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-        ),
-      );
-    });
-
     it('should return true if there is a stored bundle for the given native application descriptor', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
@@ -1606,30 +1316,16 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('getBundle', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.getBundle,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-        ),
-      );
-    });
-
     it('should throw if there is no stored bundle for the given native application descriptor', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.getBundle,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
+        rejects(
+          cauldronHelper.getBundle(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+          ),
         ),
       );
     });
@@ -1651,32 +1347,17 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('getContainerNativeDependency', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.getContainerNativeDependency,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-          'react-native-electrode-bridge',
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.getContainerNativeDependency,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
-          'react-native-electrode-bridge',
+        rejects(
+          cauldronHelper.getContainerNativeDependency(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+            'react-native-electrode-bridge',
+          ),
         ),
       );
     });
@@ -1687,11 +1368,11 @@ describe('CauldronHelper.js', () => {
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.getContainerNativeDependency,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          'foo',
+        rejects(
+          cauldronHelper.getContainerNativeDependency(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            'foo',
+          ),
         ),
       );
     });
@@ -1702,11 +1383,11 @@ describe('CauldronHelper.js', () => {
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.getContainerNativeDependency,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          'react-native-electrode-bridge@0.0.1',
+        rejects(
+          cauldronHelper.getContainerNativeDependency(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            'react-native-electrode-bridge@0.0.1',
+          ),
         ),
       );
     });
@@ -1859,47 +1540,17 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('updateJsApiImplVersionInContainer', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.updateJsApiImplVersionInContainer,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-          PackagePath.fromString('react-native-my-api-impl@1.5.0'),
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.updateJsApiImplVersionInContainer,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
-          PackagePath.fromString('react-native-my-api-impl@1.5.0'),
-        ),
-      );
-    });
-
-    it('should throw if the given native application version is released', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.updateJsApiImplVersionInContainer,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          PackagePath.fromString('react-native-my-api-impl@1.5.0'),
+        rejects(
+          cauldronHelper.updateJsApiImplVersionInContainer(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+            PackagePath.fromString('react-native-my-api-impl@1.5.0'),
+          ),
         ),
       );
     });
@@ -1935,30 +1586,16 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('getContainerJsApiImpls', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.getContainerJsApiImpls,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.getContainerJsApiImpls,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
+        rejects(
+          cauldronHelper.getContainerJsApiImpls(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+          ),
         ),
       );
     });
@@ -2068,32 +1705,17 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('getContainerJsApiImpl', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.getContainerJsApiImpl,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-          PackagePath.fromString('react-native-my-api-impl'),
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.getContainerJsApiImpl,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
-          PackagePath.fromString('react-native-my-api-impl'),
+        rejects(
+          cauldronHelper.getContainerJsApiImpl(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+            PackagePath.fromString('react-native-my-api-impl'),
+          ),
         ),
       );
     });
@@ -2104,11 +1726,11 @@ describe('CauldronHelper.js', () => {
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.getContainerJsApiImpl,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          PackagePath.fromString('foo@1.0.0'),
+        rejects(
+          cauldronHelper.getContainerJsApiImpl(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            PackagePath.fromString('foo@1.0.0'),
+          ),
         ),
       );
     });
@@ -2139,32 +1761,17 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('getContainerMiniApp', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.getContainerMiniApp,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-          'react-native-bar',
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.getContainerMiniApp,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
-          'react-native-bar',
+        rejects(
+          cauldronHelper.getContainerMiniApp(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+            'react-native-bar',
+          ),
         ),
       );
     });
@@ -2175,11 +1782,11 @@ describe('CauldronHelper.js', () => {
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.getContainerMiniApp,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          'foo@1.0.0',
+        rejects(
+          cauldronHelper.getContainerMiniApp(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            'foo@1.0.0',
+          ),
         ),
       );
     });
@@ -2190,11 +1797,11 @@ describe('CauldronHelper.js', () => {
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.getContainerMiniApp,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          'react-native-bar@0.0.1',
+        rejects(
+          cauldronHelper.getContainerMiniApp(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            'react-native-bar@0.0.1',
+          ),
         ),
       );
     });
@@ -2225,47 +1832,17 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('getCodePushJsApiImpls', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.getCodePushJsApiImpls,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-          'Production',
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.getCodePushJsApiImpls,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
-          'Production',
-        ),
-      );
-    });
-
-    it('should throw if deployment does not exist', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.getCodePushJsApiImpls,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          'Foo',
+        rejects(
+          cauldronHelper.getCodePushJsApiImpls(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+            'Production',
+          ),
         ),
       );
     });
@@ -2284,32 +1861,17 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('getCodePushEntry', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        await doesThrow(
-          cauldronHelper.getCodePushEntry,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-          'Production',
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        await doesThrow(
-          cauldronHelper.getCodePushEntry,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
-          'Production',
+        rejects(
+          cauldronHelper.getCodePushEntry(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+            'Production',
+          ),
         ),
       );
     });
@@ -2320,17 +1882,17 @@ describe('CauldronHelper.js', () => {
         cauldronDocument: fixture,
       });
       assert(
-        await doesThrow(
-          cauldronHelper.getCodePushEntry,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          'Production',
-          { label: 'v0' },
+        rejects(
+          cauldronHelper.getCodePushEntry(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            'Production',
+            { label: 'v0' },
+          ),
         ),
       );
     });
 
-    it('should return undefined if there is not mathing code push entry', async () => {
+    it('should return undefined if there is no matching code push entry', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
@@ -2371,52 +1933,37 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('getCodePushMiniApps', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.getCodePushMiniApps,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-          'Production',
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.getCodePushMiniApps,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
-          'Production',
+        rejects(
+          cauldronHelper.getCodePushMiniApps(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+            'Production',
+          ),
         ),
       );
     });
 
-    it('should throw if deployment does not exist', async () => {
+    /*it('should throw if deployment does not exist', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.getCodePushMiniApps,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          'Foo',
+        rejects(
+          cauldronHelper.getCodePushMiniApps(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            'Foo',
+          ),
         ),
       );
-    });
+    });*/
 
-    it('should return the latest CodePushed MiniApps if label is ommited', async () => {
+    it('should return the latest CodePushed MiniApps if label is omitted', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
@@ -2447,42 +1994,28 @@ describe('CauldronHelper.js', () => {
         cauldronDocument: fixture,
       });
       assert(
-        await doesThrow(
-          cauldronHelper.getCodePushMiniApps,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          'Production',
-          { label: 'v0' },
+        rejects(
+          cauldronHelper.getCodePushMiniApps(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            'Production',
+            { label: 'v0' },
+          ),
         ),
       );
     });
   });
 
   describe('getContainerMiniApps', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.getContainerMiniApps,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.getContainerMiniApps,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
+        rejects(
+          cauldronHelper.getContainerMiniApps(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+          ),
         ),
       );
     });
@@ -2540,74 +2073,39 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('addCodePushEntry', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.addCodePushEntry,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-          codePushMetadataFixtureOne,
-          miniAppsFixtureOne,
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.addCodePushEntry,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
-          codePushMetadataFixtureOne,
-          miniAppsFixtureOne,
+        rejects(
+          cauldronHelper.addCodePushEntry(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+            codePushMetadataFixtureOne,
+            miniAppsFixtureOne,
+            [],
+          ),
         ),
       );
     });
   });
 
   describe('updateCodePushEntry', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.updateCodePushEntry,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-          'Production',
-          'v17',
-          {
-            isDisabled: true,
-          },
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.updateCodePushEntry,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
-          'Production',
-          'v17',
-          {
-            isDisabled: true,
-          },
+        rejects(
+          cauldronHelper.updateCodePushEntry(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+            {
+              deploymentName: 'Production',
+              isDisabled: true,
+            },
+          ),
         ),
       );
     });
@@ -2701,20 +2199,6 @@ describe('CauldronHelper.js', () => {
         AppPlatformDescriptor.fromString('test:android'),
       );
       expect(result).not.undefined;
-    });
-
-    it('should throw if the native application does not exist', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.getContainerGeneratorConfig,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('toto:android'),
-        ),
-      );
     });
   });
 
@@ -2893,32 +2377,17 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('updateNativeAppIsReleased', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.updateNativeAppIsReleased,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-          false,
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.updateNativeAppIsReleased,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
-          false,
+        rejects(
+          cauldronHelper.updateNativeAppIsReleased(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+            false,
+          ),
         ),
       );
     });
@@ -2941,32 +2410,17 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('updateContainerVersion', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.updateContainerVersion,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-          '999.0.0',
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.updateContainerVersion,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
-          '999.0.0',
+        rejects(
+          cauldronHelper.updateContainerVersion(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+            '999.0.0',
+          ),
         ),
       );
     });
@@ -3044,30 +2498,16 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('getContainerVersion', () => {
-    it('should throw if the given native application descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      assert(
-        doesThrow(
-          cauldronHelper.getContainerVersion,
-          cauldronHelper,
-          AppPlatformDescriptor.fromString('test:android'),
-        ),
-      );
-    });
-
     it('should throw if the given native application descriptor is not in Cauldron', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.getContainerVersion,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:0.0.0'),
+        rejects(
+          cauldronHelper.getContainerVersion(
+            AppVersionDescriptor.fromString('test:android:0.0.0'),
+          ),
         ),
       );
     });
@@ -3104,11 +2544,11 @@ describe('CauldronHelper.js', () => {
         cauldronDocument: fixture,
       });
       assert(
-        doesThrow(
-          cauldronHelper.throwIfNativeAppVersionIsReleased,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:17.7.0'),
-          'released',
+        rejects(
+          cauldronHelper.throwIfNativeAppVersionIsReleased(
+            AppVersionDescriptor.fromString('test:android:17.7.0'),
+            'released',
+          ),
         ),
       );
     });
@@ -3119,11 +2559,11 @@ describe('CauldronHelper.js', () => {
         cauldronDocument: fixture,
       });
       assert(
-        doesNotThrow(
-          cauldronHelper.throwIfNativeAppVersionIsReleased,
-          cauldronHelper,
-          AppVersionDescriptor.fromString('test:android:17.8.0'),
-          'nonreleased',
+        doesNotReject(
+          cauldronHelper.throwIfNativeAppVersionIsReleased(
+            AppVersionDescriptor.fromString('test:android:17.8.0'),
+            'nonreleased',
+          ),
         ),
       );
     });
@@ -3227,25 +2667,8 @@ describe('CauldronHelper.js', () => {
       });
       const descriptor = AppNameDescriptor.fromString('test');
       assert(
-        await doesThrow(
-          cauldronHelper.getDescriptorsMatchingSemVerDescriptor,
-          null,
-          descriptor,
-        ),
-      );
-    });
-
-    it('should throw if the descriptor does not contain a version', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      const descriptor = AppPlatformDescriptor.fromString('test:android');
-      assert(
-        await doesThrow(
-          cauldronHelper.getDescriptorsMatchingSemVerDescriptor,
-          null,
-          descriptor,
+        rejects(
+          cauldronHelper.getDescriptorsMatchingSemVerDescriptor(descriptor),
         ),
       );
     });
@@ -3290,34 +2713,13 @@ describe('CauldronHelper.js', () => {
   });
 
   describe('addNativeApplicationVersion', () => {
-    it('should throw if the descriptor is partial', async () => {
-      const fixture = cloneFixture(fixtures.defaultCauldron);
-      const cauldronHelper = createCauldronHelper({
-        cauldronDocument: fixture,
-      });
-      const descriptor = AppPlatformDescriptor.fromString('test:android');
-      assert(
-        await doesThrow(
-          cauldronHelper.addNativeApplicationVersion,
-          null,
-          descriptor,
-        ),
-      );
-    });
-
     it('should throw if the native application version already exist', async () => {
       const fixture = cloneFixture(fixtures.defaultCauldron);
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
       const descriptor = AppVersionDescriptor.fromString('test:android:17.7.0');
-      assert(
-        await doesThrow(
-          cauldronHelper.addNativeApplicationVersion,
-          null,
-          descriptor,
-        ),
-      );
+      assert(rejects(cauldronHelper.addNativeApplicationVersion(descriptor)));
     });
 
     it('should add the native application version', async () => {
@@ -3379,11 +2781,11 @@ describe('CauldronHelper.js', () => {
       );
       await cauldronHelper.addNativeApplicationVersion(targetDescriptor);
       assert(
-        await doesThrow(
-          cauldronHelper.copyNativeApplicationVersion,
-          null,
-          sourceDescriptor,
-          targetDescriptor,
+        rejects(
+          cauldronHelper.copyNativeApplicationVersion(
+            sourceDescriptor,
+            targetDescriptor,
+          ),
         ),
       );
     });
@@ -3400,11 +2802,11 @@ describe('CauldronHelper.js', () => {
         'test:android:20.0.0',
       );
       assert(
-        await doesThrow(
-          cauldronHelper.copyNativeApplicationVersion,
-          null,
-          sourceDescriptor,
-          targetDescriptor,
+        rejects(
+          cauldronHelper.copyNativeApplicationVersion(
+            sourceDescriptor,
+            targetDescriptor,
+          ),
         ),
       );
     });

--- a/ern-composite-gen/test/compositegen-test.ts
+++ b/ern-composite-gen/test/compositegen-test.ts
@@ -1,5 +1,5 @@
 import { assert, expect } from 'chai';
-import { doesThrow } from 'ern-util-dev';
+import { rejects } from 'assert';
 import sinon from 'sinon';
 import path from 'path';
 import fs from 'fs-extra';
@@ -236,12 +236,13 @@ describe('ern-container-gen utils.js', () => {
         PackagePath.fromString(path.join(__dirname, 'fixtures', 'miniapp')),
       ];
       assert(
-        await doesThrow(generateComposite, null, {
-          miniApps,
-          outDir: tmpOutDir,
-          pathToYarnLock: 'hello',
-        }),
-        'No exception was thrown !',
+        rejects(
+          generateComposite({
+            miniApps,
+            outDir: tmpOutDir,
+            pathToYarnLock: 'hello',
+          }),
+        ),
       );
     });
 
@@ -251,24 +252,26 @@ describe('ern-container-gen utils.js', () => {
         PackagePath.fromString(path.join(__dirname, 'fixtures', 'miniapp')),
       ];
       assert(
-        await doesThrow(generateComposite, null, {
-          miniApps,
-          outDir: tmpOutDir,
-          pathToYarnLock: 'hello',
-        }),
-        'No exception was thrown !',
+        rejects(
+          generateComposite({
+            miniApps,
+            outDir: tmpOutDir,
+            pathToYarnLock: 'hello',
+          }),
+        ),
       );
     });
 
     it('should throw an exception if at least one of the MiniApp path is using a git scheme [1]', async () => {
       const miniApps = [PackagePath.fromString('git://github.com:org/repo')];
       assert(
-        await doesThrow(generateComposite, null, {
-          miniApps,
-          outDir: tmpOutDir,
-          pathToYarnLock: 'hello',
-        }),
-        'No exception was thrown !',
+        rejects(
+          generateComposite({
+            miniApps,
+            outDir: tmpOutDir,
+            pathToYarnLock: 'hello',
+          }),
+        ),
       );
     });
 
@@ -278,24 +281,26 @@ describe('ern-container-gen utils.js', () => {
         PackagePath.fromString('git://github.com:org/repo'),
       ];
       assert(
-        await doesThrow(generateComposite, null, {
-          miniApps,
-          outDir: tmpOutDir,
-          pathToYarnLock: 'hello',
-        }),
-        'No exception was thrown !',
+        rejects(
+          generateComposite({
+            miniApps,
+            outDir: tmpOutDir,
+            pathToYarnLock: 'hello',
+          }),
+        ),
       );
     });
 
     it('should throw an exception if one of the MiniApp is not using an explicit version [1]', async () => {
       const miniApps = [PackagePath.fromString('first-miniapp')];
       assert(
-        await doesThrow(generateComposite, null, {
-          miniApps,
-          outDir: tmpOutDir,
-          pathToYarnLock: 'hello',
-        }),
-        'No exception was thrown !',
+        rejects(
+          generateComposite({
+            miniApps,
+            outDir: tmpOutDir,
+            pathToYarnLock: 'hello',
+          }),
+        ),
       );
     });
 
@@ -305,12 +310,13 @@ describe('ern-container-gen utils.js', () => {
         PackagePath.fromString('second-miniapp@1.0.0'),
       ];
       assert(
-        await doesThrow(generateComposite, null, {
-          miniApps,
-          outDir: tmpOutDir,
-          pathToYarnLock: 'hello',
-        }),
-        'No exception was thrown !',
+        rejects(
+          generateComposite({
+            miniApps,
+            outDir: tmpOutDir,
+            pathToYarnLock: 'hello',
+          }),
+        ),
       );
     });
 
@@ -320,12 +326,13 @@ describe('ern-container-gen utils.js', () => {
         PackagePath.fromString('second-miniapp@1.0.0'),
       ];
       assert(
-        await doesThrow(generateComposite, null, {
-          miniApps,
-          outDir: tmpOutDir,
-          pathToYarnLock: path.join(tmpOutDir, 'yarn.lock'),
-        }),
-        'No exception was thrown !',
+        rejects(
+          generateComposite({
+            miniApps,
+            outDir: tmpOutDir,
+            pathToYarnLock: path.join(tmpOutDir, 'yarn.lock'),
+          }),
+        ),
       );
     });
 
@@ -335,11 +342,13 @@ describe('ern-container-gen utils.js', () => {
       );
       const miniApps: PackagePath[] = [];
       assert(
-        await doesThrow(generateComposite, null, {
-          miniApps,
-          outDir: tmpOutDir,
-          pathToYarnLock: pathToSampleYarnLock,
-        }),
+        rejects(
+          generateComposite({
+            miniApps,
+            outDir: tmpOutDir,
+            pathToYarnLock: pathToSampleYarnLock,
+          }),
+        ),
       );
     });
 

--- a/ern-core/test/ErnBinaryStore-test.ts
+++ b/ern-core/test/ErnBinaryStore-test.ts
@@ -1,6 +1,6 @@
 import { ErnBinaryStore } from '../src/ErnBinaryStore';
 import { AppVersionDescriptor } from '../src/descriptors';
-import { doesThrow } from 'ern-util-dev';
+import { rejects } from 'assert';
 import path from 'path';
 import sinon from 'sinon';
 import { assert, expect } from 'chai';
@@ -65,7 +65,7 @@ describe('ErnBinaryStore', () => {
     it('should throw if the server returns an error status code', async () => {
       nock(binaryStoreUrl).head(`/${testDescriptorFile}`).reply(500);
       const sut = createBinaryStore();
-      assert(await doesThrow(sut.hasBinary, sut, testDescriptor));
+      assert(rejects(sut.hasBinary(testDescriptor)));
     });
   });
 
@@ -105,14 +105,14 @@ describe('ErnBinaryStore', () => {
       nock(binaryStoreUrl).head(`/${testDescriptorFile}`).reply(200);
       nock(binaryStoreUrl).delete(`/${testDescriptorFile}`).reply(500);
       const sut = createBinaryStore();
-      assert(await doesThrow(sut.removeBinary, sut, testDescriptor));
+      assert(rejects(sut.removeBinary(testDescriptor)));
     });
 
     it('should throw if the server does not have the specified binary', async () => {
       nock(binaryStoreUrl).head(`/${testDescriptorFile}`).reply(404);
       nock(binaryStoreUrl).delete(`/${testDescriptorFile}`).reply(200);
       const sut = createBinaryStore();
-      assert(await doesThrow(sut.removeBinary, sut, testDescriptor));
+      assert(rejects(sut.removeBinary(testDescriptor)));
     });
   });
 

--- a/ern-core/test/FsCache-test.ts
+++ b/ern-core/test/FsCache-test.ts
@@ -1,6 +1,6 @@
 import { assert, expect } from 'chai';
 import { FsCache, maxDefaultCacheSize } from '../src/FsCache';
-import { doesThrow } from 'ern-util-dev';
+import { rejects } from 'assert';
 import shell from '../src/shell';
 import path from 'path';
 import fs from 'fs';
@@ -17,7 +17,7 @@ describe('FsCache', () => {
   });
 
   describe('constructor', () => {
-    it('should succesfully create a new instance given valid parameters', () => {
+    it('should successfully create a new instance given valid parameters', () => {
       const sut = new FsCache<string>({
         addObjectToCacheDirectory: async (obj: string, dirPath: string) =>
           Promise.resolve(),
@@ -103,7 +103,7 @@ describe('FsCache', () => {
         rootCachePath: testRootCachePath,
       });
       await sut.addToCache('AString');
-      assert(await doesThrow(sut.addToCache, sut, 'AString'));
+      assert(rejects(sut.addToCache('AString')));
     });
 
     it('should add the object to the cache', async () => {

--- a/ern-core/test/ModuleFactory-test.ts
+++ b/ern-core/test/ModuleFactory-test.ts
@@ -2,9 +2,9 @@ import path from 'path';
 import sinon from 'sinon';
 import shell from 'shelljs';
 import fs from 'fs-extra';
+import { rejects } from 'assert';
 import { assert, expect } from 'chai';
 import { ModuleFactory } from '../src/ModuleFactory';
-import { doesThrow } from 'ern-util-dev';
 import { PackagePath } from '../src/PackagePath';
 import { YarnCli } from '../src/YarnCli';
 
@@ -42,13 +42,12 @@ describe('ModuleFactory', () => {
 
   describe('constructor', () => {
     it('should successfully instantiate a ModuleFactory', () => {
-      assert.doesNotThrow(
+      expect(
         () =>
           new ModuleFactory(PACKAGE_CACHE_PATH, {
             packagePrefix: PACKAGE_PREFIX,
           }),
-        Error,
-      );
+      ).to.not.throw();
     });
   });
 
@@ -57,13 +56,8 @@ describe('ModuleFactory', () => {
       const sut = new ModuleFactory(PACKAGE_CACHE_PATH, {
         packagePrefix: PACKAGE_PREFIX,
       });
-      assert(
-        await doesThrow(
-          sut.getModuleInstance,
-          sut,
-          PackagePath.fromString('git+ssh://gihub.com/user/repo.git'),
-        ),
-      );
+      const p = PackagePath.fromString('https://github.com/org/repo.git');
+      assert(rejects(sut.getModuleInstance(p)));
     });
 
     it('should properly instantiate a local package module [without src directory]', async () => {

--- a/ern-core/test/Utils-test.ts
+++ b/ern-core/test/Utils-test.ts
@@ -6,6 +6,7 @@ import { PackagePath } from '../src/PackagePath';
 import { assert, expect } from 'chai';
 import { doesThrow } from 'ern-util-dev';
 import * as git from '../src/gitCli';
+import { rejects } from 'assert';
 
 const sandbox = sinon.createSandbox();
 
@@ -216,20 +217,20 @@ d9fa903349bbb9e7f86535cb69256e064d0fba65        refs/tags/v0.1.2`;
 
     it('should throw if the package path is not a git path', async () => {
       assert(
-        await doesThrow(
-          coreUtils.getCommitShaOfGitBranchOrTag,
-          null,
-          PackagePath.fromString('registry-package@1.2.3'),
+        rejects(
+          coreUtils.getCommitShaOfGitBranchOrTag(
+            PackagePath.fromString('registry-package@1.2.3'),
+          ),
         ),
       );
     });
 
     it('should throw if the package path does not include a branch', async () => {
       assert(
-        await doesThrow(
-          coreUtils.getCommitShaOfGitBranchOrTag,
-          null,
-          PackagePath.fromString('https://github.com/org/repo.git'),
+        rejects(
+          coreUtils.getCommitShaOfGitBranchOrTag(
+            PackagePath.fromString('https://github.com/org/repo.git'),
+          ),
         ),
       );
     });
@@ -241,10 +242,10 @@ d9fa903349bbb9e7f86535cb69256e064d0fba65        refs/tags/v0.1.2`;
         },
       });
       assert(
-        await doesThrow(
-          coreUtils.getCommitShaOfGitBranchOrTag,
-          null,
-          PackagePath.fromString('https://github.com/org/repo.git#foo'),
+        rejects(
+          coreUtils.getCommitShaOfGitBranchOrTag(
+            PackagePath.fromString('https://github.com/org/repo.git#foo'),
+          ),
         ),
       );
     });

--- a/ern-orchestrator/test/Ensure-test.js
+++ b/ern-orchestrator/test/Ensure-test.js
@@ -1,8 +1,13 @@
 import { assert, expect } from 'chai';
 import * as cauldron from 'ern-cauldron-api';
-import { createTmpDir, PackagePath, utils } from 'ern-core';
+import {
+  AppVersionDescriptor,
+  createTmpDir,
+  PackagePath,
+  utils,
+} from 'ern-core';
 import { getContainerMetadataPath } from 'ern-container-gen';
-import { doesNotThrow, doesThrow } from 'ern-util-dev';
+import { rejects } from 'assert';
 import sinon from 'sinon';
 import Ensure from '../src/Ensure';
 import * as fixtures from './fixtures/common';
@@ -11,6 +16,8 @@ import fs from 'fs';
 import path from 'path';
 
 const sandbox = sinon.createSandbox();
+
+const descriptor = AppVersionDescriptor.fromString('app:android:1.0.0');
 
 let cauldronHelperStub;
 
@@ -67,41 +74,25 @@ describe('Ensure.js', () => {
   describe('napDescritorExistsInCauldron', () => {
     it('should not throw if nap descriptor exists in Cauldron', async () => {
       cauldronHelperStub.isDescriptorInCauldron.resolves(true);
-      assert(
-        await doesNotThrow(
-          Ensure.napDescritorExistsInCauldron,
-          null,
-          'testapp:android:1.0.0',
-        ),
-      );
+      await Ensure.napDescritorExistsInCauldron('testapp:android:1.0.0');
     });
 
     it('should not throw if nap descriptors exists in Cauldron [array]', async () => {
       cauldronHelperStub.isDescriptorInCauldron.resolves(true);
-      assert(
-        await doesNotThrow(Ensure.napDescritorExistsInCauldron, null, [
-          'testapp:android:1.0.0',
-        ]),
-      );
+      await Ensure.napDescritorExistsInCauldron(['testapp:android:1.0.0']);
     });
 
     it('should throw if nap descriptor does not exist in Cauldron', async () => {
       cauldronHelperStub.isDescriptorInCauldron.resolves(false);
       assert(
-        await doesThrow(
-          Ensure.napDescritorExistsInCauldron,
-          null,
-          'testapp:android:1.0.0',
-        ),
+        rejects(Ensure.napDescritorExistsInCauldron('testapp:android:1.0.0')),
       );
     });
 
     it('should throw if nap descriptor does not exist in Cauldron [array]', async () => {
       cauldronHelperStub.isDescriptorInCauldron.resolves(false);
       assert(
-        await doesThrow(Ensure.napDescritorExistsInCauldron, null, [
-          'testapp:android:1.0.0',
-        ]),
+        rejects(Ensure.napDescritorExistsInCauldron(['testapp:android:1.0.0'])),
       );
     });
   });
@@ -110,23 +101,15 @@ describe('Ensure.js', () => {
     it('should throw if nap descriptor exists in Cauldron', async () => {
       cauldronHelperStub.isDescriptorInCauldron.resolves(true);
       assert(
-        await doesThrow(
-          Ensure.napDescritorDoesNotExistsInCauldron,
-          null,
-          'testapp:android:1.0.0',
+        rejects(
+          Ensure.napDescritorDoesNotExistsInCauldron('testapp:android:1.0.0'),
         ),
       );
     });
 
     it('should not throw if nap descriptor does not exist in Cauldron', async () => {
       cauldronHelperStub.isDescriptorInCauldron.resolves(false);
-      assert(
-        await doesNotThrow(
-          Ensure.napDescritorDoesNotExistsInCauldron,
-          null,
-          'testapp:android:1.0.0',
-        ),
-      );
+      await Ensure.napDescritorDoesNotExistsInCauldron('testapp:android:1.0.0');
     });
   });
 
@@ -134,35 +117,27 @@ describe('Ensure.js', () => {
     it('should throw if dependency is in native application version Container', async () => {
       cauldronHelperStub.isNativeDependencyInContainer.resolves(true);
       assert(
-        await doesThrow(
-          Ensure.dependencyNotInNativeApplicationVersionContainer,
-          null,
-          'depa@1.0.0',
-          'testapp:android:1.0.0',
+        rejects(
+          Ensure.dependencyNotInNativeApplicationVersionContainer(
+            'dep-a@1.0.0',
+            descriptor,
+          ),
         ),
       );
     });
 
     it('should not throw if dependency is not in native application version Container', async () => {
       cauldronHelperStub.isNativeDependencyInContainer.resolves(false);
-      assert(
-        await doesNotThrow(
-          Ensure.dependencyNotInNativeApplicationVersionContainer,
-          null,
-          'depB@1.0.0',
-          'testapp:android:1.0.0',
-        ),
+      await Ensure.dependencyNotInNativeApplicationVersionContainer(
+        'dep-b@1.0.0',
+        descriptor,
       );
     });
 
     it('should not throw if dependency is undefined', async () => {
-      assert(
-        await doesNotThrow(
-          Ensure.dependencyNotInNativeApplicationVersionContainer,
-          null,
-          undefined,
-          'testapp:android:1.0.0',
-        ),
+      await Ensure.dependencyNotInNativeApplicationVersionContainer(
+        undefined,
+        descriptor,
       );
     });
   });
@@ -172,55 +147,27 @@ describe('Ensure.js', () => {
       cauldronHelperStub.getYarnLock.resolves(
         fs.readFileSync(path.join(__dirname, 'fixtures/sample.yarn.lock')),
       );
-      assert(
-        await doesThrow(
-          Ensure.dependencyIsOrphaned,
-          null,
-          'dep-b',
-          'testapp:android:1.0.0',
-        ),
-      );
+      assert(rejects(Ensure.dependencyIsOrphaned('dep-b', descriptor)));
     });
 
     it('should not throw if dependency is orphaned [not in lock file]', async () => {
       cauldronHelperStub.getYarnLock.resolves(
         fs.readFileSync(path.join(__dirname, 'fixtures/sample.yarn.lock')),
       );
-      assert(
-        await doesNotThrow(
-          Ensure.dependencyIsOrphaned,
-          null,
-          'dep-d',
-          'testapp:android:1.0.0',
-        ),
-      );
+      await Ensure.dependencyIsOrphaned('dep-d', descriptor);
     });
 
     it('should not throw if dependency is orphaned [in lock file]', async () => {
       cauldronHelperStub.getYarnLock.resolves(
         fs.readFileSync(path.join(__dirname, 'fixtures/sample.yarn.lock')),
       );
-      assert(
-        await doesNotThrow(
-          Ensure.dependencyIsOrphaned,
-          null,
-          'dep-x',
-          'testapp:android:1.0.0',
-        ),
-      );
+      await Ensure.dependencyIsOrphaned('dep-x', descriptor);
     });
   });
 
   describe('dependencyNotInUseByAMiniApp', () => {
     it('should not throw if dependency is undefined', async () => {
-      assert(
-        await doesNotThrow(
-          Ensure.dependencyNotInUseByAMiniApp,
-          null,
-          undefined,
-          'testapp:android:1.0.0',
-        ),
-      );
+      await Ensure.dependencyNotInUseByAMiniApp(undefined, descriptor);
     });
   });
 
@@ -229,36 +176,28 @@ describe('Ensure.js', () => {
       cauldronHelperStub.getContainerNativeDependency.resolves(
         PackagePath.fromString('dep-a@1.0.0'),
       );
-      assert(
-        await doesNotThrow(
-          Ensure.dependencyIsInNativeApplicationVersionContainer,
-          null,
-          'depa@1.0.0',
-          'testapp:android:1.0.0',
-        ),
+      await Ensure.dependencyIsInNativeApplicationVersionContainer(
+        'dep-a@1.0.0',
+        descriptor,
       );
     });
 
     it('should throw if dependency is not in native application version Container', async () => {
       cauldronHelperStub.getContainerNativeDependency.resolves(undefined);
       assert(
-        await doesThrow(
-          Ensure.dependencyIsInNativeApplicationVersionContainer,
-          null,
-          'depB@1.0.0',
-          'testapp:android:1.0.0',
+        rejects(
+          Ensure.dependencyIsInNativeApplicationVersionContainer(
+            'dep-b@1.0.0',
+            descriptor,
+          ),
         ),
       );
     });
 
     it('should not throw if dependency is undefined', async () => {
-      assert(
-        await doesNotThrow(
-          Ensure.dependencyIsInNativeApplicationVersionContainer,
-          null,
-          undefined,
-          'testapp:android:1.0.0',
-        ),
+      await Ensure.dependencyIsInNativeApplicationVersionContainer(
+        undefined,
+        descriptor,
       );
     });
   });
@@ -266,46 +205,34 @@ describe('Ensure.js', () => {
   describe('miniAppIsInNativeApplicationVersionContainer', () => {
     it('should not throw if MiniApp is in native application version Container', async () => {
       cauldronHelperStub.isMiniAppInContainer.resolves(true);
-      assert(
-        await doesNotThrow(
-          Ensure.miniAppIsInNativeApplicationVersionContainer,
-          null,
-          'miniapp@1.0.0',
-          'testapp:android:1.0.0',
-        ),
+      await Ensure.miniAppIsInNativeApplicationVersionContainer(
+        'miniapp@1.0.0',
+        descriptor,
       );
     });
 
     it('should not throw for undefined MiniApp', async () => {
-      assert(
-        await doesNotThrow(
-          Ensure.miniAppIsInNativeApplicationVersionContainer,
-          null,
-          undefined,
-          'testapp:android:1.0.0',
-        ),
+      await Ensure.miniAppIsInNativeApplicationVersionContainer(
+        undefined,
+        descriptor,
       );
     });
 
     it('should not throw for null MiniApp', async () => {
-      assert(
-        await doesNotThrow(
-          Ensure.miniAppIsInNativeApplicationVersionContainer,
-          null,
-          null,
-          'testapp:android:1.0.0',
-        ),
+      await Ensure.miniAppIsInNativeApplicationVersionContainer(
+        null,
+        descriptor,
       );
     });
 
     it('should throw if MiniApp is not in native application version Container', async () => {
       cauldronHelperStub.isMiniAppInContainer.resolves(false);
       assert(
-        await doesThrow(
-          Ensure.miniAppIsInNativeApplicationVersionContainer,
-          null,
-          'miniapp@1.0.0',
-          'testapp:android:1.0.0',
+        rejects(
+          Ensure.miniAppIsInNativeApplicationVersionContainer(
+            'miniapp@1.0.0',
+            descriptor,
+          ),
         ),
       );
     });
@@ -315,26 +242,18 @@ describe('Ensure.js', () => {
     it('should not throw if miniapp is in native application version Container with different version', async () => {
       cauldronHelperStub.isMiniAppInContainer.resolves(true);
       cauldronHelperStub.getContainerMiniApp.resolves('miniapp@2.0.0');
-      assert(
-        await doesNotThrow(
-          Ensure.miniAppIsInNativeApplicationVersionContainerWithDifferentVersion,
-          null,
-          'miniapp@1.0.0',
-          'testapp:android:1.0.0',
-        ),
+      await Ensure.miniAppIsInNativeApplicationVersionContainerWithDifferentVersion(
+        'miniapp@1.0.0',
+        descriptor,
       );
     });
 
     it('should not throw if miniapp is undefined', async () => {
       cauldronHelperStub.isMiniAppInContainer.resolves(true);
       cauldronHelperStub.getContainerMiniApp.resolves('miniapp@2.0.0');
-      assert(
-        await doesNotThrow(
-          Ensure.miniAppIsInNativeApplicationVersionContainerWithDifferentVersion,
-          null,
-          undefined,
-          'testapp:android:1.0.0',
-        ),
+      await Ensure.miniAppIsInNativeApplicationVersionContainerWithDifferentVersion(
+        undefined,
+        descriptor,
       );
     });
 
@@ -342,11 +261,11 @@ describe('Ensure.js', () => {
       cauldronHelperStub.isMiniAppInContainer.resolves(true);
       cauldronHelperStub.getContainerMiniApp.resolves('miniapp@1.0.0');
       assert(
-        await doesThrow(
-          Ensure.miniAppIsInNativeApplicationVersionContainerWithDifferentVersion,
-          null,
-          'miniapp@1.0.0',
-          'testapp:android:1.0.0',
+        rejects(
+          Ensure.miniAppIsInNativeApplicationVersionContainerWithDifferentVersion(
+            'miniapp@1.0.0',
+            descriptor,
+          ),
         ),
       );
     });
@@ -357,13 +276,9 @@ describe('Ensure.js', () => {
       cauldronHelperStub.getContainerNativeDependency.resolves(
         PackagePath.fromString('dep-a@2.0.0'),
       );
-      assert(
-        await doesNotThrow(
-          Ensure.dependencyIsInNativeApplicationVersionContainerWithDifferentVersion,
-          null,
-          'dep-a@1.0.0',
-          'testapp:android:1.0.0',
-        ),
+      await Ensure.dependencyIsInNativeApplicationVersionContainerWithDifferentVersion(
+        'dep-a@1.0.0',
+        descriptor,
       );
     });
 
@@ -371,13 +286,9 @@ describe('Ensure.js', () => {
       cauldronHelperStub.getContainerNativeDependency.resolves(
         PackagePath.fromString('dep-a@2.0.0'),
       );
-      assert(
-        await doesNotThrow(
-          Ensure.dependencyIsInNativeApplicationVersionContainerWithDifferentVersion,
-          null,
-          undefined,
-          'testapp:android:1.0.0',
-        ),
+      await Ensure.dependencyIsInNativeApplicationVersionContainerWithDifferentVersion(
+        undefined,
+        descriptor,
       );
     });
 
@@ -386,11 +297,11 @@ describe('Ensure.js', () => {
         PackagePath.fromString('dep-a@1.0.0'),
       );
       assert(
-        await doesThrow(
-          Ensure.dependencyIsInNativeApplicationVersionContainerWithDifferentVersion,
-          null,
-          'dep-a@1.0.0',
-          'testapp:android:1.0.0',
+        rejects(
+          Ensure.dependencyIsInNativeApplicationVersionContainerWithDifferentVersion(
+            'dep-a@1.0.0',
+            descriptor,
+          ),
         ),
       );
     });
@@ -398,24 +309,16 @@ describe('Ensure.js', () => {
 
   describe('miniAppNotInNativeApplicationVersionContainer', () => {
     it('should not throw for undefined MiniApp', async () => {
-      assert(
-        await doesNotThrow(
-          Ensure.miniAppNotInNativeApplicationVersionContainer,
-          null,
-          undefined,
-          'testapp:android:1.0.0',
-        ),
+      await Ensure.miniAppNotInNativeApplicationVersionContainer(
+        undefined,
+        descriptor,
       );
     });
 
     it('should not throw for null MiniApp', async () => {
-      assert(
-        await doesNotThrow(
-          Ensure.miniAppNotInNativeApplicationVersionContainer,
-          null,
-          null,
-          'testapp:android:1.0.0',
-        ),
+      await Ensure.miniAppNotInNativeApplicationVersionContainer(
+        null,
+        descriptor,
       );
     });
   });
@@ -423,28 +326,24 @@ describe('Ensure.js', () => {
   describe('publishedToNpm', () => {
     it('should not throw if dependency is published to npm', async () => {
       sandbox.stub(utils, 'isPublishedToNpm').resolves(true);
-      assert(
-        await doesNotThrow(Ensure.publishedToNpm, null, 'nonpublished@1.0.0'),
-      );
+      await Ensure.publishedToNpm('dep@1.0.0');
     });
 
     it('should throw if dependency is not published to npm', async () => {
       sandbox.stub(utils, 'isPublishedToNpm').resolves(false);
-      assert(
-        await doesThrow(Ensure.publishedToNpm, null, 'nonpublished@1.0.0'),
-      );
+      assert(rejects(Ensure.publishedToNpm('dep@1.0.0')));
     });
   });
 
   /*describe('cauldronIsActive', () => {
     it('should not throw if a cauldron is active', async () => {
       isActiveStub.returns(true)
-      assert(await doesNotThrow(Ensure.cauldronIsActive))
+      await Ensure.cauldronIsActive();
     })
 
     it('should throw if no cauldron is active', async() => {
       isActiveStub.returns(false)
-      assert(await doesThrow(Ensure.cauldronIsActive))
+      assert(rejects(Ensure.cauldronIsActive()))
     })
   })*/
 
@@ -549,12 +448,12 @@ describe('Ensure.js', () => {
   describe('pathExist', () => {
     it('should not throw if path exist', async () => {
       const tmpDirPath = createTmpDir();
-      assert(await doesNotThrow(Ensure.pathExist, Ensure, tmpDirPath));
+      await Ensure.pathExist(tmpDirPath);
     });
 
     it('should throw if path does not exist', async () => {
       const tmpDirPath = createTmpDir();
-      assert(await doesThrow(Ensure.pathExist, Ensure, '/non/existing/path'));
+      assert(rejects(Ensure.pathExist('/non/existing/path')));
     });
   });
 
@@ -563,44 +462,42 @@ describe('Ensure.js', () => {
       const tmpDirPath = createTmpDir();
       const tmpFilePath = path.join(tmpDirPath, 'file.test');
       const tmpFile = fs.writeFileSync(tmpFilePath, 'CONTENT');
-      assert(await doesNotThrow(Ensure.isFilePath, Ensure, tmpFilePath));
+      await Ensure.isFilePath(tmpFilePath);
     });
 
     it('should throw if path is not a file', async () => {
       const tmpDirPath = createTmpDir();
-      assert(await doesThrow(Ensure.isFilePath, Ensure, tmpDirPath));
+      assert(rejects(Ensure.isFilePath(tmpDirPath)));
     });
 
     it('should throw if path does not exist', async () => {
       const tmpDirPath = createTmpDir();
-      assert(await doesThrow(Ensure.isFilePath, Ensure, '/non/existing/path'));
+      assert(rejects(Ensure.isFilePath('/non/existing/path')));
     });
   });
 
   describe('isDirectoryPath', () => {
     it('should not throw if path is a  directory', async () => {
       const tmpDirPath = createTmpDir();
-      assert(await doesNotThrow(Ensure.isDirectoryPath, Ensure, tmpDirPath));
+      await Ensure.isDirectoryPath(tmpDirPath);
     });
 
     it('should throw if path is not a directory', async () => {
       const tmpDirPath = createTmpDir();
       const tmpFilePath = path.join(tmpDirPath, 'file.test');
       const tmpFile = fs.writeFileSync(tmpFilePath, 'CONTENT');
-      assert(await doesThrow(Ensure.isDirectoryPath, Ensure, tmpFilePath));
+      assert(rejects(Ensure.isDirectoryPath(tmpFilePath)));
     });
 
     it('should throw if path does not exist', async () => {
       const tmpDirPath = createTmpDir();
-      assert(
-        await doesThrow(Ensure.isDirectoryPath, Ensure, '/non/existing/path'),
-      );
+      assert(rejects(Ensure.isDirectoryPath('/non/existing/path')));
     });
   });
 
   describe('isSupportedMiniAppOrJsApiImplVersion', () => {
     fixtures.supportedCauldronMiniAppsVersions.forEach((pkg) => {
-      it(`should not throw if suported version (pkg: ${pkg})`, () => {
+      it(`should not throw if supported version (pkg: ${pkg})`, () => {
         expect(
           () => Ensure.isSupportedMiniAppOrJsApiImplVersion(pkg),
           `throw for ${pkg}`,
@@ -625,12 +522,12 @@ describe('Ensure.js', () => {
         getContainerMetadataPath(tmpDirPath),
         JSON.stringify('{}'),
       );
-      assert(await doesNotThrow(Ensure.isContainerPath, Ensure, tmpDirPath));
+      Ensure.isContainerPath(tmpDirPath);
     });
 
     it('should throw if path does not points to a container', async () => {
       const tmpDirPath = createTmpDir();
-      assert(await doesThrow(Ensure.isContainerPath, Ensure, tmpDirPath));
+      expect(() => Ensure.isContainerPath(tmpDirPath)).to.throw();
     });
   });
 });

--- a/ern-orchestrator/test/launchOnDevice-test.ts
+++ b/ern-orchestrator/test/launchOnDevice-test.ts
@@ -1,7 +1,7 @@
 import * as core from 'ern-core';
 import childProcess from 'child_process';
 import * as build from '../src/buildIosRunner';
-import { doesThrow } from 'ern-util-dev';
+import { rejects } from 'assert';
 import { launchOnDevice } from '../src/launchOnDevice';
 import { assert } from 'chai';
 import sinon from 'sinon';
@@ -55,6 +55,6 @@ describe('launchOnDevice', () => {
 
   it('should throw if ios-deploy fails', async () => {
     sandbox.stub(childProcess, 'spawnSync').throws(new Error('fail'));
-    assert(await doesThrow(launchOnDevice, '/home/user/test', devices));
+    assert(rejects(launchOnDevice('/home/user/test', devices)));
   });
 });

--- a/ern-orchestrator/test/runMiniApp-test.ts
+++ b/ern-orchestrator/test/runMiniApp-test.ts
@@ -10,7 +10,8 @@ import { AppVersionDescriptor, PackagePath, Platform } from 'ern-core';
 import * as publisher from 'ern-container-publisher';
 import * as launch from '../src/launchRunner';
 import * as getRun from '../src/getRunnerGeneratorForPlatform';
-import { doesThrow, fixtures } from 'ern-util-dev';
+import { rejects } from 'assert';
+import { fixtures } from 'ern-util-dev';
 import * as gen from '../src/generateContainerForRunner';
 import { AndroidRunnerGenerator } from 'ern-runner-gen-android';
 import { runMiniApp } from '../src/runMiniApp';
@@ -113,38 +114,35 @@ describe('runMiniApp', () => {
 
   it('should throw if miniapps are provided but not the name of the main miniapp to launch [no local miniapp]', async () => {
     prepareStubs({ miniAppExistInPath: false });
-    assert(
-      await doesThrow(runMiniApp, null, 'android', {
-        miniapps: [
-          PackagePath.fromString('first-miniapp@1.0.0'),
-          PackagePath.fromString('second-miniapp@1.0.0'),
-        ],
-      }),
-    );
+    const args = {
+      miniapps: [
+        PackagePath.fromString('first-miniapp@1.0.0'),
+        PackagePath.fromString('second-miniapp@1.0.0'),
+      ],
+    };
+    assert(rejects(runMiniApp('android', args)));
   });
 
   it('should throw if js api implementations are provided along with a descriptor', async () => {
     prepareStubs();
-    assert(
-      await doesThrow(runMiniApp, null, 'android', {
-        descriptor: testAndroid1770Descriptor,
-        jsApiImpls: [PackagePath.fromString('jsapiimpl@1.0.0')],
-      }),
-    );
+    const args = {
+      descriptor: testAndroid1770Descriptor,
+      jsApiImpls: [PackagePath.fromString('jsapiimpl@1.0.0')],
+    };
+    assert(rejects(runMiniApp('android', args)));
   });
 
   it('should throw if miniapps are provided along with a descriptor', async () => {
     prepareStubs();
-    assert(
-      await doesThrow(runMiniApp, null, 'android', {
-        descriptor: testAndroid1770Descriptor,
-        mainMiniAppName: 'first-miniapp',
-        miniapps: [
-          PackagePath.fromString('first-miniapp@1.0.0'),
-          PackagePath.fromString('second-miniapp@1.0.0'),
-        ],
-      }),
-    );
+    const args = {
+      descriptor: testAndroid1770Descriptor,
+      mainMiniAppName: 'myMiniAppA',
+      miniapps: [
+        PackagePath.fromString('first-miniapp@1.0.0'),
+        PackagePath.fromString('second-miniapp@1.0.0'),
+      ],
+    };
+    assert(rejects(runMiniApp('android', args)));
   });
 
   it('should not start react native packager if dev mode is disabled [local single miniapp]', async () => {

--- a/ern-orchestrator/test/utils-test.js
+++ b/ern-orchestrator/test/utils-test.js
@@ -1,12 +1,8 @@
 import { assert, expect } from 'chai';
 import { AppVersionDescriptor, yarn } from 'ern-core';
 import * as cauldron from 'ern-cauldron-api';
-import {
-  afterTest,
-  beforeTest,
-  doesThrow,
-  fixtures as utilFixtures,
-} from 'ern-util-dev';
+import { afterTest, beforeTest, fixtures as utilFixtures } from 'ern-util-dev';
+import { rejects } from 'assert';
 import * as container from '../src/container';
 import * as composite from '../src/composite';
 import * as pipeline from '../src/runContainerPipelineForDescriptor';
@@ -236,7 +232,7 @@ describe('utils.js', () => {
 
   describe('parseJsonFromStringOrFile', () => {
     it('should throw if the passed string is not valid json', async () => {
-      assert(await doesThrow(parseJsonFromStringOrFile, null, 'invalidjson'));
+      assert(rejects(parseJsonFromStringOrFile('invalidjson')));
     });
 
     it('should return parsed json if string is a patch to a cauldron file', async () => {

--- a/ern-util-dev/src/index.js
+++ b/ern-util-dev/src/index.js
@@ -246,26 +246,6 @@ ${diffOut}
   return api;
 }
 
-export async function doesThrow(asyncFn, thisArg, ...args) {
-  let threwError = false;
-  try {
-    await asyncFn.call(thisArg, ...args);
-  } catch (e) {
-    threwError = true;
-  }
-  return threwError === true;
-}
-
-export async function doesNotThrow(asyncFn, thisArg, ...args) {
-  let threwError = false;
-  try {
-    await asyncFn.call(thisArg, ...args);
-  } catch (e) {
-    threwError = true;
-  }
-  return threwError === false;
-}
-
 let logErrorStub;
 let logInfoStub;
 let logDebugStub;


### PR DESCRIPTION
Remove the two custom methods `doesThrow` and `doesNotThrow` from `ern-util-dev`, and instead use the built-in `assert.rejects(...)` (and `expect(...).to.not.throw()` from chai):

https://nodejs.org/api/assert.html#assert_assert_rejects_asyncfn_error_message

### Example

#### Before

```typescript
      assert(
        await doesThrow(
          object.method,
          object,
          'test'.toAppDescriptor(),
        ),
      );
```

#### After

```typescript
      assert(rejects(object.method('test'.toAppDescriptor())));
```

This results in shorter test code that's easier to read&write, but aside from the cosmetics this also helped uncover several directly related code issues:

Since TypeScript can now properly detect and check parameter types, it turned out that some tests were calling the methods with wrong arguments (previously undetected), and checked for exceptions thrown. Removed these redundant tests which are not testing real world code - Potentially wrong use would be caught at compile time (e.g. "`should throw if the descriptor is partial`").

Some unit tests were not working as expected (asserting the _return_ value of `doesThrow`, instead of waiting the result). These were fixed automatically by now using `rejects` (non-applicable tests removed).