### PR TITLE
Add linked miniapps installation check for ern start

### DIFF
--- a/ern-orchestrator/src/start.ts
+++ b/ern-orchestrator/src/start.ts
@@ -186,6 +186,19 @@ export default async function start({
       ...activeLinkedPkgPaths,
     ];
 
+    const nonInstalledMiniAppsPath: string[] = [];
+    allLocalMiniAppsPaths.forEach((p) => {
+      if (!fs.pathExistsSync(path.join(p, 'node_modules'))) {
+        nonInstalledMiniAppsPath.push(p);
+      }
+    });
+    if (nonInstalledMiniAppsPath.length > 0) {
+      throw new Error(`Some linked MiniApp(s) have not been installed.
+Please run 'yarn install' or 'npm install' from the following directories before running 'ern start' :
+${nonInstalledMiniAppsPath.join('\n')}
+      `);
+    }
+
     await patchCompositeBabelRcRoots({
       cwd: composite.path,
       extraPaths: allLocalMiniAppsPaths,


### PR DESCRIPTION
Improve `ern start` command by adding a check to ensure that all linked MiniApps _(either implictly for local miniapps or explicitly for remote miniapps)_ haven been properly installed _(i.e `yarn install` or `npm install` was run from these directories)_

It actually happened to me quite a few times _(and probably to some other users)_ to use `ern start` with some local MiniApps I forgot to install, leading to a confusing obscure red screen at runtime.

This PR catches this problem early on, before launching the packager, to avoid running into a runtime issue.

