### PR TITLE
Automatically convert plugins to AndroidX if RN>60

### DIFF
--- a/ern-container-gen-android/src/AndroidGenerator.ts
+++ b/ern-container-gen-android/src/AndroidGenerator.ts
@@ -216,6 +216,27 @@ export default class AndroidGenerator implements ContainerGenerator {
             config.outDir,
             'lib/src/main',
           );
+          if (semver.gte(reactNativePlugin.version, '0.60.0')) {
+            const filesWithSupportLib: string[] = [];
+            shell.pushd(relPathToPluginSource);
+            shell.ls('**/*.java').forEach((file) => {
+              if (shell.grep('android.support', file).trim().length !== 0) {
+                filesWithSupportLib.push(file);
+              }
+            });
+            if (filesWithSupportLib.length !== 0) {
+              log.info(
+                `${plugin.name} contains source files with references to the Android Support Library (android.support.*)`,
+              );
+              filesWithSupportLib.forEach((file) => {
+                shell.sed('-i', 'android.support', 'androidx', file);
+              });
+              log.info(
+                `${filesWithSupportLib.length} files successfully converted to use AndroidX (androidx.*)`,
+              );
+            }
+            shell.popd();
+          }
           shell.cp('-R', relPathToPluginSource, absPathToCopyPluginSourceTo);
         }
 

--- a/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeMiniAppActivity.java
+++ b/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeMiniAppActivity.java
@@ -6,11 +6,12 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.RequiresApi;
 import android.view.KeyEvent;
 import android.view.MenuItem;
 import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 
 import com.facebook.react.modules.core.PermissionAwareActivity;
 import com.facebook.react.modules.core.PermissionListener;

--- a/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactActivityDelegate.java
+++ b/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactActivityDelegate.java
@@ -6,9 +6,10 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
+import android.view.View;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import android.view.View;
 
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactNativeHost;

--- a/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactContainer.java
+++ b/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactContainer.java
@@ -13,9 +13,10 @@ import com.walmartlabs.ern.container.plugins.{{name}};
 import android.app.Activity;
 import android.app.Application;
 import android.content.Intent;
+import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import android.util.Log;
 
 {{#apiImplementations}}
 import com.ern.api.impl.{{apiName}}ApiController;

--- a/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/devassist/ErnDevSettingsActivity.java
+++ b/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/devassist/ErnDevSettingsActivity.java
@@ -9,9 +9,10 @@ import android.preference.Preference;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceManager;
 import android.preference.SwitchPreference;
-import androidx.annotation.NonNull;
 import android.text.format.DateFormat;
 import android.widget.Toast;
+
+import androidx.annotation.NonNull;
 
 import com.facebook.react.modules.network.OkHttpClientProvider;
 import com.walmartlabs.ern.container.ElectrodeReactContainer;

--- a/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/plugins/ReactPlugin.java
+++ b/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/plugins/ReactPlugin.java
@@ -1,6 +1,7 @@
 package com.walmartlabs.ern.container.plugins;
 
 import android.app.Application;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 

--- a/ern-core/src/AndroidPluginConfigGenerator.ts
+++ b/ern-core/src/AndroidPluginConfigGenerator.ts
@@ -8,6 +8,7 @@ import log from './log';
 const template = `package com.walmartlabs.ern.container.plugins;
 
 import android.app.Application;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -15,6 +16,7 @@ import com.facebook.react.ReactPackage;
 import {{packageName}}.{{className}};
 
 public class {{className}}Plugin implements ReactPlugin {
+    @Override
     public ReactPackage hook(@NonNull Application application, @Nullable ReactPluginConfig config) {
         return new {{className}}();
     }

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/ernmovie/ern/api/MoviesApi.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/ernmovie/ern/api/MoviesApi.java
@@ -13,7 +13,7 @@
 
 package com.ernmovie.ern.api;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeEventListener;
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeEvent;

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/ernmovie/ern/api/MoviesRequests.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/ernmovie/ern/api/MoviesRequests.java
@@ -13,7 +13,7 @@
 
 package com.ernmovie.ern.api;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeHolder;
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeRequestHandler;

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/ernmovie/ern/model/BirthYear.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/ernmovie/ern/model/BirthYear.java
@@ -16,8 +16,8 @@ package com.ernmovie.ern.model;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import java.util.List;
 
 import com.walmartlabs.electrode.reactnative.bridge.Bridgeable;

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/ernmovie/ern/model/Movie.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/ernmovie/ern/model/Movie.java
@@ -16,8 +16,8 @@ package com.ernmovie.ern.model;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import java.util.List;
 
 import com.walmartlabs.electrode.reactnative.bridge.Bridgeable;

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/ernmovie/ern/model/Person.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/ernmovie/ern/model/Person.java
@@ -16,8 +16,8 @@ package com.ernmovie.ern.model;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import java.util.List;
 
 import com.walmartlabs.electrode.reactnative.bridge.Bridgeable;

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/ernmovie/ern/model/Synopsis.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/ernmovie/ern/model/Synopsis.java
@@ -16,8 +16,8 @@ package com.ernmovie.ern.model;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import java.util.List;
 
 import com.walmartlabs.electrode.reactnative.bridge.Bridgeable;

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/ernnavigation/ern/api/NavigateData.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/ernnavigation/ern/api/NavigateData.java
@@ -16,8 +16,8 @@ package com.ernnavigation.ern.api;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import java.util.List;
 import com.walmartlabs.electrode.reactnative.bridge.Bridgeable;
 

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/ernnavigation/ern/api/NavigationApi.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/ernnavigation/ern/api/NavigationApi.java
@@ -13,7 +13,7 @@
 
 package com.ernnavigation.ern.api;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeEventListener;
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeEvent;

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/ernnavigation/ern/api/NavigationRequests.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/ernnavigation/ern/api/NavigationRequests.java
@@ -13,7 +13,7 @@
 
 package com.ernnavigation.ern.api;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeHolder;
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeRequestHandler;

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/BridgeFailureMessage.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/BridgeFailureMessage.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public class BridgeFailureMessage implements FailureMessage {
 

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/BridgeMessage.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/BridgeMessage.java
@@ -17,8 +17,8 @@
 package com.walmartlabs.electrode.reactnative.bridge;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableMap;

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/BridgeTransaction.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/BridgeTransaction.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public class BridgeTransaction {
 

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/Bridgeable.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/Bridgeable.java
@@ -17,7 +17,7 @@
 package com.walmartlabs.electrode.reactnative.bridge;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 /**
  * Indicates that any class that implements this interface can be sent across the ElectrodeNativeBridge.

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ConstantsProvider.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ConstantsProvider.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import java.util.Map;
 

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeEvent.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeEvent.java
@@ -17,8 +17,8 @@
 package com.walmartlabs.electrode.reactnative.bridge;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.ReadableMap;
 import com.walmartlabs.electrode.reactnative.bridge.helpers.Logger;

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeEventListener.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeEventListener.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 /**
  * Provide method to be notified of incoming event

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeHolder.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeHolder.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.walmartlabs.electrode.reactnative.bridge.helpers.Logger;
 

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeRequest.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeRequest.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.ReadableMap;
 import com.walmartlabs.electrode.reactnative.bridge.helpers.Logger;

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeRequestHandler.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeRequestHandler.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Provide method to be notified of incoming request.

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeResponse.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeResponse.java
@@ -17,8 +17,8 @@
 package com.walmartlabs.electrode.reactnative.bridge;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableMap;

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeResponseListener.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeResponseListener.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Provide methods to report response for a request.

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeTransceiver.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeTransceiver.java
@@ -18,9 +18,9 @@ package com.walmartlabs.electrode.reactnative.bridge;
 
 import android.os.Handler;
 import android.os.Looper;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeNativeBridge.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeNativeBridge.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.UUID;
 

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeReactBridge.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeReactBridge.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.ReadableMap;
 

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/EventDispatcher.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/EventDispatcher.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 public interface EventDispatcher {
     void dispatchEvent(@NonNull ElectrodeBridgeEvent event);

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/EventDispatcherImpl.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/EventDispatcherImpl.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.helpers.Logger;
 

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/EventListenerProcessor.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/EventListenerProcessor.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.walmartlabs.electrode.reactnative.bridge.helpers.Logger;
 import com.walmartlabs.electrode.reactnative.bridge.util.BridgeArguments;

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/EventProcessor.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/EventProcessor.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.walmartlabs.electrode.reactnative.bridge.helpers.Logger;
 

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/EventRegistrar.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/EventRegistrar.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.util.List;
 import java.util.UUID;

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/EventRegistrarImpl.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/EventRegistrarImpl.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ExistingHandlerException.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ExistingHandlerException.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 /**
  * Exception thrown when trying to register a request handler for a request name that already

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/FailureMessage.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/FailureMessage.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Bridge failure message interface.

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/None.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/None.java
@@ -17,7 +17,7 @@
 package com.walmartlabs.electrode.reactnative.bridge;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 /**
  * Class that is used to represent an emplty request or response type.

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ReactContextWrapper.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ReactContextWrapper.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ReactContextWrapperInternal.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ReactContextWrapperInternal.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.modules.core.DeviceEventManagerModule;

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestDispatcher.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestDispatcher.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 public interface RequestDispatcher {
 

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestDispatcherImpl.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestDispatcherImpl.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.helpers.Logger;
 

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestHandlerProcessor.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestHandlerProcessor.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.walmartlabs.electrode.reactnative.bridge.helpers.Logger;
 import com.walmartlabs.electrode.reactnative.bridge.util.BridgeArguments;

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestProcessor.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestProcessor.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.walmartlabs.electrode.reactnative.bridge.helpers.Logger;
 import com.walmartlabs.electrode.reactnative.bridge.util.BridgeArguments;

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestRegistrar.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestRegistrar.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.UUID;
 

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestRegistrarImpl.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestRegistrarImpl.java
@@ -16,9 +16,9 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import com.walmartlabs.electrode.reactnative.bridge.helpers.Logger;
 

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/helpers/ArgumentsEx.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/helpers/ArgumentsEx.java
@@ -17,7 +17,7 @@
 package com.walmartlabs.electrode.reactnative.bridge.helpers;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableArray;

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/util/BridgeArguments.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/electrode/reactnative/bridge/util/BridgeArguments.java
@@ -17,9 +17,9 @@
 package com.walmartlabs.electrode.reactnative.bridge.util;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import com.walmartlabs.electrode.reactnative.bridge.BridgeMessage;
 import com.walmartlabs.electrode.reactnative.bridge.Bridgeable;

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeMiniAppActivity.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeMiniAppActivity.java
@@ -20,11 +20,12 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.RequiresApi;
 import android.view.KeyEvent;
 import android.view.MenuItem;
 import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 
 import com.facebook.react.modules.core.PermissionAwareActivity;
 import com.facebook.react.modules.core.PermissionListener;

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactActivityDelegate.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactActivityDelegate.java
@@ -6,9 +6,10 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
+import android.view.View;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import android.view.View;
 
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactNativeHost;

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactContainer.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactContainer.java
@@ -23,9 +23,10 @@ import com.walmartlabs.ern.container.plugins.BridgePlugin;
 import android.app.Activity;
 import android.app.Application;
 import android.content.Intent;
+import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import android.util.Log;
 
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/ern/container/devassist/ErnDevSettingsActivity.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/ern/container/devassist/ErnDevSettingsActivity.java
@@ -9,9 +9,10 @@ import android.preference.Preference;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceManager;
 import android.preference.SwitchPreference;
-import androidx.annotation.NonNull;
 import android.text.format.DateFormat;
 import android.widget.Toast;
+
+import androidx.annotation.NonNull;
 
 import com.facebook.react.modules.network.OkHttpClientProvider;
 import com.walmartlabs.ern.container.ElectrodeReactContainer;

--- a/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/ern/container/plugins/ReactPlugin.java
+++ b/system-tests/fixtures/android-container/lib/src/main/java/com/walmartlabs/ern/container/plugins/ReactPlugin.java
@@ -1,6 +1,7 @@
 package com.walmartlabs.ern.container.plugins;
 
 import android.app.Application;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 


### PR DESCRIPTION
When targeting React Native 0.60.0 or later (which uses AndroidX), attempt to automatically convert legacy plugin sources from `android.support` to `androidx`.

In a separate commit, this also contains minor updates to the container hull, and an update to the Android plugin config generator: Insert one blank line between `android.` and `androidx.` top level imports (this blank line is part of default Android Studio formatting, inserting it ensures no unnecessary reformatting will occur).