### PR TITLE
Fix bug in createTmpDir function

### DIFF
--- a/ern-core/src/createTmpDir.ts
+++ b/ern-core/src/createTmpDir.ts
@@ -3,14 +3,14 @@ import config from './config';
 import fs from 'fs-extra';
 
 export default function (): string {
-  const tmpDir = config.get('tmp-dir');
-  if (tmpDir) {
-    fs.ensureDirSync(tmpDir);
+  const tmpdir = config.get('tmp-dir');
+  if (tmpdir) {
+    fs.ensureDirSync(tmpdir);
   }
   const retainTmpDir = config.get('retain-tmp-dir', false);
   return fs.realpathSync(
     tmp.dirSync({
-      dir: tmpDir,
+      tmpdir,
       unsafeCleanup: !retainTmpDir,
     }).name,
   );


### PR DESCRIPTION
Fix bug introduced in ERN [v0.48.0](https://github.com/electrode-io/electrode-native/releases/tag/v0.48.0) through https://github.com/electrode-io/electrode-native/pull/1808

This bug is causing some ERN commands to fail with such an error, when and only when `tmp-dir` CLI option of ERN is used _(to override the system temporary directory location)_.

```
✖ An error occurred: dir option must be relative to "/var/folders/rt/wyyd9ym914z3cpjh00y6t5_x3blvsn/T", 
found "/Users/xxxx/ern-temp".
```

This bug is due to the bump of [tmp](https://github.com/raszi/node-tmp) dependency version _(0.0.33 -> 0.2.1)_ containing a breaking change. 
`dir` option of this module still exists but it does not have the same use anymore _(it now except a relative path, relative. to the system temporary directory)_ leading to the error. The new option name to override default system temporary directory is now `tmpDir`. 
Obviously, it wasn't caught by TypeScript, because the `dir` option still exist with same type, but with different behavior _(bad, bad, bad :()_. 

The fix is simply to use `tmpDir` option instead of `dir`.