### PR TITLE
Update ElectrodeReactContainer.java and regen fixtures

### DIFF
--- a/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactContainer.java
+++ b/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactContainer.java
@@ -26,7 +26,9 @@ import com.ern.api.impl.{{apiName}}ApiRequestHandlerProvider;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
+{{#isCustomReactNativeAar}}
 import com.facebook.react.bridge.ReactApplicationContext;
+{{/isCustomReactNativeAar}}
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.SafeActivityStarter;
 import com.facebook.react.devsupport.interfaces.DevOptionHandler;
@@ -67,8 +69,8 @@ public class ElectrodeReactContainer {
 
     private ElectrodeReactContainer() {
     }
-
 {{#isCustomReactNativeAar}}
+
     public static void setPackageName(String packageName) {
         ReactApplicationContext.PACKAGE_NAME = packageName;
     }

--- a/system-tests/fixtures/api-impl-js/ern-movie-api-impl/package.json
+++ b/system-tests/fixtures/api-impl-js/ern-movie-api-impl/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {
-    "react-native": "0.63.4"
+    "react-native": "0.64.0"
   },
   "dependencies": {
     "react-native-ernmovie-api": "0.0.11"

--- a/system-tests/fixtures/api-impl-native/ern-movie-api-impl/android/lib/build.gradle
+++ b/system-tests/fixtures/api-impl-native/ern-movie-api-impl/android/lib/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
     buildToolsVersion "28.0.3"
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 28
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
@@ -27,6 +27,6 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0'
-    implementation 'com.walmartlabs.ern:react-native:0.63.4'
+    implementation 'com.walmartlabs.ern:react-native:0.64.0'
     testImplementation 'junit:junit:4.12'
 }

--- a/system-tests/fixtures/api-impl-native/ern-movie-api-impl/ios/Podfile
+++ b/system-tests/fixtures/api-impl-native/ern-movie-api-impl/ios/Podfile
@@ -1,12 +1,30 @@
-platform :ios, '10.0'
+platform :ios, '11.0'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
 
 
+post_install do |installer|
+  react_native_post_install(installer)
+
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['BUILD_LIBRARY_FOR_DISTRIBUTION'] = 'YES'
+    end
+
+    if (target.name&.eql?('FBReactNativeSpec'))
+      target.build_phases.each do |build_phase|
+        if (build_phase.respond_to?(:name) && build_phase.name.eql?('[CP-User] Generate Specs'))
+          target.build_phases.move(build_phase, 0)
+        end
+      end
+    end
+  end
+end
+
 target 'ElectrodeApiImpl' do
   # Pods for ElectrodeApiImpl
   pod 'FBLazyVector', :path => "../node_modules/react-native/Libraries/FBLazyVector"
-  pod 'FBReactNativeSpec', :path => "../node_modules/react-native/Libraries/FBReactNativeSpec"
+  pod 'FBReactNativeSpec', :path => "../node_modules/react-native/React/FBReactNativeSpec"
   pod 'RCTRequired', :path => "../node_modules/react-native/Libraries/RCTRequired"
   pod 'RCTTypeSafety', :path => "../node_modules/react-native/Libraries/TypeSafety"
   pod 'React', :path => '../node_modules/react-native/'
@@ -29,12 +47,14 @@ target 'ElectrodeApiImpl' do
   pod 'React-jsiexecutor', :path => '../node_modules/react-native/ReactCommon/jsiexecutor'
   pod 'React-jsinspector', :path => '../node_modules/react-native/ReactCommon/jsinspector'
   pod 'React-callinvoker', :path => "../node_modules/react-native/ReactCommon/callinvoker"
+  pod 'React-runtimeexecutor', :path => "../node_modules/react-native/ReactCommon/runtimeexecutor"
+  pod 'React-perflogger', :path => "../node_modules/react-native/ReactCommon/reactperflogger"
   pod 'ReactCommon/turbomodule/core', :path => "../node_modules/react-native/ReactCommon"
   pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga', :modular_headers => true
 
   pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
   pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
-  pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
+  pod 'RCT-Folly', :podspec => '../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec'
 
 
   use_native_modules!

--- a/system-tests/fixtures/api-impl-native/ern-movie-api-impl/package.json
+++ b/system-tests/fixtures/api-impl-native/ern-movie-api-impl/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {
-    "react-native": "0.63.4"
+    "react-native": "0.64.0"
   },
   "dependencies": {
     "react-native-ernmovie-api": "0.0.11"


### PR DESCRIPTION
A very minor update to `ElectrodeReactContainer.java` (to avoid an unnecessary change to the fixtures, as well as an unused import). Also the fixtures needed to be regenerated due to some recent changes in the code base (tests were failing).