### PR TITLE
Add excludedNativeModules to ios container config

### DIFF
--- a/ern-container-gen-ios/src/IosGenerator.ts
+++ b/ern-container-gen-ios/src/IosGenerator.ts
@@ -267,13 +267,12 @@ Make sure to run these commands before building the container.`,
       config.plugins,
       mustacheView,
       config.composite,
+      config.iosConfig,
     );
 
     await kax
       .task('Adding MiniAppNavigationController Classes')
-      .run(
-        this.addMiniAppNavigationControllerClasses(config, iosProject),
-      );
+      .run(this.addMiniAppNavigationControllerClasses(config, iosProject));
 
     await kax
       .task('Adding Native Dependencies Hooks')
@@ -567,15 +566,19 @@ Make sure to run these commands before building the container.`,
       const relativePathToNavControllerFile = path.join(
         'MiniAppNavigationControllers',
         navControllerFileName,
-      )
+      );
       containerIosProject.addFile(
         relativePathToNavControllerFile,
-        containerIosProject.findPBXGroupKey({ name: 'MiniAppNavigationControllers' }),
+        containerIosProject.findPBXGroupKey({
+          name: 'MiniAppNavigationControllers',
+        }),
       );
       containerIosProject.addSourceFile(
         relativePathToNavControllerFile,
         null,
-        containerIosProject.findPBXGroupKey({ name: 'MiniAppNavigationControllers' }),
+        containerIosProject.findPBXGroupKey({
+          name: 'MiniAppNavigationControllers',
+        }),
       );
     }
   }

--- a/ern-core/src/iosUtil.ts
+++ b/ern-core/src/iosUtil.ts
@@ -33,6 +33,7 @@ export async function fillProjectHull(
   plugins: PackagePath[],
   mustacheView?: any,
   composite?: any,
+  iosConfig?: any,
 ) {
   log.debug(`[=== Starting iOS framework project hull filling ===]`);
   shell.pushd(pathSpec.rootDir);
@@ -452,7 +453,17 @@ ${JSON.stringify(options.staticLibs, null, 2)}
           shell.cp(sourcePodspecPath, destPodspecPath);
         }
 
-        if (ignorePodSpec && reExec) {
+        if (
+          (ignorePodSpec && reExec) ||
+          (reExec && iosConfig?.excludedNativeModules?.includes(reExec[1]))
+        ) {
+          log.debug(
+            `Ignoring ${reExec[1]} native module pod ${
+              ignorePodSpec
+                ? '(ignorePodSpec directive set in manifest for this module)'
+                : '(Present in ios container config excludedNativeModules array)'
+            }`,
+          );
           const podspecs: string[] = await new Promise((resolve, reject) => {
             glob(
               path.join(


### PR DESCRIPTION
Add new `excludedNativeModules` iOS container configuration property.

It can be used to selectively exclude one or more native modules pods so that they don't get injected inside the container.
It has the same effect as using `ignorePodSpec` directive in a manifest plugin configuration.
While the native module pod will be ignored, causing the native module native code to be completly ignored and not injected in the container, it won't impact the JavaScript side of the native module which will still be bundled in case the JS application code is importing and consuming the native module JS surface.

As any iOS container generator configuration, this property can either be set in cauldron configuration via `containerGenerator.iosConfig` or directly supplied to `create-container` or `run-ios` commands, using the `--extra` option.
i.e `create-container --extra='{"iosConfig": {"excludedNativeModules": ["react-native-module-name"]}'`

This property can be used in case one container flavor should contain a certain native module native code _(in case the native application depending on the container doesn't have this native code)_, while another shouldn't _(in case the native application depending on the container already contains this native code)_.. This is obviously for fringe uses cases as the native module native code shouldn't be part of the client application _(unless this is a react native application, which Electrode Native doesn't officially support -yet-)_

Due to the very fringe nature of this feature, needed only for a single internal use case, it won't be documented at this point.