### PR TITLE
Fix logic for raw and regular deps in plugins cfg

### DIFF
--- a/ern-container-gen-android/src/AndroidGenerator.ts
+++ b/ern-container-gen-android/src/AndroidGenerator.ts
@@ -269,7 +269,7 @@ You should replace "${dependency}" with "implementation ${dependency}"`,
 ${annotationProcessorPrefix} dependency prefix has been deprecated and will be removed in a future release.
 You should replace "${annotationProcessorPrefix}:${dependency}" with "annotationProcessor '${dependency}'"`,
               );
-            } else if (/^[^:]+:[^:]+:[^:]+$/.test(dependency)) {
+            } else if (/^[^:\s'(]+:[^:]+:[^:]+$/.test(dependency)) {
               androidDependencies.regular.push(dependency);
             } else {
               androidDependencies.raw.push(dependency);


### PR DESCRIPTION
This fixes an issue with the Android container generator related to distinguishing regular from raw dependencies declared in the manifest plugin configs.

If the string _before_ the first `:` contains a `'`, '`(`', or a space, is should be considered a raw dependency, *not* a regular dependency. Raw dependencies are inserted 1:1 in the generated `build.gradle` file and are the preferred way to declare dependencies from ERN 0.46 going forward (see also #1765).

Examples for regular deps:

```
    "dependencies": [
      "com.google.firebase:firebase-crashlytics:17.1.0",
      "com.google.firebase:firebase-crashlytics-ndk:17.1.0"
    ]
```

Examples for raw deps:

```
    "dependencies": [
      "implementation 'com.example:impl:1.0.0'",
      "api 'com.example:api:1.0.0'",
      "annotationProcessor 'com.example:annotation-processor:1.0.0'",
      "compileOnly 'com.example.compile-only:1.0.0'"
    ]
```