### PR TITLE
Update and fix plugin conversion to Androidx

### DIFF
--- a/ern-container-gen-android/src/AndroidGenerator.ts
+++ b/ern-container-gen-android/src/AndroidGenerator.ts
@@ -218,27 +218,21 @@ export default class AndroidGenerator implements ContainerGenerator {
             config.outDir,
             'lib/src/main',
           );
+
           if (semver.gte(reactNativePlugin.version, '0.60.0')) {
-            const filesWithSupportLib: string[] = [];
-            shell.pushd(relPathToPluginSource);
-            shell.ls('**/*.java').forEach((file) => {
-              if (shell.grep('android.support', file).trim().length !== 0) {
-                filesWithSupportLib.push(file);
-              }
-            });
-            if (filesWithSupportLib.length !== 0) {
+            const convertedFiles = this.convertToAndroidX(
+              relPathToPluginSource,
+            );
+            if (convertedFiles > 0) {
               log.info(
                 `${plugin.name} contains source files with references to the Android Support Library (android.support.*)`,
               );
-              filesWithSupportLib.forEach((file) => {
-                shell.sed('-i', 'android.support', 'androidx', file);
-              });
               log.info(
-                `${filesWithSupportLib.length} files successfully converted to use AndroidX (androidx.*)`,
+                `${convertedFiles} files successfully converted to use AndroidX (androidx.*)`,
               );
             }
-            shell.popd();
           }
+
           shell.cp('-R', relPathToPluginSource, absPathToCopyPluginSourceTo);
         }
 
@@ -707,8 +701,47 @@ You should replace "${annotationProcessorPrefix}:${dependency}" with "annotation
           'lib/src/main/java/com/walmartlabs/ern/container/plugins',
         );
         shell.cp(pathToPluginConfigHook, pathToCopyPluginConfigHookTo);
+
+        if (semver.gte(rnVersion, '0.60.0')) {
+          const filesConverted = this.convertToAndroidX(
+            pathToCopyPluginConfigHookTo,
+          );
+          if (filesConverted > 0) {
+            log.info(
+              `${plugin.name} contains source files with references to the Android Support Library (android.support.*)`,
+            );
+            log.info(
+              `${filesConverted} files successfully converted to use AndroidX (androidx.*)`,
+            );
+          }
+        }
       }
     }
+  }
+
+  /**
+   * Convert files in a directory from support library to AndroidX
+   * eg: import android.support.annotation.NonNull => import androidx.annotation.NonNull
+   */
+  public convertToAndroidX(dir: string): number {
+    const filesWithSupportLib: string[] = [];
+    shell.pushd(dir);
+    shell
+      .ls('-R', '.')
+      .filter((file) => file.match(/\.(java|kt)$/))
+      .forEach((file) => {
+        if (shell.grep('android.support', file).trim().length !== 0) {
+          filesWithSupportLib.push(file);
+        }
+      });
+
+    filesWithSupportLib.forEach((file) => {
+      shell.sed('-i', 'android.support', 'androidx', file);
+    });
+
+    shell.popd();
+
+    return filesWithSupportLib.length;
   }
 
   public async buildAndroidPluginsViews(

--- a/ern-container-gen-android/test/convertToAndroidX-test.ts
+++ b/ern-container-gen-android/test/convertToAndroidX-test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import { AndroidGenerator } from 'ern-container-gen-android';
+import { shell, createTmpDir } from 'ern-core';
+import path from 'path';
+
+describe('Test - Convert files in the directory to AndroidX Imports Logic', () => {
+  const tmpDir = createTmpDir();
+  const fixturesPath = path.join(__dirname, 'fixtures');
+
+  shell.cp('-rf', fixturesPath, tmpDir);
+
+  it('convert files in directory to AndroidX', () => {
+    expect(new AndroidGenerator().convertToAndroidX(tmpDir)).to.eq(2);
+  });
+
+  it('returns files in directory which contains existing AndroidX plugins', () => {
+    expect(new AndroidGenerator().convertToAndroidX(tmpDir)).to.eq(0);
+  });
+});

--- a/ern-container-gen-android/test/fixtures/RNHttpapiPackagePlugin.java
+++ b/ern-container-gen-android/test/fixtures/RNHttpapiPackagePlugin.java
@@ -1,0 +1,14 @@
+package com.walmartlabs.ern.container.plugins;
+
+import android.app.Application;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.facebook.react.ReactPackage;
+import com.httpapi.RNHttpapiPackage;
+
+public class RNHttpapiPackagePlugin implements ReactPlugin {
+    public ReactPackage hook(@NonNull Application application, @Nullable ReactPluginConfig config) {
+        return new RNHttpapiPackage();
+    }
+}

--- a/ern-container-gen-android/test/fixtures/WMBarcodePackagePlugin.java
+++ b/ern-container-gen-android/test/fixtures/WMBarcodePackagePlugin.java
@@ -1,0 +1,14 @@
+package com.walmartlabs.ern.container.plugins;
+
+import android.app.Application;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.facebook.react.ReactPackage;
+import com.walmart.wmbarcode.react.WMBarcodePackage;
+
+public class WMBarcodePackagePlugin implements ReactPlugin {
+    public ReactPackage hook(@NonNull Application application, @Nullable ReactPluginConfig config) {
+        return new WMBarcodePackage();
+    }
+}


### PR DESCRIPTION
When targeting React Native 0.60.0 or later (which uses AndroidX), attempt to automatically convert legacy plugin sources from android.support to androidx.