### PR TITLE
New iOS plist UsageDescription keys

### DIFF
--- a/ern-runner-gen-ios/src/hull/ErnRunner/Info.plist
+++ b/ern-runner-gen-ios/src/hull/ErnRunner/Info.plist
@@ -59,6 +59,10 @@
 	<string>ErnRunner is requesting photo library access.</string>
 	<key>NSRemindersUsageDescription</key>
 	<string>ErnRunner is requesting reminders access.</string>
+  <key>NSSiriUsageDescription</key>
+  <string>ErnRunner is requesting Siri access.</string>
+  <key>NSSpeechRecognitionUsageDescription</key>
+  <string>ErnRunner is requesting Speech Recognition access.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/ern-runner-gen-ios/src/hull/ErnRunner/Info.plist
+++ b/ern-runner-gen-ios/src/hull/ErnRunner/Info.plist
@@ -59,10 +59,10 @@
 	<string>ErnRunner is requesting photo library access.</string>
 	<key>NSRemindersUsageDescription</key>
 	<string>ErnRunner is requesting reminders access.</string>
-  <key>NSSiriUsageDescription</key>
-  <string>ErnRunner is requesting Siri access.</string>
-  <key>NSSpeechRecognitionUsageDescription</key>
-  <string>ErnRunner is requesting Speech Recognition access.</string>
+	<key>NSSiriUsageDescription</key>
+	<string>ErnRunner is requesting Siri access.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>ErnRunner is requesting Speech Recognition access.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/ern-runner-gen-ios/test/fixtures/simple-ios-runner/ErnRunner/Info.plist
+++ b/ern-runner-gen-ios/test/fixtures/simple-ios-runner/ErnRunner/Info.plist
@@ -59,6 +59,10 @@
 	<string>ErnRunner is requesting photo library access.</string>
 	<key>NSRemindersUsageDescription</key>
 	<string>ErnRunner is requesting reminders access.</string>
+  <key>NSSiriUsageDescription</key>
+  <string>ErnRunner is requesting Siri access.</string>
+  <key>NSSpeechRecognitionUsageDescription</key>
+  <string>ErnRunner is requesting Speech Recognition access.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/ern-runner-gen-ios/test/fixtures/simple-ios-runner/ErnRunner/Info.plist
+++ b/ern-runner-gen-ios/test/fixtures/simple-ios-runner/ErnRunner/Info.plist
@@ -59,10 +59,10 @@
 	<string>ErnRunner is requesting photo library access.</string>
 	<key>NSRemindersUsageDescription</key>
 	<string>ErnRunner is requesting reminders access.</string>
-  <key>NSSiriUsageDescription</key>
-  <string>ErnRunner is requesting Siri access.</string>
-  <key>NSSpeechRecognitionUsageDescription</key>
-  <string>ErnRunner is requesting Speech Recognition access.</string>
+	<key>NSSiriUsageDescription</key>
+	<string>ErnRunner is requesting Siri access.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>ErnRunner is requesting Speech Recognition access.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION

Protected Resources in iOS apps needs UsageDescription keys/values to be added to the Info.plist (Information Property List).  The string values will be presented to the user the first time they access the resource.  Failure to set the appropriate UsageDescription in the Info.plist will result in the app crashing when running in iOS 10 or greater.

Here is the complete list of Protected Resources:
https://developer.apple.com/documentation/bundleresources/information_property_list/protected_resources

The ErRunner generated by Electrode Native is missing two UsageDescriptions from that list and available to iOS 10, the minimum target typically generated: 
https://developer.apple.com/documentation/bundleresources/information_property_list/nssiriusagedescription
https://developer.apple.com/documentation/bundleresources/information_property_list/nsspeechrecognitionusagedescription

As the ErRunner is generated only for running miniapps directly (i.e., "ern run-ios") and not used in the native app that would run the container, this change is purely for the miniapp developer's convenience.