### PR TITLE
Introduce new run-container-pipeline command

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -75,6 +75,7 @@
 - [create-plugin-config](cli/create-plugin-config.md)
 - [publish-container](cli/publish-container.md)
 - [transform-container](cli/transform-container.md)
+- [run-container-pipeline](cli/run-container-pipeline.md)
 - [create-miniapp](cli/create-miniapp.md)
 - [link](cli/link.md)
 - [regen-api](cli/regen-api.md)

--- a/docs/cli/run-container-pipeline.md
+++ b/docs/cli/run-container-pipeline.md
@@ -1,0 +1,39 @@
+## `ern run-container-pipeline`
+
+#### Description
+
+- This command can be used to run a local pre-generated Container through a Container pipeline _(aribtrary sequence of transformers & publishers)_
+
+#### Syntax
+
+`ern run-container-pipeline`
+
+**Options**
+
+`--containerPath`
+
+- The local file system path to the directory containing the Container to run through the pipeline.
+- **Default** If this option is not provided, the command will look for a Container in the default platform directory `~/.ern/containergen/out/[platform]`.
+
+`--pipeline`
+
+- Path to the JSON file containing the pipeline configuration.
+- Can either be a local file system path to the JSON file, or a path to a JSON file stored in the cauldron _(for example cauldron://config/my-pipeline.json for a my-pipeline.json file stored in config directory in the cauldron)_
+
+`--platform`
+
+- Specify the native platform of the target Container (`android` or `ios`)
+- This option is required, there is no default.
+
+`--version/-v`
+
+- Specify the Container version to use for publication.
+- The version will be ignored if the pipeline is only composed of transformers.
+- Defaults to `1.0.0`.
+
+#### Remarks
+
+Refer to [container publication] and [container integration] documentation for more details regarding the structure of the JSON pertaining to pipeline configuration.
+
+[container publication]: ../platform-parts/container/container-publication.md
+[container integration]: ../platform-parts/container/container-integration.md

--- a/ern-local-cli/src/commands/run-container-pipeline.ts
+++ b/ern-local-cli/src/commands/run-container-pipeline.ts
@@ -1,0 +1,92 @@
+import { log, NativePlatform, PackagePath, Platform, kax } from 'ern-core';
+import {
+  parseJsonFromStringOrFile,
+  runContainerPipeline,
+} from 'ern-orchestrator';
+import { epilog, logErrorAndExitIfNotSatisfied, tryCatchWrap } from '../lib';
+import { Argv } from 'yargs';
+import untildify from 'untildify';
+
+export const command = 'run-container-pipeline';
+export const desc = 'Run a Container pipeline';
+
+export const builder = (argv: Argv) => {
+  return argv
+    .option('containerPath', {
+      describe: 'Local path to the Container to run through the pipeline',
+      type: 'string',
+    })
+    .coerce('containerPath', (p) => untildify(p))
+    .option('pipeline', {
+      demandOption: true,
+      describe: 'Path to pipeline (local or cauldron)',
+      type: 'string',
+    })
+    .coerce('pipeline', (p) => untildify(p))
+    .option('platform', {
+      choices: ['android', 'ios'],
+      demandOption: true,
+      describe: 'The native platform of the Container',
+      type: 'string',
+    })
+    .option('version', {
+      alias: 'v',
+      default: '1.0.0',
+      describe: 'Container version to use for publication',
+      type: 'string',
+    })
+    .epilog(epilog(exports));
+};
+
+export const commandHandler = async ({
+  containerPath,
+  pipeline,
+  platform,
+  version,
+}: {
+  containerPath?: string;
+  pipeline: string;
+  platform: NativePlatform;
+  version: string;
+}) => {
+  containerPath =
+    containerPath || Platform.getContainerGenOutDirectory(platform);
+
+  await logErrorAndExitIfNotSatisfied({
+    isContainerPath: {
+      extraErrorMessage: `Make sure that ${containerPath} is the root of a Container project`,
+      p: containerPath!,
+    },
+  });
+
+  let pipelineObj: any;
+  try {
+    pipelineObj = await parseJsonFromStringOrFile(pipeline);
+  } catch (e) {
+    throw new Error('(--pipeline option): Invalid input');
+  }
+
+  if (!pipelineObj?.containerGenerator?.pipeline) {
+    throw new Error(`Invalid pipeline configuration.
+Make sure that the pipeline is an array set inside containerGenerator as illustrated below.
+{
+  "containerGenerator": {
+    "pipeline": [
+    ]
+  }
+}`);
+  }
+
+  await kax.task('Running Container pipeline').run(
+    runContainerPipeline({
+      containerPath,
+      containerVersion: version,
+      pipeline: pipelineObj.containerGenerator.pipeline,
+      platform,
+    }),
+  );
+
+  kax.task('Container pipeline successfully run').succeed();
+};
+
+export const handler = tryCatchWrap(commandHandler);


### PR DESCRIPTION
This PR introduces a new Electrode Native command, `run-container-pipeline`.

It allows to run a locally created container through a given Container pipeline.

A Container pipeline is a collection of Container `transformers` and/or `publishers` _(defined as `pipeline blocks`)_ that are run in sequence, one after the other, when using the `cauldron regen-container` command.

This is a convenient structure as it allows to define a chain of transformer and/or publishers to run, along with their configuration, in the form of JSON configuration files stored locally, or in a Cauldron. It ultimately simplifies the sequencing of transformers/publishers without having to chain multiple `transform-container`/`publish-container` commands manually, each having to be fed their own configuration.

One limitation, thus far, of such a pipeline configuration, is that it is only consumed when using the `cauldron regen-container` command. This command, first of all strongly requires a Cauldron, but also encompass many other tasks _(generating the container, updating the cauldron descriptor, yarn lock ...)_ which might not be needed or desired in case one just wants to run a sequence of transformer/publishers conveniently for a pre-generated container, and nothing more.

Up until this PR, the only was to run a container through a sequence of transformers/publishers, was to manually sequence `publish-container`/`transform-container` commands. This PR tackles this inconvenience, with the introduction of the `run-container-pipeline` command, that allows to run a container through a pipeline, configured in a JSON file _(either stored locally or in a remote cauldron)_, simplifying some use cases.

