### PR TITLE
Update and fix plugin conversion to support Androidx

### DIFF
--- a/ern-container-gen-android/test/convertToAndroidX-test.ts
+++ b/ern-container-gen-android/test/convertToAndroidX-test.ts
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import { AndroidGenerator } from 'ern-container-gen-android';
+
+describe('Test Convert to AndroidX Imports Logic', () => {
+  it('Expect files in directory to be converted to AndroidX', () => {
+    expect(new AndroidGenerator().convertToAndroidX('fixtures')).to.eq(2);
+  });
+
+  it('Return 0 files converting the existing AndroidX plugins above', () => {
+    expect(new AndroidGenerator().convertToAndroidX('fixtures')).to.eq(0);
+  });
+});

--- a/ern-container-gen-android/test/fixtures/RNHttpapiPackagePlugin.java
+++ b/ern-container-gen-android/test/fixtures/RNHttpapiPackagePlugin.java
@@ -1,0 +1,14 @@
+package com.walmartlabs.ern.container.plugins;
+
+import android.app.Application;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.facebook.react.ReactPackage;
+import com.httpapi.RNHttpapiPackage;
+
+public class RNHttpapiPackagePlugin implements ReactPlugin {
+    public ReactPackage hook(@NonNull Application application, @Nullable ReactPluginConfig config) {
+        return new RNHttpapiPackage();
+    }
+}

--- a/ern-container-gen-android/test/fixtures/WMBarcodePackagePlugin.java
+++ b/ern-container-gen-android/test/fixtures/WMBarcodePackagePlugin.java
@@ -1,0 +1,14 @@
+package com.walmartlabs.ern.container.plugins;
+
+import android.app.Application;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.facebook.react.ReactPackage;
+import com.walmart.wmbarcode.react.WMBarcodePackage;
+
+public class WMBarcodePackagePlugin implements ReactPlugin {
+    public ReactPackage hook(@NonNull Application application, @Nullable ReactPluginConfig config) {
+        return new WMBarcodePackage();
+    }
+}


### PR DESCRIPTION
When targeting React Native 0.60.0 or later (which uses AndroidX), attempt to automatically convert legacy plugin sources from android.support to androidx.
