### PR TITLE
Update plugin config gen with kotlin support

### DIFF
--- a/ern-core/src/PluginConfigGenerator.ts
+++ b/ern-core/src/PluginConfigGenerator.ts
@@ -23,16 +23,13 @@ export class PluginConfigGenerator {
 
     if (androidGenerator.doesPluginSupportAndroid) {
       try {
-        const androidConfig = await androidGenerator.generateConfig({
+        result.pluginConfig = result.pluginConfig || {};
+        result.pluginConfig.android = await androidGenerator.generateConfig({
           resolveDependencyVersion,
           revolveBuildGradlePath,
         });
-        const androidPluginSource =
-          await androidGenerator.generatePluginJavaSource();
-        result.pluginConfig = result.pluginConfig || {};
-        result.pluginConfig.android = androidConfig;
-        result.androidPluginSource = androidPluginSource;
-
+        result.androidPluginSource =
+          await androidGenerator.generatePluginSource();
         log.info('Generated Android plugin configuration');
       } catch (e) {
         throw new Error(`Failed to generate Android Plugin Configuration.
@@ -47,11 +44,10 @@ Reason: ${e.message}`);
 
     if (iosGenerator.doesPluginSupportIos) {
       try {
-        const iosConfig = await iosGenerator.generateConfig({
+        result.pluginConfig = result.pluginConfig || {};
+        result.pluginConfig.ios = await iosGenerator.generateConfig({
           resolvePbxProjPath,
         });
-        result.pluginConfig = result.pluginConfig || {};
-        result.pluginConfig.ios = iosConfig;
         log.info('Generated iOS plugin configuration');
       } catch (e) {
         throw new Error(`Failed to generate iOS Plugin Configuration.

--- a/ern-core/test/AndroidPluginConfigGenerator-test.ts
+++ b/ern-core/test/AndroidPluginConfigGenerator-test.ts
@@ -1,26 +1,24 @@
 import { AndroidPluginConfigGenerator } from '../src/AndroidPluginConfigGenerator';
 import path from 'path';
 import { expect } from 'chai';
+import fs from 'fs-extra';
+
+const fixturesPath = path.join(
+  __dirname,
+  'fixtures/PluginConfigGenerator/android',
+);
+
+async function getFixture(file: string) {
+  return (await fs.readFile(path.join(fixturesPath, file))).toString();
+}
 
 describe('AndroidPluginConfigGenerator', () => {
-  const fixturesPath = path.join(
-    __dirname,
-    'fixtures/PluginConfigGenerator/android',
-  );
-
-  const dependenciesFixturePath = path.join(fixturesPath, 'dependencies');
-  const dependenciesBuildGradlePath = path.join(
-    dependenciesFixturePath,
-    'build.gradle',
-  );
+  const sut = AndroidPluginConfigGenerator.fromPath(fixturesPath);
 
   describe('getDependenciesFromBuildGradle', () => {
     it('should get dependencies', async () => {
-      const sut = AndroidPluginConfigGenerator.fromPath(
-        dependenciesFixturePath,
-      );
       const dependencies = await sut.getDependenciesFromBuildGradle(
-        dependenciesBuildGradlePath,
+        path.join(fixturesPath, 'build.gradle'),
         () => Promise.resolve('1.0.0'),
       );
       expect(dependencies).deep.equal([
@@ -31,5 +29,93 @@ describe('AndroidPluginConfigGenerator', () => {
         "implementation 'com.example:aar-dep:1.0.0'", // gradle-to-js currently does not support closure blocks and artifact type selectors (@aar)
       ]);
     });
+  });
+
+  describe('getPackageDeclarationFromSource', () => {
+    it('should return null if not found', async () => {
+      expect(sut.getPackageDeclarationFromSource('no package')).to.be.null;
+    });
+
+    it('should return package name from Java source', () => {
+      const source = 'package com.example;';
+      expect(sut.getPackageDeclarationFromSource(source)).to.equal(
+        'com.example',
+      );
+    });
+
+    it('should return package name from Kotlin source', () => {
+      const source = 'package com.example';
+      expect(sut.getPackageDeclarationFromSource(source)).to.equal(
+        'com.example',
+      );
+    });
+  });
+
+  describe('getClassNameFromSource', () => {
+    it('should return null if not found', async () => {
+      expect(sut.getClassNameFromSource('no class name')).to.be.null;
+    });
+    for (const t of [
+      {
+        source: 'public class TestPackage implements ReactPackage',
+        type: 'Java source',
+      },
+      {
+        source: 'class TestPackage : ReactPackage',
+        type: 'Kotlin source (standard formatting)',
+      },
+      {
+        source: 'class TestPackage:ReactPackage',
+        type: 'Kotlin source (no space)',
+      },
+      {
+        source: 'class TestPackage(test: String) : ReactPackage',
+        type: 'Kotlin source (with primary constructor)',
+      },
+      {
+        source: 'class TestPackage(test:String):ReactPackage',
+        type: 'Kotlin source (with primary constructor, no space)',
+      },
+    ]) {
+      it(`should detect class name in ${t.type}`, async () => {
+        expect(sut.getClassNameFromSource(t.source)).to.equal('TestPackage');
+      });
+    }
+  });
+
+  describe('hasNoArgumentConstructor', () => {
+    for (const t of [
+      { className: 'TestPackage', type: 'java', expected: false },
+      { className: 'TestNoArgCtorPackage', type: 'java', expected: true },
+      { className: 'TestCustomCtorPackage', type: 'java', expected: false },
+      { className: 'TestPackage', type: 'kt', expected: false },
+      { className: 'TestNoArgCtorPackage', type: 'kt', expected: true },
+      { className: 'TestCustomCtorPackage', type: 'kt', expected: false },
+      { className: 'TestPrimaryCtorPackage', type: 'kt', expected: false },
+    ]) {
+      it(`should detect constructor in ${t.type} source [${t.className}]`, async () => {
+        const src = await getFixture(`${t.className}.${t.type}`);
+        expect(sut.hasNoArgumentConstructor(src, t.className)).to.eq(
+          t.expected,
+        );
+      });
+    }
+  });
+
+  describe('hasNonDefaultConstructor', () => {
+    for (const t of [
+      { className: 'TestPackage', type: 'java', expected: false },
+      { className: 'TestNoArgCtorPackage', type: 'java', expected: false },
+      { className: 'TestCustomCtorPackage', type: 'java', expected: true },
+      { className: 'TestPackage', type: 'kt', expected: false },
+      { className: 'TestNoArgCtorPackage', type: 'kt', expected: false },
+      { className: 'TestCustomCtorPackage', type: 'kt', expected: true },
+      { className: 'TestPrimaryCtorPackage', type: 'kt', expected: true },
+    ]) {
+      it(`should detect custom constructor in ${t.type} source [${t.className}]`, async () => {
+        const src = await getFixture(`${t.className}.${t.type}`);
+        expect(sut.hasCustomConstructors(src, t.className)).to.eq(t.expected);
+      });
+    }
   });
 });

--- a/ern-core/test/fixtures/PluginConfigGenerator/android/TestCustomCtorPackage.java
+++ b/ern-core/test/fixtures/PluginConfigGenerator/android/TestCustomCtorPackage.java
@@ -1,0 +1,28 @@
+package com.example;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.Collections;
+import java.util.List;
+
+public class TestCustomCtorPackage implements ReactPackage {
+    public TestCustomCtorPackage(String test) {
+    }
+
+    @NonNull
+    @Override
+    public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
+        return Collections.singletonList(new TestModule(reactContext));
+    }
+
+    @NonNull
+    @Override
+    public List<ViewManager> createViewManagers(@NonNull ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+}

--- a/ern-core/test/fixtures/PluginConfigGenerator/android/TestCustomCtorPackage.kt
+++ b/ern-core/test/fixtures/PluginConfigGenerator/android/TestCustomCtorPackage.kt
@@ -1,0 +1,19 @@
+package com.example
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class TestCustomCtorPackage : ReactPackage {
+    constructor(test: String) {
+    }
+
+    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
+        return emptyList()
+    }
+
+    override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
+        return listOf(TestPackage())
+    }
+}

--- a/ern-core/test/fixtures/PluginConfigGenerator/android/TestNoArgCtorPackage.java
+++ b/ern-core/test/fixtures/PluginConfigGenerator/android/TestNoArgCtorPackage.java
@@ -1,0 +1,28 @@
+package com.example;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.Collections;
+import java.util.List;
+
+public class TestNoArgCtorPackage implements ReactPackage {
+    public TestNoArgCtorPackage() {
+    }
+
+    @NonNull
+    @Override
+    public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
+        return Collections.singletonList(new TestModule(reactContext));
+    }
+
+    @NonNull
+    @Override
+    public List<ViewManager> createViewManagers(@NonNull ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+}

--- a/ern-core/test/fixtures/PluginConfigGenerator/android/TestNoArgCtorPackage.kt
+++ b/ern-core/test/fixtures/PluginConfigGenerator/android/TestNoArgCtorPackage.kt
@@ -1,0 +1,19 @@
+package com.example
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class TestNoArgCtorPackage : ReactPackage {
+    constructor() {
+    }
+
+    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
+        return emptyList()
+    }
+
+    override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
+        return listOf(TestPackage())
+    }
+}

--- a/ern-core/test/fixtures/PluginConfigGenerator/android/TestPackage.java
+++ b/ern-core/test/fixtures/PluginConfigGenerator/android/TestPackage.java
@@ -1,0 +1,25 @@
+package com.example;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.Collections;
+import java.util.List;
+
+public class TestPackage implements ReactPackage {
+    @NonNull
+    @Override
+    public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
+        return Collections.singletonList(new TestModule(reactContext));
+    }
+
+    @NonNull
+    @Override
+    public List<ViewManager> createViewManagers(@NonNull ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+}

--- a/ern-core/test/fixtures/PluginConfigGenerator/android/TestPackage.kt
+++ b/ern-core/test/fixtures/PluginConfigGenerator/android/TestPackage.kt
@@ -1,0 +1,16 @@
+package com.example
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class TestPackage : ReactPackage {
+    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
+        return emptyList()
+    }
+
+    override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
+        return listOf(TestPackage())
+    }
+}

--- a/ern-core/test/fixtures/PluginConfigGenerator/android/TestPrimaryCtorPackage.kt
+++ b/ern-core/test/fixtures/PluginConfigGenerator/android/TestPrimaryCtorPackage.kt
@@ -1,0 +1,19 @@
+package com.example
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class TestPrimaryCtorPackage(test: String) : ReactPackage {
+    init {
+    }
+
+    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
+        return emptyList()
+    }
+
+    override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
+        return listOf(TestPackage())
+    }
+}

--- a/ern-core/test/fixtures/PluginConfigGenerator/android/build.gradle
+++ b/ern-core/test/fixtures/PluginConfigGenerator/android/build.gradle
@@ -47,4 +47,7 @@ dependencies {
   api 'com.example:api:1.0.0'
   compileOnly 'com.example:compile-only:1.0.0'
   implementation('com.example:aar-dep:1.0.0@aar') { transitive = true }
+  implementation fileTree(dir: 'libs', include: ['*.jar'])
+  testImplementation 'com.example:test:1.0.0'
+  testCompile 'com.example:test:1.0.0'
 }


### PR DESCRIPTION
Several updates and improvements to `AndroidPluginConfigGenerator.ts`. Biggest user visible change is that it now includes basic support for detecting and processing Kotlin source files in plugins when running `ern create-plugin-config`. Added new test cases to verify new use cases.

Closes #1757