### PR TITLE
Add support for React Native 0.64.0

### DIFF
--- a/ern-api-impl-gen/src/generators/android/ApiImplAndroidGenerator.ts
+++ b/ern-api-impl-gen/src/generators/android/ApiImplAndroidGenerator.ts
@@ -114,7 +114,11 @@ export default class ApiImplAndroidGenerator implements ApiImplGeneratable {
         paths,
         apis,
       );
-      await this.updateGradleProperties(paths, outputDirectory);
+      await this.updateGradleProperties(
+        paths,
+        reactNativeVersion,
+        outputDirectory,
+      );
       await this.updateBuildGradle(paths, reactNativeVersion, outputDirectory);
     } finally {
       shell.popd();
@@ -157,6 +161,7 @@ export default class ApiImplAndroidGenerator implements ApiImplGeneratable {
     let mustacheView: any = {};
     const versions = android.resolveAndroidVersions({
       androidGradlePlugin: '3.2.1',
+      reactNativeVersion,
     });
     mustacheView.reactNativeVersion = reactNativeVersion;
     mustacheView = Object.assign(mustacheView, versions);
@@ -174,10 +179,11 @@ export default class ApiImplAndroidGenerator implements ApiImplGeneratable {
 
   public updateGradleProperties(
     paths: any,
+    reactNativeVersion: string,
     outputDirectory: string,
   ): Promise<any> {
     let mustacheView: any = {};
-    const versions = android.resolveAndroidVersions();
+    const versions = android.resolveAndroidVersions({ reactNativeVersion });
     mustacheView = Object.assign(mustacheView, versions);
     return mustacheUtils.mustacheRenderToOutputFileUsingTemplateFile(
       path.join(

--- a/ern-composite-gen/src/Composite.ts
+++ b/ern-composite-gen/src/Composite.ts
@@ -29,4 +29,5 @@ export interface Composite {
   }: {
     manifestId?: string;
   }): Promise<NativeDependencies>;
+  getReactNativeVersion(): string;
 }

--- a/ern-composite-gen/src/GeneratedComposite.ts
+++ b/ern-composite-gen/src/GeneratedComposite.ts
@@ -185,4 +185,8 @@ export class GeneratedComposite implements Composite {
     this.cachedNativeDependencies = nativeDependencies;
     return this.cachedNativeDependencies;
   }
+
+  public getReactNativeVersion(): string {
+    return this.packageJson.dependencies['react-native'];
+  }
 }

--- a/ern-composite-gen/src/WorkspaceComposite.ts
+++ b/ern-composite-gen/src/WorkspaceComposite.ts
@@ -9,6 +9,7 @@ import {
   NativePlatform,
   PackagePath,
   readPackageJson,
+  readPackageJsonSync,
 } from 'ern-core';
 import { Composite } from './Composite';
 
@@ -33,6 +34,7 @@ export class WorkspaceComposite implements Composite {
   public constructor(workspacePath: string) {
     this.path = workspacePath;
     this.miniappsDir = path.join(workspacePath, 'miniapps');
+    this.packageJson = readPackageJsonSync(workspacePath);
   }
 
   public async getJsApiImpls(): Promise<PackagePath[]> {
@@ -136,5 +138,9 @@ export class WorkspaceComposite implements Composite {
     );
     this.cachedNativeDependencies = nativeDependencies;
     return this.cachedNativeDependencies;
+  }
+
+  public getReactNativeVersion(): string {
+    return this.packageJson.dependencies['react-native'];
   }
 }

--- a/ern-composite-gen/src/createMetroConfig.ts
+++ b/ern-composite-gen/src/createMetroConfig.ts
@@ -2,6 +2,8 @@ import fs from 'fs-extra';
 import path from 'path';
 import beautify from 'js-beautify';
 import os from 'os';
+import semver from 'semver';
+import { getMetroBlacklistPath } from 'ern-core';
 
 export async function createMetroConfig({
   cwd,
@@ -9,16 +11,20 @@ export async function createMetroConfig({
   blacklistRe,
   extraNodeModules,
   watchFolders,
+  reactNativeVersion,
 }: {
   cwd?: string;
   projectRoot?: string;
   blacklistRe?: RegExp[];
   extraNodeModules?: { [pkg: string]: string };
   watchFolders?: string[];
+  reactNativeVersion: string;
 }) {
   return fs.writeFile(
     path.join(cwd ?? path.resolve(), 'metro.config.js'),
-    beautify.js(`const blacklist = require('metro-config/src/defaults/blacklist');
+    beautify.js(`const blacklist = require('${getMetroBlacklistPath(
+      reactNativeVersion,
+    )}');
 module.exports = {
   ${projectRoot ? `projectRoot: "${projectRoot}",` : ''}
   ${

--- a/ern-composite-gen/src/generateComposite.ts
+++ b/ern-composite-gen/src/generateComposite.ts
@@ -311,15 +311,16 @@ You should resolve the following version mismatches prior to retrying.${os.EOL}`
       extraPaths: localMiniAppsPaths,
     });
     await createBabelRc({ cwd: outDir, extraPaths: localMiniAppsPaths });
+    const rnVersion = await getNodeModuleVersion({
+      cwd: outDir,
+      name: 'react-native',
+    });
     await createMetroConfig({
       blacklistRe,
       cwd: outDir,
       extraNodeModules,
+      reactNativeVersion: rnVersion,
       watchFolders: localMiniAppsPaths,
-    });
-    const rnVersion = await getNodeModuleVersion({
-      cwd: outDir,
-      name: 'react-native',
     });
     if (semver.gte(rnVersion, '0.57.0')) {
       await createRNCliConfig({ cwd: outDir });

--- a/ern-container-gen-android/src/AndroidGenerator.ts
+++ b/ern-container-gen-android/src/AndroidGenerator.ts
@@ -123,7 +123,10 @@ export default class AndroidGenerator implements ContainerGenerator {
       .run(this.addAndroidPluginHookClasses(config.plugins, config.outDir));
 
     kax.task('Setting Android tools and libraries versions').succeed();
-    const versions = android.resolveAndroidVersions(config.androidConfig);
+    const versions = android.resolveAndroidVersions({
+      reactNativeVersion: reactNativePlugin.version,
+      ...config.androidConfig,
+    });
     mustacheView = Object.assign(mustacheView, versions);
 
     const injectPluginsTaskMsg = 'Injecting Native Dependencies';

--- a/ern-core/src/MiniApp.ts
+++ b/ern-core/src/MiniApp.ts
@@ -21,6 +21,7 @@ import { packageCache } from './packageCache';
 import kax from './kax';
 import { BaseMiniApp } from './BaseMiniApp';
 import _ from 'lodash';
+import { getMetroBlacklistPath } from './getMetroBlacklistPath';
 
 const npmIgnoreContent = `ios/
 android/
@@ -247,7 +248,9 @@ You can find instructions to install CocoaPods @ https://cocoapods.org`);
     if (semver.gt(reactNativeVersion, '0.57.0') && !template) {
       await fs.writeFile(
         path.join(miniAppPath, 'metro.config.js'),
-        `const blacklist = require('metro-config/src/defaults/blacklist');
+        `const blacklist = require('${getMetroBlacklistPath(
+          reactNativeVersion,
+        )}');
 module.exports = {
   resolver: {
     blacklistRE: blacklist([

--- a/ern-core/src/android.ts
+++ b/ern-core/src/android.ts
@@ -19,7 +19,8 @@ export const DEFAULT_BUILD_TOOLS_VERSION = '28.0.3';
 export const DEFAULT_COMPILE_SDK_VERSION = '28';
 export const DEFAULT_GRADLE_DISTRIBUTION_VERSION = '5.4.1';
 export const DEFAULT_JSC_VARIANT = 'android-jsc';
-export const DEFAULT_MIN_SDK_VERSION = '19';
+export const DEFAULT_MIN_SDK_VERSION_PRE_RN64 = '19';
+export const DEFAULT_MIN_SDK_VERSION_POST_RN64 = '21';
 export const DEFAULT_SUPPORT_LIBRARY_VERSION = '28.0.0';
 export const DEFAULT_TARGET_SDK_VERSION = '28';
 export const DEFAULT_SOURCE_COMPATIBILITY = 'VERSION_1_8';
@@ -49,12 +50,32 @@ export function resolveAndroidVersions({
   buildToolsVersion = DEFAULT_BUILD_TOOLS_VERSION,
   compileSdkVersion = DEFAULT_COMPILE_SDK_VERSION,
   gradleDistributionVersion = DEFAULT_GRADLE_DISTRIBUTION_VERSION,
-  minSdkVersion = DEFAULT_MIN_SDK_VERSION,
+  minSdkVersion,
   sourceCompatibility = DEFAULT_SOURCE_COMPATIBILITY,
   supportLibraryVersion = DEFAULT_SUPPORT_LIBRARY_VERSION,
   targetCompatibility = DEFAULT_TARGET_COMPATIBILITY,
   targetSdkVersion = DEFAULT_TARGET_SDK_VERSION,
+  reactNativeVersion,
+}: {
+  androidGradlePlugin?: string;
+  androidxAppcompactVersion?: string;
+  androidxLifecycleExtrnsionsVersion?: string;
+  buildToolsVersion?: string;
+  compileSdkVersion?: string;
+  gradleDistributionVersion?: string;
+  minSdkVersion?: string;
+  sourceCompatibility?: string;
+  supportLibraryVersion?: string;
+  targetCompatibility?: string;
+  targetSdkVersion?: string;
+  reactNativeVersion?: string;
 } = {}): AndroidResolvedVersions {
+  const resolvedMinSdkVersion = minSdkVersion
+    ? minSdkVersion
+    : semver.gte(reactNativeVersion!, '0.64.0')
+    ? DEFAULT_MIN_SDK_VERSION_POST_RN64
+    : DEFAULT_MIN_SDK_VERSION_PRE_RN64;
+
   return {
     androidGradlePlugin,
     androidxAppcompactVersion,
@@ -62,7 +83,7 @@ export function resolveAndroidVersions({
     buildToolsVersion,
     compileSdkVersion,
     gradleDistributionVersion,
-    minSdkVersion,
+    minSdkVersion: resolvedMinSdkVersion,
     sourceCompatibility,
     supportLibraryVersion,
     targetCompatibility,
@@ -433,7 +454,10 @@ export function androidEmulatorPath(): string {
 export function getDefaultHermesVersion(
   reactNativeVersion: string,
 ): string | never {
-  if (semver.gte(reactNativeVersion, '0.63.0')) {
+  if (semver.gte(reactNativeVersion, '0.64.0')) {
+    // https://github.com/facebook/react-native/blob/v0.64.0/package.json#L97
+    return '~0.7.0';
+  } else if (semver.gte(reactNativeVersion, '0.63.0')) {
     // https://github.com/facebook/react-native/blob/v0.63.0/package.json#L98
     return '~0.5.0';
   } else if (semver.gte(reactNativeVersion, '0.62.0')) {

--- a/ern-core/src/getMetroBlacklistPath.ts
+++ b/ern-core/src/getMetroBlacklistPath.ts
@@ -1,0 +1,7 @@
+import semver from 'semver';
+
+export function getMetroBlacklistPath(reactNativeVersion: string) {
+  return semver.gte(reactNativeVersion, '0.64.0')
+    ? 'metro-config/src/defaults/exclusionList'
+    : 'metro-config/src/defaults/blacklist';
+}

--- a/ern-core/src/index.ts
+++ b/ern-core/src/index.ts
@@ -109,3 +109,4 @@ export { getCodePushInitConfig } from './getCodePushInitConfig';
 export { PackageManager } from './PackageManager';
 export { LogLevel } from './coloredLog';
 export { IosDevice } from './ios';
+export { getMetroBlacklistPath } from './getMetroBlacklistPath';

--- a/ern-core/src/iosUtil.ts
+++ b/ern-core/src/iosUtil.ts
@@ -558,7 +558,9 @@ function switchToOldDirectoryStructure(
 }
 
 export const getDefaultIosDeploymentTarget = (rnVersion: string): string => {
-  if (semver.gte(rnVersion, '0.63.0')) {
+  if (semver.gte(rnVersion, '0.64.0')) {
+    return '11.0';
+  } else if (semver.gte(rnVersion, '0.63.0')) {
     return '10.0';
   } else if (semver.gte(rnVersion, '0.56.0')) {
     return '9.0';

--- a/ern-core/test/android-test.ts
+++ b/ern-core/test/android-test.ts
@@ -209,8 +209,10 @@ describe('android.js', () => {
   });
 
   describe('resolveAndroidVersions', () => {
-    it('should return all default versions if no versions are provided', () => {
-      const versions = android.resolveAndroidVersions();
+    it('should return all default versions if no versions are provided [>= RN 0.64.0]', () => {
+      const versions = android.resolveAndroidVersions({
+        reactNativeVersion: '0.64.0',
+      });
       expect(versions).deep.equal({
         androidGradlePlugin: android.DEFAULT_ANDROID_GRADLE_PLUGIN_VERSION,
         androidxAppcompactVersion: android.DEFAULT_ANDROIDX_APPCOMPACT_VERSION,
@@ -219,7 +221,27 @@ describe('android.js', () => {
         buildToolsVersion: android.DEFAULT_BUILD_TOOLS_VERSION,
         compileSdkVersion: android.DEFAULT_COMPILE_SDK_VERSION,
         gradleDistributionVersion: android.DEFAULT_GRADLE_DISTRIBUTION_VERSION,
-        minSdkVersion: android.DEFAULT_MIN_SDK_VERSION,
+        minSdkVersion: android.DEFAULT_MIN_SDK_VERSION_POST_RN64,
+        sourceCompatibility: android.DEFAULT_SOURCE_COMPATIBILITY,
+        supportLibraryVersion: android.DEFAULT_SUPPORT_LIBRARY_VERSION,
+        targetCompatibility: android.DEFAULT_TARGET_COMPATIBILITY,
+        targetSdkVersion: android.DEFAULT_TARGET_SDK_VERSION,
+      });
+    });
+
+    it('should return all default versions if no versions are provided [< RN 0.64.0]', () => {
+      const versions = android.resolveAndroidVersions({
+        reactNativeVersion: '0.63.0',
+      });
+      expect(versions).deep.equal({
+        androidGradlePlugin: android.DEFAULT_ANDROID_GRADLE_PLUGIN_VERSION,
+        androidxAppcompactVersion: android.DEFAULT_ANDROIDX_APPCOMPACT_VERSION,
+        androidxLifecycleExtrnsionsVersion:
+          android.DEFAULT_ANDROIDX_LIFECYCLE_EXTENSIONS_VERSION,
+        buildToolsVersion: android.DEFAULT_BUILD_TOOLS_VERSION,
+        compileSdkVersion: android.DEFAULT_COMPILE_SDK_VERSION,
+        gradleDistributionVersion: android.DEFAULT_GRADLE_DISTRIBUTION_VERSION,
+        minSdkVersion: android.DEFAULT_MIN_SDK_VERSION_PRE_RN64,
         sourceCompatibility: android.DEFAULT_SOURCE_COMPATIBILITY,
         supportLibraryVersion: android.DEFAULT_SUPPORT_LIBRARY_VERSION,
         targetCompatibility: android.DEFAULT_TARGET_COMPATIBILITY,

--- a/ern-orchestrator/src/start.ts
+++ b/ern-orchestrator/src/start.ts
@@ -194,6 +194,7 @@ export default async function start({
       blacklistRe,
       cwd: composite.path,
       extraNodeModules,
+      reactNativeVersion: composite.getReactNativeVersion(),
       watchFolders: allLocalMiniAppsPaths,
     });
   }

--- a/ern-runner-gen-android/src/AndroidRunnerGenerator.ts
+++ b/ern-runner-gen-android/src/AndroidRunnerGenerator.ts
@@ -86,7 +86,10 @@ function configureMustacheView(
   config: RunnerGeneratorConfig,
   mustacheView: any,
 ) {
-  const versions = android.resolveAndroidVersions(config.extra?.androidConfig);
+  const versions = android.resolveAndroidVersions({
+    reactNativeVersion: config.reactNativeVersion,
+    ...config.extra?.androidConfig,
+  });
   mustacheView = Object.assign(mustacheView, versions);
 
   mustacheView.isReactNativeDevSupportEnabled =


### PR DESCRIPTION
Add Android & iOS support for React Native 0.64.0.

React Native 0.64.0 AAR has already been published to [Maven Central](https://repo1.maven.org/maven2/com/walmartlabs/ern/react-native/0.64.0/). 

The changes to Electrode Native, part of this PR, accounts for the following changes in RN 0.64 :

### Android 

- Minimum SDK level now set to 21
- Hermes engine package version bumped to ~0.0.7

### iOS

- New requirement on react-native-codegen package to generate Turbo Modules from specs
- Updated module locations and new modules _(changes done through new plugin configuration in manifest : https://github.com/electrode-io/electrode-native-manifest/pull/214)_

### Platform Independent

- Metro blacklist source file renamed from `blacklist` to `exclusionList`