### PR TITLE
Improve ern start command logging

### DIFF
--- a/ern-orchestrator/src/start.ts
+++ b/ern-orchestrator/src/start.ts
@@ -75,6 +75,12 @@ export default async function start({
     );
   }
 
+  miniapps
+    .filter((m) => m.isFilePath)
+    .forEach((m) => {
+      kax.task(`Auto linking local MiniApp from ${m.basePath}`).succeed();
+    });
+
   let resolutions;
   if (descriptor && cauldron) {
     miniapps = await cauldron.getContainerMiniApps(descriptor, {
@@ -210,6 +216,10 @@ ${nonInstalledMiniAppsPath.join('\n')}
       reactNativeVersion: composite.getReactNativeVersion(),
       watchFolders: allLocalMiniAppsPaths,
     });
+
+    allLocalMiniAppsPaths.forEach((m) =>
+      log.info(`Watching for changes in linked directory ${m}`),
+    );
   }
 
   reactnative.startPackager({


### PR DESCRIPTION
Improve `ern start` command logging to give better feedback on all linked MiniApps.

- Reintroduce logging of linked directories _(fixing regression done in [this commit](https://github.com/electrode-io/electrode-native/commit/e52951cf60a86b4a9d5f59cb73a2119afa6a9a20#diff-d74ec06d0d0c724b4a896c9322f1b2c20e815c9aa8f47a0545b4b8e0b9f30574L208-L213))_
- Add explicit logging indicating auto linking of local MiniApps, prior to generating the composite.

Sample output :

```
➜  ern start --miniapps /Users/foo/first-miniapp git+ssh://git@github.com:foo/second-miniapp.git
✔ Ensuring that metro server is not running 3s
✔ Auto linking local MiniApp from /Users/foo/first-miniapp 0s
✔ Generating MiniApps composite 44s
  ✔ Cleaning up existing composite directory 0s
  ✔ [1/1] Adding git+ssh://git@github.com:foo/second-miniapp.git 33s
  ✔ Adding extra packages to the composite 7s
  ✔ Syncing https://github.com/electrode-io/electrode-native-manifest.git Manifest 1s
ℹ Watching for changes in linked directory /Users/foo/first-miniapp
ℹ Watching for changes in linked directory /Users/foo/second-miniapp
```