### PR TITLE
Ensure composite dependencies are version limited

### DIFF
--- a/ern-composite-gen/src/generateComposite.ts
+++ b/ern-composite-gen/src/generateComposite.ts
@@ -194,7 +194,7 @@ async function generateFullComposite(
       );
       // Also add latest version of the bridge
       extraJsDependencies.push(
-        PackagePath.fromString('react-native-electrode-bridge'),
+        PackagePath.fromString('react-native-electrode-bridge@^1.0.0'),
       );
       extraJsDependencies = [...extraJsDependencies, ...jsApiImplDependencies];
     }
@@ -213,8 +213,8 @@ async function generateFullComposite(
       installExtraPackages({
         cwd: outDir,
         extraJsDependencies: [
-          PackagePath.fromString('ern-bundle-store-metro-asset-plugin'),
-          PackagePath.fromString('react-native-svg-transformer'),
+          PackagePath.fromString('ern-bundle-store-metro-asset-plugin@^1.0.0'),
+          PackagePath.fromString('react-native-svg-transformer@^1.0.0'),
           ...extraJsDependencies,
         ],
       }),


### PR DESCRIPTION
Use versions restricted to semver major component for additional packages added to the composite to avoid breaking compatibility.