### PR TITLE
Update RN to 0.66.5 in system test fixtures

### DIFF
--- a/system-tests/fixtures/api-impl-js/ern-movie-api-impl/package.json
+++ b/system-tests/fixtures/api-impl-js/ern-movie-api-impl/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {
-    "react-native": "0.66.4"
+    "react-native": "0.66.5"
   },
   "dependencies": {
     "react-native-ernmovie-api": "0.0.11"

--- a/system-tests/fixtures/api-impl-native/ern-movie-api-impl/android/lib/build.gradle
+++ b/system-tests/fixtures/api-impl-native/ern-movie-api-impl/android/lib/build.gradle
@@ -27,6 +27,6 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0'
-    implementation 'com.walmartlabs.ern:react-native:0.66.4'
+    implementation 'com.walmartlabs.ern:react-native:0.66.5'
     testImplementation 'junit:junit:4.12'
 }

--- a/system-tests/fixtures/api-impl-native/ern-movie-api-impl/package.json
+++ b/system-tests/fixtures/api-impl-native/ern-movie-api-impl/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {
-    "react-native": "0.66.4"
+    "react-native": "0.66.5"
   },
   "dependencies": {
     "react-native-ernmovie-api": "0.0.11"


### PR DESCRIPTION
Updated RN 0.66.5 in Manifest - https://github.com/electrode-io/electrode-native-manifest/pull/234

Fix all the test fixtures to use RN 0.66.5