### PR TITLE
Declare variants for publishing for AGP 8

### DIFF
--- a/ern-container-gen-android/src/hull/lib/build.gradle
+++ b/ern-container-gen-android/src/hull/lib/build.gradle
@@ -29,6 +29,11 @@ android {
     lintOptions {
         abortOnError false
     }
+    publishing {
+        multipleVariants {
+            allVariants()
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Starting with AGP 8.0:
Automatic component creation is disabled by default.
To publish, you need to manually configure component creation using the publishing DSL.
When configuring multiple variants for publishing, the component name is set to "default" by default, unless we specify a different name in the multipleVariants function call.
Therefore, if we were previously publishing the "release" variant using components.release, we would now refer to the component as components.default when using the multiple variants publishing approach with the default component name.

The change from components.release to components.default is a consequence of AGP 8.0 disabling automatic component creation and adopting a different naming convention for the default component created when publishing multiple variants using the publishing DSL. We now will use multipleVariants

Ref: https://developer.android.com/reference/tools/gradle-api/8.3/null/com/android/build/api/dsl/Publishing