### PR TITLE
Lock node-ipc to 9.2.1

### DIFF
--- a/ern-core/package.json
+++ b/ern-core/package.json
@@ -58,7 +58,7 @@
     "lodash": "^4.17.21",
     "mustache": "^4.2.0",
     "node-fetch": "^2.6.1",
-    "node-ipc": "^9.1.4",
+    "node-ipc": "9.2.1",
     "node-simctl": "^6.4.1",
     "react-native-cli": "^2.0.1",
     "semver": "^7.3.5",

--- a/ern-local-cli/package.json
+++ b/ern-local-cli/package.json
@@ -61,7 +61,7 @@
     "inquirer": "^8.0.0",
     "kax": "^3.0.0",
     "lodash": "^4.17.21",
-    "node-ipc": "^9.1.4",
+    "node-ipc": "9.2.1",
     "semver": "^7.3.5",
     "treeify": "^1.1.0",
     "untildify": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5056,7 +5056,7 @@ node-gyp@^7.1.0:
     tar "^6.0.2"
     which "^2.0.2"
 
-node-ipc@^9.1.4:
+node-ipc@9.2.1:
   version "9.2.1"
   resolved "https://registry.yarnpkg.com/node-ipc/-/node-ipc-9.2.1.tgz#b32f66115f9d6ce841dc4ec2009d6a733f98bb6b"
   integrity sha512-mJzaM6O3xHf9VT8BULvJSbdVbmHUKRNOH7zDDkCrA1/T+CVjq2WVIDfLt0azZRXpgArJtl3rtmEozrbXPZ9GaQ==


### PR DESCRIPTION
Precaution to avoid unintended upgrades to a version containing malicious code:

https://gist.github.com/MidSpike/f7ae3457420af78a54b38a31cc0c809c

Closes #1858