### PR TITLE
add support to execute pre/post scripts

### DIFF
--- a/ern-container-gen/src/executeBundleHooks.ts
+++ b/ern-container-gen/src/executeBundleHooks.ts
@@ -1,0 +1,39 @@
+import fs from 'fs-extra';
+import { getActiveCauldron } from 'ern-cauldron-api';
+import path from 'path';
+import shell from 'shelljs';
+import tmp from 'tmp';
+
+export async function executeBundleHooks(
+  scriptPath: string,
+  workingDirectory: string,
+): Promise<number> {
+  let pathToScript = scriptPath;
+  if (pathToScript.startsWith('cauldron://')) {
+    const localRepoPath = tmp.dirSync({ unsafeCleanup: true }).name;
+    const cauldron = await getActiveCauldron({
+      localRepoPath,
+      throwIfNoActiveCauldron: false,
+    });
+    if (!cauldron) {
+      throw new Error(`A Cauldron needs to be active to run ${pathToScript}`);
+    } else if (!(await cauldron.hasFile({ cauldronFilePath: pathToScript }))) {
+      throw new Error(`Cannot find ${pathToScript} in Cauldron`);
+    }
+    const scriptFile = await cauldron.getFile({
+      cauldronFilePath: pathToScript,
+    });
+    const scriptFileName = path.basename(
+      pathToScript.replace('cauldron://', ''),
+    );
+    const tmpScriptDir = tmp.dirSync({ unsafeCleanup: true }).name;
+    pathToScript = path.join(tmpScriptDir, scriptFileName);
+    fs.writeFileSync(pathToScript, scriptFile.toString());
+    shell.chmod('+x', pathToScript);
+  }
+  const scriptResult = shell.exec(pathToScript, { cwd: workingDirectory });
+  if (scriptResult.code !== 0) {
+    throw new Error(`Script execution failed with code ${scriptResult.code}`);
+  }
+  return scriptResult.code;
+}

--- a/ern-container-gen/src/generateContainer.ts
+++ b/ern-container-gen/src/generateContainer.ts
@@ -5,6 +5,7 @@ import { copyRnConfigAssets } from './copyRnConfigAssets';
 import { addContainerMetadata } from './addContainerMetadata';
 import { ContainerGeneratorConfig, ContainerGenResult } from './types';
 import { BundlingResult, kax, shell } from 'ern-core';
+import { executeBundleHooks } from './executeBundleHooks';
 import fs from 'fs-extra';
 import path from 'path';
 import _ from 'lodash';
@@ -65,6 +66,10 @@ export async function generateContainer(
     shell.popd();
   }
 
+  if (config?.hooks?.preBundle) {
+    await executeBundleHooks(config?.hooks?.preBundle, config.composite.path);
+  }
+
   const bundlingResult: BundlingResult = await kax
     .task('Bundling MiniApps')
     .run(
@@ -77,6 +82,10 @@ export async function generateContainer(
         sourceMapOutput: config.sourceMapOutput,
       }),
     );
+
+  if (config?.hooks?.postBundle) {
+    await executeBundleHooks(config?.hooks?.postBundle, config.outDir);
+  }
 
   if (postBundle) {
     await postBundle(config, bundlingResult, reactNativePlugin?.version!);

--- a/ern-container-gen/src/types/ContainerGeneratorConfig.ts
+++ b/ern-container-gen/src/types/ContainerGeneratorConfig.ts
@@ -1,5 +1,6 @@
 import { NativePlatform, PackagePath } from 'ern-core';
 import { Composite } from 'ern-composite-gen';
+import { ContainerGeneratorHooks } from './ContainerGeneratorHooks';
 
 export interface ContainerGeneratorConfig {
   /**
@@ -47,4 +48,8 @@ export interface ContainerGeneratorConfig {
    * Indicates whether to reset the React Native cache prior to bundling
    */
   resetCache?: boolean;
+  /**
+   * Path to run script pre and/or post js bundling
+   */
+  hooks?: ContainerGeneratorHooks;
 }

--- a/ern-container-gen/src/types/ContainerGeneratorHooks.ts
+++ b/ern-container-gen/src/types/ContainerGeneratorHooks.ts
@@ -1,0 +1,10 @@
+export interface ContainerGeneratorHooks {
+  /**
+   * Path to script to be executed just after composite generation
+   */
+  preBundle?: string;
+  /**
+   * Path to script to be executed just after metro bundler has been run
+   */
+  postBundle?: string;
+}

--- a/ern-orchestrator/src/container.ts
+++ b/ern-orchestrator/src/container.ts
@@ -48,12 +48,12 @@ export async function runLocalContainerGen(
 ): Promise<ContainerGenResult> {
   try {
     const generator = getGeneratorForPlatform(platform);
-
     return kax.task('Generating Container').run(
       generator.generate({
         androidConfig: (extra && extra.androidConfig) || {},
         composite,
         devJsBundle,
+        hooks: extra?.containerGenerator?.hooks ?? {},
         ignoreRnpmAssets,
         iosConfig: (extra && extra.iosConfig) || {},
         jsMainModuleName,
@@ -117,6 +117,7 @@ export async function runCauldronContainerGen(
             devJsBundle === undefined
               ? containerGeneratorConfig && containerGeneratorConfig.devJsBundle
               : devJsBundle,
+          hooks: containerGeneratorConfig?.hooks ?? {},
           ignoreRnpmAssets:
             containerGeneratorConfig &&
             containerGeneratorConfig.ignoreRnpmAssets,


### PR DESCRIPTION
sample commands 
- `ern run-android --extra '{"containerGenerator": {"hooks": {"preBundle": "/Users/k0s00ly/workspace/ern/picking-miniapp/script/pre-script.sh","postBundle": "/Users/k0s00ly/workspace/ern/picking-miniapp/script/post-script.sh"}}}'
`
- `ern run-android --extra cauldron://config/config.json
`
- `ern create-container --miniapps file:///Users/k0s00ly/workspace/ern/picking-miniapp --extra cauldron://config/config.json
`

****** OUTPUT ******

```
exec /var/folders/qw/0dxtwnhn2px_n55zdrtcx46w0000gp/T/tmp-36171kyCBi44Y8br5/pre-script.sh
{
  cwd: '/private/var/folders/qw/0dxtwnhn2px_n55zdrtcx46w0000gp/T/tmp-36171HCvrf9IJcFIL'
}
Recognized Pre Script
```
```
exec /var/folders/qw/0dxtwnhn2px_n55zdrtcx46w0000gp/T/tmp-3617133qECZy0xWqR/post-script.sh 
{ cwd: '/Users/k0s00ly/.ern/containergen/out/android' }
Recognized Post Script
```
Description
hooks to run an arbitrary script, before and/or after JS bundling. The hooks object will expose two optional properties preBundle and postBundle both taking a path to a script (either local path on the machine OR path to script stored in Cauldron)

If a script is defined as a `preBundle` hook, it should be executed just after composite generation, prior to running metro bundler, from the directory containing the generated composite project, without any arguments passed to it.

If a script is defined as a `postBundle` hook, it should be executed just after metro bundler has been run, from the directory containing the bundle, without any arguments passed to it.

Program to use to run the script should be indicated using `shebang pattern` in the script itself as first-line (for ex `#!/usr/bin/env node`) so that the shell can run the script accordingly.
