### PR TITLE
Update azure macOS image to 11

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ stages:
           - template: azure/templates/unit-tests.yml
       - job: macOS
         pool:
-          vmImage: 'macOS-10.15'
+          vmImage: 'macOS-11'
         steps:
           - template: azure/templates/unit-tests.yml
       - job: Linux


### PR DESCRIPTION
MacOS 10.15 is not available in azure pipelines. Update to BigSur https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml