### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,31 +1,29 @@
-## Contributing to Electrode Native
+# Contributing
 
 You can contribute to the Electrode Native open source project in several ways:
 
-- As an Electrode Native user, if you face any issue with the platform, you can open a [new issue].
-- While reading the documentation, if you notice any typo (even a minor typpo ;), any misleading or wrong information or missing content, you can edit the documentation directly and issue a Pull Request. Using GitHub, this can be done online without having to fork the repository on your workstation.
-- If you want to suggest a new feature or an improvement for an existing one, you can create a [new issue]. Over time, we will create labels to easily classify issues.
-- In case you would like to use a native module that is not currently supported by Electrode Native, you can contribute a plugin configuration in the master manifest to add support for this native module. Check the documentation on [Reusing existing native modules](https://native.electrode.io/reference/index-3#reusing-existing-native-modules) for more information.
-- By resolving an [open issue]. For this you'll have to setup your workstation accordingly to be able to work on the platform code, as explained below.
-- You can also contribute to the [Electrode Native Bridge] library.
+- As an Electrode Native user, if you face any issue with the platform, open a [new issue].
+- While reading the documentation, if you notice a typo, misleading or wrong information, or missing content, edit the documentation and open a Pull Request. Using GitHub, this can be done online without having to clone the repository.
+- If you want to suggest a new feature or an improvement for an existing one, create a [new issue]. Labels are used to classify issues.
+- In case you would like to use a native module that is not currently supported by Electrode Native, create a plugin configuration in the [electrode-native-manifest][10] repo. See [Reusing existing native modules](https://native.electrode.io/reference/index-3#reusing-existing-native-modules) for more information.
+- Resolve an [open issue]. For this you'll have to [set up your workstation](#Electrode-Native-development-setup) to be able to work on the platform code, as explained below.
+- You can also contribute to [react-native-electrode-bridge].
 
 ## Electrode Native development prerequisites
 
 You'll need to install [Yarn][3].
 
-Electrode Native is using [Yarn Workspaces][1] and [Lerna][2] to manage `ern-` modules, which in turn use Yarn instead of NPM to install all `ern-` module dependencies.
+Electrode Native uses [Yarn Workspaces][1] and [Lerna][2] to manage `ern-` modules, which in turn uses Yarn instead of npm to install all `ern-` module dependencies.
 
 ## Electrode Native development setup
 
-If you want to contribute code to the Electrode Native platform, you'll first need to setup a development environment to work on Electrode Native. It's actually quite easy to start working on the platform.
-
-1. If you have not already installed the platform, install by running the following command:
+1. If you have not already installed the global CLI, install it by running the following command:
 
     ```bash
     npm install -g electrode-native
     ```
 
-1. Fork and clone the `electrode-native` repository.
+1. Clone the `electrode-native` repository.
 
 1. In your local working directory of the `electrode-native` repository, run the following command:
 
@@ -33,7 +31,7 @@ If you want to contribute code to the Electrode Native platform, you'll first ne
     node setup-dev
     ```
 
-   It takes care of installing all the needed dependencies for all Electrode Native modules, creates a new local version `1000.0.0` of the platform, and installs [Git hooks](#git-hooks).
+   It takes care of installing dependencies for all Electrode Native modules, creates a new local version `1000.0.0` of the platform, and installs [Git hooks](#git-hooks).
 
 1. Upon completion, use the following command to switch Electrode Native to this version:  
 
@@ -41,9 +39,9 @@ If you want to contribute code to the Electrode Native platform, you'll first ne
     ern platform use 1000.0.0
     ```
 
-    Version `1000.0.0` is the development version and it points to your Electrode Native working folder.
+    Version `1000.0.0` is the development version pointing to your Electrode Native working folder.
 
-    This version is also taking care of running transpilation of the code on the fly, which means that any code modification you'll make to any of the modules will be immediately reflected when running any `ern` command.
+    This version transpiles the code on the fly, which means that any code modification you'll make to any of the modules will be immediately reflected when running `ern` commands.
 
 With this setup, you can also use Electrode Native as any other non-developer user. You can install new released platform versions or even switch between versions.  
 The only difference with a regular user will be that you'll have access to version `1000.0.0` of the platform, which is the development version.
@@ -51,9 +49,9 @@ The only difference with a regular user will be that you'll have access to versi
 ## Electrode Native development remarks
 
 Electrode Native workspace is composed of multiple independent packages (all prefixed by `ern-`) that are managed by [Yarn Workspaces][1] and [Lerna][2].
-When using the development version, after pulling the latest from our `master`, you might sometimes experience errors such as `Cannot find module ...` when running `ern` again. This is because some new package dependencies might have been added to one or more `ern-` modules and needs to be installed. The same applies if you add a new package dependency to the `package.json` of one of the `ern-` module project, you'll need to install it using Yarn.
+When using the development version, after updating the repository, you might sometimes experience errors such as `Cannot find module ...` when running `ern` again. This is because some new package dependencies might have been added to one or more `ern-` modules and needs to be installed. The same applies if you add a new package dependency to the `package.json` of one of the `ern-` module project, you'll need to install it using Yarn.
 
-The way to do this is to just run `yarn && yarn build` in the root directory of your Electrode Native clone.
+The way to do this is to run `yarn && yarn build` in the root directory of the repository.
 
 ### Git hooks
 
@@ -75,49 +73,45 @@ cp -a .githooks/* .git/hooks/
 
 Electrode Native uses [TypeScript] across all of its modules.
 
-[TypeScript] comes with integration support for many JavaScript editors. If you want to see [flow] errors from within your editor, please check the list of supported [flow editors] and configure your editor accordingly.
-
-Electrode Native has a pre-commit hook setup, that will run [tslint] for every commit. In case a commit contains some flow errors, it won't go through. You'll have to fix the error(s) first before being able to commit your changes.
-
 ### Tests
 
-Electrode Native contains two different test suites :
+Electrode Native contains two different test suites:
 - Unit tests
 - System tests
 
-The unit test suite is not taking long to run, and will be run on any `git push`. You can also run them manually, by running `yarn test:unit` from the root of the `electrode-native` directory. Tests from all modules will be executed.
+The unit test suite is not taking long to run, and will be run on any `git push`. You can also run them manually from the root of the repository: `yarn test:unit`. Tests from all modules will be executed.
 
-System tests are running `ern` commands as a user would do. This test suite is taking way longer to run than the unit tests one, and should mostly only be run following heavy modifications to the code base. They can be launched by running `yarn test:system` from the root of the `electrode-native` directory.
+System tests are running `ern` commands as a user would do. This test suite is taking longer to run than the unit tests one, and should mostly only be run following heavy modifications to the code base. They can be launched by running `yarn test:system` from the root repository.
 
-Our tests are written using [mocha], [chai] and [sinon].
+Our tests are written using [mocha], chai and [sinon].
 
 ### Coverage
 
-We are using [nyc][5] to generate and report test coverage.
+We use [nyc][5] to generate and report test coverage.
 
-The following commands can be used to get coverage reports locally:
+Use the following commands to get coverage reports locally:
 
 - `yarn coverage:unit`\
-To generate and report unit tests coverage
+Generates a unit tests coverage report
 - `yarn coverage:system`\
-To generate and report system tests coverage
+Generate a system tests coverage report
 - `yarn coverage`\
-To generate and report combined UT/ST coverage
+Generate a combined UT/ST coverage report
 
-Once done, the coverage will be reported in the terminal.\
-An html report will also be generated in the `coverage` directory.
+Once done, the coverage will be reported in the terminal, together with an html
+report in the `coverage` directory.
 
-Combine UT/ST coverage of the `master` branch is posted daily to [coveralls][6].
+Combined UT/ST coverage on the default branch is posted daily to [coveralls][6].
 
 ## Guidelines for documentation contributions
 
-We are using [GitBook] for our documentation.  
+We use [GitBook] for our documentation.  
 
 All our documentation pages are stored as markdown files withing the `/docs` directory.
 
-If you need to make light edits to our documentation, such as simple rewording or fixing a few typos in a page, the simplest way is to just edit the page directly from GitHub. Just navigate to the page in our GitHub repository, or if you are looking at the documentation online, just click the `Edit this page` button in the top left corner of the page, which will take you to the page in GitHub.  
+If you need to make light edits to our documentation, such as simple rewording or fixing a few typos in a page, the simplest way is to edit the page directly on GitHub. If you are looking at the documentation online, click the `Edit this page` button in the top left corner of the page, which will take you to the page in GitHub.  
 
-From there, just click the `Edit this file` button and make your modifications. You can then select the option `Create a new branch for this commit and start a pull request` at the bottom of the page to automatically issue a Pull Request for your change.
+From there, click the `Edit this file` button and make your modifications. You can then select the option `Create a new branch for this commit and start a pull request` at the bottom of the page to create a Pull Request for your change.
 
 In case you need to go through more heavy edits (reformatting, adding pages, adding images, working on templatized content -android v.s ios-), you might want to visualize your changes before actually opening a Pull Request, just to make sure the updated content is properly rendered by GitBook.
 
@@ -147,13 +141,46 @@ You can keep the server running. Any time you'll do a change in the documentatio
 
 ## Continuous Integration
 
-We are using [Azure DevOps] for our Continuous Integration (CI).
+We use [GitHub Actions][4] and [Azure DevOps] for our Continuous Integration (CI).
 
-The CI job is run on every opened Pull Request (PR). It runs [TSLint][4] checks along with running all of the unit tests, in parallel, on Windows, Linux and OSX, as well as running all of the unit tests on a Linux node for different Node versions (8/10 and 12).
-
-We will only merge PRs that pass the CI (green status). TSLint checks are automatically run for you on every commit, and unit tests will be executed on git push, so you should not have any surprise for these checks when it comes to the CI.
+The CI jobs run on every opened Pull Request (PR). It will run lint checks along with all the unit tests, in parallel, on Linux, macOS, and Windows, as well as the unit tests on a Linux node for different Node versions.
 
 Another CI job is taking care of running the complete system test suite daily.
+
+## Releasing new platform versions
+
+Contributors with permissions to run workflows in the repo can use GitHub
+Actions to version and publish new releases of the platform.
+
+### Step 1: [version.yml][7] (triggered manually)
+
+Once the repo is in a state ready for a new release, use the version workflow
+to trigger the versioning process.
+
+- Open the [version workflow][7] and click the gray "Run workflow" dropdown
+- Select the correct branch
+  - The default branch for a new minor release
+  - An existing `v0.x` branch for a new patch release
+- Click the green "Run workflow" button
+
+The workflow will create the new release branch (for minor releases), update
+versions, commit changes, create tags, and push everything back to the repo. It
+will then create a draft GitHub Release with auto generated release notes for
+the new version.
+
+### Step 2: [publish.yml][8] (runs when a GitHub Release is published)
+
+After all versioning is done there is a final chance to verify everything works
+as expected before publishing the new version to npm.
+
+- Fetch from the repo
+- Validate locally
+
+Once verified:
+
+- Go to [GitHub Releases][9] and select the new draft
+- Check and update release notes as necessary
+- Click Publish
 
 [Azure DevOps]: https://dev.azure.com/ElectrodeNative/Electrode%20Native/_build?definitionId=1&_a=summary
 
@@ -161,19 +188,13 @@ Another CI job is taking care of running the complete system test suite daily.
 
 [open issue]: https://github.com/electrode-io/electrode-native/issues
 
-[Electrode Native Bridge]:https://github.com/electrode-io/react-native-electrode-bridge
+[react-native-electrode-bridge]: https://github.com/electrode-io/react-native-electrode-bridge
 
-[CLI]: https://github.com/electrode-io/electrode-native/blob/master/docs/platform-parts/cli.md#ern-local-client
-
-[editor plugins]: https://standardjs.com/awesome.html#editor-plugins
-
-[TypeScript]: http://www.typescriptlang.org/
+[TypeScript]: https://www.typescriptlang.org/
 
 [mocha]: https://mochajs.org/
 
-[chai]: http://chaijs.com/
-
-[sinon]: http://sinonjs.org/
+[sinon]: https://sinonjs.org/
 
 [gitbook]: https://www.gitbook.com
 
@@ -182,6 +203,10 @@ Another CI job is taking care of running the complete system test suite daily.
 [1]: https://yarnpkg.com/lang/en/docs/workspaces/
 [2]: https://github.com/lerna/lerna
 [3]: https://github.com/yarnpkg/yarn
-[4]: https://palantir.github.io/tslint/
+[4]: https://github.com/electrode-io/electrode-native/actions/
 [5]: https://github.com/istanbuljs/nyc
 [6]: https://coveralls.io/github/electrode-io/electrode-native
+[7]: https://github.com/electrode-io/electrode-native/actions/workflows/version.yml
+[8]: https://github.com/electrode-io/electrode-native/actions/workflows/publish.yml
+[9]: https://github.com/electrode-io/electrode-native/releases
+[10]: https://github.com/electrode-io/electrode-native-manifest


### PR DESCRIPTION
This updates CONTRIBUTING.md with several minor corrections and improvements, as well as a new section **Releasing new platform versions** with details on the new versioning/publishing workflows introduced in #1841. These instructions will replace the release process info that is currently contained in the repo's [wiki](https://github.com/electrode-io/electrode-native/wiki).