### PR TITLE
Make electrode plugin delegates nullable

### DIFF
--- a/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeReactNative.h
+++ b/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeReactNative.h
@@ -108,7 +108,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)startWithConfigurations:(id<ElectrodePluginConfig>)reactContainerConfig ernDelegate:(id<ERNDelegate> _Nullable)ernDelegate
                         {{#plugins}}
                         {{#configurable}}
-                        {{{lcname}}}: (id<ElectrodePluginConfig>) {{{lcname}}}
+                        {{{lcname}}}: (id<ElectrodePluginConfig> _Nullable) {{{lcname}}}
                         {{/configurable}}
                         {{/plugins}}
                         {{#hasAtleastOneApiImplConfig}}

--- a/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeReactNative.m
+++ b/ern-container-gen-ios/src/hull/ElectrodeContainer/ElectrodeReactNative.m
@@ -155,7 +155,7 @@ static NSString *enableBundleStore = @"enableBundleStore";
 + (void)startWithConfigurations:(id<ElectrodePluginConfig>)reactContainerConfig ernDelegate:(id<ERNDelegate> _Nullable)ernDelegate
                 {{#plugins}}
                 {{#configurable}}
-                {{{lcname}}}: (id<ElectrodePluginConfig>) {{{lcname}}}
+                {{{lcname}}}: (id<ElectrodePluginConfig> _Nullable) {{{lcname}}}
                 {{/configurable}}
                 {{/plugins}}
                 {{#hasAtleastOneApiImplConfig}}


### PR DESCRIPTION
This allows calling of start method from swift to be able to pass nil to electrode plugin config. Found after runner was moved to Swift.