### PR TITLE
Update rule of create custom publisher/transformer

### DIFF
--- a/docs/platform-parts/container/container-publication.md
+++ b/docs/platform-parts/container/container-publication.md
@@ -62,7 +62,7 @@ Check our [dummy publisher]([https://github.com/electrode-io/ern-container-publi
 
 A few things to keep in mind when creating a Container publisher :
 
-- The package name must be prefixed with `ern-container-publisher-`. This is a convention for Electrode Native Container publishers, and is enforced by Electrode Native.
+- The package name must include `ern-container-publisher`. This is a convention for Electrode Native Container publishers, and is enforced by Electrode Native.
 
 - You should add a keyword `ern-container-publisher` in the keywords list of the package.json. This is not required, but could be leveraged later on by Electrode Native to facilitate container publishers discovery.
 

--- a/docs/platform-parts/container/container-transformation.md
+++ b/docs/platform-parts/container/container-transformation.md
@@ -59,6 +59,6 @@ Check our [dummy transforrmer]([https://github.com/electrode-io/ern-container-tr
 
 A few things to keep in mind when creating a Container publisher :
 
-- The package name must be prefixed with `ern-container-transformer-`. This is a convention for Electrode Native Container transformers, and is enforced by Electrode Native.
+- The package name must include `ern-container-transformer`. This is a convention for Electrode Native Container transformers, and is enforced by Electrode Native.
 
 - You should add a keyword `ern-container-transformer` in the keywords list of the package.json. This is not required, but could be leveraged later on by Electrode Native to facilitate container transformers discovery.

--- a/ern-local-cli/src/commands/publish-container.ts
+++ b/ern-local-cli/src/commands/publish-container.ts
@@ -54,7 +54,7 @@ export const builder = (argv: Argv) => {
     .epilog(epilog(exports));
 };
 
-const publisherPackagePrefix = 'ern-container-publisher-';
+const publisherPackageId = 'ern-container-publisher';
 
 export const commandHandler = async ({
   containerPath,
@@ -92,15 +92,13 @@ export const commandHandler = async ({
 
   if (
     publisher.isRegistryPath &&
-    !publisher.basePath.startsWith(publisherPackagePrefix)
+    !publisher.basePath.includes(publisherPackageId)
   ) {
     publisher = publisher.version
       ? PackagePath.fromString(
-          `${publisherPackagePrefix}${publisher.basePath}@${publisher.version}`,
+          `${publisherPackageId}-${publisher.basePath}@${publisher.version}`,
         )
-      : PackagePath.fromString(
-          `${publisherPackagePrefix}${publisher.basePath}`,
-        );
+      : PackagePath.fromString(`${publisherPackageId}-${publisher.basePath}`);
   }
 
   await publishContainer({

--- a/ern-local-cli/src/commands/transform-container.ts
+++ b/ern-local-cli/src/commands/transform-container.ts
@@ -35,7 +35,7 @@ export const builder = (argv: Argv) => {
     .epilog(epilog(exports));
 };
 
-const transformerPackagePrefix = 'ern-container-transformer-';
+const transformerPackageId = 'ern-container-transformer';
 
 export const commandHandler = async ({
   containerPath,
@@ -67,14 +67,14 @@ export const commandHandler = async ({
 
   if (
     transformer.isRegistryPath &&
-    !transformer.basePath.startsWith(transformerPackagePrefix)
+    !transformer.basePath.includes(transformerPackageId)
   ) {
     transformer = transformer.version
       ? PackagePath.fromString(
-          `${transformerPackagePrefix}${transformer.basePath}@${transformer.version}`,
+          `${transformerPackageId}-${transformer.basePath}@${transformer.version}`,
         )
       : PackagePath.fromString(
-          `${transformerPackagePrefix}${transformer.basePath}`,
+          `${transformerPackageId}-${transformer.basePath}`,
         );
   }
 


### PR DESCRIPTION
Updated prefix rule. 

Because we must use scope company prefix. Like this `@company/ern-container-transformer-zfr`