### PR TITLE
Generate miniapp navigation controllers for iOS containers

### DIFF
--- a/ern-container-gen-ios/src/hull/ElectrodeContainer.xcodeproj/project.pbxproj
+++ b/ern-container-gen-ios/src/hull/ElectrodeContainer.xcodeproj/project.pbxproj
@@ -128,6 +128,13 @@
 			name = APIs;
 			sourceTree = "<group>";
 		};
+		22C096A91EA0893F00E1486B /* MiniAppNavigationControllers */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = MiniAppNavigationControllers;
+			sourceTree = "<group>";
+		};
 		22FD4D1E1E96ECBB00FC81DB /* ElectrodeReactNativeBridge */ = {
 			isa = PBXGroup;
 			children = (
@@ -171,6 +178,7 @@
 				301CBA4B1F342FB00048C58B /* Resources */,
 				2265A4A11EB26943007D6C3D /* Info.plist */,
 				22C096A91EA0893F00E1486A /* APIs */,
+				22C096A91EA0893F00E1486B /* MiniAppNavigationControllers */,
 				22FD4D1E1E96ECBB00FC81DB /* ElectrodeReactNativeBridge */,
 				968333D51E54E3470031C565 /* ElectrodeBridgeDelegate.h */,
 				968333D61E54E3470031C565 /* ElectrodeBridgeDelegate.m */,

--- a/ern-container-gen-ios/src/hull/ElectrodeContainer/MiniAppNavigationControllers/README.md
+++ b/ern-container-gen-ios/src/hull/ElectrodeContainer/MiniAppNavigationControllers/README.md
@@ -1,0 +1,1 @@
+MiniAppNavigationControllers

--- a/ern-container-gen-ios/src/templates/MiniAppNavigationController.mustache
+++ b/ern-container-gen-ios/src/templates/MiniAppNavigationController.mustache
@@ -1,0 +1,9 @@
+{{>licenseInfo}}
+
+open class {{{pascalCaseName}}}NavigationController: ENBaseNavigationController {
+
+    open override func getRootComponentName() -> String {
+        return "{{{name}}}"
+    }
+
+}

--- a/ern-container-gen-ios/src/templates/licenseInfo.mustache
+++ b/ern-container-gen-ios/src/templates/licenseInfo.mustache
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2020 Walmart Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/system-tests/fixtures/ios-container/ElectrodeContainer/MiniAppNavigationControllers/MovieDetailsMiniAppNavigationController.swift
+++ b/system-tests/fixtures/ios-container/ElectrodeContainer/MiniAppNavigationControllers/MovieDetailsMiniAppNavigationController.swift
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Walmart Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+open class MovieDetailsMiniAppNavigationController: ENBaseNavigationController {
+
+    open override func getRootComponentName() -> String {
+        return "MovieDetailsMiniApp"
+    }
+
+}

--- a/system-tests/fixtures/ios-container/ElectrodeContainer/MiniAppNavigationControllers/MovieListMiniAppNavigationController.swift
+++ b/system-tests/fixtures/ios-container/ElectrodeContainer/MiniAppNavigationControllers/MovieListMiniAppNavigationController.swift
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Walmart Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+open class MovieListMiniAppNavigationController: ENBaseNavigationController {
+
+    open override func getRootComponentName() -> String {
+        return "MovieListMiniApp"
+    }
+
+}

--- a/system-tests/fixtures/ios-container/ElectrodeContainer/MiniAppNavigationControllers/README.md
+++ b/system-tests/fixtures/ios-container/ElectrodeContainer/MiniAppNavigationControllers/README.md
@@ -1,0 +1,1 @@
+MiniAppNavigationControllers


### PR DESCRIPTION
@belemaire goal is to generate subclasses of ENBaseNavigationController inside the container. I'm able to generate the files, following the example from https://github.com/electrode-io/electrode-native/blob/master/ern-container-gen-android/src/AndroidGenerator.ts

However, not sure how to include the references to the new files inside the pbxproj file of the container so that it will show up in the project navigator when using Xcode.