### PR TITLE
Update simple-git and add support for GIT_TOKEN

### DIFF
--- a/ern-core/package.json
+++ b/ern-core/package.json
@@ -62,7 +62,7 @@
     "react-native-cli": "^2.0.1",
     "semver": "^7.3.5",
     "shelljs": "^0.8.4",
-    "simple-git": "^2.38.1",
+    "simple-git": "^3.25.0",
     "tmp": "^0.2.1",
     "treeify": "^1.1.0",
     "tunnel": "^0.0.6",

--- a/ern-core/src/gitCli.ts
+++ b/ern-core/src/gitCli.ts
@@ -1,5 +1,14 @@
-import simpleGit = require('simple-git/promise');
+import simpleGit from 'simple-git';
 
 export function gitCli(workingDir?: string) {
-  return simpleGit(workingDir);
+  const sGit = simpleGit(workingDir);
+
+  if (process.env.ERN_GITHUB_TOKEN) {
+    sGit.addConfig(
+      'http.extraheader',
+      `Authorization: Basic ${process.env.ERN_GITHUB_TOKEN}`,
+    );
+  }
+
+  return sGit;
 }

--- a/tsconfig.release.json
+++ b/tsconfig.release.json
@@ -3,7 +3,8 @@
     "target": "es2018",
     "allowJs": false,
     "esModuleInterop": true,
-    "lib": ["es2018"],
+    // Simple-git uses DOM object (Abort Signal) here - https://github.com/steveukx/git-js/blob/859699d0cc1d0c9b94f53de9c61a060a2cecb656/simple-git/src/lib/types/index.ts#L66.
+    "lib": ["es2018", "DOM"],
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2534,10 +2534,10 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
-  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.5.tgz#e83444eceb9fedd4a1da56d671ae2446a01a6e1e"
+  integrity sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==
   dependencies:
     ms "2.1.2"
 
@@ -6470,14 +6470,14 @@ signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.6.tgz#24e630c4b0f03fea446a2bd299e62b4a6ca8d0af"
   integrity sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==
 
-simple-git@^2.38.1:
-  version "2.48.0"
-  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-2.48.0.tgz#87c262dba8f84d7b96bb3a713e9e34701c1f6e3b"
-  integrity sha512-z4qtrRuaAFJS4PUd0g+xy7aN4y+RvEt/QTJpR184lhJguBA1S/LsVlvE/CM95RsYMOFJG3NGGDjqFCzKU19S/A==
+simple-git@^3.25.0:
+  version "3.25.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.25.0.tgz#3666e76d6831f0583dc380645945b97e0ac4aab6"
+  integrity sha512-KIY5sBnzc4yEcJXW7Tdv4viEz8KyG+nU0hay+DWZasvdFOYKeUZ6Xc25LUHHjw0tinPT7O1eY6pzX7pRT1K8rw==
   dependencies:
     "@kwsites/file-exists" "^1.1.1"
     "@kwsites/promise-deferred" "^1.1.1"
-    debug "^4.3.2"
+    debug "^4.3.5"
 
 simple-plist@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
- Electrode Native Platform uses simple-git for git cli operations.
- Right now ERN only has SSH to authenticate in CI.  Updated simple-git to latest and add ability to support github_token to authenticate the cli commands. 
- Updated simple-git/promise since its going to be deprecated soon.
- ern-core -> yarn build since typescript lib doesn't support DOM. Simple-git uses DOM object AbortSignal. 