### PR TITLE
Use macOS-latest for Azure CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ stages:
           - template: azure/templates/unit-tests.yml
       - job: macOS
         pool:
-          vmImage: 'macOS-11'
+          vmImage: 'macOS-latest'
         steps:
           - template: azure/templates/unit-tests.yml
       - job: Linux


### PR DESCRIPTION
Update Azure pipelines config to use `macOS-latest` instead of `macOS-11`.

[According to the docs](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml), macOS-latest is currently pointing to macOS-12, while macOS-11 is marked as deprecated.

Hopefully, this will fix a strange macOS related CI failure. See https://github.com/electrode-io/electrode-native/runs/26834219060 and #1903 for example