### PR TITLE
Fix iOS container generation for RN 0.64+

### DIFF
--- a/ern-container-gen-ios/src/IosGenerator.ts
+++ b/ern-container-gen-ios/src/IosGenerator.ts
@@ -357,7 +357,10 @@ Make sure to run these commands before building the container.`,
           // for iOS container builds.
           shell.rm('-rf', path.join(nodeModulesDir, '**/android'));
 
-          if (semver.gte(reactNativePlugin.version!, '0.64.0')) {
+          const codegenVersion = iosUtil.getReactNativeCodegenVersion(
+            reactNativePlugin.version,
+          );
+          if (codegenVersion) {
             // Starting with React Native 0.64.0, code generation for Turbo Modules
             // is performed using react-native-codegen package.
             // The package entry point is invoked during Xcode build of FBReactNativeSpec
@@ -368,7 +371,7 @@ Make sure to run these commands before building the container.`,
             // container generation and get rid of the the build script phase after doing
             // that, so that we don't clutter node_modules of the container pushed to git
             // and that Node does not have to be a requirement to build containers.
-            await this.addReactNativeCodeGen(config.outDir);
+            await this.addReactNativeCodegen(config.outDir, codegenVersion);
           }
         } finally {
           shell.popd();
@@ -377,13 +380,13 @@ Make sure to run these commands before building the container.`,
     }
   }
 
-  public async addReactNativeCodeGen(targetDir: string): Promise<void> {
+  public async addReactNativeCodegen(targetDir: string, version: string) {
     log.debug('Adding react-native-codegen package');
     const tmpDir = createTmpDir();
     shell.pushd(tmpDir);
     try {
       await yarn.init();
-      await yarn.add(PackagePath.fromString('react-native-codegen'));
+      await yarn.add(PackagePath.fromString(`react-native-codegen@${version}`));
       // mkdirp and invariant are also needed
       await yarn.add(PackagePath.fromString('mkdirp'));
       await yarn.add(PackagePath.fromString('invariant'));

--- a/ern-core/src/iosUtil.ts
+++ b/ern-core/src/iosUtil.ts
@@ -574,3 +574,15 @@ export const getDefaultIosDeploymentTarget = (rnVersion: string): string => {
     return '8.0';
   }
 };
+
+export const getReactNativeCodegenVersion = (
+  rnVersion: string,
+): string | null => {
+  if (semver.gte(rnVersion, '0.65.0')) {
+    return '^0.0.7';
+  } else if (semver.gte(rnVersion, '0.64.0')) {
+    return '^0.0.6';
+  } else {
+    return null;
+  }
+};


### PR DESCRIPTION
iOS container builds for RN 0.64+ started failing on 2022-03-23 due to a change in the external dependency `react-native-codegen` (which the container generator added without specifying a version).

This aligns the version of react-native-codegen with the version of React Native during iOS container generation.