### PR TITLE
Revert "Use androidx imports in api-impl-gen"

### DIFF
--- a/ern-api-impl-gen/resources/android/RequestHandlerProvider.java.mustache
+++ b/ern-api-impl-gen/resources/android/RequestHandlerProvider.java.mustache
@@ -2,7 +2,7 @@
 
 package com.ern.api.impl;
 
-import androidx.annotation.Nullable;
+import android.support.annotation.Nullable;
 
 {{>generatedCode}}
 

--- a/ern-api-impl-gen/resources/android/apiController.mustache
+++ b/ern-api-impl-gen/resources/android/apiController.mustache
@@ -2,9 +2,8 @@
 
 package com.ern.api.impl;
 
+import android.support.annotation.Nullable;
 import android.util.Log;
-
-import androidx.annotation.Nullable;
 
 {{>generatedCode}}
 

--- a/ern-api-impl-gen/resources/android/requestHandlerProvider.mustache
+++ b/ern-api-impl-gen/resources/android/requestHandlerProvider.mustache
@@ -2,7 +2,7 @@
 
 package com.ern.api.impl;
 
-import androidx.annotation.Nullable;
+import android.support.annotation.Nullable;
 
 /**
  * A generated placeholder for your {{apiName}} implementation.

--- a/system-tests/fixtures/api-impl-native/ern-movie-api-impl/android/lib/src/main/java/com/ern/api/impl/MoviesApiController.java
+++ b/system-tests/fixtures/api-impl-native/ern-movie-api-impl/android/lib/src/main/java/com/ern/api/impl/MoviesApiController.java
@@ -16,9 +16,8 @@
 
 package com.ern.api.impl;
 
+import android.support.annotation.Nullable;
 import android.util.Log;
-
-import androidx.annotation.Nullable;
 
 //
 // GENERATED CODE: DO NOT MODIFY

--- a/system-tests/fixtures/api-impl-native/ern-movie-api-impl/android/lib/src/main/java/com/ern/api/impl/MoviesApiRequestHandlerProvider.java
+++ b/system-tests/fixtures/api-impl-native/ern-movie-api-impl/android/lib/src/main/java/com/ern/api/impl/MoviesApiRequestHandlerProvider.java
@@ -16,7 +16,7 @@
 
 package com.ern.api.impl;
 
-import androidx.annotation.Nullable;
+import android.support.annotation.Nullable;
 
 /**
  * A generated placeholder for your Movies implementation.

--- a/system-tests/fixtures/api-impl-native/ern-movie-api-impl/android/lib/src/main/java/com/ern/api/impl/RequestHandlerProvider.java
+++ b/system-tests/fixtures/api-impl-native/ern-movie-api-impl/android/lib/src/main/java/com/ern/api/impl/RequestHandlerProvider.java
@@ -16,7 +16,7 @@
 
 package com.ern.api.impl;
 
-import androidx.annotation.Nullable;
+import android.support.annotation.Nullable;
 
 //
 // GENERATED CODE: DO NOT MODIFY

--- a/system-tests/fixtures/api/complex-api/package.json
+++ b/system-tests/fixtures/api/complex-api/package.json
@@ -8,7 +8,7 @@
   ],
   "author": "generated",
   "dependencies": {
-    "react-native-electrode-bridge": "^1.6.0"
+    "react-native-electrode-bridge": "^1.5.27"
   },
   "ern": {
     "message": {

--- a/system-tests/fixtures/api/test-api/package.json
+++ b/system-tests/fixtures/api/test-api/package.json
@@ -8,7 +8,7 @@
   ],
   "author": "generated",
   "dependencies": {
-    "react-native-electrode-bridge": "^1.6.0"
+    "react-native-electrode-bridge": "^1.5.27"
   },
   "ern": {
     "message": {


### PR DESCRIPTION
Reverts electrode-io/electrode-native#1885

On closer inspection, it turns out there is quite a bit more support library leftover in ern-api-impl-gen which is currently causing some issues.
For the next release it is probably safer to revert this change - I'll follow up with a more thorough PR at a later date.