### PR TITLE
CI: Remove Node.js 12, add Node.js 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
         node: ['16']
         os: [macos-latest, ubuntu-latest, windows-latest]
         include:
-          - node: '12'
-            os: ubuntu-latest
           - node: '14'
+            os: ubuntu-latest
+          - node: '18'
             os: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Node.js 12 is end-of-life (and also deprecated on GitHub Actions). Remove it from CI matrix build, and add Node.js 18 instead.

<img width="679" alt="image" src="https://user-images.githubusercontent.com/743291/223525440-d1fefb12-67f9-4568-b157-5eb57787ac85.png">

~This also removes the engines restriction from package.json.~ (will be done in separate PR).