### PR TITLE
Fix ios container mustache template copy

### DIFF
--- a/ern-container-gen-ios/package.json
+++ b/ern-container-gen-ios/package.json
@@ -54,6 +54,10 @@
     {
       "source": "src/hull",
       "dest": "dist"
+    },
+    {
+      "source": "src/templates",
+      "dest": "dist"
     }
   ]
 }


### PR DESCRIPTION
Fix bug introduced in ERN 0.47.0 via https://github.com/electrode-io/electrode-native/pull/1790

Some mustache templates to generate iOS files in the container were introduced in this PR, but were not copied over to release package directory, leading to error when trying to generate an iOS container.

Will be released as hotfix in ERN 0.47.1