### PR TITLE
Add GitHub action workflow for ern release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release new Electrode Native version
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release-ern:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+      - name: Install
+        run: yarn install
+      - name: Release
+        run: |
+          ERN_VERSION=$(cat lerna.json | jq .version)
+          echo "Releasing Electrode Native v${ERN_VERSION}"
+          lerna publish ${ERN_VERSION} --yes --no-git-tag-version --no-push --exact
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Add initial GitHub action workflow to take care of publishing new Electrode Native releases to npm.

With this PR, the release process is still partially manual. Full automation is not what's intended in this PR _(this might be tackled on later on if deemed necessary)_. 
This workflow only takes care of publishing new versions to npm, to avoid having to perform this step from a workstation, mainly to improve security _(mostly to avoid any compromised env or having to share publication password with all maintainers)._

It triggers whenever a tag is pushed to the repository _(we only use tags for versioning in this repository)_. 
The job will read the version to publish from the `lerna.json` file kept at the root of the repository, and run `lerna publish` to publish all packages with this verrsion.

The [release process outlined in the wiki](https://github.com/electrode-io/electrode-native/wiki/New-platform-version-release-process) will be updated accordingly post PR review / merge. It will not be changed drastically. Only change would be that instead of manually running `lerna publish`, the step would change to indicate to manually update the version in `lerna.json`, both for new main version releases and for patch version releases.