### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -18,8 +18,8 @@ jobs:
       - name: Set variables
         id: vars
         run: |
-          echo ::set-output name=currentVersion::"$(jq -r .version lerna.json)"
-          echo ::set-output name=lastMinor::"$((npm --silent info ern-core version || echo '0.0.0') | sed 's/[0-9]*\.\([0-9]*\).*/\1/')"
+          echo currentVersion="$(jq -r .version lerna.json)" >> $GITHUB_OUTPUT
+          echo lastMinor="$((npm --silent info ern-core version || echo '0.0.0') | sed 's/[0-9]*\.\([0-9]*\).*/\1/')" >> $GITHUB_OUTPUT
       - run: yarn --frozen-lockfile
       - name: Minor version
         if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


