### PR TITLE
Migrate to androidx package

### DIFF
--- a/ern-api-gen/resources/android/libraries/ern/api.mustache
+++ b/ern-api-gen/resources/android/libraries/ern/api.mustache
@@ -2,7 +2,7 @@
 
 package {{package}};
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeEvent;
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeEventListener;

--- a/ern-api-gen/resources/android/libraries/ern/apidatamodel.mustache
+++ b/ern-api-gen/resources/android/libraries/ern/apidatamodel.mustache
@@ -5,8 +5,8 @@ package {{package}};
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import java.util.List;
 
 import com.walmartlabs.electrode.reactnative.bridge.Bridgeable;

--- a/ern-api-gen/resources/android/libraries/ern/apievents.mustache
+++ b/ern-api-gen/resources/android/libraries/ern/apievents.mustache
@@ -2,7 +2,7 @@
 
 package {{{package}}};
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeEvent;
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeEventListener;

--- a/ern-api-gen/resources/android/libraries/ern/apirequests.mustache
+++ b/ern-api-gen/resources/android/libraries/ern/apirequests.mustache
@@ -2,7 +2,7 @@
 
 package {{{package}}};
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeHolder;
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeRequestHandler;

--- a/ern-api-gen/resources/android/libraries/ern/model.mustache
+++ b/ern-api-gen/resources/android/libraries/ern/model.mustache
@@ -5,8 +5,8 @@ package {{package}};
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import java.util.List;
 
 import com.walmartlabs.electrode.reactnative.bridge.Bridgeable;

--- a/ern-container-gen-android/src/AndroidGenerator.ts
+++ b/ern-container-gen-android/src/AndroidGenerator.ts
@@ -336,9 +336,7 @@ You should replace "${annotationProcessorPrefix}:${dependency}" with "annotation
     androidDependencies.regular.push(
       `com.walmartlabs.ern:react-native:${versions.reactNativeAarVersion}`,
     );
-    androidDependencies.regular.push(
-      `com.android.support:appcompat-v7:${versions.supportLibraryVersion}`,
-    );
+
     if (isKotlinEnabled) {
       androidDependencies.regular.push(
         `org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlinVersion}`,
@@ -600,9 +598,9 @@ You should replace "${annotationProcessorPrefix}:${dependency}" with "annotation
 
     // Replace versions of support libraries with set version
     dependencies.regular = dependencies.regular.map((d) =>
-      d.startsWith('com.android.support:')
+      d.startsWith('androidx.appcompat:')
         ? `${d.slice(0, d.lastIndexOf(':'))}:${
-            androidVersions.supportLibraryVersion
+            androidVersions.androidxAppcompactVersion
           }`
         : d,
     );

--- a/ern-container-gen-android/src/hull/gradle.properties
+++ b/ern-container-gen-android/src/hull/gradle.properties
@@ -15,3 +15,10 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+# AndroidX package structure to make it clearer which packages are bundled with the
+# Android operating system, and which are packaged with your app's APK
+# https://developer.android.com/topic/libraries/support-library/androidx-rn
+android.useAndroidX=true
+# Automatically convert third-party libraries to use AndroidX
+android.enableJetifier=true

--- a/ern-core/src/AndroidPluginConfigGenerator.ts
+++ b/ern-core/src/AndroidPluginConfigGenerator.ts
@@ -8,8 +8,8 @@ import log from './log';
 const template = `package com.walmartlabs.ern.container.plugins;
 
 import android.app.Application;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.ReactPackage;
 import {{packageName}}.{{className}};

--- a/ern-core/test/AndroidPluginConfigGenerator-test.ts
+++ b/ern-core/test/AndroidPluginConfigGenerator-test.ts
@@ -22,7 +22,7 @@ describe('AndroidPluginConfigGenerator', () => {
         () => Promise.resolve('1.0.0'),
       );
       expect(dependencies).deep.equal([
-        "implementation 'com.android.support:support-v4:28.0.0'",
+        "implementation 'androidx.appcompat:appcompat:1.1.0'",
         "annotationProcessor 'com.example:annotation-processor:1.0.0'",
         "api 'com.example:api:1.0.0'",
         "compileOnly 'com.example:compile-only:1.0.0'",

--- a/ern-core/test/fixtures/PluginConfigGenerator/android/build.gradle
+++ b/ern-core/test/fixtures/PluginConfigGenerator/android/build.gradle
@@ -42,7 +42,7 @@ dependencies {
   implementation fileTree(include: ['*.jar'], dir: 'libs1')
   implementation fileTree(dir: 'libs2', include: ['*.jar'])
   implementation 'com.facebook.react:react-native:+'
-  implementation "com.android.support:support-v4:${safeExtGet('supportLibVersion', '28.0.0')}"
+  implementation "androidx.appcompat:appcompat:${safeExtGet('supportLibVersion', '1.1.0')}"
   annotationProcessor 'com.example:annotation-processor:1.0.0'
   api 'com.example:api:1.0.0'
   compileOnly 'com.example:compile-only:1.0.0'

--- a/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complex/ern/api/SystemTestEventApi.java
+++ b/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complex/ern/api/SystemTestEventApi.java
@@ -16,7 +16,7 @@
 
 package com.complex.ern.api;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeEvent;
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeEventListener;

--- a/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complex/ern/api/SystemTestEventEvents.java
+++ b/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complex/ern/api/SystemTestEventEvents.java
@@ -16,7 +16,7 @@
 
 package com.complex.ern.api;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeEvent;
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeEventListener;

--- a/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complex/ern/api/SystemTestEventRequests.java
+++ b/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complex/ern/api/SystemTestEventRequests.java
@@ -16,7 +16,7 @@
 
 package com.complex.ern.api;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeHolder;
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeRequestHandler;

--- a/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complex/ern/api/SystemTestsApi.java
+++ b/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complex/ern/api/SystemTestsApi.java
@@ -16,7 +16,7 @@
 
 package com.complex.ern.api;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeEvent;
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeEventListener;

--- a/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complex/ern/api/SystemTestsRequests.java
+++ b/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complex/ern/api/SystemTestsRequests.java
@@ -16,7 +16,7 @@
 
 package com.complex.ern.api;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeHolder;
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeRequestHandler;

--- a/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complex/ern/api/TestEventObjectParamApi.java
+++ b/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complex/ern/api/TestEventObjectParamApi.java
@@ -16,7 +16,7 @@
 
 package com.complex.ern.api;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeEvent;
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeEventListener;

--- a/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complex/ern/api/TestEventObjectParamData.java
+++ b/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complex/ern/api/TestEventObjectParamData.java
@@ -19,8 +19,8 @@ package com.complex.ern.api;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import java.util.List;
 
 import com.walmartlabs.electrode.reactnative.bridge.Bridgeable;

--- a/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complex/ern/api/TestEventObjectParamEvents.java
+++ b/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complex/ern/api/TestEventObjectParamEvents.java
@@ -16,7 +16,7 @@
 
 package com.complex.ern.api;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeEvent;
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeEventListener;

--- a/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complex/ern/api/TestEventObjectParamRequests.java
+++ b/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complex/ern/api/TestEventObjectParamRequests.java
@@ -16,7 +16,7 @@
 
 package com.complex.ern.api;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeHolder;
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeRequestHandler;

--- a/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complex/ern/api/TestMultiArgsData.java
+++ b/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complex/ern/api/TestMultiArgsData.java
@@ -19,8 +19,8 @@ package com.complex.ern.api;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import java.util.List;
 
 import com.walmartlabs.electrode.reactnative.bridge.Bridgeable;

--- a/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complex/ern/model/ErnObject.java
+++ b/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complex/ern/model/ErnObject.java
@@ -19,8 +19,8 @@ package com.complex.ern.model;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import java.util.List;
 
 import com.walmartlabs.electrode.reactnative.bridge.Bridgeable;

--- a/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complex/ern/model/NavBarButton.java
+++ b/system-tests/fixtures/api/complex-api/android/lib/src/main/java/com/complex/ern/model/NavBarButton.java
@@ -19,8 +19,8 @@ package com.complex.ern.model;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import java.util.List;
 
 import com.walmartlabs.electrode.reactnative.bridge.Bridgeable;

--- a/system-tests/fixtures/api/test-api/android/lib/src/main/java/com/test/ern/api/WalmartItemApi.java
+++ b/system-tests/fixtures/api/test-api/android/lib/src/main/java/com/test/ern/api/WalmartItemApi.java
@@ -16,7 +16,7 @@
 
 package com.test.ern.api;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeEvent;
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeEventListener;

--- a/system-tests/fixtures/api/test-api/android/lib/src/main/java/com/test/ern/api/WalmartItemEvents.java
+++ b/system-tests/fixtures/api/test-api/android/lib/src/main/java/com/test/ern/api/WalmartItemEvents.java
@@ -16,7 +16,7 @@
 
 package com.test.ern.api;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeEvent;
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeEventListener;

--- a/system-tests/fixtures/api/test-api/android/lib/src/main/java/com/test/ern/api/WalmartItemRequests.java
+++ b/system-tests/fixtures/api/test-api/android/lib/src/main/java/com/test/ern/api/WalmartItemRequests.java
@@ -16,7 +16,7 @@
 
 package com.test.ern.api;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeHolder;
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeRequestHandler;

--- a/system-tests/fixtures/api/test-api/android/lib/src/main/java/com/test/ern/model/Item.java
+++ b/system-tests/fixtures/api/test-api/android/lib/src/main/java/com/test/ern/model/Item.java
@@ -19,8 +19,8 @@ package com.test.ern.model;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import java.util.List;
 
 import com.walmartlabs.electrode.reactnative.bridge.Bridgeable;


### PR DESCRIPTION
Update erncontainer-gen and ern-api-gen to use androidx packages
Migration to Androidx - https://developer.android.com/jetpack/androidx/migrate