### PR TITLE
Automate publishing and versioning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,9 @@
 name: publish
 on:
-  push:
-    tags: ['v[0-9]+.[0-9]+.[0-9]+']
+  release:
+    types: [published]
 jobs:
   publish:
-    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -12,10 +11,7 @@ jobs:
         with:
           node-version: '16'
           registry-url: 'https://registry.npmjs.org'
-      - name: Set variables
-        id: vars
-        run: echo ::set-output name=version::"$(jq -r .version lerna.json)"
       - run: yarn --frozen-lockfile
-      - run: yarn lerna publish ${{ steps.vars.outputs.version }} -y --no-git-tag-version --no-push --exact
+      - run: yarn lerna publish from-git -y
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,48 @@
+name: version
+on:
+  workflow_dispatch:
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - name: Set Git user
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+      - name: Set variables
+        id: vars
+        run: |
+          echo ::set-output name=currentVersion::"$(jq -r .version lerna.json)"
+          echo ::set-output name=lastMinor::"$((npm --silent info ern-core version || echo '0.0.0') | sed 's/[0-9]*\.\([0-9]*\).*/\1/')"
+      - run: yarn --frozen-lockfile
+      - name: Minor version
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        run: |
+          git checkout -b v0.$((MINOR+1))
+          git push -u origin v0.$((MINOR+1))
+          yarn lerna version 0.$((MINOR+1)).0 -y --exact --force-publish
+        env:
+          MINOR: ${{ steps.vars.outputs.lastMinor }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Patch version
+        if: startsWith(steps.vars.outputs.currentVersion, '0.')
+        run: yarn lerna version patch -y --exact --force-publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: echo "VERSION=$(jq -r .version lerna.json)" >> $GITHUB_ENV
+      - name: Create Release Notes
+        uses: actions/github-script@v5
+        with:
+          script: |
+            await github.request(`POST /repos/${{ github.repository }}/releases`, {
+              draft: true,
+              generate_release_notes: true,
+              name: "${{ env.VERSION }}",
+              tag_name: "v${{ env.VERSION }}"
+            });


### PR DESCRIPTION
This PR introduces a new workflow **version.yml**, which, together with **publish.yml**, fully automates new releases of Electrode Native.

After this is merged, the following is **no longer required**:

- Manual creation/synchronization of release branches
- Updates to `lerna.json`
- Locally committing and tagging
- Pushing of tags

Instead, we now have two separate workflows that work together as follows:

1. **Step 1: version.yml** (GitHub side, triggered **manually**)
  Once the repo is in a state ready for a new release, the version workflow is triggered on the respective branch:
    - The _default_ branch for a new _minor_ release
    - An existing `v0.x` branch for a new patch release

    The workflow will create the new release branch (if necessary), update versions, commit changes, create tags, and push it back to the repo. It will then auto populate release notes and create a _draft_ **GitHub Release** for the new version.
2. **Step 2: publish.yml** (npm side, triggered when a **GitHub Release is published**)
  After all versioning is done there is a final chance to verify everything works as expected. Then go to GitHub Releases, select the new draft, check and update release notes and click **Publish**.