### PR TITLE
Add MiniAppsConfig file to iOS container gen

### DIFF
--- a/ern-container-gen-ios/src/IosGenerator.ts
+++ b/ern-container-gen-ios/src/IosGenerator.ts
@@ -540,6 +540,44 @@ Make sure to run these commands before building the container.`,
       );
     };
 
+    log.debug('Creating miniapps config');
+    const configFileName = `MiniAppsConfig.swift`;
+    const pathToMiniAppsConfigMustacheTemplate = path.join(
+      PATH_TO_TEMPLATES_DIR,
+      'MiniAppsConfig.mustache',
+    );
+    const pathToOutputConfigFile = path.join(
+      config.outDir,
+      'ElectrodeContainer',
+      'MiniAppNavigationControllers',
+      configFileName,
+    );
+    const mustacheView: any = {};
+    mustacheView.miniApps = await config.composite.getMiniApps();
+    await mustacheUtils.mustacheRenderToOutputFileUsingTemplateFile(
+      pathToMiniAppsConfigMustacheTemplate,
+      mustacheView,
+      pathToOutputConfigFile,
+      partialProxy,
+    );
+    const relativePathToConfigFile = path.join(
+      'MiniAppNavigationControllers',
+      configFileName,
+    );
+    containerIosProject.addFile(
+      relativePathToConfigFile,
+      containerIosProject.findPBXGroupKey({
+        name: 'MiniAppNavigationControllers',
+      }),
+    );
+    containerIosProject.addSourceFile(
+      relativePathToConfigFile,
+      null,
+      containerIosProject.findPBXGroupKey({
+        name: 'MiniAppNavigationControllers',
+      }),
+    );
+
     log.debug('Creating miniapp nav controllers');
     const compositeMiniApps = await config.composite.getMiniApps();
     for (const miniApp of compositeMiniApps) {

--- a/ern-container-gen-ios/src/templates/MiniAppNavigationController.mustache
+++ b/ern-container-gen-ios/src/templates/MiniAppNavigationController.mustache
@@ -1,5 +1,7 @@
 {{>licenseInfo}}
 
+{{>generatedCode}}
+
 open class {{{pascalCaseName}}}NavigationController: ENBaseNavigationController {
 
     open override func getRootComponentName() -> String {

--- a/ern-container-gen-ios/src/templates/MiniAppsConfig.mustache
+++ b/ern-container-gen-ios/src/templates/MiniAppsConfig.mustache
@@ -1,0 +1,15 @@
+{{>licenseInfo}}
+
+{{>generatedCode}}
+
+open class MiniAppsConfig {
+
+    public init() {}
+
+    public let miniApps = [
+        {{#miniApps}}
+                "{{normalizedName}}",
+        {{/miniApps}}
+    ]
+
+}

--- a/ern-container-gen-ios/src/templates/generatedCode.mustache
+++ b/ern-container-gen-ios/src/templates/generatedCode.mustache
@@ -1,0 +1,3 @@
+//
+// GENERATED CODE: DO NOT MODIFY
+//

--- a/system-tests/fixtures/ios-container/ElectrodeContainer/MiniAppNavigationControllers/MiniAppsConfig.swift
+++ b/system-tests/fixtures/ios-container/ElectrodeContainer/MiniAppNavigationControllers/MiniAppsConfig.swift
@@ -18,10 +18,13 @@
 // GENERATED CODE: DO NOT MODIFY
 //
 
-open class MovieListMiniAppNavigationController: ENBaseNavigationController {
+open class MiniAppsConfig {
 
-    open override func getRootComponentName() -> String {
-        return "MovieListMiniApp"
-    }
+    public init() {}
+
+    public let miniApps = [
+                "MovieDetailsMiniApp",
+                "MovieListMiniApp",
+    ]
 
 }

--- a/system-tests/fixtures/ios-container/ElectrodeContainer/MiniAppNavigationControllers/MovieDetailsMiniAppNavigationController.swift
+++ b/system-tests/fixtures/ios-container/ElectrodeContainer/MiniAppNavigationControllers/MovieDetailsMiniAppNavigationController.swift
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+//
+// GENERATED CODE: DO NOT MODIFY
+//
+
 open class MovieDetailsMiniAppNavigationController: ENBaseNavigationController {
 
     open override func getRootComponentName() -> String {


### PR DESCRIPTION
This PR allows access to miniapp names for consuming native app.