### PR TITLE
Fix yarn info generic message when package not exists

### DIFF
--- a/ern-core/src/YarnCli.ts
+++ b/ern-core/src/YarnCli.ts
@@ -100,7 +100,11 @@ export class YarnCli {
           // 'warning' and 'error' packet types are sent to stderr
           // we want to fail only on 'error'
           if (jsonLine.type === 'error') {
-            reject(jsonLine.data);
+            if (jsonLine.data.includes('Received invalid response from npm.')) {
+              reject(new Error('Package not found'));
+            } else {
+              reject(jsonLine.data);
+            }
           }
         });
       });


### PR DESCRIPTION
When using ern regen-api in not published api folder, it throws an error saying "Received invalid response from npm.". This PR fixes this yarn info command issue and replaces generic message with 'Package not found'.

Closes #1764