### PR TITLE
Fix bug in code-push release

### DIFF
--- a/ern-orchestrator/src/codepush.ts
+++ b/ern-orchestrator/src/codepush.ts
@@ -371,16 +371,28 @@ export async function performCodePushOtaUpdate(
       );
     }
 
-    const miniAppsToBeCodePushed = _.unionBy(
-      referenceMiniAppsToCodePush,
+    const miniAppsToBeCodePushedUnordered: PackagePath[] = _.unionBy(
       miniApps,
+      referenceMiniAppsToCodePush,
       (x) => x.basePath,
     );
 
-    const jsApiImplsToBeCodePushed = _.unionBy(
-      referenceJsApiImplsToCodePush,
+    // Reorder MiniApps to preserve current order set in Cauldron
+    const miniAppsToBeCodePushed: PackagePath[] = orderPackagePaths(
+      referenceMiniAppsToCodePush,
+      miniAppsToBeCodePushedUnordered,
+    );
+
+    const jsApiImplsToBeCodePushedUnordered = _.unionBy(
       jsApiImpls,
+      referenceJsApiImplsToCodePush,
       (x) => x.basePath,
+    );
+
+    // Reorder JS API implementations to preserve current order set in Cauldron
+    const jsApiImplsToBeCodePushed: PackagePath[] = orderPackagePaths(
+      referenceJsApiImplsToCodePush,
+      jsApiImplsToBeCodePushedUnordered,
     );
 
     const pathsToMiniAppsToBeCodePushed = _.map(miniAppsToBeCodePushed, (m) =>
@@ -657,4 +669,24 @@ export async function getCodePushAppName(
       napDescriptor.platform === 'ios' ? 'Ios' : 'Android'
     }`
   );
+}
+
+// Reorder packages to preserve current order as set in Cauldron
+export function orderPackagePaths(
+  referencePackagePaths: PackagePath[],
+  packagePaths: PackagePath[],
+): PackagePath[] {
+  const packages: PackagePath[] = [];
+  for (const m of referencePackagePaths) {
+    const x = _.find(packagePaths, (p) => p.basePath === m.basePath) ?? m;
+    packages.push(x);
+  }
+  // Add all new packages if any
+  const newPackages: PackagePath[] = _.differenceBy(
+    packagePaths,
+    referencePackagePaths,
+    (p) => p.basePath,
+  );
+  packages.push(...newPackages);
+  return packages;
 }

--- a/ern-orchestrator/test/codepush-test.ts
+++ b/ern-orchestrator/test/codepush-test.ts
@@ -851,4 +851,61 @@ describe('codepush', () => {
       expect(result).equal('app-android');
     });
   });
+
+  describe('orderPackagePaths', () => {
+    const referencePackagePaths: PackagePath[] = [
+      PackagePath.fromString(
+        'git+ssh://git@github.com/foo/A.git#24f0eebdd714949ec5af5366a1adcf6aeb759bdf',
+      ),
+      PackagePath.fromString(
+        'git+ssh://git@github.com/foo/B.git#a4e7b1b1f4671330edac9d7ac09be66e29a56e43',
+      ),
+      PackagePath.fromString(
+        'git+ssh://git@github.com/foo/C.git#09f6a4f8c19ced184bad428272b1f02f76ffd5b8',
+      ),
+    ];
+    const [originalPkgA, originalPkgB, originalPkgC] = referencePackagePaths;
+
+    const updatedPackagedPaths: PackagePath[] = [
+      PackagePath.fromString(
+        'git+ssh://git@github.com/foo/A.git#b554f6e7a3433f9118de8a677e34d27b161f501a',
+      ),
+      PackagePath.fromString(
+        'git+ssh://git@github.com/foo/B.git#683c50cd2e50c6146f87cc377b9db1e24e722de6',
+      ),
+      PackagePath.fromString(
+        'git+ssh://git@github.com/foo/C.git#9548e24c79830658be6f038177310b98298653b2',
+      ),
+    ];
+    const [updatedPkgA, updatedPkgB, updatedPkgC] = updatedPackagedPaths;
+
+    it('should preserve packages reference order', () => {
+      const res = sut.orderPackagePaths(referencePackagePaths, [
+        updatedPkgC,
+        updatedPkgA,
+        updatedPkgB,
+      ]);
+      expect(res).deep.equal([updatedPkgA, updatedPkgB, updatedPkgC]);
+    });
+
+    it('should keep reference packages that are not updated', () => {
+      const res = sut.orderPackagePaths(referencePackagePaths, [
+        updatedPkgB,
+        updatedPkgA,
+      ]);
+      expect(res).deep.equal([updatedPkgA, updatedPkgB, originalPkgC]);
+    });
+
+    it('should keep new packages that are not part of reference packages', () => {
+      const newPkg = PackagePath.fromString(
+        'git+ssh://git@github.com/foo/D.git#ccf32848ae53ce9e339090bb3a1b26c971041734',
+      );
+      const res = sut.orderPackagePaths(referencePackagePaths, [
+        updatedPkgB,
+        updatedPkgA,
+        newPkg,
+      ]);
+      expect(res).deep.equal([updatedPkgA, updatedPkgB, originalPkgC, newPkg]);
+    });
+  });
 });


### PR DESCRIPTION
Fix a regression of `code-push release` command, that got introduced in [v0.44.1](https://github.com/electrode-io/electrode-native/releases/tag/v0.44.1) release through https://github.com/electrode-io/electrode-native/pull/1720

The bug comes from the fact that `unionBy` keeps entries from the first array, causing the current MiniApps SHA _(or JS API impls)_, as set in Cauldron, to be picked, instead of the ones supplied to the command, leading to the CodePush release being a noop.

Instead of preserving the ordering by switching `unionBy` arrays _(causing this buggy side effect)_, revert the order of the arguments to the right one, and reorder MiniApps/JS API implementations via a post processing function.