### PR TITLE
Throw in case metro fails to generate the bundle silently

### DIFF
--- a/ern-core/src/ReactNativeCli.ts
+++ b/ern-core/src/ReactNativeCli.ts
@@ -101,6 +101,16 @@ ${sourceMapOutput ? `--sourcemap-output=${sourceMapOutput}` : ''} \
 ${resetCache ? '--reset-cache' : ''}`;
 
     await execp(bundleCommand, { cwd: workingDir });
+    if (!(await fs.pathExists(bundleOutput))) {
+      // Under some circumstances, Metro bundler process might fail
+      // with some logs, but exit the process with a non error status code.
+      // This guard is to make sure that the bundle was generated,
+      // independently of the exit status code returned by Metro process.
+      throw new Error(
+        'Metro failed to generate the JS bundle. Check Metro logs for more details.',
+      );
+    }
+
     return {
       assetsPath: assetsDest,
       bundlePath: bundleOutput,


### PR DESCRIPTION
Under some rare circumstances _(watchman related)_ we have noticed metro bundler failing to generate the JS bundle but exiting its process with a non error status code.

In that case, Electrode Native will continue its container generation pipeline execution as if nothing happened and will ultimately fail later on when it tries to copy the bundle to the container. 
This is a problem for multiple reasons. First, the build will take a while more before failing _(it might take up to many more minutes before it reaches the point where it will fail)_. Second, because the error is thrown much later on in the process, it might cause confusion as to what exactly the problem is.

We should instead fail fast, at the site of the problem, in that case just after Metro bundler process exit. 
This PR just adds a check to make sure that the bundle was correctly generated, independently of metro exit code, and will throw otherwise.