### PR TITLE
Update yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4176,7 +4176,7 @@ json-refs@^2.1.5:
     graphlib "^2.1.1"
     js-yaml "^3.8.3"
     native-promise-only "^0.8.1"
-    path-loader "^1.0.2"
+    path-loader "1.0.10"
     slash "^1.0.0"
     uri-js "^3.0.2"
 
@@ -5630,7 +5630,7 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-loader@^1.0.2:
+path-loader@1.0.10:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/path-loader/-/path-loader-1.0.10.tgz#dd3d1bd54cb6f2e6423af2ad334a41cc0bce4cf6"
   integrity sha512-CMP0v6S6z8PHeJ6NFVyVJm6WyJjIwFvyz2b0n2/4bKdS/0uZa/9sKUlYZzubrn3zuDRU0zIuEDX9DZYQ2ZI8TA==


### PR DESCRIPTION
Follow up to https://github.com/electrode-io/electrode-native/pull/1917

Need to update json-refs library dependency to use path-loader@1.0.10 to use a lower version of superagent. 
https://github.com/electrode-io/electrode-native/pull/1918

path-loader@1.0.12 is using superagent "^7.1.6" which uses formidable@2.1.5 which uses @paralleldrive/cuid2" "^2.2.2" which breaks ERN build