### PR TITLE
Do not mustache process Android res directory

### DIFF
--- a/ern-container-gen-android/src/AndroidGenerator.ts
+++ b/ern-container-gen-android/src/AndroidGenerator.ts
@@ -340,6 +340,7 @@ You should replace "${annotationProcessorPrefix}:${dependency}" with "annotation
     const pathLibSrcMainJniLibs = path.normalize('lib/src/main/jniLibs');
     const pathLibSrcMainAssets = path.normalize('lib/src/main/assets');
     const pathLibSrcMainJavaCom = path.join(pathLibSrcMain, 'java/com');
+    const pathLibSrcMainRes = path.join(pathLibSrcMain, 'res');
     const pathLibSrcMainJavaComWalmartlabsErnContainer = path.join(
       pathLibSrcMainJavaCom,
       'walmartlabs/ern/container',
@@ -349,7 +350,8 @@ You should replace "${annotationProcessorPrefix}:${dependency}" with "annotation
         (file.startsWith(pathLibSrcMainJavaCom) &&
           !file.startsWith(pathLibSrcMainJavaComWalmartlabsErnContainer)) ||
         file.startsWith(pathLibSrcMainAssets) ||
-        file.startsWith(pathLibSrcMainJniLibs)
+        file.startsWith(pathLibSrcMainJniLibs) ||
+        file.startsWith(pathLibSrcMainRes)
       ) {
         // We don't want to Mustache process library files. It can lead to bad things
         // We also don't want to process assets files ...


### PR DESCRIPTION
Mustache processing the `res` container directory can cause mustache templating to fail, _(because for example some binary file present in res, such as an image png, contains {{ by chance, causing mustache templater to throw an error for unclosed placeholder in a file)_.

This PR addresses this issue by adding Android Container `res` directory to the list of directories excluded from mustache template processing.