### PR TITLE
Use standard semver version for api gen bridge

### DIFF
--- a/ern-api-gen/src/generateProject.ts
+++ b/ern-api-gen/src/generateProject.ts
@@ -64,9 +64,7 @@ export function generatePackageJson({
   const options = { ...conf, apiSchemaPath: 'schema.json' };
   const dependencies = bridgeVersion
     ? {
-        'react-native-electrode-bridge': `${bridgeVersion.split('.')[0]}.${
-          bridgeVersion.split('.')[1]
-        }.x`,
+        'react-native-electrode-bridge': `^${bridgeVersion}`,
       }
     : undefined;
   // tslint:disable:object-literal-sort-keys

--- a/ern-api-gen/test/generateProject-test.js
+++ b/ern-api-gen/test/generateProject-test.js
@@ -65,7 +65,7 @@ describe('generatePackageJson', function () {
       main: 'javascript/src/index.js',
       keywords: ['ern-api'],
       dependencies: {
-        'react-native-electrode-bridge': '1.2.x',
+        'react-native-electrode-bridge': '^1.2.3',
       },
       ern: {
         message: {

--- a/system-tests/fixtures/api/complex-api/package.json
+++ b/system-tests/fixtures/api/complex-api/package.json
@@ -8,7 +8,7 @@
   ],
   "author": "generated",
   "dependencies": {
-    "react-native-electrode-bridge": "1.5.x"
+    "react-native-electrode-bridge": "^1.5.27"
   },
   "ern": {
     "message": {

--- a/system-tests/fixtures/api/test-api/package.json
+++ b/system-tests/fixtures/api/test-api/package.json
@@ -8,7 +8,7 @@
   ],
   "author": "generated",
   "dependencies": {
-    "react-native-electrode-bridge": "1.5.x"
+    "react-native-electrode-bridge": "^1.5.27"
   },
   "ern": {
     "message": {


### PR DESCRIPTION
Instead of `{major}.{minor}.x`, use standard `^{major}.{minor}.{patch}` for `react-native-electrode-bridge` in generated api projects.

Note: `{major}.{minor}.x` is effectively `~{major}.{minor}.{patch}` - There is no reason to limit only patch updates (if semver is followed correctly).