### PR TITLE
Add optional podRepoUpdate flag in iosConfig

### DIFF
--- a/docs/platform-parts/container/container-integration.md
+++ b/docs/platform-parts/container/container-integration.md
@@ -386,6 +386,18 @@ You can override the iOS deployment target version to use by setting `iosConfig`
 }
 ```
 
+You can run pod repo update before pod install by setting `podRepoUpdate` in the cauldron as show below.
+
+```json
+{
+  "containerGenerator": {
+    "iosConfig": {
+      "podRepoUpdate": true
+    }
+  }
+}
+```
+
 [1]: https://github.com/electrode-io/ern-container-transformer-xcframework
 [2]: https://github.com/electrode-io/ern-container-publisher-cocoapod-git
 [transform-container]: ../../cli/transform-container

--- a/ern-container-gen-ios/src/IosGenerator.ts
+++ b/ern-container-gen-ios/src/IosGenerator.ts
@@ -291,9 +291,16 @@ Make sure to run these commands before building the container.`,
           ? `_${ernConfig.get('podVersion')}_`
           : '';
 
-        const podCmdArgs = [podVersionArg, 'install', '--verbose'].filter(
-          (x: string) => x !== '',
-        );
+        const podRepoUpdateArg = config?.iosConfig?.podRepoUpdate
+          ? '--repo-update'
+          : '';
+
+        const podCmdArgs = [
+          podVersionArg,
+          'install',
+          podRepoUpdateArg,
+          '--verbose',
+        ].filter((x: string) => x !== '');
 
         shell.pushd(config.outDir);
 


### PR DESCRIPTION
Add optional podRepoUpdate flag in iosConfig

- Can be used to update the pod specs when running pod install in container generation. Flag is by default disabled and can be enabled in cauldron below.
This flag was made to use in regen-container command - it generates the container with updating the pod specs during pod install and updates the cauldron with new version and yarnlocks.

```
{
  "containerGenerator": {
    "iosConfig": {
      "podRepoUpdate": true
    }
  }
}
```

or can be using in extra argument in create-container command 
--extra '{"iosConfig": {"deploymentTarget": "11.0", "podRepoUpdate": true}}'