### PR TITLE
Fix cuid2 build error by removing ^ from code-push

### DIFF
--- a/ern-core/package.json
+++ b/ern-core/package.json
@@ -46,7 +46,7 @@
     "bugsnag-sourcemaps": "^1.3.0",
     "chalk": "^4.1.1",
     "cli-table": "^0.3.6",
-    "code-push": "^4.0.4",
+    "code-push": "4.0.5",
     "cross-spawn": "^7.0.3",
     "form-data": "^4.0.0",
     "fs-extra": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2191,7 +2191,7 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-code-push@^4.0.4:
+code-push@4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/code-push/-/code-push-4.0.5.tgz#e4b308ed7b61d19aaddcd046ac92998d18f1481d"
   integrity sha512-YPhPFDySKVFv/ikB2FTNaiiIwU3A1cu5i5WKS3YY9EmmxlUWdt41xr7FLP7RSslA4YaMNIdg6CsKiLiRJLABZQ==


### PR DESCRIPTION
The following library paralleldrive/cuid2 has released a breaking version (2.3.0) 5 days ago. 
https://github.com/paralleldrive/cuid2/releases/tag/v2.3.0

Due to this breaking version ERN platforms are broken and unable to be built due to the following error
```
/Users/r0h0gg6/.ern/versions/0.53.2/node_modules/formidable/src/Formidable.js:8
const cuid2 = require('@paralleldrive/cuid2');
              ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/r0h0gg6/.ern/versions/0.53.2/node_modules/@paralleldrive/cuid2/index.js from /Users/r0h0gg6/.ern/versions/0.53.2/node_modules/formidable/src/Formidable.js not supported.
Instead change the require of index.js in /Users/r0h0gg6/.ern/versions/0.53.2/node_modules/formidable/src/Formidable.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/Users/r0h0gg6/.ern/versions/0.53.2/node_modules/formidable/src/Formidable.js:8:15)
    at Object.<anonymous> (/Users/r0h0gg6/.ern/versions/0.53.2/node_modules/formidable/src/index.js:5:20)
    at Object.<anonymous> (/Users/r0h0gg6/.ern/versions/0.53.2/node_modules/superagent/lib/node/index.js:29:20)
    at Object.<anonymous> (/Users/r0h0gg6/.ern/versions/0.53.2/node_modules/code-push/utils/request-manager.js:2:18)
    at Object.<anonymous> (/Users/r0h0gg6/.ern/versions/0.53.2/node_modules/code-push/utils/adapter/adapter.js:41:41)
    at Object.<anonymous> (/Users/r0h0gg6/.ern/versions/0.53.2/node_modules/code-push/script/management-sdk.js:73:33)
    at Object.<anonymous> (/Users/r0h0gg6/.ern/versions/0.53.2/node_modules/code-push/script/index.js:2:22)
    at Object.<anonymous> (/Users/r0h0gg6/.ern/versions/0.53.2/node_modules/ern-core/dist/CodePushSdk.js:6:37)
    at Object.<anonymous> (/Users/r0h0gg6/.ern/versions/0.53.2/node_modules/ern-core/dist/index.js:34:39)
    at Object.<anonymous> (/Users/r0h0gg6/.ern/versions/0.53.2/node_modules/ern-cauldron-api/dist/CauldronApi.js:30:20)
    at Object.<anonymous> (/Users/r0h0gg6/.ern/versions/0.53.2/node_modules/ern-cauldron-api/dist/index.js:21:39)
    at Object.<anonymous> (/Users/r0h0gg6/.ern/versions/0.53.2/node_modules/ern-local-cli/dist/index.js:9:28)
    at Object.<anonymous> (/Users/r0h0gg6/.ern/versions/0.53.2/node_modules/ern-local-cli/src/index.prod.js:12:1)
    at runLocalCli (/Users/r0h0gg6/.nvm/versions/node/v18.20.8/lib/node_modules/electrode-native/src/index.js:229:3)
    at ChildProcess.<anonymous> (/Users/r0h0gg6/.nvm/versions/node/v18.20.8/lib/node_modules/electrode-native/src/index.js:164:9)
    at ChildProcess.emit (node:events:517:28) {
  code: 'ERR_REQUIRE_ESM'
}
```

This dependency is coming from the code-push version from https://github.com/electrode-io/electrode-native/blob/437da4422644c897a160a899d83764ce5f4727d7/ern-core/package.json#L49

Due to code-push having ^, it resolves to code-push@4.2.3 which cascades into the following dependency tree
```
code-push@4.2.3 -> superagent@8.1.2 -> formidable@2.1.5 -> @paralleldrive/cuid2@^2.2.2 -> resolves to  @paralleldrive/cuid2@2.3.0
```

Previously the latest stable version for cuid2 was using 2.2.2 @paralleldrive/cuid2@2.2.2.

**SOLUTION 1**

If we set code-push to a lower version 4.0.5, it will in turn user a lower version of superagent https://github.com/microsoft/code-push/blob/v4.0.5/package.json#L37

Which in turn will use a lower version of formidable 
https://github.com/microsoft/code-push/blob/v4.0.5/package.json#L37

Which does not have the @paralleldrive/cuid2 library dependency

**SOLUTION 2**
Per this discussion, https://github.com/paralleldrive/cuid2/issues/105

We can wait for the library maintainer to do a new build that reverts the breaking change or point back to last stable release.