### PR TITLE
Dedupe yarn.log and apply formatter

### DIFF
--- a/ern-api-gen/src/ApiGenUtils.ts
+++ b/ern-api-gen/src/ApiGenUtils.ts
@@ -24,10 +24,8 @@ export default class ApiGenUtils {
       }[] = [];
       for (const apiKey in apis) {
         if (apis.hasOwnProperty(apiKey)) {
-          const {
-            requests,
-            events,
-          } = ApiGenUtils.generateApiEventsAndRequestNames(apis[apiKey]);
+          const { requests, events } =
+            ApiGenUtils.generateApiEventsAndRequestNames(apis[apiKey]);
           result.push({ apiName: apiKey, requests, events });
         }
       }
@@ -37,9 +35,10 @@ export default class ApiGenUtils {
     }
   }
 
-  public static generateApiEventsAndRequestNames(
-    api: any,
-  ): { requests: string[]; events: string[] } {
+  public static generateApiEventsAndRequestNames(api: any): {
+    requests: string[];
+    events: string[];
+  } {
     const requests: string[] = [];
     const events: string[] = [];
     for (const key in api) {

--- a/ern-api-gen/src/DefaultCodegen.ts
+++ b/ern-api-gen/src/DefaultCodegen.ts
@@ -2110,7 +2110,9 @@ Using global produces (${swagger.getProduces()}) for ${op.operationId}`,
       }
       if (property == null) {
         log.warn(
-          `warning!  Property type "${type}" not found for parameter "${(param as any).getName()}", using String`,
+          `warning!  Property type "${type}" not found for parameter "${(
+            param as any
+          ).getName()}", using String`,
         );
         property = (new StringProperty() as any).description(
           '//TODO automatically added by swagger-codegen.  Type was ' +
@@ -2331,11 +2333,19 @@ Using global produces (${swagger.getProduces()}) for ${op.operationId}`,
         schemeDefinition != null &&
         schemeDefinition instanceof BasicAuthDefinition
       ) {
-        sec.isKeyInHeader = sec.isKeyInQuery = sec.isApiKey = sec.isOAuth = false;
+        sec.isKeyInHeader =
+          sec.isKeyInQuery =
+          sec.isApiKey =
+          sec.isOAuth =
+            false;
         sec.isBasic = true;
       } else {
         const oauth2Definition = schemeDefinition;
-        sec.isKeyInHeader = sec.isKeyInQuery = sec.isApiKey = sec.isBasic = false;
+        sec.isKeyInHeader =
+          sec.isKeyInQuery =
+          sec.isApiKey =
+          sec.isBasic =
+            false;
         sec.isOAuth = true;
         sec.flow = oauth2Definition.getFlow();
         switch (sec.flow) {

--- a/ern-api-gen/src/DefaultGenerator.ts
+++ b/ern-api-gen/src/DefaultGenerator.ts
@@ -329,9 +329,8 @@ export default class DefaultGenerator extends AbstractGenerator {
             );
           }
         }
-        allProcessedModels = this.config.postProcessAllModels(
-          allProcessedModels,
-        );
+        allProcessedModels =
+          this.config.postProcessAllModels(allProcessedModels);
         for (const [name, models] of allProcessedModels) {
           try {
             if (this.config.importMapping().containsKey(name)) {
@@ -715,9 +714,8 @@ export default class DefaultGenerator extends AbstractGenerator {
             this.config.getCommonTemplateDir(),
             swaggerCodegenIgnore,
           );
-          const ignoreFileContents = this.readResourceContents(
-            ignoreFileNameSource,
-          );
+          const ignoreFileContents =
+            this.readResourceContents(ignoreFileNameSource);
           try {
             this.writeToFile(ignoreFileNameTarget, ignoreFileContents);
           } catch (e) {

--- a/ern-api-gen/src/apigen.ts
+++ b/ern-api-gen/src/apigen.ts
@@ -181,9 +181,8 @@ async function _checkDependencyVersion(
   targetDependencies: PackagePath[],
 ) {
   const pluginDependency = pkg.peerDependencies || {};
-  const targetNativeDependenciesMap = _constructTargetNativeDependenciesMap(
-    targetDependencies,
-  );
+  const targetNativeDependenciesMap =
+    _constructTargetNativeDependenciesMap(targetDependencies);
   for (const key of Object.keys(pluginDependency)) {
     if (
       targetNativeDependenciesMap.has(key) &&

--- a/ern-api-gen/src/java/StringUtils.ts
+++ b/ern-api-gen/src/java/StringUtils.ts
@@ -23,7 +23,8 @@ function indexOfDifference(cs1, cs2?: any) {
 
   return INDEX_NOT_FOUND;
 }
-const smallWords = /^(a|an|and|as|at|but|by|en|for|if|in|nor|of|on|or|per|the|to|vs?\.?|via)$/i;
+const smallWords =
+  /^(a|an|and|as|at|but|by|en|for|if|in|nor|of|on|or|per|the|to|vs?\.?|via)$/i;
 
 const capitalizeFully$inner = (match, index, title) => {
   if (

--- a/ern-api-gen/src/languages/AndroidClientCodegen.ts
+++ b/ern-api-gen/src/languages/AndroidClientCodegen.ts
@@ -488,9 +488,10 @@ export default class AndroidClientCodegen extends DefaultCodegen {
     } else {
       this.setLibrary(this.getLibrary());
     }
-    const f = this[
-      `addSupportingFilesFor${DefaultCodegen.camelize(this.getLibrary())}`
-    ];
+    const f =
+      this[
+        `addSupportingFilesFor${DefaultCodegen.camelize(this.getLibrary())}`
+      ];
     if (f) {
       f.call(this);
     }

--- a/ern-api-gen/src/languages/ES6Codegen.ts
+++ b/ern-api-gen/src/languages/ES6Codegen.ts
@@ -26,11 +26,12 @@ export default class ES6Codegen extends JavascriptClientCodegen {
 
   public processOpts() {
     super.processOpts();
-    const f = this[
-      `addSupportingFilesFor${JavascriptClientCodegen.camelize(
-        this.getLibrary(),
-      )}`
-    ];
+    const f =
+      this[
+        `addSupportingFilesFor${JavascriptClientCodegen.camelize(
+          this.getLibrary(),
+        )}`
+      ];
     if (f) {
       f.call(this);
     }

--- a/ern-api-gen/src/languages/ErnSwiftCodegen.ts
+++ b/ern-api-gen/src/languages/ErnSwiftCodegen.ts
@@ -30,9 +30,8 @@ export default class ErnSwiftCodegen extends SwiftCodegen {
   public processOpts() {
     super.processOpts();
     // Events and Requests files.
-    const f = this[
-      `addSupportingFilesFor${SwiftCodegen.camelize(this.getLibrary())}`
-    ];
+    const f =
+      this[`addSupportingFilesFor${SwiftCodegen.camelize(this.getLibrary())}`];
     if (f) {
       f.call(this);
     }

--- a/ern-api-impl-gen/src/generators/android/ApiImplAndroidGenerator.ts
+++ b/ern-api-impl-gen/src/generators/android/ApiImplAndroidGenerator.ts
@@ -216,13 +216,11 @@ export default class ApiImplAndroidGenerator implements ApiImplGeneratable {
       fs.ensureDirSync(outputDir);
 
       for (const api of apis) {
-        const {
-          files,
-          classNames,
-        } = ApiImplAndroidGenerator.getMustacheFileNamesMap(
-          resourceDir,
-          api.apiName,
-        );
+        const { files, classNames } =
+          ApiImplAndroidGenerator.getMustacheFileNamesMap(
+            resourceDir,
+            api.apiName,
+          );
         for (const file of files) {
           if (file === 'requestHandlerProvider.mustache') {
             editableFiles.push(path.join(outputDir, classNames[file]));

--- a/ern-api-impl-gen/src/generators/ios/ApiImplIosGenerator.ts
+++ b/ern-api-impl-gen/src/generators/ios/ApiImplIosGenerator.ts
@@ -65,9 +65,8 @@ export default class ApiImplIosGenerator implements ApiImplGeneratable {
       };
 
       const projectSpec = {
-        deploymentTarget: iosUtil.getDefaultIosDeploymentTarget(
-          reactNativeVersion,
-        ),
+        deploymentTarget:
+          iosUtil.getDefaultIosDeploymentTarget(reactNativeVersion),
         nodeModulesRelativePath: '../node_modules',
         projectName: 'ElectrodeApiImpl',
       };

--- a/ern-cauldron-api/src/CauldronHelper.ts
+++ b/ern-cauldron-api/src/CauldronHelper.ts
@@ -590,9 +590,8 @@ export class CauldronHelper {
       descriptor,
       funcAddPackageToContainer: this.addMiniAppToContainer.bind(this),
       funcGetPackagesFromContainer: this.getContainerMiniApps.bind(this),
-      funcUpdatePackageInContainer: this.updateMiniAppVersionInContainer.bind(
-        this,
-      ),
+      funcUpdatePackageInContainer:
+        this.updateMiniAppVersionInContainer.bind(this),
       localPackages,
     });
   }
@@ -605,9 +604,8 @@ export class CauldronHelper {
       descriptor,
       funcAddPackageToContainer: this.addJsApiImplToContainer.bind(this),
       funcGetPackagesFromContainer: this.getContainerJsApiImpls.bind(this),
-      funcUpdatePackageInContainer: this.updateJsApiImplVersionInContainer.bind(
-        this,
-      ),
+      funcUpdatePackageInContainer:
+        this.updateJsApiImplVersionInContainer.bind(this),
       localPackages,
     });
   }
@@ -1254,9 +1252,9 @@ export class CauldronHelper {
     const miniAppsBranches = (
       await this.cauldron.getContainerMiniAppsBranches(descriptor)
     ).map((p) => PackagePath.fromString(p));
-    const miniApps = (
-      await this.cauldron.getContainerMiniApps(descriptor)
-    ).map((p) => PackagePath.fromString(p));
+    const miniApps = (await this.cauldron.getContainerMiniApps(descriptor)).map(
+      (p) => PackagePath.fromString(p),
+    );
     for (const miniAppBranch of miniAppsBranches) {
       const latestCommitSha = await coreUtils.getCommitShaOfGitBranchOrTag(
         miniAppBranch,

--- a/ern-cauldron-api/src/GitDocumentStore.ts
+++ b/ern-cauldron-api/src/GitDocumentStore.ts
@@ -8,7 +8,8 @@ const CAULDRON_FILENAME = 'cauldron.json';
 
 export default class GitDocumentStore
   extends BaseGit
-  implements ICauldronDocumentStore {
+  implements ICauldronDocumentStore
+{
   public readonly jsonPath: string;
   private cauldron: Cauldron;
 

--- a/ern-cauldron-api/src/GitFileStore.ts
+++ b/ern-cauldron-api/src/GitFileStore.ts
@@ -6,7 +6,8 @@ import { ICauldronFileStore } from './types';
 
 export default class GitFileStore
   extends BaseGit
-  implements ICauldronFileStore {
+  implements ICauldronFileStore
+{
   private readonly prefix: string;
 
   constructor({

--- a/ern-cauldron-api/src/getActiveCauldron.ts
+++ b/ern-cauldron-api/src/getActiveCauldron.ts
@@ -84,7 +84,8 @@ export default async function getActiveCauldron({
           : cauldronRepoUrlWithoutBranch,
       });
       currentCauldronHelperInstance = new CauldronHelper(cauldronCli);
-      const schemaVersionUsedByCauldron = await currentCauldronHelperInstance.getCauldronSchemaVersion();
+      const schemaVersionUsedByCauldron =
+        await currentCauldronHelperInstance.getCauldronSchemaVersion();
       const schemaVersionOfCurrentCauldronApi = getCurrentSchemaVersion();
       if (
         !ignoreSchemaVersionMismatch &&
@@ -114,9 +115,10 @@ export default async function getActiveCauldron({
         }
       }
       if (!ignoreRequiredErnVersionMismatch) {
-        const requiredErnVersion = await currentCauldronHelperInstance.getConfigForKey(
-          'requiredErnVersion',
-        );
+        const requiredErnVersion =
+          await currentCauldronHelperInstance.getConfigForKey(
+            'requiredErnVersion',
+          );
         if (requiredErnVersion) {
           if (!semver.satisfies(Platform.currentVersion, requiredErnVersion)) {
             throw new Error(

--- a/ern-cauldron-api/test/CauldronHelper-test.ts
+++ b/ern-cauldron-api/test/CauldronHelper-test.ts
@@ -1664,9 +1664,8 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
-      const result = cauldronHelper.getCauldronConfigLevelMatchingDescriptor(
-        undefined,
-      );
+      const result =
+        cauldronHelper.getCauldronConfigLevelMatchingDescriptor(undefined);
       expect(result).eql(CauldronConfigLevel.Top);
     });
 
@@ -2679,9 +2678,8 @@ describe('CauldronHelper.js', () => {
         cauldronDocument: fixture,
       });
       const descriptor = AppVersionDescriptor.fromString('test:android:5.0.0');
-      const result = await cauldronHelper.getDescriptorsMatchingSemVerDescriptor(
-        descriptor,
-      );
+      const result =
+        await cauldronHelper.getDescriptorsMatchingSemVerDescriptor(descriptor);
       expect(result).to.be.an('array').empty;
     });
 
@@ -2693,9 +2691,8 @@ describe('CauldronHelper.js', () => {
       const descriptor = AppVersionDescriptor.fromString(
         'test:android:^17.0.0',
       );
-      const result = await cauldronHelper.getDescriptorsMatchingSemVerDescriptor(
-        descriptor,
-      );
+      const result =
+        await cauldronHelper.getDescriptorsMatchingSemVerDescriptor(descriptor);
       expect(result).to.be.an('array').of.length(2);
     });
 
@@ -2705,9 +2702,8 @@ describe('CauldronHelper.js', () => {
         cauldronDocument: fixture,
       });
       const descriptor = AppVersionDescriptor.fromString('test:android:17.7.x');
-      const result = await cauldronHelper.getDescriptorsMatchingSemVerDescriptor(
-        descriptor,
-      );
+      const result =
+        await cauldronHelper.getDescriptorsMatchingSemVerDescriptor(descriptor);
       expect(result).to.be.an('array').of.length(1);
     });
   });
@@ -2773,9 +2769,8 @@ describe('CauldronHelper.js', () => {
       const cauldronHelper = createCauldronHelper({
         cauldronDocument: fixture,
       });
-      const sourceDescriptor = AppVersionDescriptor.fromString(
-        'test:android:5.0.0',
-      );
+      const sourceDescriptor =
+        AppVersionDescriptor.fromString('test:android:5.0.0');
       const targetDescriptor = AppVersionDescriptor.fromString(
         'test:android:20.0.0',
       );
@@ -3036,9 +3031,8 @@ describe('CauldronHelper.js', () => {
       });
       const descriptor = AppPlatformDescriptor.fromString('test:android');
       const version1780 = jp.query(fixture, testAndroid1780Path)[0];
-      const latestVersion = await cauldronHelper.getMostRecentNativeApplicationVersion(
-        descriptor,
-      );
+      const latestVersion =
+        await cauldronHelper.getMostRecentNativeApplicationVersion(descriptor);
       expect(latestVersion).deep.equal(version1780);
     });
   });

--- a/ern-cauldron-api/test/util-test.ts
+++ b/ern-cauldron-api/test/util-test.ts
@@ -76,9 +76,8 @@ describe('util.js', () => {
 
   describe('getSchemaVersionMatchingCauldronApiVersion', () => {
     it('should return 3.0.0 for version 1000.0.0', () => {
-      const result = util.getSchemaVersionMatchingCauldronApiVersion(
-        '1000.0.0',
-      );
+      const result =
+        util.getSchemaVersionMatchingCauldronApiVersion('1000.0.0');
       expect(result).eql('3.0.0');
     });
 

--- a/ern-composite-gen/src/GeneratedComposite.ts
+++ b/ern-composite-gen/src/GeneratedComposite.ts
@@ -179,9 +179,10 @@ export class GeneratedComposite implements Composite {
     nativeDependencies.all = nativeDependencies.all.filter(
       (x) => !miniAppsPaths.includes(x.basePath),
     );
-    nativeDependencies.thirdPartyNotInManifest = nativeDependencies.thirdPartyNotInManifest.filter(
-      (x) => !miniAppsPaths.includes(x.basePath),
-    );
+    nativeDependencies.thirdPartyNotInManifest =
+      nativeDependencies.thirdPartyNotInManifest.filter(
+        (x) => !miniAppsPaths.includes(x.basePath),
+      );
     this.cachedNativeDependencies = nativeDependencies;
     return this.cachedNativeDependencies;
   }

--- a/ern-composite-gen/src/WorkspaceComposite.ts
+++ b/ern-composite-gen/src/WorkspaceComposite.ts
@@ -133,9 +133,10 @@ export class WorkspaceComposite implements Composite {
     nativeDependencies.all = nativeDependencies.all.filter(
       (x) => !miniAppsPaths.includes(x.basePath),
     );
-    nativeDependencies.thirdPartyNotInManifest = nativeDependencies.thirdPartyNotInManifest.filter(
-      (x) => !miniAppsPaths.includes(x.basePath),
-    );
+    nativeDependencies.thirdPartyNotInManifest =
+      nativeDependencies.thirdPartyNotInManifest.filter(
+        (x) => !miniAppsPaths.includes(x.basePath),
+      );
     this.cachedNativeDependencies = nativeDependencies;
     return this.cachedNativeDependencies;
   }

--- a/ern-composite-gen/src/generateComposite.ts
+++ b/ern-composite-gen/src/generateComposite.ts
@@ -248,9 +248,10 @@ async function generateFullComposite(
       // Exclude api/api impls as they are not native modules
       allNativeDeps.apis = [];
       allNativeDeps.nativeApisImpl = [];
-      const dedupedNativeModules = nativeDepenciesVersionResolution.resolveNativeDependenciesVersionsEx(
-        allNativeDeps,
-      );
+      const dedupedNativeModules =
+        nativeDepenciesVersionResolution.resolveNativeDependenciesVersionsEx(
+          allNativeDeps,
+        );
 
       if (dedupedNativeModules.pluginsWithMismatchingVersions.length > 0) {
         let errorMsg = `Mismatching native module versions detected.

--- a/ern-composite-gen/src/installPackagesUsingYarnLock.ts
+++ b/ern-composite-gen/src/installPackagesUsingYarnLock.ts
@@ -47,10 +47,8 @@ export async function installPackagesUsingYarnLock({
       `[generateComposite] miniAppsDeltas: ${JSON.stringify(miniAppsDeltas)}`,
     );
 
-    compositePackageJson.dependencies = getPackageJsonDependenciesUsingMiniAppDeltas(
-      miniAppsDeltas,
-      yarnLock,
-    );
+    compositePackageJson.dependencies =
+      getPackageJsonDependenciesUsingMiniAppDeltas(miniAppsDeltas, yarnLock);
 
     await writePackageJson(cwd, compositePackageJson);
 

--- a/ern-composite-gen/src/miniAppsDeltasUtils.ts
+++ b/ern-composite-gen/src/miniAppsDeltasUtils.ts
@@ -73,9 +73,8 @@ export function getPackageJsonDependenciesUsingMiniAppDeltas(
         // seen in package.json is not know by the PackagePath object
         // Only way to find the name of the dependency is to look in
         // the yarn.lock file as it records the name of git based dependencies
-        const name = getYarnLockTopLevelGitDependencyRe(m).exec(
-          yarnlock,
-        )![1 /*name*/];
+        const name =
+          getYarnLockTopLevelGitDependencyRe(m).exec(yarnlock)![1 /*name*/];
         // Sample package.json entry :
         // "test-miniapp": "https://github.com/org/test-miniapp.git#master"
         result[name] = m.fullPath;
@@ -92,9 +91,8 @@ export function getPackageJsonDependenciesUsingMiniAppDeltas(
       if (m.isRegistryPath) {
         result[m.basePath] = initialVersion;
       } else if (m.isGitPath) {
-        const name = getYarnLockTopLevelGitDependencyRe(m).exec(
-          yarnlock,
-        )![1 /*name*/];
+        const name =
+          getYarnLockTopLevelGitDependencyRe(m).exec(yarnlock)![1 /*name*/];
         result[name] = `${m.basePath}#${initialVersion}`;
       }
     }

--- a/ern-container-gen-android/src/AndroidGenerator.ts
+++ b/ern-container-gen-android/src/AndroidGenerator.ts
@@ -163,9 +163,8 @@ export default class AndroidGenerator implements ContainerGenerator {
         continue;
       }
 
-      let pluginConfig:
-        | PluginConfig<'android'>
-        | undefined = await manifest.getPluginConfig(plugin, 'android');
+      let pluginConfig: PluginConfig<'android'> | undefined =
+        await manifest.getPluginConfig(plugin, 'android');
       if (!pluginConfig) {
         log.warn(
           `Skipping ${plugin.name} as it does not have an Android configuration`,

--- a/ern-container-gen-ios/src/IosGenerator.ts
+++ b/ern-container-gen-ios/src/IosGenerator.ts
@@ -437,9 +437,8 @@ Make sure to run these commands before building the container.`,
       if (plugin.name === 'react-native') {
         continue;
       }
-      const pluginConfig:
-        | PluginConfig<'ios'>
-        | undefined = await manifest.getPluginConfig(plugin, 'ios');
+      const pluginConfig: PluginConfig<'ios'> | undefined =
+        await manifest.getPluginConfig(plugin, 'ios');
       if (!pluginConfig) {
         log.warn(
           `${plugin.name} does not have any injection configuration for ios platform`,

--- a/ern-core/src/BundleStoreSdk.ts
+++ b/ern-core/src/BundleStoreSdk.ts
@@ -110,7 +110,7 @@ export class BundleStoreSdk {
         ...getGotCommonOpts(),
         json: { assets },
       }).json;
-      return (res as any) as string[];
+      return res as any as string[];
     } catch (err) {
       throw new Error(err.response?.text ?? err.message);
     }

--- a/ern-core/src/GitHubApi.ts
+++ b/ern-core/src/GitHubApi.ts
@@ -195,14 +195,16 @@ export class GitHubApi {
     newContent: string;
     commitMessage: string;
   }) {
-    const sha = ((
-      await this.octokit.repos.getContent({
-        owner: this.owner,
-        path,
-        ref: onBranch || undefined,
-        repo: this.repo,
-      })
-    ).data as any).sha;
+    const sha = (
+      (
+        await this.octokit.repos.getContent({
+          owner: this.owner,
+          path,
+          ref: onBranch || undefined,
+          repo: this.repo,
+        })
+      ).data as any
+    ).sha;
 
     const buff = new Buffer(newContent);
     const content = buff.toString('base64');

--- a/ern-core/src/LocalManifest.ts
+++ b/ern-core/src/LocalManifest.ts
@@ -139,11 +139,10 @@ export class LocalManifest {
     //   '/home/user/.ern/ern-override-manifest/plugins/ern_v0.10.0+',
     //   '/home/user/.ern/ern-override-manifest/plugins/ern_v0.5.0+'
     // ]
-    const orderedPluginsConfigurationDirectories = this.getPluginsConfigurationDirectories(
-      platformVersion,
-    ).sort((a, b) =>
-      semver.rcompare(versionRe.exec(a)![1], versionRe.exec(b)![1]),
-    );
+    const orderedPluginsConfigurationDirectories =
+      this.getPluginsConfigurationDirectories(platformVersion).sort((a, b) =>
+        semver.rcompare(versionRe.exec(a)![1], versionRe.exec(b)![1]),
+      );
 
     for (const pluginsConfigurationDirectory of orderedPluginsConfigurationDirectories) {
       let pluginScope: string | undefined;
@@ -210,11 +209,10 @@ export class LocalManifest {
     }
 
     const versionRe = /_v(.+)\+/;
-    const orderedPluginsConfigurationDirectories = this.getPluginsConfigurationDirectories(
-      platformVersion,
-    ).sort((a, b) =>
-      semver.rcompare(versionRe.exec(a)![1], versionRe.exec(b)![1]),
-    );
+    const orderedPluginsConfigurationDirectories =
+      this.getPluginsConfigurationDirectories(platformVersion).sort((a, b) =>
+        semver.rcompare(versionRe.exec(a)![1], versionRe.exec(b)![1]),
+      );
 
     for (const pluginsConfigurationDirectory of orderedPluginsConfigurationDirectories) {
       // Directory names cannot contain '/', so, replaced by ':'

--- a/ern-core/src/MiniApp.ts
+++ b/ern-core/src/MiniApp.ts
@@ -320,7 +320,8 @@ module.exports = {
   // This method checks dependencies from the package.json of the MiniApp and
   // exclude native dependencies (plugins).
   public async getJsDependencies(): Promise<PackagePath[]> {
-    const nativeDependencies: NativeDependencies = await this.getNativeDependencies();
+    const nativeDependencies: NativeDependencies =
+      await this.getNativeDependencies();
     const nativeDependenciesNames: string[] = _.map(
       nativeDependencies.all,
       (d) => d.name!,
@@ -503,16 +504,14 @@ does not match version declared in manifest: ${manifestDep.version}`,
     for (const manifestDependency of manifestDependencies) {
       if (this.packageJson.dependencies[manifestDependency.basePath]) {
         const dependencyManifestVersion = manifestDependency.version;
-        const localDependencyVersion = this.packageJson.dependencies[
-          manifestDependency.basePath
-        ];
+        const localDependencyVersion =
+          this.packageJson.dependencies[manifestDependency.basePath];
         if (dependencyManifestVersion !== localDependencyVersion) {
           log.info(
             `${manifestDependency.basePath} : ${localDependencyVersion} => ${dependencyManifestVersion}`,
           );
-          this.packageJson.dependencies[
-            manifestDependency.basePath
-          ] = dependencyManifestVersion;
+          this.packageJson.dependencies[manifestDependency.basePath] =
+            dependencyManifestVersion;
         }
       }
     }

--- a/ern-core/src/PluginConfigGenerator.ts
+++ b/ern-core/src/PluginConfigGenerator.ts
@@ -27,7 +27,8 @@ export class PluginConfigGenerator {
           resolveDependencyVersion,
           revolveBuildGradlePath,
         });
-        const androidPluginSource = await androidGenerator.generatePluginJavaSource();
+        const androidPluginSource =
+          await androidGenerator.generatePluginJavaSource();
         result.pluginConfig = result.pluginConfig || {};
         result.pluginConfig.android = androidConfig;
         result.androidPluginSource = androidPluginSource;

--- a/ern-core/src/index.ts
+++ b/ern-core/src/index.ts
@@ -80,7 +80,8 @@ export const dependencyLookup = _dependencyLookup;
 export const deviceConfig = _deviceConfig;
 export const getCodePushSdk = _getCodePushSdk;
 export { ErnBinaryStore } from './ErnBinaryStore';
-export const nativeDepenciesVersionResolution = _nativeDepenciesVersionResolution;
+export const nativeDepenciesVersionResolution =
+  _nativeDepenciesVersionResolution;
 export { getPackagePathsDiffs } from './getPackagePathsDiffs';
 export * from './findDirectoriesHavingRnConfig';
 export * from './BundleStoreSdk';

--- a/ern-core/src/iosUtil.ts
+++ b/ern-core/src/iosUtil.ts
@@ -105,13 +105,8 @@ export async function fillProjectHull(
         continue;
       }
 
-      let pluginConfig:
-        | PluginConfig<'ios'>
-        | undefined = await manifest.getPluginConfig(
-        plugin,
-        'ios',
-        projectSpec.projectName,
-      );
+      let pluginConfig: PluginConfig<'ios'> | undefined =
+        await manifest.getPluginConfig(plugin, 'ios', projectSpec.projectName);
       if (!pluginConfig) {
         continue;
       }

--- a/ern-core/src/resolveNativeDependenciesVersions.ts
+++ b/ern-core/src/resolveNativeDependenciesVersions.ts
@@ -137,10 +137,11 @@ export function resolveNativeDependenciesVersionsEx(
     apisAndApiImplsNativeDeps.push(..._.flatten(dependencies.nativeApisImpl));
   }
   apisAndApiImplsNativeDeps = _.flatten(apisAndApiImplsNativeDeps);
-  const apiAndApiImplsResolvedVersions = resolvePackageVersionsGivenMismatchLevel(
-    apisAndApiImplsNativeDeps,
-    'major',
-  );
+  const apiAndApiImplsResolvedVersions =
+    resolvePackageVersionsGivenMismatchLevel(
+      apisAndApiImplsNativeDeps,
+      'major',
+    );
 
   // Resolve native dependencies versions third party native modules
   let thirdPartyNativeModules: PackagePath[] = [];
@@ -155,10 +156,8 @@ export function resolveNativeDependenciesVersionsEx(
     );
   }
   thirdPartyNativeModules = _.flatten(thirdPartyNativeModules);
-  const thirdPartyNativeModulesResolvedVersions = resolvePackageVersionsGivenMismatchLevel(
-    thirdPartyNativeModules,
-    'patch',
-  );
+  const thirdPartyNativeModulesResolvedVersions =
+    resolvePackageVersionsGivenMismatchLevel(thirdPartyNativeModules, 'patch');
 
   return {
     pluginsWithMismatchingVersions: [

--- a/ern-core/src/sortObjectByKeys.ts
+++ b/ern-core/src/sortObjectByKeys.ts
@@ -1,6 +1,6 @@
-export function sortObjectByKeys(obj: {
+export function sortObjectByKeys(obj: { [key: string]: any }): {
   [key: string]: any;
-}): { [key: string]: any } {
+} {
   const res: { [key: string]: any } = {};
   Object.keys(obj)
     .sort()

--- a/ern-core/test/utils-test.ts
+++ b/ern-core/test/utils-test.ts
@@ -393,9 +393,8 @@ describe('utils.js', () => {
   describe('coerceToAppVersionDescriptorArray', () => {
     it('should coerce a string to a AppVersionDescriptor array', () => {
       const descriptor = AppVersionDescriptor.fromString('test:android:1.0.0');
-      const result = utils.coerceToAppVersionDescriptorArray(
-        'test:android:1.0.0',
-      );
+      const result =
+        utils.coerceToAppVersionDescriptorArray('test:android:1.0.0');
       expect(result).is.an('array').of.length(1);
       expect(result[0]).eql(descriptor);
     });

--- a/ern-orchestrator/src/Ensure.ts
+++ b/ern-orchestrator/src/Ensure.ts
@@ -297,10 +297,11 @@ export default class Ensure {
     );
     const dependencies = coreUtils.coerceToPackagePathArray(obj);
     for (const dependency of dependencies) {
-      const dependencyFromCauldron = await cauldron.getContainerNativeDependency(
-        napDescriptor,
-        dependency.basePath,
-      );
+      const dependencyFromCauldron =
+        await cauldron.getContainerNativeDependency(
+          napDescriptor,
+          dependency.basePath,
+        );
       if (
         dependencyFromCauldron &&
         dependencyFromCauldron.version === dependency.version
@@ -330,10 +331,11 @@ export default class Ensure {
     const miniApps = await cauldron.getContainerMiniApps(napDescriptor);
 
     for (const dependency of dependencies) {
-      const miniAppsUsingDependency = await dependencyLookup.getMiniAppsUsingNativeDependency(
-        miniApps,
-        dependency,
-      );
+      const miniAppsUsingDependency =
+        await dependencyLookup.getMiniAppsUsingNativeDependency(
+          miniApps,
+          dependency,
+        );
       if (miniAppsUsingDependency?.length > 0) {
         let errorMessage = '';
         errorMessage += 'The following MiniApp(s) are using this dependency\n';

--- a/ern-orchestrator/src/codepush.ts
+++ b/ern-orchestrator/src/codepush.ts
@@ -148,10 +148,8 @@ export async function performCodePushPromote(
         sourceNapDescriptor.version !== targetNapDescriptor.version &&
         !skipNativeDependenciesVersionAlignedCheck
       ) {
-        const nativeDependenciesVersionAligned = await compatibility.areCompatible(
-          miniApps,
-          targetNapDescriptor,
-        );
+        const nativeDependenciesVersionAligned =
+          await compatibility.areCompatible(miniApps, targetNapDescriptor);
 
         if (!nativeDependenciesVersionAligned && force) {
           log.warn(
@@ -323,10 +321,8 @@ export async function performCodePushOtaUpdate(
 
     const tmpWorkingDir = createTmpDir();
 
-    const miniAppsNativeDependenciesVersionAligned = await compatibility.areCompatible(
-      miniApps,
-      napDescriptor,
-    );
+    const miniAppsNativeDependenciesVersionAligned =
+      await compatibility.areCompatible(miniApps, napDescriptor);
 
     if (!miniAppsNativeDependenciesVersionAligned && force) {
       log.warn(
@@ -554,7 +550,8 @@ export async function performCodePushOtaUpdate(
             await fs.realpath(path.join(composite.path, 'node_modules')),
             await fs.realpath(sourceMapOutput),
           ];
-          const compositeMiniAppsPackages = await composite.getMiniAppsPackages();
+          const compositeMiniAppsPackages =
+            await composite.getMiniAppsPackages();
           await bugsnagUpload({
             apiKey,
             minifiedFile,

--- a/ern-orchestrator/src/compatibility.ts
+++ b/ern-orchestrator/src/compatibility.ts
@@ -155,9 +155,8 @@ export async function getNativeAppCompatibilityReport(
                 nativeAppPlatform.name,
                 nativeAppVersion.name,
               );
-              const nativeAppDependencies = await cauldron.getNativeDependencies(
-                napDescriptor,
-              );
+              const nativeAppDependencies =
+                await cauldron.getNativeDependencies(napDescriptor);
               const compatibility = getCompatibility(
                 miniappDependencies,
                 nativeAppDependencies,

--- a/ern-orchestrator/src/constants.ts
+++ b/ern-orchestrator/src/constants.ts
@@ -82,14 +82,12 @@ export const availableUserConfigKeys = [
     values: ['string'],
   },
   {
-    desc:
-      'Local manifest configuration (takes precedence on manifest configuration from cauldron)',
+    desc: 'Local manifest configuration (takes precedence on manifest configuration from cauldron)',
     name: 'manifest',
     values: ['object'],
   },
   {
-    desc:
-      'Version of CocoaPods to use for iOS container generation (version must be available locally)',
+    desc: 'Version of CocoaPods to use for iOS container generation (version must be available locally)',
     name: 'podVersion',
     values: ['string'],
   },

--- a/ern-orchestrator/src/gitHub.ts
+++ b/ern-orchestrator/src/gitHub.ts
@@ -213,9 +213,8 @@ async function updatePackageJson({
         log.info(
           `${manifestDependency.basePath} : ${localDependencyVersion} => ${dependencyManifestVersion}`,
         );
-        packageJson.dependencies[
-          manifestDependency.basePath
-        ] = dependencyManifestVersion;
+        packageJson.dependencies[manifestDependency.basePath] =
+          dependencyManifestVersion;
         wasUpdated = true;
       }
     }

--- a/ern-orchestrator/src/runMiniApp.ts
+++ b/ern-orchestrator/src/runMiniApp.ts
@@ -210,9 +210,8 @@ export async function runMiniApp(
     });
   }
 
-  const compositeNativeDeps = await containerGenResult.config.composite.getNativeDependencies(
-    {},
-  );
+  const compositeNativeDeps =
+    await containerGenResult.config.composite.getNativeDependencies({});
   const reactNativeDep = _.find(
     compositeNativeDeps.all,
     (p) => p.name === 'react-native',

--- a/ern-orchestrator/src/start.ts
+++ b/ern-orchestrator/src/start.ts
@@ -164,9 +164,10 @@ export default async function start({
       ...allNativeDeps.thirdPartyInManifest,
       ...allNativeDeps.thirdPartyNotInManifest,
     ];
-    const dedupedNativeModules = nativeDepenciesVersionResolution.resolveNativeDependenciesVersionsEx(
-      allNativeDeps,
-    );
+    const dedupedNativeModules =
+      nativeDepenciesVersionResolution.resolveNativeDependenciesVersionsEx(
+        allNativeDeps,
+      );
     const extraNodeModules: { [pkg: string]: string } = {};
     dedupedNativeModules.resolved.forEach((m) => {
       extraNodeModules[m.name!] = m.basePath;

--- a/ern-runner-gen-ios/src/IosRunnerGenerator.ts
+++ b/ern-runner-gen-ios/src/IosRunnerGenerator.ts
@@ -84,8 +84,9 @@ export default class IosRunerGenerator implements RunnerGenerator {
       path.join(config.extra.containerGenWorkingDir, 'out/ios'),
     );
     const mustacheView = {
-      deploymentTarget:
-        semver.gte(config.reactNativeVersion, '0.64.0') ? '11.0' : '10.3',
+      deploymentTarget: semver.gte(config.reactNativeVersion, '0.64.0')
+        ? '11.0'
+        : '10.3',
       isReactNativeDevSupportEnabled:
         config.reactNativeDevSupportEnabled === true ? 'true' : 'false',
       miniAppName: config.mainMiniAppName,

--- a/ern-util-dev/src/index.js
+++ b/ern-util-dev/src/index.js
@@ -16,7 +16,8 @@ require('colors');
 
 const CLI = path.resolve(__dirname, '../../ern-local-cli/src/index.dev.js');
 
-const excludeFilterRe = /node_modules(\/|$)|yarn\.lock|gradle\.build|\.xcodeproj\.pbxproj|\.DS_Store|genapp-tvOS|npm-debug.log/;
+const excludeFilterRe =
+  /node_modules(\/|$)|yarn\.lock|gradle\.build|\.xcodeproj\.pbxproj|\.DS_Store|genapp-tvOS|npm-debug.log/;
 // a function that will pass in an object and exclude it if the function returns true.  Used when doing a compare
 const _excludeFilter = ({ name1, name2, relativePath }) =>
   excludeFilterRe.test(relativePath) ||
@@ -86,57 +87,59 @@ export default function setup(
   const cwd = (...args) => {
     return path.resolve(tmpDir, ...args);
   };
-  const compare = (src, dest, excludeFilter = _excludeFilter) => () => {
-    dest = path.join(workingCwd, dest);
-    src = api.cwd(src);
-    if (!fs.existsSync(dest)) {
-      shell.mkdir('-p', path.join(dest, '..'));
-      shell.cp('-r', src, dest);
-      return Promise.resolve(true);
-    } else {
-      return dirCompare(src, dest, {
-        compareDate: false,
-        dateTolerance: 500000,
-        compareContent: true,
-      }).then((resp = { diffSet: [] }) => {
-        const { diffSet } = resp;
+  const compare =
+    (src, dest, excludeFilter = _excludeFilter) =>
+    () => {
+      dest = path.join(workingCwd, dest);
+      src = api.cwd(src);
+      if (!fs.existsSync(dest)) {
+        shell.mkdir('-p', path.join(dest, '..'));
+        shell.cp('-r', src, dest);
+        return Promise.resolve(true);
+      } else {
+        return dirCompare(src, dest, {
+          compareDate: false,
+          dateTolerance: 500000,
+          compareContent: true,
+        }).then((resp = { diffSet: [] }) => {
+          const { diffSet } = resp;
 
-        for (const diff of diffSet) {
-          if (!diff.name2 && !excludeFilter(diff)) {
-            assert(
-              false,
-              `${diff.relativePath} is missing ${diff.name1} in ${dest}`,
-            );
-          }
-          const nf = `${diff.path1}/${diff.name1}`;
-          const of = `${dest}/${diff.relativePath.replace(/^\//, '')}/${
-            diff.name2
-          }`;
-          if (!excludeFilter(diff) && diff.state !== 'equal') {
-            const cmd = `git diff --ignore-blank-lines --ignore-space-at-eol -b -w ${nf} ${of}`;
-            try {
-              execSync(cmd);
-            } catch (e) {
-              console.log('ERROR:\n', cmd);
-              const diffOut = e.output
-                .filter(Boolean)
-                .map((v) => v + '')
-                .join('\n');
+          for (const diff of diffSet) {
+            if (!diff.name2 && !excludeFilter(diff)) {
               assert(
                 false,
-                `Not the same ${diff.relativePath.replace(/^\//, '')}/${
-                  diff.name2
-                } ${diff.path1}/${diff.name1}
-${diffOut}
-`,
+                `${diff.relativePath} is missing ${diff.name1} in ${dest}`,
               );
             }
+            const nf = `${diff.path1}/${diff.name1}`;
+            const of = `${dest}/${diff.relativePath.replace(/^\//, '')}/${
+              diff.name2
+            }`;
+            if (!excludeFilter(diff) && diff.state !== 'equal') {
+              const cmd = `git diff --ignore-blank-lines --ignore-space-at-eol -b -w ${nf} ${of}`;
+              try {
+                execSync(cmd);
+              } catch (e) {
+                console.log('ERROR:\n', cmd);
+                const diffOut = e.output
+                  .filter(Boolean)
+                  .map((v) => v + '')
+                  .join('\n');
+                assert(
+                  false,
+                  `Not the same ${diff.relativePath.replace(/^\//, '')}/${
+                    diff.name2
+                  } ${diff.path1}/${diff.name1}
+${diffOut}
+`,
+                );
+              }
+            }
           }
-        }
-        return true;
-      });
-    }
-  };
+          return true;
+        });
+      }
+    };
   const exists = (file) => () =>
     assert(fs.existsSync(api.cwd(file)), `Expected "${file}" to exist`);
   const execIn = (cmd, opts) =>
@@ -151,18 +154,20 @@ ${diffOut}
       );
     });
 
-  const gradle = (project, cmd = 'build') => () =>
-    new Promise((resolve, reject) => {
-      exec(
-        `${api.cwd(project, 'android', 'gradlew')} ${cmd}`,
-        { cwd: api.cwd(project, 'android') },
-        (err, stdout, stderr) => {
-          if (err) return reject(err);
-          /BUILD SUCCESSFUL/.test(stdout);
-          resolve();
-        },
-      );
-    });
+  const gradle =
+    (project, cmd = 'build') =>
+    () =>
+      new Promise((resolve, reject) => {
+        exec(
+          `${api.cwd(project, 'android', 'gradlew')} ${cmd}`,
+          { cwd: api.cwd(project, 'android') },
+          (err, stdout, stderr) => {
+            if (err) return reject(err);
+            /BUILD SUCCESSFUL/.test(stdout);
+            resolve();
+          },
+        );
+      });
 
   const json = (file, _test) => () => {
     assert(fs.existsSync(api.cwd(file)), `File should exist ${api.cwd(file)}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2065,15 +2065,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
-  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
-chalk@^4.1.1:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
   integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
@@ -2430,19 +2422,7 @@ cookiejar@^2.1.0, cookiejar@^2.1.2:
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
   integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
 
-copyfiles@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/copyfiles/-/copyfiles-2.3.0.tgz#1c26ebbe3d46bba2d309a3fd8e3aaccf53af8c76"
-  integrity sha512-73v7KFuDFJ/ofkQjZBMjMBFWGgkS76DzXvBMUh7djsMOE5EELWtAO/hRB6Wr5Vj5Zg+YozvoHemv0vnXpqxmOQ==
-  dependencies:
-    glob "^7.0.5"
-    minimatch "^3.0.3"
-    mkdirp "^1.0.4"
-    noms "0.0.0"
-    through2 "^2.0.1"
-    yargs "^15.3.1"
-
-copyfiles@^2.4.1:
+copyfiles@^2.3.0, copyfiles@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/copyfiles/-/copyfiles-2.4.1.tgz#d2dcff60aaad1015f09d0b66e7f0f1c5cd3c5da5"
   integrity sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==
@@ -2551,14 +2531,7 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debug@4, debug@^4.1.0, debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
-  dependencies:
-    ms "^2.1.1"
-
-debug@4.3.1, debug@^4.3.1:
+debug@4, debug@4.3.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -2756,15 +2729,7 @@ diff@^4.0.1, diff@^4.0.2:
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
-dir-compare@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/dir-compare/-/dir-compare-3.2.0.tgz#d18e3cc0b638d1a050b0d96b08040dd07a06125f"
-  integrity sha512-m0yNIMqLTtC9J9hloGiOVMUQa5t3JDMKmCbb9s+kqaWO9vFXdFufjz4/TN8HYm3icN0GGakBW0YjA8t3egcBsg==
-  dependencies:
-    buffer-equal "^1.0.0"
-    minimatch "^3.0.4"
-
-dir-compare@^3.3.0:
+dir-compare@^3.2.0, dir-compare@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/dir-compare/-/dir-compare-3.3.0.tgz#2c749f973b5c4b5d087f11edaae730db31788416"
   integrity sha512-J7/et3WlGUCxjdnD3HAAzQ6nsnc0WL6DD7WcwJb7c39iH1+AWfg+9OqzJNaI6PkBwBvm1mhZNL9iY/nRiZXlPg==
@@ -3075,12 +3040,7 @@ fast-levenshtein@~2.0.4:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fast-safe-stringify@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz#04b26106cc56681f51a044cfc0d76cf0008ac2c2"
-  integrity sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg==
-
-fast-safe-stringify@^2.0.7:
+fast-safe-stringify@^2.0.6, fast-safe-stringify@^2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
   integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
@@ -3217,12 +3177,7 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
-formidable@^1.2.0, formidable@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
-  integrity sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==
-
-formidable@^1.2.2:
+formidable@^1.2.0, formidable@^1.2.1, formidable@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.2.tgz#bf69aea2972982675f00865342b982986f6b8dd9"
   integrity sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==
@@ -3471,7 +3426,7 @@ glob-parent@^5.1.0, glob-parent@^5.1.1, glob-parent@~5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob@7.1.6, glob@^7.0.0, glob@^7.0.5, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -3483,7 +3438,7 @@ glob@7.1.6, glob@^7.0.0, glob@^7.0.5, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4, glo
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.7:
+glob@^7.0.0, glob@^7.0.5, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7:
   version "7.1.7"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
   integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
@@ -3529,12 +3484,7 @@ got@^11.8.2:
     p-cancelable "^2.0.0"
     responselike "^2.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
-  integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
-
-graceful-fs@^4.2.3:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.3:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
@@ -3652,12 +3602,7 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
-http-cache-semantics@^4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz#495704773277eeef6e43f9ab2c2c7d259dda25c5"
-  integrity sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==
-
-http-cache-semantics@^4.1.0:
+http-cache-semantics@^4.0.0, http-cache-semantics@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
   integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
@@ -4176,15 +4121,7 @@ js-yaml@4.0.0:
   dependencies:
     argparse "^2.0.1"
 
-js-yaml@^3.13.1:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
-  integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
-
-js-yaml@^3.5.2, js-yaml@^3.8.3:
+js-yaml@^3.13.1, js-yaml@^3.5.2, js-yaml@^3.8.3:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -4562,12 +4499,7 @@ lodash.union@^4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"
   integrity sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=
 
-lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.2.1:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
-
-lodash@^4.17.21, lodash@^4.2.0, lodash@^4.7.0:
+lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -4753,12 +4685,7 @@ mime@^1.4.1:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mime@^2.4.4:
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
-  integrity sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==
-
-mime@^2.4.6:
+mime@^2.4.4, mime@^2.4.6:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe"
   integrity sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==
@@ -4958,12 +4885,12 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-ms@2.1.2, ms@^2.0.0, ms@^2.1.1:
+ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3:
+ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -5343,12 +5270,7 @@ object-assign@^4.0.1, object-assign@^4.1.0:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
-object-inspect@^1.7.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
-  integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
-
-object-inspect@^1.9.0:
+object-inspect@^1.7.0, object-inspect@^1.9.0:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.10.3.tgz#c2aa7d2d09f50c99375704f7a0adf24c5782d369"
   integrity sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==
@@ -5388,14 +5310,7 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-onetime@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.0.tgz#fff0f3c91617fe62bb50189636e99ac8a6df7be5"
-  integrity sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
-  dependencies:
-    mimic-fn "^2.1.0"
-
-onetime@^5.1.2:
+onetime@^5.1.0, onetime@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
@@ -5699,17 +5614,10 @@ path-parse@^1.0.6:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
-path-to-regexp@^1.2.1:
+path-to-regexp@^1.2.1, path-to-regexp@^1.7.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
   integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
-  dependencies:
-    isarray "0.0.1"
-
-path-to-regexp@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
-  integrity sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=
   dependencies:
     isarray "0.0.1"
 
@@ -5965,12 +5873,7 @@ q@^1.1.2, q@^1.5.1:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
-qs@^6.5.1, qs@^6.7.0:
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.8.0.tgz#87b763f0d37ca54200334cd57bb2ef8f68a1d081"
-  integrity sha512-tPSkj8y92PfZVbinY1n84i1Qdx75lZjMQYx9WZhnkofyxzw2r7Ho39G3/aEvSUdebxpnnM4LZJCtvE/Aq3+s9w==
-
-qs@^6.9.4:
+qs@^6.5.1, qs@^6.7.0, qs@^6.9.4:
   version "6.10.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
   integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
@@ -6349,14 +6252,7 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.3.2:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
-  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
-  dependencies:
-    path-parse "^1.0.6"
-
-resolve@^1.20.0:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.20.0, resolve@^1.3.2:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -6430,14 +6326,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@^6.4.0, rxjs@^6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.0.tgz#af2901eedf02e3a83ffa7f886240ff9018bbec84"
-  integrity sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==
-  dependencies:
-    tslib "^1.9.0"
-
-rxjs@^6.6.6:
+rxjs@^6.4.0, rxjs@^6.6.0, rxjs@^6.6.6:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
@@ -6464,7 +6353,7 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@7.3.5, semver@^7.1.1, semver@^7.1.3, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
+semver@7.3.5, semver@^7.0.0, semver@^7.1.1, semver@^7.1.3, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
@@ -6475,11 +6364,6 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.0.0:
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
-  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
 serialize-javascript@5.0.1:
   version "5.0.1"
@@ -7218,15 +7102,10 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.13.0:
+tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^1.8.1, tslib@^1.9.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
-  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
 tslib@^2.0.1:
   version "2.2.0"
@@ -7474,12 +7353,7 @@ uuid@^7.0.3:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
-uuid@^8.0.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.2.0.tgz#cb10dd6b118e2dada7d0cd9730ba7417c93d920e"
-  integrity sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q==
-
-uuid@^8.3.2:
+uuid@^8.0.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
@@ -7771,7 +7645,7 @@ yargs@16.2.0, yargs@^16.1.0, yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^15.0.2, yargs@^15.3.1:
+yargs@^15.0.2:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
   integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==


### PR DESCRIPTION
Two quick commits here with no functional changes:

- Deduplicate yarn.lock (removing > 100 lines of duplicate declarations)
- Format code base (there were a bunch of pending changes, likely a result of the `prettier` update in #1808)