### PR TITLE
Fix paths for miniapp nav controllers to be relative

### DIFF
--- a/ern-container-gen-ios/src/IosGenerator.ts
+++ b/ern-container-gen-ios/src/IosGenerator.ts
@@ -564,12 +564,16 @@ Make sure to run these commands before building the container.`,
         pathToOutputNavControllerFile,
         partialProxy,
       );
+      const relativePathToNavControllerFile = path.join(
+        'MiniAppNavigationControllers',
+        navControllerFileName,
+      )
       containerIosProject.addFile(
-        pathToOutputNavControllerFile,
+        relativePathToNavControllerFile,
         containerIosProject.findPBXGroupKey({ name: 'MiniAppNavigationControllers' }),
       );
       containerIosProject.addSourceFile(
-        pathToOutputNavControllerFile,
+        relativePathToNavControllerFile,
         null,
         containerIosProject.findPBXGroupKey({ name: 'MiniAppNavigationControllers' }),
       );


### PR DESCRIPTION
Pbxproj file paths should be relative instead of full

ex: 
path = "MiniAppNavigationControllers/AccountMiniAppNavigationController.swift"

instead of 

path = "/Users/jenkinspan/looper-workspace/workspace/.../ios/ElectrodeContainer/MiniAppNavigationControllers/AccountMiniAppNavigationController.swift"