### PR TITLE
Fix ios node modules copy

### DIFF
--- a/ern-container-gen-ios/src/IosGenerator.ts
+++ b/ern-container-gen-ios/src/IosGenerator.ts
@@ -312,7 +312,7 @@ Make sure to run these commands before building the container.`,
 
           //
           // Build an array of these directories
-          const re = RegExp('"../node_modules/([^"]+)"', 'g');
+          const re = RegExp('"?../node_modules/([^"]+)"?;', 'g');
           const matches = [];
           let match = re.exec(f);
           while (match !== null) {


### PR DESCRIPTION
Fix a bug in iOS container generator, that results in some native modules not being properly copied over to target node_modules directory of generated containers.

The bug was due to the RegEx being used to detect the node modules being required by the container pods project, which was missing some modules in some rare case. The only and first occurrence of this issue was noticed with AppCenter native module.

For example, in the usual case _(99% of native modules experienced so far)_ the path to a native module specified in the Pods project.pbxproj will look like this _(quoted)_ :

```
path = "../node_modules/foo/bar";
```

Whereas for the AppCenter native module the path is as follow _(unquoted)_

```
path = ../node_modules/appcenter/ios;
```