### PR TITLE
Add support for ObjC APIs injection

### DIFF
--- a/ern-core/src/Manifest.ts
+++ b/ern-core/src/Manifest.ts
@@ -876,10 +876,21 @@ export class Manifest {
                 path: 'APIs',
                 public: true,
               },
+              {
+                from: 'IOS/*.h',
+                group: 'APIs',
+                path: 'APIs',
+                public: true,
+              },
             ],
             addSource: [
               {
                 from: 'IOS/*.swift',
+                group: 'APIs',
+                path: 'APIs',
+              },
+              {
+                from: 'IOS/*.m',
                 group: 'APIs',
                 path: 'APIs',
               },

--- a/ern-core/src/nativeDependenciesLookup.ts
+++ b/ern-core/src/nativeDependenciesLookup.ts
@@ -9,7 +9,7 @@ const NodeModulesLen = 'node_modules'.length;
 
 export function findDirectoriesContainingNativeCode(rootDir: string): string[] {
   return readDir(rootDir)
-    .filter((a) => /.swift$|.pbxproj$|.java$|.framework\//.test(a))
+    .filter((a) => /\.swift$|\.m$|\.pbxproj$|\.java$|\.framework\//.test(a))
     .filter((a) => !/ElectrodeContainer.framework/.test(a));
 }
 


### PR DESCRIPTION
Add support for injecting ObjectiveC APIs in the iOS container. 

**Please note that such APIs will not be auto generated as the iOS API generator only generates Swift APIs**

This can however be needed in case an ObjectiveC API is manually created _(which can be useful in some scenarios)_.
Indeed, while 99% of APIs use cases will be limited to using generated APIs, one handy thing about APIs is that their sources are injected into the container and exposed to the client application, which can be useful to inject arbitrary native custom code into the container that can be invoked from the client application _(without any JS<->Native cross communication as is the typical use case for APIs)_.

This PR also fixes the RegExp used to detect directories contain native code. 
The problem with this RegExp was that it is looking for specific file/directories extensions, but it was doing so in an incorrect way. For example, it was looking for files ending with `.swift`, without escaping the `.` character, which in RegExp grammar means "any character". So anything ending with `swift` was matched _(same for other file extensions looked for)_.
While it seems like it didn't cause any bad side effects as far as we know _(this code has been here forever and exercised during every container generation)_, it could have _(and still can in current version)_.